### PR TITLE
feat: ignore id mismatch

### DIFF
--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -175,6 +175,7 @@ impl ObjectFile {
 
             if let Some(ref debug_id) = object_id.debug_id {
                 if parsed.debug_id() != *debug_id {
+                    metric!(counter("object.debug_id_mismatch") += 1);
                     log::debug!(
                         "debug id mismatch. got {}, expected {}",
                         parsed.debug_id(),
@@ -186,6 +187,7 @@ impl ObjectFile {
             if let Some(ref code_id) = object_id.code_id {
                 if let Some(ref object_code_id) = parsed.code_id() {
                     if object_code_id != code_id {
+                        metric!(counter("object.code_id_mismatch") += 1);
                         log::debug!(
                             "code id mismatch. got {}, expected {}",
                             object_code_id,


### PR DESCRIPTION
in theory it would make sense to error about id mismatches but
tests show that at least microsoft's symbol server will just return
PDBs with different ages.  As an example ntdll.dll with the debug ID
4A236F6A0B3941D1966B41A4FC77738C2 is reported as
4A236F6A0B3941D1966B41A4FC77738C4 from the server.

Example symbol: https://msdl.microsoft.com/download/symbols/wntdll.pdb/4A236F6A0B3941D1966B41A4FC77738C2/wntdll.pdb