### PR TITLE
feat: Add metrics for cache file sizes

### DIFF
--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -136,7 +136,7 @@ impl CacheItemRequest for FetchFile {
                         file.sync_all().context(ObjectErrorKind::Io)?;
 
                         let metadata = file.metadata().context(ObjectErrorKind::Io)?;
-                        metric!(gauge("objects.size") = metadata.len());
+                        metric!(time_raw("objects.size") = metadata.len());
 
                         Ok(final_scope)
                     });

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -132,7 +132,7 @@ impl CacheItemRequest for FetchFile {
                     })
                     .map(|file| {
                         if let Ok(metadata) = file.metadata() {
-                            metric!(gauge("fetch_object.size") = metadata.len());
+                            metric!(gauge("objects.size") = metadata.len());
                         }
 
                         final_scope
@@ -146,7 +146,7 @@ impl CacheItemRequest for FetchFile {
         });
 
         Box::new(measure_task(
-            "fetch_object",
+            "objects",
             Some((Duration::from_secs(600), ObjectErrorKind::Timeout.into())),
             result,
         ))

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -119,19 +119,26 @@ impl CacheItemRequest for FetchFile {
         let result = request.and_then(move |payload| {
             if let Some(payload) = payload {
                 log::info!("Resolved debug file for {}", cache_key);
-                let file = fs::File::create(&path)
-                    .map_err(|e| ObjectError::from(e.context(ObjectErrorKind::Io)))
-                    .into_future();
 
-                let result = file.and_then(|file| {
-                    payload.fold(file, move |mut file, chunk| {
-                        threadpool.spawn_handle(future::lazy(move || {
-                            file.write_all(&chunk).map(|_| file)
-                        }))
+                let future = fs::File::create(&path)
+                    .map_err(|e| e.context(ObjectErrorKind::Io).into())
+                    .into_future()
+                    .and_then(|file| {
+                        payload.fold(file, move |mut file, chunk| {
+                            threadpool.spawn_handle(future::lazy(move || {
+                                file.write_all(&chunk).map(|_| file)
+                            }))
+                        })
                     })
-                });
+                    .map(|file| {
+                        if let Ok(metadata) = file.metadata() {
+                            metric!(gauge("fetch_object.size") = metadata.len());
+                        }
 
-                Either::A(result.map(|_| final_scope))
+                        final_scope
+                    });
+
+                Either::A(future)
             } else {
                 log::debug!("No debug file found for {}", cache_key);
                 Either::B(Ok(final_scope).into_future())

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -158,7 +158,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
                             file.sync_all().context(SymCacheErrorKind::Io)?;
 
                             let metadata = file.metadata().context(SymCacheErrorKind::Io)?;
-                            metric!(gauge("symcaches.size") = metadata.len());
+                            metric!(time_raw("symcaches.size") = metadata.len());
                         }
                         Ok(None) => (),
                         Err(err) => {


### PR DESCRIPTION
This updates metrics around cache files:

 - `fetch_object.*` and `fetch_symcache.*` renamed to `objects.*` and `symcaches.*`, respectively
 - Adds `objects.size` and `symcaches.size`
 - Ensures that written files are flushed (including metadata), before moving on