### PR TITLE
fix: Call capture_fail in every step of the pipeline

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -518,6 +518,11 @@ impl SymCacheLookup {
                                             }
 
                                             _ => {
+                                                // Just in case we didn't handle an error properly,
+                                                // capture it here. If an error was captured with
+                                                // `capture_fail` further down in the callstack, it
+                                                // should be explicitly handled here as a
+                                                // SymCacheErrorKind variant.
                                                 capture_fail(&*e);
                                                 DebugFileStatus::Other
                                             }


### PR DESCRIPTION
We want to capture the real `Fail` without any wrapper `Fail`s attached, because:

* due to how error chains are currently grouped in Sentry (least specific error is the one shown in title)
* in async envs, breadcrumbs are probably better when capturing close to the error