### PR TITLE
feat: Use global scope for proxy

### DIFF
--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -35,9 +35,7 @@ fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)> {
     let (leading_fn, signature, trailing_fn) = path.splitn(3, '/').collect_tuple()?;
 
     let leading_fn_lower = leading_fn.to_lowercase();
-    if !trailing_fn.eq_ignore_ascii_case("file.ptr")
-        && !leading_fn_lower.eq_ignore_ascii_case(trailing_fn)
-    {
+    if !leading_fn_lower.eq_ignore_ascii_case(trailing_fn) {
         return None;
     }
 
@@ -91,7 +89,7 @@ fn proxy_symstore_request(
                 filetypes,
                 identifier: object_id,
                 sources: state.config.sources.clone(),
-                scope: Scope::Proxy,
+                scope: Scope::Global,
                 purpose: ObjectPurpose::Debug,
             })
             .map_err(|e| e.context(ProxyErrorKind::Mailbox).into())

--- a/src/types.rs
+++ b/src/types.rs
@@ -277,8 +277,6 @@ impl SourceConfig {
 pub enum Scope {
     #[serde(rename = "global")]
     Global,
-    #[serde(rename = "proxy")]
-    Proxy,
     Scoped(String),
 }
 
@@ -286,7 +284,6 @@ impl AsRef<str> for Scope {
     fn as_ref(&self) -> &str {
         match *self {
             Scope::Global => "global",
-            Scope::Proxy => "proxy",
             Scope::Scoped(ref s) => &s,
         }
     }
@@ -302,7 +299,6 @@ impl fmt::Display for Scope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Scope::Global => f.write_str("global"),
-            Scope::Proxy => f.write_str("proxy"),
             Scope::Scoped(ref scope) => f.write_str(&scope),
         }
     }


### PR DESCRIPTION
This uses the global scope for the proxy and removes the proxy scope.