### PR TITLE
feat: Add concept of cache expiry and a subcommand to delete expired files

### DIFF
--- a/src/actors/cache.rs
+++ b/src/actors/cache.rs
@@ -103,11 +103,7 @@ impl<T: CacheItemRequest> Handler<ComputeMemoized<T>> for CacheActor<T> {
 
             let result = file.and_then(clone!(key, |file| {
                 for &scope in &[&key.scope, &Scope::Global] {
-                    let path = tryf!(get_scope_path(
-                        config.cache_dir(),
-                        &scope,
-                        &key.cache_key
-                    ));
+                    let path = tryf!(get_scope_path(config.cache_dir(), &scope, &key.cache_key));
 
                     let path = match path {
                         Some(x) => x,

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -15,7 +15,8 @@ use symbolic::debuginfo::Object;
 use tempfile::tempfile_in;
 use tokio_threadpool::ThreadPool;
 
-use crate::actors::cache::{CacheActor, CacheItemRequest, CacheKey};
+use crate::actors::cache::{CacheActor, CacheItemRequest};
+use crate::cache::{Cache, CacheKey};
 use crate::types::{
     FileType, HttpSourceConfig, ObjectId, S3SourceConfig, Scope, SentrySourceConfig, SourceConfig,
 };
@@ -325,8 +326,11 @@ pub struct ObjectsActor {
 }
 
 impl ObjectsActor {
-    pub fn new(cache: Addr<CacheActor<FetchFileRequest>>, threadpool: Arc<ThreadPool>) -> Self {
-        ObjectsActor { cache, threadpool }
+    pub fn new(cache: Cache, threadpool: Arc<ThreadPool>) -> Self {
+        ObjectsActor {
+            cache: CacheActor::new(cache).start(),
+            threadpool,
+        }
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -181,7 +181,7 @@ fn run_server(config: Config) -> Result<(), CliError> {
     let symcaches =
         SymCacheActor::new(caches.symcaches, objects.clone(), cpu_threadpool.clone()).start();
 
-    let cficaches = CfiCacheActor::new(caches.cficaches, objects, cpu_threadpool.clone()).start();
+    let cficaches = CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone()).start();
 
     let symbolication =
         SymbolicationActor::new(symcaches, cficaches, cpu_threadpool.clone()).start();

--- a/src/app.rs
+++ b/src/app.rs
@@ -181,7 +181,8 @@ fn run_server(config: Config) -> Result<(), CliError> {
     let symcaches =
         SymCacheActor::new(caches.symcaches, objects.clone(), cpu_threadpool.clone()).start();
 
-    let cficaches = CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone()).start();
+    let cficaches =
+        CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone()).start();
 
     let symbolication =
         SymbolicationActor::new(symcaches, cficaches, cpu_threadpool.clone()).start();

--- a/src/app.rs
+++ b/src/app.rs
@@ -136,15 +136,15 @@ impl Caches {
         Caches {
             objects: {
                 let path = config.cache_dir.as_ref().map(|x| x.join("./objects/"));
-                Cache::new("objects", path, config.caches.objects.clone())
+                Cache::new("objects", path, config.caches.downloaded)
             },
             symcaches: {
                 let path = config.cache_dir.as_ref().map(|x| x.join("./symcaches/"));
-                Cache::new("symcaches", path, config.caches.symcaches.clone())
+                Cache::new("symcaches", path, config.caches.derived)
             },
             cficaches: {
                 let path = config.cache_dir.as_ref().map(|x| x.join("./cficaches/"));
-                Cache::new("cficaches", path, config.caches.cficaches.clone())
+                Cache::new("cficaches", path, config.caches.derived)
             },
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -311,7 +311,7 @@ fn test_retry_misses_after() -> Result<(), CleanupError> {
 
     File::create(tempdir.path().join("keepthis"))?.write_all(b"hi")?;
     File::create(tempdir.path().join("killthis"))?.write_all(b"")?;
-    sleep(Duration::from_millis(11));
+    sleep(Duration::from_millis(20));
 
     File::create(tempdir.path().join("keepthis2"))?.write_all(b"")?;
     cache.cleanup()?;
@@ -331,6 +331,7 @@ fn test_retry_misses_after() -> Result<(), CleanupError> {
 #[test]
 fn test_cleanup_malformed() -> Result<(), CleanupError> {
     use std::io::Write;
+    use std::thread::sleep;
 
     let tempdir = tempfile::tempdir()?;
 
@@ -339,6 +340,8 @@ fn test_cleanup_malformed() -> Result<(), CleanupError> {
     File::create(tempdir.path().join("keepthis2"))?.write_all(b"hi")?;
 
     File::create(tempdir.path().join("killthis"))?.write_all(b"malformed")?;
+
+    sleep(Duration::from_millis(10));
 
     // Creation of this struct == "process startup"
     let cache = Cache::new("test", Some(tempdir.path()), Default::default());

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -258,12 +258,17 @@ where
     }
 }
 
+#[cfg(test)]
+fn tempdir() -> io::Result<tempfile::TempDir> {
+    tempfile::tempdir_in(".")
+}
+
 #[test]
 fn test_max_unused_for() -> Result<(), CleanupError> {
     use std::io::Write;
     use std::thread::sleep;
 
-    let tempdir = tempfile::tempdir()?;
+    let tempdir = tempdir()?;
 
     let cache = Cache::new(
         "test",
@@ -298,7 +303,7 @@ fn test_retry_misses_after() -> Result<(), CleanupError> {
     use std::io::Write;
     use std::thread::sleep;
 
-    let tempdir = tempfile::tempdir()?;
+    let tempdir = tempdir()?;
 
     let cache = Cache::new(
         "test",
@@ -333,7 +338,7 @@ fn test_cleanup_malformed() -> Result<(), CleanupError> {
     use std::io::Write;
     use std::thread::sleep;
 
-    let tempdir = tempfile::tempdir()?;
+    let tempdir = tempdir()?;
 
     // File has same amount of chars, check that optimization  works
     File::create(tempdir.path().join("keepthis"))?.write_all(b"additive")?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,238 @@
+/// Core logic for cache files. Used by `crate::actors::cache`.
+///
+/// Terminology:
+/// * positive cache item: A cache item that represents the presence of something. E.g. we succeeded in downloading an object file and cached that file.
+/// * Negative cache item: A cache item that represents the absence of something. E.g. we encountered a 404 while trying to download a file, and cached that fact. Represented by an empty file.
+///
+/// * item age: When the item was computed and created.
+/// * item last used: Last time this item was involved in a cache hit.
+use std::fs::{create_dir_all, read_dir, remove_file, File, OpenOptions};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use failure::Fail;
+
+use sentry::integrations::failure::capture_fail;
+use symbolic::common::ByteView;
+
+use crate::config::CacheConfig;
+use crate::logging::LogError;
+use crate::types::Scope;
+
+/// Content of symcaches/cficaches whose writing failed.
+///
+/// Items with this value will be considered expired after the next process restart, or will be
+/// pruned once `symbolicator cleanup` runs. Independently of any `max_age` or `max_last_used`.
+///
+/// The malformed state is useful for failed computations that are unlikely to succeed before the
+/// next deploy. For example, symcache writing may fail due to an object file symbolic can't parse
+/// yet.
+pub const MALFORMED_MARKER: &[u8] = b"malformed";
+
+#[derive(Debug, Fail, derive_more::From)]
+pub enum CleanupError {
+    #[fail(display = "No caching configured! Did you provide a path to your config file?")]
+    NoCachingConfigured,
+
+    #[fail(display = "Not a file")]
+    NotAFile,
+
+    #[fail(display = "Failed to access filesystem")]
+    Io(#[fail(cause)] io::Error),
+}
+
+/// Utilities for a sym/cfi or object cache.
+#[derive(Debug, Clone)]
+pub struct Cache {
+    /// Cache identifier used for metric names.
+    pub name: &'static str,
+
+    /// Directory to use for storing cache items. Will be created if it does not exist.
+    pub cache_dir: Option<PathBuf>,
+
+    /// Time when this process started.
+    start_time: SystemTime,
+
+    /// Options intended to be user-configurable.
+    pub cache_config: CacheConfig,
+}
+
+impl Cache {
+    pub fn new<P: AsRef<Path>>(
+        name: &'static str,
+        cache_dir: Option<P>,
+        cache_config: CacheConfig,
+    ) -> Self {
+        Cache {
+            name,
+            cache_dir: cache_dir.map(|x| x.as_ref().to_owned()),
+            start_time: SystemTime::now(),
+            cache_config,
+        }
+    }
+
+    pub fn cleanup(&self) -> Result<(), CleanupError> {
+        log::info!("Cleaning up cache: {}", self.name);
+        let cache_dir = match self.cache_dir {
+            Some(ref x) => x,
+            None => return Err(CleanupError::NoCachingConfigured),
+        };
+
+        let entries = match catch_not_found(|| read_dir(cache_dir))? {
+            Some(x) => x,
+            None => {
+                log::warn!("Directory not found");
+                return Ok(());
+            }
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if let Err(e) = self.try_cleanup_path(&path) {
+                log::error!("Failed to clean up {}: {}", path.display(), LogError(&e));
+                capture_fail(&e);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_cleanup_path(&self, path: &Path) -> Result<(), CleanupError> {
+        log::debug!("Looking at {}", path.display());
+        if path.is_file() {
+            if catch_not_found(|| self.check_expiry(path))?.is_none() {
+                log::info!("Removing {}", path.display());
+                catch_not_found(|| remove_file(path))?;
+            }
+
+            Ok(())
+        } else {
+            Err(CleanupError::NotAFile)
+        }
+    }
+
+    /// Validate cache expiration of path. If cache should not be used,
+    /// `Err(io::ErrorKind::NotFound)` is returned.  If cache is usable, `Ok(x)` is returned, where
+    /// `x` indicates whether the file should be touched before using.
+    fn check_expiry(&self, path: &Path) -> io::Result<bool> {
+        let metadata = path.metadata()?;
+
+        log::trace!("File length: {}", metadata.len());
+
+        // Immediately expire malformed items that have been created before this process started.
+        // See docstring of MALFORMED_MARKER
+        if MALFORMED_MARKER.len() as u64 == metadata.len() {
+            let created_at = metadata.created()?;
+            if created_at < self.start_time {
+                log::trace!("Created at is older than start time");
+                let mut file = File::open(path)?;
+                let mut buf = vec![0; MALFORMED_MARKER.len()];
+                file.read_exact(&mut buf)?;
+
+                log::trace!("First {} bytes: {:?}", buf.len(), buf);
+
+                if buf == MALFORMED_MARKER {
+                    return Err(io::ErrorKind::NotFound.into());
+                }
+            }
+        }
+
+        let is_negative = metadata.len() == 0;
+
+        let (max_age, max_last_used) = if is_negative {
+            (
+                self.cache_config.max_negative_age,
+                self.cache_config.max_negative_last_used,
+            )
+        } else {
+            (self.cache_config.max_age, self.cache_config.max_last_used)
+        };
+
+        if let Some(max_age) = max_age {
+            let created_at = metadata.created()?;
+
+            if created_at.elapsed().map(|x| x > max_age).unwrap_or(true) {
+                return Err(io::ErrorKind::NotFound.into());
+            }
+        }
+
+        // We use mtime to keep track of "cache last used", because filesystem is usually mounted
+        // with `noatime` and therefore atime is nonsense.
+        let last_used = if let Some(max_last_used) = max_last_used {
+            let last_used = metadata.modified()?.elapsed().ok();
+
+            if last_used.map(|x| x > max_last_used).unwrap_or(true) {
+                return Err(io::ErrorKind::NotFound.into());
+            }
+
+            last_used
+        } else {
+            None
+        };
+
+        Ok(last_used
+            .map(|x| x > Duration::from_secs(3600))
+            .unwrap_or(true))
+    }
+
+    /// Validate cachefile against expiration config and open a byteview on it. Takes care of
+    /// bumping mtime.
+    pub fn open_cachefile(&self, path: &Path) -> io::Result<Option<ByteView<'static>>> {
+        // `io::ErrorKind::NotFound` can be returned from multiple locations in this function. All
+        // of those can indicate a cache miss as cache cleanup can run inbetween. Only when we have
+        // an open ByteView we can be sure to have a cache hit.
+        catch_not_found(|| {
+            let should_touch = self.check_expiry(path)?;
+
+            if should_touch {
+                OpenOptions::new()
+                    .append(true)
+                    .truncate(false)
+                    .open(&path)?;
+            }
+
+            ByteView::open(path)
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CacheKey {
+    pub cache_key: String,
+    pub scope: Scope,
+}
+
+pub fn get_scope_path(
+    cache_dir: Option<&Path>,
+    scope: &Scope,
+    cache_key: &str,
+) -> Result<Option<PathBuf>, io::Error> {
+    let dir = match cache_dir {
+        Some(x) => x.join(safe_path_segment(scope.as_ref())),
+        None => return Ok(None),
+    };
+
+    create_dir_all(&dir)?;
+    Ok(Some(dir.join(safe_path_segment(cache_key))))
+}
+
+fn safe_path_segment(s: &str) -> String {
+    s.replace(".", "_") // protect against ..
+        .replace("/", "_") // protect against absolute paths
+        .replace(":", "_") // not a threat on POSIX filesystems, but confuses OS X Finder
+}
+
+fn catch_not_found<F, R>(f: F) -> io::Result<Option<R>>
+where
+    F: FnOnce() -> io::Result<R>,
+{
+    match f() {
+        Ok(x) => Ok(Some(x)),
+        Err(e) => match e.kind() {
+            io::ErrorKind::NotFound => Ok(None),
+            _ => Err(e),
+        },
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -50,16 +50,16 @@ pub enum CleanupError {
 #[derive(Debug, Clone)]
 pub struct Cache {
     /// Cache identifier used for metric names.
-    pub name: &'static str,
+    name: &'static str,
 
     /// Directory to use for storing cache items. Will be created if it does not exist.
-    pub cache_dir: Option<PathBuf>,
+    cache_dir: Option<PathBuf>,
 
     /// Time when this process started.
     start_time: SystemTime,
 
     /// Options intended to be user-configurable.
-    pub cache_config: CacheConfig,
+    cache_config: CacheConfig,
 }
 
 impl Cache {
@@ -74,6 +74,14 @@ impl Cache {
             start_time: SystemTime::now(),
             cache_config,
         }
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn cache_dir(&self) -> Option<&Path> {
+        self.cache_dir.as_ref().map(|x| &**x)
     }
 
     pub fn cleanup(&self) -> Result<(), CleanupError> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -287,7 +287,6 @@ fn test_max_unused_for() -> Result<(), CleanupError> {
     cache.cleanup()?;
 
     let mut basenames: Vec<_> = read_dir(tempdir.path())?
-        .into_iter()
         .map(|x| x.unwrap().file_name().into_string().unwrap())
         .collect();
 
@@ -309,20 +308,19 @@ fn test_retry_misses_after() -> Result<(), CleanupError> {
         "test",
         Some(tempdir.path()),
         CacheConfig {
-            retry_misses_after: Some(Duration::from_millis(10)),
+            retry_misses_after: Some(Duration::from_millis(20)),
             ..Default::default()
         },
     );
 
     File::create(tempdir.path().join("keepthis"))?.write_all(b"hi")?;
     File::create(tempdir.path().join("killthis"))?.write_all(b"")?;
-    sleep(Duration::from_millis(20));
+    sleep(Duration::from_millis(25));
 
     File::create(tempdir.path().join("keepthis2"))?.write_all(b"")?;
     cache.cleanup()?;
 
     let mut basenames: Vec<_> = read_dir(tempdir.path())?
-        .into_iter()
         .map(|x| x.unwrap().file_name().into_string().unwrap())
         .collect();
 
@@ -340,8 +338,8 @@ fn test_cleanup_malformed() -> Result<(), CleanupError> {
 
     let tempdir = tempdir()?;
 
-    // File has same amount of chars, check that optimization  works
-    File::create(tempdir.path().join("keepthis"))?.write_all(b"additive")?;
+    // File has same amount of chars as "malformed", check that optimization works
+    File::create(tempdir.path().join("keepthis"))?.write_all(b"addictive")?;
     File::create(tempdir.path().join("keepthis2"))?.write_all(b"hi")?;
 
     File::create(tempdir.path().join("killthis"))?.write_all(b"malformed")?;
@@ -350,12 +348,12 @@ fn test_cleanup_malformed() -> Result<(), CleanupError> {
 
     // Creation of this struct == "process startup"
     let cache = Cache::new("test", Some(tempdir.path()), Default::default());
-    cache.cleanup()?;
 
     File::create(tempdir.path().join("keepthis3"))?.write_all(b"malformed")?;
 
+    cache.cleanup()?;
+
     let mut basenames: Vec<_> = read_dir(tempdir.path())?
-        .into_iter()
         .map(|x| x.unwrap().file_name().into_string().unwrap())
         .collect();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,9 @@ pub struct CacheConfig {
 
     /// Maximum duration since creation of negative cache item (item age).
     pub retry_misses_after: Option<Duration>,
+
+    /// Maximum duration since creation of malformed cache item (item age).
+    pub retry_malformed_after: Option<Duration>,
 }
 
 impl Default for CacheConfig {
@@ -90,6 +93,7 @@ impl Default for CacheConfig {
         CacheConfig {
             max_unused_for: Some(Duration::from_secs(3600 * 24 * 7)),
             retry_misses_after: Some(Duration::from_secs(3600)),
+            retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use failure::Fail;
 use log::LevelFilter;
@@ -71,6 +72,41 @@ impl Default for Metrics {
     }
 }
 
+/// Options for fine-tuning cache expiry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheConfig {
+    /// Maximum duration since last use of (positive) cache item (item age).
+    pub max_age: Option<Duration>,
+
+    /// Maximum duration since last use of (positive) cache item (item last used).
+    pub max_last_used: Option<Duration>,
+
+    /// Maximum duration since creation of negative cache item (item age).
+    pub max_negative_age: Option<Duration>,
+
+    /// Maximum duration since last use of negative cache item (item last used).
+    pub max_negative_last_used: Option<Duration>,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        CacheConfig {
+            max_age: None,
+            max_last_used: Some(Duration::from_secs(3600 * 24 * 7)),
+            max_negative_age: Some(Duration::from_secs(3600)),
+            max_negative_last_used: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct CacheConfigs {
+    pub symcaches: CacheConfig,
+    pub cficaches: CacheConfig,
+    pub objects: CacheConfig,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -88,6 +124,9 @@ pub struct Config {
 
     /// DSN to report internal errors to
     pub sentry_dsn: Option<Dsn>,
+
+    /// Fine-tune cache expiry
+    pub caches: CacheConfigs,
 }
 
 /// Checks if we are running in docker.
@@ -119,6 +158,7 @@ impl Default for Config {
             logging: Logging::default(),
             metrics: Metrics::default(),
             sentry_dsn: None,
+            caches: CacheConfigs::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,28 +73,20 @@ impl Default for Metrics {
 }
 
 /// Options for fine-tuning cache expiry.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct CacheConfig {
-    /// Maximum duration since last use of (positive) cache item (item age).
-    pub max_age: Option<Duration>,
-
-    /// Maximum duration since last use of (positive) cache item (item last used).
-    pub max_last_used: Option<Duration>,
+    /// Maximum duration since last use of cache item (item last used).
+    pub max_unused_for: Option<Duration>,
 
     /// Maximum duration since creation of negative cache item (item age).
-    pub max_negative_age: Option<Duration>,
-
-    /// Maximum duration since last use of negative cache item (item last used).
-    pub max_negative_last_used: Option<Duration>,
+    pub retry_misses_after: Option<Duration>,
 }
 
 impl Default for CacheConfig {
     fn default() -> Self {
         CacheConfig {
-            max_age: None,
-            max_last_used: Some(Duration::from_secs(3600 * 24 * 7)),
-            max_negative_age: Some(Duration::from_secs(3600)),
-            max_negative_last_used: None,
+            max_unused_for: Some(Duration::from_secs(3600 * 24 * 7)),
+            retry_misses_after: Some(Duration::from_secs(3600)),
         }
     }
 }
@@ -102,9 +94,10 @@ impl Default for CacheConfig {
 #[derive(Clone, Debug, Deserialize, Default)]
 #[serde(default)]
 pub struct CacheConfigs {
-    pub symcaches: CacheConfig,
-    pub cficaches: CacheConfig,
-    pub objects: CacheConfig,
+    /// Configure how long downloads are cached for.
+    pub downloaded: CacheConfig,
+    /// Configure how long caches derived from downloads are cached for.
+    pub derived: CacheConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod metrics;
 mod sentry;
 
 mod actors;
+mod cache;
 mod config;
 mod endpoints;
 mod hex;


### PR DESCRIPTION
* CacheActor will look at a file, and if it's considered expired, will just overwrite it.
* `symbolicator cleanup` will go through all caches synchronously and delete files it considers expired.