### PR TITLE
feat(casing): Added SSQP directory layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,13 @@ These are common parameters that work on most symbol sources (except `sentry`):
 - `layout`: configures the file system layout of the sources.  This configuration
   key is an object with two keys:
   - `type`: defines the general layout of the directory.  Possible values are
-    `native`, `symstore` and `ssqp`.  `native` uses the file type's native format.
-    `symstore` and `ssqp` both use the Microsoft Symbol Server format but control
-    the case conventions.  `symstore` uses the conventional casing rules for
-    signatures and filenames, `ssqp` uses the Microsoft SSQP casing rules instead.
+    `native`, `symstore`, `symstore_index2` and `ssqp`.  `native` uses the file
+    type's native format.  `symstore` and `ssqp` both use the Microsoft Symbol Server
+    format but control the case conventions.  `symstore` uses the conventional
+    casing rules for signatures and filenames, `ssqp` uses the Microsoft SSQP
+    casing rules instead.  Additionally `symstore_index2` works like `symstore`
+    but uses the "Two tier" (index2.txt) layout where the first two characters of
+    the filename are used as a toplevel extra folder.
   - `casing`: enforces a casing style.  The default is not to touch the casing and
     forward it unchanged.  If the backend does not support a case insensitive
     backend (eg: S3) then it's recommended to set this to `lowercase` to enforce

--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ These are common parameters that work on most symbol sources (except `sentry`):
 - `layout`: configures the file system layout of the sources.  This configuration
   key is an object with two keys:
   - `type`: defines the general layout of the directory.  Possible values are
-    `native` and `symstore`.  `native` uses the file type's native format and
-    `symstore` enforces symstore with SSQP rules.
+    `native`, `symstore` and `ssqp`.  `native` uses the file type's native format.
+    `symstore` and `ssqp` both use the Microsoft Symbol Server format but control
+    the case conventions.  `symstore` uses the conventional casing rules for
+    signatures and filenames, `ssqp` uses the Microsoft SSQP casing rules instead.
   - `casing`: enforces a casing style.  The default is not to touch the casing and
     forward it unchanged.  If the backend does not support a case insensitive
     backend (eg: S3) then it's recommended to set this to `lowercase` to enforce

--- a/src/actors/objects/paths.rs
+++ b/src/actors/objects/paths.rs
@@ -205,6 +205,11 @@ fn get_symstore_path(
         FileType::ElfCode => {
             let code_id = identifier.code_id.as_ref()?;
             let code_file = identifier.code_file_basename()?;
+            let code_file = if ssqp_casing {
+                Cow::Owned(code_file.to_lowercase())
+            } else {
+                Cow::Borrowed(code_file)
+            };
             Some(format!(
                 "{}/elf-buildid-{}/{}",
                 code_file, code_id, code_file
@@ -217,6 +222,11 @@ fn get_symstore_path(
 
         FileType::MachCode => {
             let code_file = identifier.code_file_basename()?;
+            let code_file = if ssqp_casing {
+                Cow::Owned(code_file.to_lowercase())
+            } else {
+                Cow::Borrowed(code_file)
+            };
             let uuid = get_mach_uuid(identifier)?;
             Some(format!(
                 "{}/mach-uuid-{}/{}",

--- a/src/actors/objects/paths.rs
+++ b/src/actors/objects/paths.rs
@@ -114,9 +114,17 @@ fn get_pdb_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<Str
         Cow::Borrowed(debug_file)
     };
     let debug_id = if ssqp_casing {
-        format!("{:x}{:X}", debug_id.uuid(), debug_id.appendix())
+        format!(
+            "{:x}{:X}",
+            debug_id.uuid().to_simple_ref(),
+            debug_id.appendix()
+        )
     } else {
-        format!("{:X}{:x}", debug_id.uuid(), debug_id.appendix())
+        format!(
+            "{:X}{:x}",
+            debug_id.uuid().to_simple_ref(),
+            debug_id.appendix()
+        )
     };
 
     Some(format!("{}/{}/{}", debug_file, debug_id, debug_file))

--- a/src/actors/objects/paths.rs
+++ b/src/actors/objects/paths.rs
@@ -241,6 +241,18 @@ fn get_symstore_path(
     }
 }
 
+fn get_symstore_index2_path(filetype: FileType, identifier: &ObjectId) -> Option<String> {
+    let rv = get_symstore_path(filetype, identifier, false)?;
+    if let Some(prefix) = rv.get(..2) {
+        if prefix.ends_with('/') || prefix.ends_with('.') {
+            return Some(format!("{}/{}", &prefix[..1], rv));
+        } else {
+            return Some(format!("{}/{}", prefix, rv));
+        }
+    }
+    Some(rv)
+}
+
 /// Determines the path for an object file in the given layout.
 fn get_directory_path(
     directory_layout: DirectoryLayout,
@@ -250,6 +262,7 @@ fn get_directory_path(
     let mut path = match directory_layout.ty {
         DirectoryLayoutType::Native => get_native_path(filetype, identifier)?,
         DirectoryLayoutType::Symstore => get_symstore_path(filetype, identifier, false)?,
+        DirectoryLayoutType::SymstoreIndex2 => get_symstore_index2_path(filetype, identifier)?,
         DirectoryLayoutType::SSQP => get_symstore_path(filetype, identifier, true)?,
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -223,6 +223,9 @@ pub enum DirectoryLayoutType {
     Native,
     /// Uses Microsoft symbol server conventions.
     Symstore,
+    /// Uses Microsoft SSQP server conventions.
+    #[serde(rename = "ssqp")]
+    SSQP,
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -217,12 +217,16 @@ impl Default for DirectoryLayout {
 
 /// Known conventions for `DirectoryLayout`
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub enum DirectoryLayoutType {
     /// Uses conventions of native debuggers.
+    #[serde(rename = "native")]
     Native,
     /// Uses Microsoft symbol server conventions.
+    #[serde(rename = "symstore")]
     Symstore,
+    /// Uses Microsoft symbol server conventions (2 Tier Layout)
+    #[serde(rename = "symstore_index2")]
+    SymstoreIndex2,
     /// Uses Microsoft SSQP server conventions.
     #[serde(rename = "ssqp")]
     SSQP,


### PR DESCRIPTION
This improves SSQP/SymStore compatibility by implementing the
different casing rules for signatures and pdb filenames for
SymStore and SSQP.  There are many existing SymStores like Unity
and Google that are stored on case sensitive file systems and as
such need the exact casing rules that the Microsoft client sends.

These are not the rules that SSQP defines.  As such this now
adds a second layout to control them.

Fixes #36
Fixes #35 