### PR TITLE
fix: Avoid pointless rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,11 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,7 +2293,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3097,7 +3091,6 @@ dependencies = [
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum gimli 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb3243218ca3773e9aa00d27602f35bd1daca3be1b7112ea5fc23b2899f1a4f3"
-"checksum git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bc37021f50d852a4b134b05722b1c8e0ec7cd14262471e89a14a3df12c44a6"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,3 @@ zstd = "0.4.22+zstd.1.3.8"
 flate2 = "1.0.7"
 glob = "0.3.0"
 itertools = "0.8.0"
-
-[build-dependencies]
-git-version = "0.2.1"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,8 @@
 use std::io;
 use std::process::{Command, Stdio};
 
-fn main() -> Result<(), io::Error> {
+
+fn emit_version_var() -> Result<(), io::Error> {
     let cmd = Command::new("git")
         .args(&["describe", "--always", "--dirty=-modified"])
         .stderr(Stdio::inherit())
@@ -17,7 +18,11 @@ fn main() -> Result<(), io::Error> {
     let ver = String::from_utf8_lossy(&cmd.stdout);
 
     println!("cargo:rustc-env=SYMBOLICATOR_GIT_VERSION={}", ver);
-    println!("cargo:rerun-if-changed=.git/config");
+    println!("cargo:rerun-if-changed=.git/index");
 
     Ok(())
+}
+
+fn main() {
+    emit_version_var().ok();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::process::{Command, Stdio};
 
-
 fn emit_version_var() -> Result<(), io::Error> {
     let cmd = Command::new("git")
         .args(&["describe", "--always", "--dirty=-modified"])

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,23 @@
-fn main() {
-    git_version::set_env_with_name("SYMBOLICATOR_GIT_VERSION");
+use std::io;
+use std::process::{Command, Stdio};
+
+fn main() -> Result<(), io::Error> {
+    let cmd = Command::new("git")
+        .args(&["describe", "--always", "--dirty=-modified"])
+        .stderr(Stdio::inherit())
+        .output()?;
+
+    if !cmd.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("`git describe' failed: {}", cmd.status),
+        ));
+    }
+
+    let ver = String::from_utf8_lossy(&cmd.stdout);
+
+    println!("cargo:rustc-env=SYMBOLICATOR_GIT_VERSION={}", ver);
+    println!("cargo:rerun-if-changed=.git/config");
+
+    Ok(())
 }


### PR DESCRIPTION
The old crate for the git version forces a rebuild constantly.  This implementation
now only watches the git index.