### PR TITLE
ref: Move part of path code into utils

### DIFF
--- a/src/actors/objects/common.rs
+++ b/src/actors/objects/common.rs
@@ -1,0 +1,105 @@
+use crate::actors::objects::DownloadPath;
+use crate::types::{DirectoryLayout, FileType, Glob, ObjectId, SourceFilters};
+use crate::utils::paths::get_directory_path;
+
+const GLOB_OPTIONS: glob::MatchOptions = glob::MatchOptions {
+    case_sensitive: false,
+    require_literal_separator: false,
+    require_literal_leading_dot: false,
+};
+
+/// Generate a list of filepaths to try downloading from.
+///
+/// `object_id`: Information about the image we want to download.
+/// `filetypes`: Limit search to these filetypes.
+/// `filters`: Filters from a `SourceConfig` to limit the amount of generated paths.
+/// `layout`: Directory from `SourceConfig` to define what kind of paths we generate.
+pub fn prepare_download_paths<'a>(
+    object_id: &'a ObjectId,
+    filetypes: &'static [FileType],
+    filters: &'a SourceFilters,
+    layout: DirectoryLayout,
+) -> impl Iterator<Item = DownloadPath> + 'a {
+    filetypes.iter().filter_map(move |&filetype| {
+        if (filters.filetypes.is_empty() || filters.filetypes.contains(&filetype))
+            && matches_path_patterns(object_id, &filters.path_patterns)
+        {
+            Some(DownloadPath(get_directory_path(
+                layout, filetype, &object_id,
+            )?))
+        } else {
+            None
+        }
+    })
+}
+
+fn matches_path_patterns(object_id: &ObjectId, patterns: &[Glob]) -> bool {
+    fn canonicalize_path(s: &str) -> String {
+        s.replace(r"\", "/")
+    }
+
+    if patterns.is_empty() {
+        return true;
+    }
+
+    for pattern in patterns {
+        for path in &[&object_id.code_file, &object_id.debug_file] {
+            if let Some(ref path) = path {
+                if pattern.matches_with(&canonicalize_path(path), GLOB_OPTIONS) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+fn pattern(x: &str) -> Glob {
+    Glob(x.parse().unwrap())
+}
+
+#[test]
+fn test_matches_path_patterns_empty() {
+    assert!(matches_path_patterns(
+        &ObjectId {
+            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
+            ..Default::default()
+        },
+        &[]
+    ));
+}
+
+#[test]
+fn test_matches_path_patterns_single_star() {
+    assert!(matches_path_patterns(
+        &ObjectId {
+            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
+            ..Default::default()
+        },
+        &[pattern("c:/windows/*")]
+    ));
+}
+
+#[test]
+fn test_matches_path_patterns_drive_letter_wildcard() {
+    assert!(matches_path_patterns(
+        &ObjectId {
+            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
+            ..Default::default()
+        },
+        &[pattern("?:/windows/*")]
+    ));
+}
+
+#[test]
+fn test_matches_path_patterns_drive_letter() {
+    assert!(!matches_path_patterns(
+        &ObjectId {
+            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
+            ..Default::default()
+        },
+        &[pattern("d:/windows/**")]
+    ));
+}

--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -7,7 +7,7 @@ use futures::{future, Future, IntoFuture, Stream};
 use tokio_threadpool::ThreadPool;
 
 use crate::actors::common::cache::Cacher;
-use crate::actors::objects::paths::prepare_download_paths;
+use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
     DownloadPath, DownloadStream, FetchFileInner, FetchFileRequest, ObjectError, ObjectErrorKind,
     PrioritizedDownloads, USER_AGENT,

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -21,8 +21,8 @@ use crate::types::{
     FileType, HttpSourceConfig, ObjectId, S3SourceConfig, Scope, SentrySourceConfig, SourceConfig,
 };
 
+mod common;
 mod http;
-mod paths;
 mod s3;
 mod sentry;
 

--- a/src/actors/objects/s3.rs
+++ b/src/actors/objects/s3.rs
@@ -10,7 +10,7 @@ use tokio::codec::{BytesCodec, FramedRead};
 use tokio_threadpool::ThreadPool;
 
 use crate::actors::common::cache::Cacher;
-use crate::actors::objects::paths::prepare_download_paths;
+use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
     DownloadPath, DownloadStream, FetchFileInner, FetchFileRequest, ObjectError, ObjectErrorKind,
     PrioritizedDownloads,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,6 @@ mod http;
 mod logging;
 mod middlewares;
 mod types;
+mod utils;
 
 pub mod app;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod paths;

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -3,63 +3,7 @@ use std::fmt::Write;
 
 use symbolic::common::Uuid;
 
-use crate::actors::objects::DownloadPath;
-use crate::types::{
-    DirectoryLayout, DirectoryLayoutType, FileType, FilenameCasing, Glob, ObjectId, SourceFilters,
-};
-
-const GLOB_OPTIONS: glob::MatchOptions = glob::MatchOptions {
-    case_sensitive: false,
-    require_literal_separator: false,
-    require_literal_leading_dot: false,
-};
-
-/// Generate a list of filepaths to try downloading from.
-///
-/// `object_id`: Information about the image we want to download.
-/// `filetypes`: Limit search to these filetypes.
-/// `filters`: Filters from a `SourceConfig` to limit the amount of generated paths.
-/// `layout`: Directory from `SourceConfig` to define what kind of paths we generate.
-pub fn prepare_download_paths<'a>(
-    object_id: &'a ObjectId,
-    filetypes: &'static [FileType],
-    filters: &'a SourceFilters,
-    layout: DirectoryLayout,
-) -> impl Iterator<Item = DownloadPath> + 'a {
-    filetypes.iter().filter_map(move |&filetype| {
-        if (filters.filetypes.is_empty() || filters.filetypes.contains(&filetype))
-            && matches_path_patterns(object_id, &filters.path_patterns)
-        {
-            Some(DownloadPath(get_directory_path(
-                layout, filetype, &object_id,
-            )?))
-        } else {
-            None
-        }
-    })
-}
-
-fn matches_path_patterns(object_id: &ObjectId, patterns: &[Glob]) -> bool {
-    fn canonicalize_path(s: &str) -> String {
-        s.replace(r"\", "/")
-    }
-
-    if patterns.is_empty() {
-        return true;
-    }
-
-    for pattern in patterns {
-        for path in &[&object_id.code_file, &object_id.debug_file] {
-            if let Some(ref path) = path {
-                if pattern.matches_with(&canonicalize_path(path), GLOB_OPTIONS) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
-}
+use crate::types::{DirectoryLayout, DirectoryLayoutType, FileType, FilenameCasing, ObjectId};
 
 fn get_gdb_path(identifier: &ObjectId) -> Option<String> {
     let code_id = identifier.code_id.as_ref()?;
@@ -272,7 +216,7 @@ fn get_symstore_index2_path(filetype: FileType, identifier: &ObjectId) -> Option
 }
 
 /// Determines the path for an object file in the given layout.
-fn get_directory_path(
+pub fn get_directory_path(
     directory_layout: DirectoryLayout,
     filetype: FileType,
     identifier: &ObjectId,
@@ -291,53 +235,4 @@ fn get_directory_path(
     };
 
     Some(path)
-}
-
-#[cfg(test)]
-fn pattern(x: &str) -> Glob {
-    Glob(x.parse().unwrap())
-}
-
-#[test]
-fn test_matches_path_patterns_empty() {
-    assert!(matches_path_patterns(
-        &ObjectId {
-            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
-            ..Default::default()
-        },
-        &[]
-    ));
-}
-
-#[test]
-fn test_matches_path_patterns_single_star() {
-    assert!(matches_path_patterns(
-        &ObjectId {
-            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
-            ..Default::default()
-        },
-        &[pattern("c:/windows/*")]
-    ));
-}
-
-#[test]
-fn test_matches_path_patterns_drive_letter_wildcard() {
-    assert!(matches_path_patterns(
-        &ObjectId {
-            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
-            ..Default::default()
-        },
-        &[pattern("?:/windows/*")]
-    ));
-}
-
-#[test]
-fn test_matches_path_patterns_drive_letter() {
-    assert!(!matches_path_patterns(
-        &ObjectId {
-            code_file: Some("C:\\Windows\\System32\\kernel32.dll".to_owned()),
-            ..Default::default()
-        },
-        &[pattern("d:/windows/**")]
-    ));
 }


### PR DESCRIPTION
This makes it easier to reuse this code outside of the object lookup.