### PR TITLE
fix: Compute proper code identifiers for lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2253,21 +2253,21 @@ dependencies = [
 [[package]]
 name = "symbolic"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
 ]
 
 [[package]]
 name = "symbolic-common"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
- "debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
  "dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2293,45 +2293,45 @@ dependencies = [
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
 ]
 
 [[package]]
 name = "symbolic-demangle"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "msvc-demangler 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
 ]
 
 [[package]]
 name = "symbolic-minidump"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c#471165b26ab934b1471d8cba33b1354fff70372c"
+source = "git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84#37b465ff0b14a278aed9f6cab9f49e78bfd75c84"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
 ]
 
 [[package]]
@@ -2365,7 +2365,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)",
+ "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3121,7 +3121,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
-"checksum debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "143cd6fa7ba77a61118cc1c307fc69dcf83b040db6b9d07b2f90d1e44d0f23dd"
+"checksum debugid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b52d59e9ccf8f7caf3455d021442ba7b38b8650bb9f581fd9ae4fea10a9eecc6"
 "checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
@@ -3313,12 +3313,12 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
-"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
-"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
-"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
-"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
-"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=471165b26ab934b1471d8cba33b1354fff70372c)" = "<none>"
+"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
+"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
+"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
+"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
+"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
+"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=37b465ff0b14a278aed9f6cab9f49e78bfd75c84)" = "<none>"
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.3.0"
 parking_lot = "0.7.1"
 tokio = "0.1.18"
 uuid = "0.7.4"
-symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "471165b26ab934b1471d8cba33b1354fff70372c", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
+symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "37b465ff0b14a278aed9f6cab9f49e78bfd75c84", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
 sentry = "0.15.2"
 sentry-actix = "0.15.2"
 rusoto_s3 = "0.37.0"

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -9,7 +9,7 @@ MACHO_HELLO_DATA = {
     "modules": [
         {
             "type": "macho",
-            "code_id": str(debug_id).upper(),
+            "code_id": str(debug_id).replace("-", "").upper(),
             "debug_id": str(debug_id),
             "image_vmaddr": "0x0000000100000000",
             "image_size": 4096,
@@ -31,7 +31,7 @@ MACHO_SUCCESS = {
     "modules": [
         {
             "arch": "x86_64",
-            "code_id": str(debug_id).upper(),
+            "code_id": str(debug_id).replace("-", "").upper(),
             "debug_id": str(debug_id),
             "image_addr": "0x100000000",
             "image_size": 4096,


### PR DESCRIPTION
This fixes an issue where PE code identifiers where not parsed correctly when the had an uneven number of characters. This can happen, however, due to the way they are formatted. 

The actual fix is contained in symbolic.