### PR TITLE
fix: Bump download timeouts

### DIFF
--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -483,11 +483,13 @@ fn download_from_source(
 ) -> Box<Future<Item = Option<DownloadStream>, Error = ObjectError>> {
     match *request {
         FetchFileInner::Sentry(ref source, ref file_id) => {
-            sentry::download_from_source(source, file_id)
+            sentry::download_from_source(source.clone(), file_id)
         }
         FetchFileInner::Http(ref source, ref file_id) => {
-            http::download_from_source(source, file_id)
+            http::download_from_source(source.clone(), file_id)
         }
-        FetchFileInner::S3(ref source, ref file_id) => s3::download_from_source(source, file_id),
+        FetchFileInner::S3(ref source, ref file_id) => {
+            s3::download_from_source(source.clone(), file_id)
+        }
     }
 }

--- a/src/actors/objects/s3.rs
+++ b/src/actors/objects/s3.rs
@@ -90,7 +90,7 @@ pub fn prepare_downloads(
 }
 
 pub fn download_from_source(
-    source: &S3SourceConfig,
+    source: Arc<S3SourceConfig>,
     download_path: &DownloadPath,
 ) -> Box<Future<Item = Option<DownloadStream>, Error = ObjectError>> {
     let key = {

--- a/src/actors/objects/sentry.rs
+++ b/src/actors/objects/sentry.rs
@@ -121,7 +121,7 @@ pub fn prepare_downloads(
 }
 
 pub fn download_from_source(
-    source: &SentrySourceConfig,
+    source: Arc<SentrySourceConfig>,
     file_id: &SentryFileId,
 ) -> Box<Future<Item = Option<DownloadStream>, Error = ObjectError>> {
     let download_url = {
@@ -136,8 +136,12 @@ pub fn download_from_source(
         client::get(&download_url)
             .header("User-Agent", USER_AGENT)
             .header("Authorization", format!("Bearer {}", token))
-            // Sentry fetches the entire file from an external service before starting response.
-            .timeout(Duration::from_secs(60))
+            // This timeout is for the entire HTTP download *including* the response stream
+            // itself, in contrast to what the Actix-Web docs say. We have tested this
+            // manually.
+            //
+            // The intent is to disable the timeout entirely, but there is no API for that.
+            .timeout(Duration::from_secs(9999))
             .finish()
             .unwrap()
             .send()

--- a/src/actors/objects/sentry.rs
+++ b/src/actors/objects/sentry.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use actix_web::{client, HttpMessage};
 
@@ -135,6 +136,8 @@ pub fn download_from_source(
         client::get(&download_url)
             .header("User-Agent", USER_AGENT)
             .header("Authorization", format!("Bearer {}", token))
+            // Sentry fetches the entire file from an external service before starting response.
+            .timeout(Duration::from_secs(60))
             .finish()
             .unwrap()
             .send()


### PR DESCRIPTION
I don't quite understand the problem but it seems Sentry is just slow to respond here. Maybe we want this for external buckets someday too, but I think we generally give the customer less connectivity guarantees to external services. For now just make sure we can roll Symbolicator out without regressing.