### PR TITLE
ref: Skip empty identifiers gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,19 +2254,19 @@ dependencies = [
 [[package]]
 name = "symbolic"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
 ]
 
 [[package]]
 name = "symbolic-common"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
  "debugid 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
  "dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2294,45 +2294,45 @@ dependencies = [
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
 ]
 
 [[package]]
 name = "symbolic-demangle"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "msvc-demangler 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
 ]
 
 [[package]]
 name = "symbolic-minidump"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed#bf09887d9389d1aa21203bfccc22fadfc61cc9ed"
+source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)",
+ "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3314,12 +3314,12 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
-"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
-"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
-"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
-"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
-"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=bf09887d9389d1aa21203bfccc22fadfc61cc9ed)" = "<none>"
+"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.3.0"
 parking_lot = "0.8.0"
 tokio = "0.1.19"
 uuid = "0.7.4"
-symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "bf09887d9389d1aa21203bfccc22fadfc61cc9ed", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
+symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "e242738811939de65b613baaff24d080245ea21c", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
 sentry = "0.15.4"
 sentry-actix = "0.15.4"
 rusoto_s3 = "0.38.0"

--- a/src/types.rs
+++ b/src/types.rs
@@ -518,21 +518,17 @@ pub struct CompleteObjectInfo {
 
 impl From<RawObjectInfo> for CompleteObjectInfo {
     fn from(mut raw: RawObjectInfo) -> Self {
-        if let Some(ref raw_id) = raw.debug_id {
-            if !raw_id.is_empty() {
-                if let Ok(id) = DebugId::from_breakpad(raw_id.as_str()) {
-                    raw.debug_id = Some(id.to_string());
-                }
-            }
-        }
+        raw.debug_id = raw
+            .debug_id
+            .filter(|id| !id.is_empty())
+            .and_then(|id| id.parse::<DebugId>().ok())
+            .map(|id| id.to_string());
 
-        if let Some(ref raw_id) = raw.code_id {
-            if !raw_id.is_empty() {
-                if let Ok(id) = raw_id.parse::<CodeId>() {
-                    raw.code_id = Some(id.to_string());
-                }
-            }
-        }
+        raw.code_id = raw
+            .code_id
+            .filter(|id| !id.is_empty())
+            .and_then(|id| id.parse::<CodeId>().ok())
+            .map(|id| id.to_string());
 
         CompleteObjectInfo {
             debug_status: Default::default(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -519,14 +519,18 @@ pub struct CompleteObjectInfo {
 impl From<RawObjectInfo> for CompleteObjectInfo {
     fn from(mut raw: RawObjectInfo) -> Self {
         if let Some(ref raw_id) = raw.debug_id {
-            if let Ok(id) = DebugId::from_breakpad(raw_id.as_str()) {
-                raw.debug_id = Some(id.to_string());
+            if !raw_id.is_empty() {
+                if let Ok(id) = DebugId::from_breakpad(raw_id.as_str()) {
+                    raw.debug_id = Some(id.to_string());
+                }
             }
         }
 
         if let Some(ref raw_id) = raw.code_id {
-            if let Ok(id) = raw_id.parse::<CodeId>() {
-                raw.code_id = Some(id.to_string());
+            if !raw_id.is_empty() {
+                if let Ok(id) = raw_id.parse::<CodeId>() {
+                    raw.code_id = Some(id.to_string());
+                }
             }
         }
 


### PR DESCRIPTION
This really shouldn't happen, but there's also no reason not to handle empty strings gracefully.