### PR TITLE
fix(objects): Support multi-arch archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,19 +2254,19 @@ dependencies = [
 [[package]]
 name = "symbolic"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
 ]
 
 [[package]]
 name = "symbolic-common"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
  "debugid 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
  "dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2294,45 +2294,45 @@ dependencies = [
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
 ]
 
 [[package]]
 name = "symbolic-demangle"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "msvc-demangler 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
 ]
 
 [[package]]
 name = "symbolic-minidump"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "6.1.2"
-source = "git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c#e242738811939de65b613baaff24d080245ea21c"
+source = "git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe#85628063ff9dbd982e0c2ecdb53b133bc372fdbe"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
- "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
+ "symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)",
+ "symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3314,12 +3314,12 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
-"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
-"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
-"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
-"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
-"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=e242738811939de65b613baaff24d080245ea21c)" = "<none>"
+"checksum symbolic 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
+"checksum symbolic-common 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
+"checksum symbolic-debuginfo 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
+"checksum symbolic-demangle 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
+"checksum symbolic-minidump 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
+"checksum symbolic-symcache 6.1.2 (git+https://github.com/getsentry/symbolic?rev=85628063ff9dbd982e0c2ecdb53b133bc372fdbe)" = "<none>"
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.3.0"
 parking_lot = "0.8.0"
 tokio = "0.1.19"
 uuid = "0.7.4"
-symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "e242738811939de65b613baaff24d080245ea21c", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
+symbolic = { version = "6.1.2", git = "https://github.com/getsentry/symbolic", rev = "85628063ff9dbd982e0c2ecdb53b133bc372fdbe", features = ["common-serde", "demangle", "minidump", "minidump-serde", "symcache"] }
 sentry = "0.15.4"
 sentry-actix = "0.15.4"
 rusoto_s3 = "0.38.0"

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -12,7 +12,7 @@ use ::sentry::configure_scope;
 use ::sentry::integrations::failure::capture_fail;
 use futures::{future, Future, IntoFuture, Stream};
 use symbolic::common::ByteView;
-use symbolic::debuginfo::Object;
+use symbolic::debuginfo::{Archive, Object};
 use tempfile::tempfile_in;
 use tokio_threadpool::ThreadPool;
 
@@ -22,6 +22,7 @@ use crate::sentry::{SentryFutureExt, WriteSentryScope};
 use crate::types::{
     FileType, HttpSourceConfig, ObjectId, S3SourceConfig, Scope, SentrySourceConfig, SourceConfig,
 };
+use crate::utils::objects;
 
 mod common;
 mod http;
@@ -149,6 +150,8 @@ impl CacheItemRequest for FetchFileRequest {
         let mut cache_key = self.get_cache_key();
         cache_key.scope = final_scope.clone();
 
+        let object_id = self.object_id.clone();
+
         configure_scope(|scope| {
             scope.set_transaction(Some("download_file"));
             self.request.write_sentry_scope(scope);
@@ -160,6 +163,8 @@ impl CacheItemRequest for FetchFileRequest {
 
                 let download_dir = tryf!(path.parent().ok_or(ObjectErrorKind::NoTempDir));
                 let download_file = tryf!(tempfile_in(download_dir).context(ObjectErrorKind::Io));
+                let mut extract_file =
+                    tryf!(tempfile_in(download_dir).context(ObjectErrorKind::Io));
 
                 let future = payload
                     .fold(
@@ -199,13 +204,16 @@ impl CacheItemRequest for FetchFileRequest {
                             // wrapper around a Write. Only zstd doesn't. If we can get this into
                             // zstd we could save one tempfile and especially avoid the io::copy
                             // for downloads that were not compressed.
-                            match magic_bytes {
+                            let mut decompressed = match magic_bytes {
                                 // Magic bytes for zstd
                                 // https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2.1.1
                                 [0x28, 0xb5, 0x2f, 0xfd] => {
                                     log::trace!("Decompressing (zstd): {}", cache_key);
-                                    zstd::stream::copy_decode(download_file, persist_file)
+
+                                    zstd::stream::copy_decode(download_file, &mut extract_file)
                                         .context(ObjectErrorKind::Parsing)?;
+
+                                    extract_file
                                 }
                                 // Magic bytes for gzip
                                 // https://tools.ietf.org/html/rfc1952#section-2.3.1
@@ -216,22 +224,61 @@ impl CacheItemRequest for FetchFileRequest {
                                     // values compared to GzDecoder.
                                     let mut reader =
                                         flate2::read::MultiGzDecoder::new(download_file);
-                                    io::copy(&mut reader, &mut persist_file)
+                                    io::copy(&mut reader, &mut extract_file)
                                         .context(ObjectErrorKind::Io)?;
+
+                                    extract_file
                                 }
                                 // Magic bytes for zlib
                                 [0x78, 0x01, _, _] | [0x78, 0x9c, _, _] | [0x78, 0xda, _, _] => {
                                     log::trace!("Decompressing (zlib): {}", cache_key);
+
                                     let mut reader = flate2::read::ZlibDecoder::new(download_file);
-                                    io::copy(&mut reader, &mut persist_file)
+                                    io::copy(&mut reader, &mut extract_file)
                                         .context(ObjectErrorKind::Io)?;
+
+                                    extract_file
                                 }
                                 // Probably not compressed
                                 _ => {
-                                    log::trace!("Moving to cache: {}", cache_key);
-                                    io::copy(&mut download_file, &mut persist_file)
-                                        .context(ObjectErrorKind::Io)?;
+                                    log::trace!("No compression detected: {}", cache_key);
+                                    download_file
                                 }
+                            };
+
+                            // Seek back to the start and parse this object to we can deal with it.
+                            // Since objects in Sentry (and potentially also other sources) might be
+                            // multi-arch files (e.g. FatMach), we parse as Archive and try to
+                            // extract the wanted file.
+                            decompressed
+                                .seek(SeekFrom::Start(0))
+                                .context(ObjectErrorKind::Io)?;
+                            let view = ByteView::map_file(decompressed)?;
+                            let archive =
+                                Archive::parse(&view).context(ObjectErrorKind::Parsing)?;
+
+                            if archive.is_multi() {
+                                let object_opt = archive
+                                    .objects()
+                                    .filter_map(Result::ok)
+                                    .find(|object| objects::match_id(&object, &object_id));
+
+                                // If we do not find the desired object in this archive - either
+                                // because we can't parse any of the objects within, or because none
+                                // of the objects match the identifier we're looking for - we return
+                                // early. This will create an empty file, indicating a negative
+                                // cache.
+                                // TODO(markus): Make this more explicit.
+                                let object = match object_opt {
+                                    Some(object) => object,
+                                    None => return Ok(final_scope),
+                                };
+
+                                io::copy(&mut object.data(), &mut persist_file)
+                                    .context(ObjectErrorKind::Io)?;
+                            } else {
+                                io::copy(&mut view.as_ref(), &mut persist_file)
+                                    .context(ObjectErrorKind::Io)?;
                             }
 
                             Ok(final_scope)

--- a/src/utils/objects.rs
+++ b/src/utils/objects.rs
@@ -3,8 +3,7 @@ use symbolic::debuginfo::Object;
 use crate::types::ObjectId;
 
 /// Validates that the object matches expected identifiers.
-#[allow(unused)]
-pub fn validate_object_ids(object: &Object<'_>, identifiers: &ObjectId) -> bool {
+pub fn match_id(object: &Object<'_>, identifiers: &ObjectId) -> bool {
     if let Some(ref debug_id) = identifiers.debug_id {
         let parsed_id = object.debug_id();
 
@@ -16,12 +15,6 @@ pub fn validate_object_ids(object: &Object<'_>, identifiers: &ObjectId) -> bool 
         // `4A236F6A0B3941D1966B41A4FC77738C4` from the server.
         //                                  ^
         if parsed_id.uuid() != debug_id.uuid() || parsed_id.appendix() < debug_id.appendix() {
-            metric!(counter("object.debug_id_mismatch") += 1);
-            log::debug!(
-                "Debug id mismatch. got {}, expected {}",
-                object.debug_id(),
-                debug_id
-            );
             return false;
         }
     }
@@ -29,12 +22,6 @@ pub fn validate_object_ids(object: &Object<'_>, identifiers: &ObjectId) -> bool 
     if let Some(ref code_id) = identifiers.code_id {
         if let Some(ref object_code_id) = object.code_id() {
             if object_code_id != code_id {
-                metric!(counter("object.code_id_mismatch") += 1);
-                log::debug!(
-                    "Code id mismatch. got {}, expected {}",
-                    object_code_id,
-                    code_id
-                );
                 return false;
             }
         }


### PR DESCRIPTION
Sources may contain multi-arch object files (such as Fat MachO), for which we currently throw an object parse error. This PR adds support for those archives by unpacking just the one object that we might be interested in. 

Note that we intentionally do not validate identifiers for the non-fat case.