### PR TITLE
build(docker): Build with debug information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
 ADD Cargo.toml Cargo.lock ./
 RUN mkdir -p src \
     && echo "fn main() {}" > src/main.rs \
-    && cargo build --release --locked
+    && RUSTFLAGS=-g cargo build --release --locked
 
 COPY . .
 RUN RUSTFLAGS=-g cargo build --release --locked

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p src \
     && cargo build --release --locked
 
 COPY . .
-RUN cargo build --release --locked
+RUN RUSTFLAGS=-g cargo build --release --locked
 RUN cp ./target/release/symbolicator /usr/local/bin
 
 # Copy the compiled binary to a clean image


### PR DESCRIPTION
Enables release builds with debug information. Locally, release builds still do not contain debugging information for faster builds and smaller target directory sizes.