### PR TITLE
fix: Un-break redirects

### DIFF
--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -65,8 +65,9 @@ pub fn download_from_source(
     log::debug!("Fetching debug file from {}", download_url);
     let response = clone!(download_url, source, || {
         http::follow_redirects(
-            Box::new(clone!(download_url, source, || {
-                let mut builder = client::get(&download_url);
+            download_url.clone(),
+            Box::new(clone!(source, |url| {
+                let mut builder = client::get(&url);
                 for (key, value) in source.headers.iter() {
                     if let Ok(key) = HeaderName::from_bytes(key.as_bytes()) {
                         builder.header(key, value.as_str());

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -128,10 +128,16 @@ def hitcounter(request):
                 hits.setdefault(path, 0)
                 hits[path] += 1
 
-            if path.startswith("/msdl/"):
+            if path.startswith("/redirect/"):
+                path = path[len("/redirect") :]
+                start_response("302 Found", [("Location", path)])
+                yield b""
+            elif path.startswith("/msdl/"):
                 path = path[len("/msdl/") :]
+
                 with requests.get(
-                    f"https://msdl.microsoft.com/download/symbols/{path}"
+                    f"https://msdl.microsoft.com/download/symbols/{path}",
+                    allow_redirects=False  # test redirects with msdl
                 ) as r:
                     start_response(f"{r.status_code} BOGUS", list(r.headers.items()))
                     yield r.content

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,7 +137,7 @@ def hitcounter(request):
 
                 with requests.get(
                     f"https://msdl.microsoft.com/download/symbols/{path}",
-                    allow_redirects=False  # test redirects with msdl
+                    allow_redirects=False,  # test redirects with msdl
                 ) as r:
                     start_response(f"{r.status_code} BOGUS", list(r.headers.items()))
                     yield r.content

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -339,3 +339,25 @@ def test_path_patterns(symbolicator, hitcounter, patterns, output):
     response.raise_for_status()
 
     assert response.json() == output
+
+
+def test_redirects(symbolicator, hitcounter):
+    input = dict(
+        sources=[
+            {
+                "type": "http",
+                "id": "microsoft",
+                "layout": {"type": "symstore"},
+                "url": f"{hitcounter.url}/redirect/msdl/",
+            }
+        ],
+        **WINDOWS_DATA,
+    )
+
+    service = symbolicator()
+    service.wait_healthcheck()
+
+    response = service.post("/symbolicate", json=input)
+    response.raise_for_status()
+
+    assert response.json() == SUCCESS_WINDOWS


### PR DESCRIPTION
Two commits here:

* First one un-breaks redirects in general: We used the old URL instead of the one in headers
* Now redirects worked, but MSDL returned 400 Bad Request on the second request. It seems that `ClientRequest::set_url` does not set the correct host header. Refactor to set correct URL in request ctor.