### PR TITLE
ref: Perform object lookup for every symcache lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 /cache/objects/
 /cache/symcaches/
 /cache/cficaches/
+/cache/object_meta/

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -15,7 +15,7 @@ use symbolic::{common::ByteView, minidump::cfi::CfiCache};
 use tokio_threadpool::ThreadPool;
 
 use crate::actors::common::cache::{CacheItemRequest, Cacher};
-use crate::actors::objects::{FetchObject, ObjectFileWithData, ObjectPurpose, ObjectsActor};
+use crate::actors::objects::{FetchObject, ObjectFile, ObjectPurpose, ObjectsActor};
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sentry::{SentryFutureExt, WriteSentryScope};
 use crate::types::{FileType, ObjectId, ObjectType, Scope, SourceConfig};
@@ -93,7 +93,7 @@ impl CfiCacheFile {
 #[derive(Clone)]
 struct FetchCfiCacheInternal {
     request: FetchCfiCache,
-    object: Arc<ObjectFileWithData>,
+    object: Arc<ObjectFile>,
     threadpool: Arc<ThreadPool>,
 }
 
@@ -218,7 +218,7 @@ impl CfiCacheActor {
     }
 }
 
-fn write_cficache(path: &Path, object_file: &ObjectFileWithData) -> Result<(), CfiCacheError> {
+fn write_cficache(path: &Path, object_file: &ObjectFile) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_cficache"));
         object_file.write_sentry_scope(scope);

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::Future;
+use futures::{
+    future::{Either, IntoFuture},
+    Future,
+};
 use sentry::configure_scope;
 use sentry::integrations::failure::capture_fail;
 use symbolic::{common::ByteView, minidump::cfi::CfiCache};
@@ -90,7 +93,7 @@ impl CfiCacheFile {
 #[derive(Clone)]
 struct FetchCfiCacheInternal {
     request: FetchCfiCache,
-    objects: Arc<ObjectsActor>,
+    object: Arc<ObjectFile>,
     threadpool: Arc<ThreadPool>,
 }
 
@@ -99,52 +102,37 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     type Error = CfiCacheError;
 
     fn get_cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.request.identifier.cache_key(),
-            scope: self.request.scope.clone(),
-        }
+        self.object.cache_key().clone()
     }
 
     fn compute(
         &self,
         path: &Path,
     ) -> Box<dyn Future<Item = (CacheStatus, Scope), Error = Self::Error>> {
-        let objects = self.objects.clone();
+        let object = self.object.clone();
 
         let path = path.to_owned();
         let threadpool = self.threadpool.clone();
 
-        let result = objects
-            .fetch(FetchObject {
-                filetypes: FileType::from_object_type(&self.request.object_type),
-                identifier: self.request.identifier.clone(),
-                sources: self.request.sources.clone(),
-                scope: self.request.scope.clone(),
-                purpose: ObjectPurpose::Unwind,
+        let result = threadpool.spawn_handle(
+            futures::lazy(move || {
+                if object.status() != CacheStatus::Positive {
+                    return Ok((object.status(), object.scope().clone()));
+                }
+
+                let status = if let Err(e) = write_cficache(&path, &*object) {
+                    log::warn!("Could not write cficache: {}", e);
+                    capture_fail(e.cause().unwrap_or(&e));
+
+                    CacheStatus::Malformed
+                } else {
+                    CacheStatus::Positive
+                };
+
+                Ok((status, object.scope().clone()))
             })
-            .map_err(|e| CfiCacheError::from(e.context(CfiCacheErrorKind::Fetching)))
-            .and_then(move |object| {
-                threadpool.spawn_handle(
-                    futures::lazy(move || {
-                        if object.status() != CacheStatus::Positive {
-                            return Ok((object.status(), object.scope().clone()));
-                        }
-
-                        let status = if let Err(e) = write_cficache(&path, &*object) {
-                            log::warn!("Could not write cficache: {}", e);
-                            capture_fail(e.cause().unwrap_or(&e));
-
-                            CacheStatus::Malformed
-                        } else {
-                            CacheStatus::Positive
-                        };
-
-                        Ok((status, object.scope().clone()))
-                    })
-                    .sentry_hub_current(),
-                )
-            })
-            .sentry_hub_current();
+            .sentry_hub_current(),
+        );
 
         let num_sources = self.request.sources.len();
 
@@ -187,11 +175,48 @@ impl CfiCacheActor {
         &self,
         request: FetchCfiCache,
     ) -> impl Future<Item = Arc<CfiCacheFile>, Error = Arc<CfiCacheError>> {
-        self.cficaches.compute_memoized(FetchCfiCacheInternal {
-            request,
-            objects: self.objects.clone(),
-            threadpool: self.threadpool.clone(),
-        })
+        let object = self
+            .objects
+            .fetch(FetchObject {
+                filetypes: FileType::from_object_type(&request.object_type),
+                identifier: request.identifier.clone(),
+                sources: request.sources.clone(),
+                scope: request.scope.clone(),
+                purpose: ObjectPurpose::Unwind,
+            })
+            .map_err(|e| Arc::new(CfiCacheError::from(e.context(CfiCacheErrorKind::Fetching))));
+
+        let cficaches = self.cficaches.clone();
+        let threadpool = self.threadpool.clone();
+
+        let object_type = request.object_type.clone();
+        let identifier = request.identifier.clone();
+        let scope = request.scope.clone();
+
+        let cficache = object.and_then(move |object| {
+            object
+                .map(|object| {
+                    Either::A(cficaches.compute_memoized(FetchCfiCacheInternal {
+                        request,
+                        object,
+                        threadpool,
+                    }))
+                })
+                .unwrap_or_else(move || {
+                    Either::B(
+                        Ok(Arc::new(CfiCacheFile {
+                            object_type,
+                            identifier,
+                            scope,
+                            data: ByteView::from_slice(b""),
+                            status: CacheStatus::Negative,
+                        }))
+                        .into_future(),
+                    )
+                })
+        });
+
+        cficache
     }
 }
 
@@ -209,9 +234,7 @@ fn write_cficache(path: &Path, object_file: &ObjectFile) -> Result<(), CfiCacheE
     let file = File::create(&path).context(CfiCacheErrorKind::Io)?;
     let writer = BufWriter::new(file);
 
-    if let Some(cache_key) = object_file.cache_key() {
-        log::debug!("Converting cficache for {}", cache_key);
-    }
+    log::debug!("Converting cficache for {}", object_file.cache_key());
 
     CfiCache::from_object(&object)
         .context(CfiCacheErrorKind::ObjectParsing)?

--- a/src/actors/objects/common.rs
+++ b/src/actors/objects/common.rs
@@ -14,7 +14,7 @@ const GLOB_OPTIONS: glob::MatchOptions = glob::MatchOptions {
 /// `filetypes`: Limit search to these filetypes.
 /// `filters`: Filters from a `SourceConfig` to limit the amount of generated paths.
 /// `layout`: Directory from `SourceConfig` to define what kind of paths we generate.
-pub fn prepare_download_paths<'a>(
+pub(super) fn prepare_download_paths<'a>(
     object_id: &'a ObjectId,
     filetypes: &'static [FileType],
     filters: &'a SourceFilters,

--- a/src/actors/objects/filesystem.rs
+++ b/src/actors/objects/filesystem.rs
@@ -5,16 +5,14 @@ use std::sync::Arc;
 use futures::{Future, IntoFuture};
 
 use crate::actors::objects::common::prepare_download_paths;
-use crate::actors::objects::{
-    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
-};
+use crate::actors::objects::{DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind};
 use crate::types::{FileType, FilesystemSourceConfig, ObjectId};
 
 pub(super) fn prepare_downloads(
     source: &Arc<FilesystemSourceConfig>,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
+) -> Box<Future<Item = Vec<FileId>, Error = ObjectError>> {
     let ids = prepare_download_paths(
         object_id,
         filetypes,

--- a/src/actors/objects/filesystem.rs
+++ b/src/actors/objects/filesystem.rs
@@ -2,50 +2,29 @@ use std::fs::File;
 use std::io;
 use std::sync::Arc;
 
-use failure::Fail;
-use futures::{future, Future, IntoFuture};
-use tokio_threadpool::ThreadPool;
+use futures::{Future, IntoFuture};
 
-use crate::actors::common::cache::Cacher;
 use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
-    DownloadPath, DownloadStream, FetchFileRequest, FileId, ObjectError, ObjectErrorKind,
-    PrioritizedDownloads,
+    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
 };
-use crate::sentry::SentryFutureExt;
-use crate::types::{ArcFail, FileType, FilesystemSourceConfig, ObjectId, Scope};
+use crate::types::{FileType, FilesystemSourceConfig, ObjectId};
 
-pub fn prepare_downloads(
+pub(super) fn prepare_downloads(
     source: &Arc<FilesystemSourceConfig>,
-    scope: Scope,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-    threadpool: Arc<ThreadPool>,
-    cache: Arc<Cacher<FetchFileRequest>>,
 ) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
-    let mut requests = vec![];
-
-    for download_path in prepare_download_paths(
+    let ids = prepare_download_paths(
         object_id,
         filetypes,
         &source.files.filters,
         source.files.layout,
-    ) {
-        let request = cache
-            .compute_memoized(FetchFileRequest {
-                scope: scope.clone(),
-                file_id: FileId::Filesystem(source.clone(), download_path),
-                object_id: object_id.clone(),
-                threadpool: threadpool.clone(),
-            })
-            .sentry_hub_new_from_current() // new hub because of join_all
-            .map_err(|e| ArcFail(e).context(ObjectErrorKind::Caching).into())
-            .then(Ok);
+    )
+    .map(|download_path| FileId::Filesystem(source.clone(), download_path))
+    .collect();
 
-        requests.push(request);
-    }
-
-    Box::new(future::join_all(requests))
+    Box::new(Ok(ids).into_future())
 }
 
 pub(super) fn download_from_source(

--- a/src/actors/objects/gcs.rs
+++ b/src/actors/objects/gcs.rs
@@ -11,9 +11,7 @@ use tokio_retry::Retry;
 use url::percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
 use crate::actors::objects::common::prepare_download_paths;
-use crate::actors::objects::{
-    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
-};
+use crate::actors::objects::{DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind};
 use crate::types::{FileType, GcsSourceConfig, GcsSourceKey, ObjectId};
 
 lazy_static::lazy_static! {
@@ -141,7 +139,7 @@ pub(super) fn prepare_downloads(
     source: &Arc<GcsSourceConfig>,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
+) -> Box<Future<Item = Vec<FileId>, Error = ObjectError>> {
     let ids = prepare_download_paths(
         object_id,
         filetypes,

--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -10,8 +10,7 @@ use tokio_retry::Retry;
 
 use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
-    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
-    USER_AGENT,
+    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, USER_AGENT,
 };
 use crate::http;
 use crate::types::{FileType, HttpSourceConfig, ObjectId};
@@ -20,7 +19,7 @@ pub(super) fn prepare_downloads(
     source: &Arc<HttpSourceConfig>,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
+) -> Box<Future<Item = Vec<FileId>, Error = ObjectError>> {
     let ids = prepare_download_paths(
         object_id,
         filetypes,

--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -4,52 +4,33 @@ use std::time::Duration;
 use actix_web::http::header::HeaderName;
 use actix_web::{client, HttpMessage};
 use failure::Fail;
-use futures::{future, Future, IntoFuture, Stream};
+use futures::{Future, IntoFuture, Stream};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
-use tokio_threadpool::ThreadPool;
 
-use crate::actors::common::cache::Cacher;
 use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
-    DownloadPath, DownloadStream, FetchFileRequest, FileId, ObjectError, ObjectErrorKind,
-    PrioritizedDownloads, USER_AGENT,
+    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
+    USER_AGENT,
 };
 use crate::http;
-use crate::sentry::SentryFutureExt;
-use crate::types::{ArcFail, FileType, HttpSourceConfig, ObjectId, Scope};
+use crate::types::{FileType, HttpSourceConfig, ObjectId};
 
-pub fn prepare_downloads(
+pub(super) fn prepare_downloads(
     source: &Arc<HttpSourceConfig>,
-    scope: Scope,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-    threadpool: Arc<ThreadPool>,
-    cache: Arc<Cacher<FetchFileRequest>>,
 ) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
-    let mut requests = vec![];
-
-    for download_path in prepare_download_paths(
+    let ids = prepare_download_paths(
         object_id,
         filetypes,
         &source.files.filters,
         source.files.layout,
-    ) {
-        let request = cache
-            .compute_memoized(FetchFileRequest {
-                scope: scope.clone(),
-                file_id: FileId::Http(source.clone(), download_path),
-                object_id: object_id.clone(),
-                threadpool: threadpool.clone(),
-            })
-            .sentry_hub_new_from_current() // new hub because of join_all
-            .map_err(|e| ArcFail(e).context(ObjectErrorKind::Caching).into())
-            .then(Ok);
+    )
+    .map(|download_path| FileId::Http(source.clone(), download_path))
+    .collect();
 
-        requests.push(request);
-    }
-
-    Box::new(future::join_all(requests))
+    Box::new(Ok(ids).into_future())
 }
 
 pub(super) fn download_from_source(

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -551,7 +551,7 @@ impl ObjectsActor {
                                             ArcFail(e).context(ObjectErrorKind::Caching),
                                         )
                                     })
-                                    .then(|response| Ok(response))
+                                    .then(Ok)
                             }))
                         }
                     ))
@@ -560,7 +560,7 @@ impl ObjectsActor {
             .collect();
 
         future::join_all(prepare_futures).and_then(move |responses| {
-            let response = responses
+            responses
                 .into_iter()
                 .flatten()
                 .enumerate()
@@ -582,9 +582,7 @@ impl ObjectsActor {
                     (score, *i)
                 })
                 .map(|(_, response)| response)
-                .transpose();
-
-            response
+                .transpose()
         })
     }
 }

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -414,6 +414,7 @@ pub struct ObjectFile {
     file_id: FileId,
     cache_key: CacheKey,
 
+    /// The mmapped object.
     data: ByteView<'static>,
     status: CacheStatus,
 }
@@ -421,6 +422,10 @@ pub struct ObjectFile {
 impl ObjectFile {
     pub fn len(&self) -> usize {
         self.data.len()
+    }
+
+    pub fn has_object(&self) -> bool {
+        self.status == CacheStatus::Positive
     }
 
     pub fn parse(&self) -> Result<Option<Object<'_>>, ObjectError> {
@@ -431,10 +436,6 @@ impl ObjectFile {
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(ObjectErrorKind::Parsing.into()),
         }
-    }
-
-    pub fn has_object(&self) -> bool {
-        self.status == CacheStatus::Positive
     }
 
     pub fn status(&self) -> CacheStatus {

--- a/src/actors/objects/s3.rs
+++ b/src/actors/objects/s3.rs
@@ -8,9 +8,7 @@ use rusoto_s3::S3;
 use tokio::codec::{BytesCodec, FramedRead};
 
 use crate::actors::objects::common::prepare_download_paths;
-use crate::actors::objects::{
-    DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads,
-};
+use crate::actors::objects::{DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind};
 use crate::types::{FileType, ObjectId, S3SourceConfig, S3SourceKey};
 
 lazy_static::lazy_static! {
@@ -55,7 +53,7 @@ pub(super) fn prepare_downloads(
     source: &Arc<S3SourceConfig>,
     filetypes: &'static [FileType],
     object_id: &ObjectId,
-) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
+) -> Box<Future<Item = Vec<FileId>, Error = ObjectError>> {
     let ids = prepare_download_paths(
         object_id,
         filetypes,

--- a/src/actors/objects/sentry.rs
+++ b/src/actors/objects/sentry.rs
@@ -12,8 +12,7 @@ use tokio_retry::Retry;
 use url::Url;
 
 use crate::actors::objects::{
-    DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads, SentryFileId,
-    USER_AGENT,
+    DownloadStream, FileId, ObjectError, ObjectErrorKind, SentryFileId, USER_AGENT,
 };
 use crate::types::{FileType, ObjectId, SentrySourceConfig};
 
@@ -112,7 +111,7 @@ pub(super) fn prepare_downloads(
     source: &Arc<SentrySourceConfig>,
     _filetypes: &'static [FileType],
     object_id: &ObjectId,
-) -> Box<Future<Item = PrioritizedDownloads, Error = ObjectError>> {
+) -> Box<Future<Item = Vec<FileId>, Error = ObjectError>> {
     let index_url = {
         let mut url = source.url.clone();
         if let Some(ref debug_id) = object_id.debug_id {

--- a/src/actors/objects/sentry.rs
+++ b/src/actors/objects/sentry.rs
@@ -1,19 +1,26 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use actix_web::{client, HttpMessage};
 
 use failure::Fail;
 use futures::future::Either;
 use futures::{Future, IntoFuture, Stream};
+use parking_lot::Mutex;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
+use url::Url;
 
 use crate::actors::objects::{
     DownloadStream, FileId, ObjectError, ObjectErrorKind, PrioritizedDownloads, SentryFileId,
     USER_AGENT,
 };
 use crate::types::{FileType, ObjectId, SentrySourceConfig};
+
+lazy_static::lazy_static! {
+    static ref SENTRY_SEARCH_RESULTS: Mutex<lru::LruCache<SearchQuery, (Instant, Vec<SearchResult>)>> =
+        Mutex::new(lru::LruCache::new(2000));
+}
 
 #[derive(Debug, Fail, Clone, Copy)]
 pub enum SentryErrorKind {
@@ -27,10 +34,16 @@ pub enum SentryErrorKind {
     SendRequest,
 }
 
-#[derive(serde::Deserialize)]
-struct FileEntry {
+#[derive(Clone, Debug, serde::Deserialize)]
+struct SearchResult {
     id: String,
     // TODO: Add more fields
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct SearchQuery {
+    index_url: Url,
+    token: String,
 }
 
 symbolic::common::derive_failure!(
@@ -38,6 +51,62 @@ symbolic::common::derive_failure!(
     SentryErrorKind,
     doc = "Errors happening while fetching data from Sentry"
 );
+
+fn perform_search(
+    query: SearchQuery,
+) -> impl Future<Item = Vec<SearchResult>, Error = ObjectError> {
+    if let Some((created, entries)) = SENTRY_SEARCH_RESULTS.lock().get(&query) {
+        if created.elapsed() < Duration::from_secs(3600) {
+            return Either::A(Ok(entries.clone()).into_future());
+        }
+    }
+
+    let index_url = query.index_url.clone();
+    let token = query.token.clone();
+
+    log::debug!("Fetching list of Sentry debug files from {}", index_url);
+    let index_request = move || {
+        client::get(&index_url)
+            .header("User-Agent", USER_AGENT)
+            .header("Authorization", format!("Bearer {}", token.clone()))
+            .finish()
+            .unwrap()
+            .send()
+            .map_err(|e| e.context(SentryErrorKind::SendRequest).into())
+            .and_then(move |response| {
+                if response.status().is_success() {
+                    log::trace!("Success fetching index from Sentry");
+                    Either::A(
+                        response
+                            .json::<Vec<SearchResult>>()
+                            .map_err(|e| e.context(SentryErrorKind::Parsing).into()),
+                    )
+                } else {
+                    log::warn!("Sentry returned status code {}", response.status());
+                    Either::B(Err(SentryError::from(SentryErrorKind::BadStatusCode)).into_future())
+                }
+            })
+    };
+
+    let index_request = Retry::spawn(
+        ExponentialBackoff::from_millis(100).map(jitter).take(3),
+        index_request,
+    );
+
+    let index_request = index_request.map(move |entries| {
+        SENTRY_SEARCH_RESULTS
+            .lock()
+            .put(query, (Instant::now(), entries.clone()));
+        entries
+    });
+
+    Either::B(
+        future_metrics!("downloads.sentry.index", None, index_request).map_err(|e| match e {
+            tokio_retry::Error::OperationError(e) => e.context(ObjectErrorKind::Sentry).into(),
+            e => panic!("{}", e),
+        }),
+    )
+}
 
 pub(super) fn prepare_downloads(
     source: &Arc<SentrySourceConfig>,
@@ -59,51 +128,19 @@ pub(super) fn prepare_downloads(
         url
     };
 
-    log::debug!("Fetching list of Sentry debug files from {}", index_url);
-    let index_request = clone!(source, || {
-        client::get(&index_url)
-            .header("User-Agent", USER_AGENT)
-            .header("Authorization", format!("Bearer {}", source.token.clone()))
-            .finish()
-            .unwrap()
-            .send()
-            .map_err(|e| e.context(SentryErrorKind::SendRequest).into())
-            .and_then(move |response| {
-                if response.status().is_success() {
-                    log::trace!("Success fetching index from Sentry");
-                    Either::A(
-                        response
-                            .json::<Vec<FileEntry>>()
-                            .map_err(|e| e.context(SentryErrorKind::Parsing).into()),
-                    )
-                } else {
-                    log::warn!("Sentry returned status code {}", response.status());
-                    Either::B(Err(SentryError::from(SentryErrorKind::BadStatusCode)).into_future())
-                }
-            })
-    });
+    let query = SearchQuery {
+        index_url,
+        token: source.token.clone(),
+    };
 
-    let index_request = Retry::spawn(
-        ExponentialBackoff::from_millis(100).map(jitter).take(3),
-        index_request,
-    );
+    let entries = perform_search(query.clone()).map(clone!(source, |entries| {
+        entries
+            .into_iter()
+            .map(move |api_response| FileId::Sentry(source.clone(), SentryFileId(api_response.id)))
+            .collect()
+    }));
 
-    let index_request = future_metrics!("downloads.sentry.index", None, index_request);
-
-    Box::new(
-        index_request
-            .map(clone!(source, |entries| entries
-                .into_iter()
-                .map(move |api_response| FileId::Sentry(
-                    source.clone(),
-                    SentryFileId(api_response.id),
-                ),)
-                .collect()))
-            .map_err(|e| match e {
-                tokio_retry::Error::OperationError(e) => e.context(ObjectErrorKind::Sentry).into(),
-                e => panic!("{}", e),
-            }),
-    )
+    Box::new(entries)
 }
 
 pub(super) fn download_from_source(

--- a/src/actors/snapshots/symbolication__actors::symbolication::test_add_bucket-2.snap
+++ b/src/actors/snapshots/symbolication__actors::symbolication::test_add_bucket-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-06T11:56:08.920269Z"
+created: "2019-06-06T12:04:12.322524Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -7,12 +7,19 @@ expression: response
 status: completed
 stacktraces:
   - frames:
-      - status: missing
+      - status: symbolicated
         original_index: 0
+        lang: c
+        symbol: main
+        sym_addr: 0x100000fa0
+        function: main
+        filename: hello.c
+        abs_path: /tmp/hello.c
+        lineno: 1
         instruction_addr: 0x100000fa0
 modules:
-  - debug_status: missing
-    arch: unknown
+  - debug_status: found
+    arch: x86_64
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7

--- a/src/actors/snapshots/symbolication__actors::symbolication::test_remove_bucket-2.snap
+++ b/src/actors/snapshots/symbolication__actors::symbolication::test_remove_bucket-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-06T10:53:37.526201Z"
+created: "2019-06-06T10:56:46.999452Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -7,19 +7,12 @@ expression: response
 status: completed
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing
         original_index: 0
-        lang: c
-        symbol: main
-        sym_addr: 0x100000fa0
-        function: main
-        filename: hello.c
-        abs_path: /tmp/hello.c
-        lineno: 1
         instruction_addr: 0x100000fa0
 modules:
-  - debug_status: found
-    arch: x86_64
+  - debug_status: missing
+    arch: unknown
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::Future;
+use futures::{
+    future::{Either, IntoFuture},
+    Future,
+};
 use sentry::configure_scope;
 use sentry::integrations::failure::capture_fail;
 use symbolic::common::{Arch, ByteView};
@@ -97,7 +100,7 @@ impl SymCacheFile {
 #[derive(Clone)]
 struct FetchSymCacheInternal {
     request: FetchSymCache,
-    objects: Arc<ObjectsActor>,
+    object: Arc<ObjectFile>,
     threadpool: Arc<ThreadPool>,
 }
 
@@ -106,52 +109,35 @@ impl CacheItemRequest for FetchSymCacheInternal {
     type Error = SymCacheError;
 
     fn get_cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.request.identifier.cache_key(),
-            scope: self.request.scope.clone(),
-        }
+        self.object.cache_key().clone()
     }
 
     fn compute(
         &self,
         path: &Path,
     ) -> Box<dyn Future<Item = (CacheStatus, Scope), Error = Self::Error>> {
-        let objects = self.objects.clone();
-
         let path = path.to_owned();
-        let threadpool = self.threadpool.clone();
+        let object = self.object.clone();
 
-        let result = objects
-            .fetch(FetchObject {
-                filetypes: FileType::from_object_type(&self.request.object_type),
-                identifier: self.request.identifier.clone(),
-                sources: self.request.sources.clone(),
-                scope: self.request.scope.clone(),
-                purpose: ObjectPurpose::Debug,
+        let result = self.threadpool.spawn_handle(
+            futures::lazy(move || {
+                if object.status() != CacheStatus::Positive {
+                    return Ok((object.status(), object.scope().clone()));
+                }
+
+                let status = if let Err(e) = write_symcache(&path, &*object) {
+                    log::warn!("Failed to write symcache: {}", e);
+                    capture_fail(e.cause().unwrap_or(&e));
+
+                    CacheStatus::Malformed
+                } else {
+                    CacheStatus::Positive
+                };
+
+                Ok((status, object.scope().clone()))
             })
-            .map_err(|e| SymCacheError::from(e.context(SymCacheErrorKind::Fetching)))
-            .and_then(move |object| {
-                threadpool.spawn_handle(
-                    futures::lazy(move || {
-                        if object.status() != CacheStatus::Positive {
-                            return Ok((object.status(), object.scope().clone()));
-                        }
-
-                        let status = if let Err(e) = write_symcache(&path, &*object) {
-                            log::warn!("Failed to write symcache: {}", e);
-                            capture_fail(e.cause().unwrap_or(&e));
-
-                            CacheStatus::Malformed
-                        } else {
-                            CacheStatus::Positive
-                        };
-
-                        Ok((status, object.scope().clone()))
-                    })
-                    .sentry_hub_current(),
-                )
-            })
-            .sentry_hub_current();
+            .sentry_hub_current(),
+        );
 
         let num_sources = self.request.sources.len();
 
@@ -200,11 +186,49 @@ impl SymCacheActor {
         &self,
         request: FetchSymCache,
     ) -> impl Future<Item = Arc<SymCacheFile>, Error = Arc<SymCacheError>> {
-        self.symcaches.compute_memoized(FetchSymCacheInternal {
-            request,
-            objects: self.objects.clone(),
-            threadpool: self.threadpool.clone(),
-        })
+        let object = self
+            .objects
+            .fetch(FetchObject {
+                filetypes: FileType::from_object_type(&request.object_type),
+                identifier: request.identifier.clone(),
+                sources: request.sources.clone(),
+                scope: request.scope.clone(),
+                purpose: ObjectPurpose::Debug,
+            })
+            .map_err(|e| Arc::new(SymCacheError::from(e.context(SymCacheErrorKind::Fetching))));
+
+        let symcaches = self.symcaches.clone();
+        let threadpool = self.threadpool.clone();
+
+        let object_type = request.object_type.clone();
+        let identifier = request.identifier.clone();
+        let scope = request.scope.clone();
+
+        let symcache = object.and_then(move |object| {
+            object
+                .map(|object| {
+                    Either::A(symcaches.compute_memoized(FetchSymCacheInternal {
+                        request,
+                        object,
+                        threadpool,
+                    }))
+                })
+                .unwrap_or_else(move || {
+                    Either::B(
+                        Ok(Arc::new(SymCacheFile {
+                            object_type,
+                            identifier,
+                            scope,
+                            data: ByteView::from_slice(b""),
+                            status: CacheStatus::Negative,
+                            arch: Arch::Unknown,
+                        }))
+                        .into_future(),
+                    )
+                })
+        });
+
+        symcache
     }
 }
 
@@ -222,9 +246,7 @@ fn write_symcache(path: &Path, object: &ObjectFile) -> Result<(), SymCacheError>
     let file = File::create(&path).context(SymCacheErrorKind::Io)?;
     let mut writer = BufWriter::new(file);
 
-    if let Some(cache_key) = object.cache_key() {
-        log::debug!("Converting symcache for {}", cache_key);
-    }
+    log::debug!("Converting symcache for {}", object.cache_key());
 
     if let Err(e) = SymCacheWriter::write_object(&symbolic_object, &mut writer) {
         match e.kind() {

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -16,7 +16,7 @@ use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use tokio_threadpool::ThreadPool;
 
 use crate::actors::common::cache::{CacheItemRequest, Cacher};
-use crate::actors::objects::{FetchObject, ObjectFile, ObjectPurpose, ObjectsActor};
+use crate::actors::objects::{FetchObject, ObjectFileWithData, ObjectPurpose, ObjectsActor};
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sentry::{SentryFutureExt, WriteSentryScope};
 use crate::types::{FileType, ObjectId, ObjectType, Scope, SourceConfig};
@@ -100,7 +100,7 @@ impl SymCacheFile {
 #[derive(Clone)]
 struct FetchSymCacheInternal {
     request: FetchSymCache,
-    object: Arc<ObjectFile>,
+    object: Arc<ObjectFileWithData>,
     threadpool: Arc<ThreadPool>,
 }
 
@@ -204,7 +204,7 @@ impl SymCacheActor {
         let identifier = request.identifier.clone();
         let scope = request.scope.clone();
 
-        let symcache = object.and_then(move |object| {
+        object.and_then(move |object| {
             object
                 .map(|object| {
                     Either::A(symcaches.compute_memoized(FetchSymCacheInternal {
@@ -226,13 +226,11 @@ impl SymCacheActor {
                         .into_future(),
                     )
                 })
-        });
-
-        symcache
+        })
     }
 }
 
-fn write_symcache(path: &Path, object: &ObjectFile) -> Result<(), SymCacheError> {
+fn write_symcache(path: &Path, object: &ObjectFileWithData) -> Result<(), SymCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_symcache"));
         object.write_sentry_scope(scope);

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -16,7 +16,7 @@ use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use tokio_threadpool::ThreadPool;
 
 use crate::actors::common::cache::{CacheItemRequest, Cacher};
-use crate::actors::objects::{FetchObject, ObjectFileWithData, ObjectPurpose, ObjectsActor};
+use crate::actors::objects::{FetchObject, ObjectFile, ObjectPurpose, ObjectsActor};
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sentry::{SentryFutureExt, WriteSentryScope};
 use crate::types::{FileType, ObjectId, ObjectType, Scope, SourceConfig};
@@ -100,7 +100,7 @@ impl SymCacheFile {
 #[derive(Clone)]
 struct FetchSymCacheInternal {
     request: FetchSymCache,
-    object: Arc<ObjectFileWithData>,
+    object: Arc<ObjectFile>,
     threadpool: Arc<ThreadPool>,
 }
 
@@ -230,7 +230,7 @@ impl SymCacheActor {
     }
 }
 
-fn write_symcache(path: &Path, object: &ObjectFileWithData) -> Result<(), SymCacheError> {
+fn write_symcache(path: &Path, object: &ObjectFile) -> Result<(), SymCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_symcache"));
         object.write_sentry_scope(scope);

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -120,7 +120,10 @@ def test_basic(symbolicator, cache_dir_param, is_public, hitcounter):
             symcache, = (
                 cache_dir_param.join("symcaches").join(stored_in_scope).listdir()
             )
-            assert symcache.basename == "ff9f9f78-41db-88f0-cded-a9e1e9bff3b5-1_"
+            assert (
+                symcache.basename
+                == "microsoft_wkernel32_pdb_FF9F9F7841DB88F0CDEDA9E1E9BFF3B51_wkernel32_pdb"
+            )
             assert symcache.size() > 0
 
         count = 1 if cache_dir_param else (i + 1)
@@ -144,9 +147,7 @@ def test_no_sources(symbolicator, cache_dir_param):
 
     if cache_dir_param:
         assert not cache_dir_param.join("objects/global").exists()
-        symcache, = cache_dir_param.join("symcaches/global").listdir()
-        assert symcache.basename == "ff9f9f78-41db-88f0-cded-a9e1e9bff3b5-1_"
-        assert symcache.size() == 0
+        assert not cache_dir_param.join("symcaches/global").exists()
 
 
 @pytest.mark.parametrize("is_public", [True, False])


### PR DESCRIPTION
(symcache is used as synonym for symcache/cficache)

**We recently discovered that global symcaches could be used on symbolicator even though the corresponding source was not enabled.** This is another manifestation of #19, where we previously were fine with implementing a few workarounds such as shorter cache retention.

1. Refactor symcache lookup to simulate an object lookup every time. This means that symcaches use the same exact cache key as their backing object.
2. Introduce another caching layer to avoid downloading and parsing objects every time we look up a symcache. The new cache is stored in `{cache_dir}/object_meta/` and contains all parameters necessary for deciding which object should be used: `has_debug_info`, `has_unwind_info` and `has_symbols`.
3. Introduce an in-memory cache for search results from Sentry since every symcache lookup would now trigger this codepath.

## Overview of control flow

The new logic for looking up debug information for an image looks as follows (simplified, conflating code_name vs debug_name + code_id vs debug_id):

<br>

<details><summary>Before</summary>

* (cached) lookup of symcache `name=wkernel32.pdb, id=0xdeadbeef`
  * Lookup of object `name=wkernel32.pdb, id=0xdeadbeef` (uncached, parallelized):
    * Fetching sentry index for `id=0xdeadbeef` (uncached) -> returns `[123456]`
    * (cached) lookup of object `[sentry, 123456]` -> returns pdb with debug info
    * (cached) lookup of object `[microsoft, /wkernel32.pdb/deadbeef/wkernel32.pdb]` -> returns pdb, but only symbol table
    * Sentry project symbol wins, because it has more than just a symbol table
</details>

<br>

<details><summary>After</summary>

* Lookup of object `name=wkernel32.pdb, id=0xdeadbeef` (uncached, parallelized):
  * (cached) Fetching sentry index for `id=0xdeadbeef` (uncached) -> returns `[123456]`
  * (cached) lookup of object *metadata* `[sentry, 123456]` -> returns `has_debug_info=true, ...`
    * (cached) lookup of object *file* `[sentry, 123456]`
  * (cached) lookup of object *metadata* `[microsoft, /wkernel32.pdb/deadbeef/wkernel32.pdb]` -> returns `has_debug_info=false, ...`
    * (cached) lookup of object *file* `[microsoft, /wkernel32.pdb/deadbeef/wkernel32.pdb]`
  * Sentry project symbol wins, because it has more than symbol table
* (cached) lookup of symcache `[sentry, 123456]`
</details>

<br>

All steps that are behind a caching layer are prefixed with `(cached)`. If a cache hit occurs, the sub-bulletpoints are not executed.

## Risks in deploying

* All symcaches are recomputed because they have a new cache key (means a lot of object downloads as well) -- we already did this and it was a blip in CPU usage (from 1% to 30%)
* A cache hit for symcaches is more expensive -- probably not by a lot? Perhaps finally add a frame cache?