### PR TITLE
fix: Prefix symcaches with source id

### DIFF
--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -102,12 +102,14 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     }
 
     fn get_lookup_cache_keys(&self) -> Vec<CacheKey> {
-        self.request.sources.iter().map(|source: &SourceConfig| {
-            CacheKey {
+        self.request
+            .sources
+            .iter()
+            .map(|source: &SourceConfig| CacheKey {
                 cache_key: format!("{}.{}", source.id(), self.request.identifier.cache_key()),
-                scope: self.request.scope.clone()
-            }
-        }).collect()
+                scope: self.request.scope.clone(),
+            })
+            .collect()
     }
 
     fn compute(
@@ -133,10 +135,16 @@ impl CacheItemRequest for FetchCfiCacheInternal {
                     futures::lazy(move || {
                         let new_cache_key = if let Some(ref source) = object.source() {
                             Some(CacheKey {
-                                cache_key: format!("{}.{}", source.id(), object.object_id().cache_key()),
+                                cache_key: format!(
+                                    "{}.{}",
+                                    source.id(),
+                                    object.object_id().cache_key()
+                                ),
                                 scope: object.scope().clone(),
                             })
-                        } else { None };
+                        } else {
+                            None
+                        };
 
                         if object.status() != CacheStatus::Positive {
                             return Ok((object.status(), new_cache_key));
@@ -174,7 +182,12 @@ impl CacheItemRequest for FetchCfiCacheInternal {
             .unwrap_or(false)
     }
 
-    fn load(&self, _cache_key: Option<CacheKey>, status: CacheStatus, data: ByteView<'static>) -> Self::Item {
+    fn load(
+        &self,
+        _cache_key: Option<CacheKey>,
+        status: CacheStatus,
+        data: ByteView<'static>,
+    ) -> Self::Item {
         CfiCacheFile {
             object_type: self.request.object_type.clone(),
             identifier: self.request.identifier.clone(),

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -87,7 +87,12 @@ pub trait CacheItemRequest: 'static + Send {
     }
 
     /// Loads an existing element from the cache.
-    fn load(&self, cache_key: Option<CacheKey>, status: CacheStatus, data: ByteView<'static>) -> Self::Item;
+    fn load(
+        &self,
+        cache_key: Option<CacheKey>,
+        status: CacheStatus,
+        data: ByteView<'static>,
+    ) -> Self::Item;
 }
 
 impl<T: CacheItemRequest> Cacher<T> {
@@ -110,7 +115,11 @@ impl<T: CacheItemRequest> Cacher<T> {
             .into_future()
             .and_then(move |file| {
                 for key in request.get_lookup_cache_keys().into_iter() {
-                    let path = tryf!(get_scope_path(config.cache_dir(), &key.scope, &key.cache_key));
+                    let path = tryf!(get_scope_path(
+                        config.cache_dir(),
+                        &key.scope,
+                        &key.cache_key
+                    ));
 
                     let path = match path {
                         Some(x) => x,
@@ -156,9 +165,8 @@ impl<T: CacheItemRequest> Cacher<T> {
                 // just got pruned.
                 metric!(counter(&format!("caches.{}.file.miss", name)) += 1);
 
-                let future = request
-                    .compute(file.path())
-                    .and_then(move |(status, new_cache_key)| {
+                let future = request.compute(file.path()).and_then(
+                    move |(status, new_cache_key)| {
                         let new_cache_path = if let Some(ref new_cache_key) = new_cache_key {
                             tryf!(get_scope_path(
                                 config.cache_dir(),
@@ -199,7 +207,8 @@ impl<T: CacheItemRequest> Cacher<T> {
                         }
 
                         Box::new(Ok(item).into_future())
-                    });
+                    },
+                );
 
                 Box::new(future) as Box<dyn Future<Item = T::Item, Error = T::Error>>
             })

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -290,10 +290,17 @@ impl CacheItemRequest for FetchFileRequest {
         ))
     }
 
-    fn load(&self, cache_key: Option<CacheKey>, status: CacheStatus, data: ByteView<'static>) -> Self::Item {
+    fn load(
+        &self,
+        cache_key: Option<CacheKey>,
+        status: CacheStatus,
+        data: ByteView<'static>,
+    ) -> Self::Item {
         let object = ObjectFile {
             object_id: self.object_id.clone(),
-            scope: cache_key.map(|key| key.scope).unwrap_or_else(|| self.scope.clone()),
+            scope: cache_key
+                .map(|key| key.scope)
+                .unwrap_or_else(|| self.scope.clone()),
 
             file_id: Some(self.file_id.clone()),
             cache_key: Some(self.get_cache_key()),

--- a/src/actors/snapshots/symbolication__actors::symbolication::test_add_bucket-2.snap
+++ b/src/actors/snapshots/symbolication__actors::symbolication::test_add_bucket-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-06T11:56:08.920269Z"
+created: "2019-06-11T14:06:32.373815Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -7,12 +7,19 @@ expression: response
 status: completed
 stacktraces:
   - frames:
-      - status: missing
+      - status: symbolicated
         original_index: 0
+        lang: c
+        symbol: main
+        sym_addr: 0x100000fa0
+        function: main
+        filename: hello.c
+        abs_path: /tmp/hello.c
+        lineno: 1
         instruction_addr: 0x100000fa0
 modules:
-  - debug_status: missing
-    arch: unknown
+  - debug_status: found
+    arch: x86_64
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7

--- a/src/actors/snapshots/symbolication__actors::symbolication::test_remove_bucket-2.snap
+++ b/src/actors/snapshots/symbolication__actors::symbolication::test_remove_bucket-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-06T10:53:37.526201Z"
+created: "2019-06-11T14:06:32.369372Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -7,19 +7,12 @@ expression: response
 status: completed
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing
         original_index: 0
-        lang: c
-        symbol: main
-        sym_addr: 0x100000fa0
-        function: main
-        filename: hello.c
-        abs_path: /tmp/hello.c
-        lineno: 1
         instruction_addr: 0x100000fa0
 modules:
-  - debug_status: found
-    arch: x86_64
+  - debug_status: missing
+    arch: unknown
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -109,12 +109,14 @@ impl CacheItemRequest for FetchSymCacheInternal {
     }
 
     fn get_lookup_cache_keys(&self) -> Vec<CacheKey> {
-        self.request.sources.iter().map(|source: &SourceConfig| {
-            CacheKey {
+        self.request
+            .sources
+            .iter()
+            .map(|source: &SourceConfig| CacheKey {
                 cache_key: format!("{}.{}", source.id(), self.request.identifier.cache_key()),
-                scope: self.request.scope.clone()
-            }
-        }).collect()
+                scope: self.request.scope.clone(),
+            })
+            .collect()
     }
 
     fn compute(
@@ -140,10 +142,16 @@ impl CacheItemRequest for FetchSymCacheInternal {
                     futures::lazy(move || {
                         let new_cache_key = if let Some(ref source) = object.source() {
                             Some(CacheKey {
-                                cache_key: format!("{}.{}", source.id(), object.object_id().cache_key()),
+                                cache_key: format!(
+                                    "{}.{}",
+                                    source.id(),
+                                    object.object_id().cache_key()
+                                ),
                                 scope: object.scope().clone(),
                             })
-                        } else { None };
+                        } else {
+                            None
+                        };
 
                         if object.status() != CacheStatus::Positive {
                             return Ok((object.status(), new_cache_key));
@@ -181,7 +189,12 @@ impl CacheItemRequest for FetchSymCacheInternal {
             .unwrap_or(false)
     }
 
-    fn load(&self, _cache_key: Option<CacheKey>, status: CacheStatus, data: ByteView<'static>) -> Self::Item {
+    fn load(
+        &self,
+        _cache_key: Option<CacheKey>,
+        status: CacheStatus,
+        data: ByteView<'static>,
+    ) -> Self::Item {
         // TODO: Figure out if this double-parsing could be avoided
         let arch = SymCache::parse(&data)
             .map(|cache| cache.arch())

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -119,7 +119,9 @@ def test_basic(symbolicator, cache_dir_param, is_public, hitcounter):
             symcache, = (
                 cache_dir_param.join("symcaches").join(stored_in_scope).listdir()
             )
-            assert symcache.basename == "microsoft_ff9f9f78-41db-88f0-cded-a9e1e9bff3b5-1_"
+            assert (
+                symcache.basename == "microsoft_ff9f9f78-41db-88f0-cded-a9e1e9bff3b5-1_"
+            )
             assert symcache.size() > 0
 
         count = 1 if cache_dir_param else (i + 1)


### PR DESCRIPTION
Alternative fix of #19, related to #80. Solves the same main problem but avoids a whole lot of performance regressions at the cost of possible glitches during cache hits.