### PR TITLE
fix: Deduplicate channels for global objects

### DIFF
--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -33,12 +33,21 @@ type ComputationMap<T, E> = Arc<RwLock<BTreeMap<CacheKey, ComputationChannel<T, 
 /// trait and associated types.
 ///
 /// Internally deduplicates concurrent cache lookups (in-memory).
-#[derive(Clone)]
 pub struct Cacher<T: CacheItemRequest> {
     config: Cache,
 
     /// Used for deduplicating cache lookups.
     current_computations: ComputationMap<T::Item, T::Error>,
+}
+
+impl<T: CacheItemRequest> Clone for Cacher<T> {
+    fn clone(&self) -> Self {
+        // https://github.com/rust-lang/rust/issues/26925
+        Cacher {
+            config: self.config.clone(),
+            current_computations: self.current_computations.clone(),
+        }
+    }
 }
 
 impl<T: CacheItemRequest> Cacher<T> {
@@ -68,10 +77,7 @@ pub trait CacheItemRequest: 'static + Send {
 
     /// Invoked to compute an instance of this item and put it at the given location in the file
     /// system. This is used to populate the cache for a previously missing element.
-    fn compute(
-        &self,
-        path: &Path,
-    ) -> Box<dyn Future<Item = (CacheStatus, Scope), Error = Self::Error>>;
+    fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>>;
 
     /// Determines whether this item should be loaded.
     fn should_load(&self, _data: &[u8]) -> bool {
@@ -83,6 +89,51 @@ pub trait CacheItemRequest: 'static + Send {
 }
 
 impl<T: CacheItemRequest> Cacher<T> {
+    fn lookup_cache(&self, request: &T) -> Result<Option<T::Item>, T::Error> {
+        let name = self.config.name();
+        let key = request.get_cache_key();
+
+        let path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key)?;
+
+        let path = match path {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+
+        let byteview = match self.config.open_cachefile(&path)? {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+
+        let status = CacheStatus::from_content(&byteview);
+        if status == CacheStatus::Positive && !request.should_load(&byteview) {
+            log::trace!("Discarding {} at path {:?}", name, path);
+            metric!(counter(&format!("caches.{}.file.discarded", name)) += 1);
+            return Ok(None);
+        }
+
+        // This is also reported for "negative cache hits": When we cached the 404 response from a
+        // server as empty file.
+        metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
+
+        metric!(
+            time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
+            "hit" => "true"
+        );
+
+        configure_scope(|scope| {
+            scope.set_extra(
+                &format!("cache.{}.cache_path", name),
+                format!("{:?}", path).into(),
+            );
+        });
+
+        log::trace!("Loading {} at path {:?}", name, path);
+
+        let item = request.load(key.scope, status, byteview);
+        Ok(Some(item))
+    }
+
     pub fn compute_memoized(
         &self,
         request: T,
@@ -116,50 +167,13 @@ impl<T: CacheItemRequest> Cacher<T> {
             None => NamedTempFile::new(),
         };
 
+        let slf = (*self).clone();
+
         let compute_future = file_result
             .map_err(T::Error::from)
             .into_future()
             .and_then(clone!(key, |file| {
-                for &scope in &[&key.scope, &Scope::Global] {
-                    let path = tryf!(get_scope_path(config.cache_dir(), &scope, &key.cache_key));
-
-                    let path = match path {
-                        Some(x) => x,
-                        None => continue,
-                    };
-
-                    let byteview = match tryf!(config.open_cachefile(&path)) {
-                        Some(x) => x,
-                        None => continue,
-                    };
-
-                    let status = CacheStatus::from_content(&byteview);
-                    if status == CacheStatus::Positive && !request.should_load(&byteview) {
-                        log::trace!("Discarding {} at path {:?}", name, path);
-                        metric!(counter(&format!("caches.{}.file.discarded", name)) += 1);
-                        continue;
-                    }
-
-                    // This is also reported for "negative cache hits": When we cached the 404 response from a
-                    // server as empty file.
-                    metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
-
-                    metric!(
-                        time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
-                        "hit" => "true"
-                    );
-
-                    configure_scope(|scope| {
-                        scope.set_extra(
-                            &format!("cache.{}.cache_path", name),
-                            format!("{:?}", path).into(),
-                        );
-                    });
-
-                    log::trace!("Loading {} at path {:?}", name, path);
-
-                    let item = request.load(scope.clone(), status, byteview);
-
+                if let Some(item) = tryf!(slf.lookup_cache(&request)) {
                     return Box::new(Ok(item).into_future());
                 }
 
@@ -167,46 +181,44 @@ impl<T: CacheItemRequest> Cacher<T> {
                 // just got pruned.
                 metric!(counter(&format!("caches.{}.file.miss", name)) += 1);
 
-                let future = request
-                    .compute(file.path())
-                    .and_then(move |(status, new_scope)| {
-                        let new_cache_path = tryf!(get_scope_path(
-                            config.cache_dir(),
-                            &new_scope,
-                            &key.cache_key
-                        ));
+                let future = request.compute(file.path()).and_then(move |status| {
+                    let cache_path = tryf!(get_scope_path(
+                        config.cache_dir(),
+                        &key.scope,
+                        &key.cache_key
+                    ));
 
-                        if let Some(ref cache_path) = new_cache_path {
-                            configure_scope(|scope| {
-                                scope.set_extra(
-                                    &format!("cache.{}.cache_path", name),
-                                    format!("{:?}", cache_path).into(),
-                                );
-                            });
+                    if let Some(ref cache_path) = cache_path {
+                        configure_scope(|scope| {
+                            scope.set_extra(
+                                &format!("cache.{}.cache_path", name),
+                                format!("{:?}", cache_path).into(),
+                            );
+                        });
 
-                            log::trace!("Creating {} at path {:?}", name, cache_path);
-                        }
+                        log::trace!("Creating {} at path {:?}", name, cache_path);
+                    }
 
-                        let byteview = tryf!(ByteView::open(file.path()));
+                    let byteview = tryf!(ByteView::open(file.path()));
 
-                        metric!(
-                            counter(&format!("caches.{}.file.write", name)) += 1,
-                            "status" => status.as_ref(),
-                        );
+                    metric!(
+                        counter(&format!("caches.{}.file.write", name)) += 1,
+                        "status" => status.as_ref(),
+                    );
 
-                        metric!(
-                            time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
-                            "hit" => "false"
-                        );
+                    metric!(
+                        time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
+                        "hit" => "false"
+                    );
 
-                        let item = request.load(new_scope, status, byteview);
+                    let item = request.load(key.scope.clone(), status, byteview);
 
-                        if let Some(ref cache_path) = new_cache_path {
-                            tryf!(status.persist_item(cache_path, file));
-                        }
+                    if let Some(ref cache_path) = cache_path {
+                        tryf!(status.persist_item(cache_path, file));
+                    }
 
-                        Box::new(Ok(item).into_future())
-                    });
+                    Box::new(Ok(item).into_future())
+                });
 
                 Box::new(future) as Box<dyn Future<Item = T::Item, Error = T::Error>>
             }))


### PR DESCRIPTION
With #80 we know ahead of time in which scope a potential cache hit will
be, since every cache lookup is now tied to a source (and therefore we
can look at is_public earlier). This allows us to simplify Cacher such
that it no longer needs to look at two filepaths.

Channel deduplication never worked properly for deduplicating lookup of
globally stored cache items (cache lookups were effectively only
deduplicated per-project/per-local-scope). This commit fixes that
indirectly.