### PR TITLE
doc: Add design docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__
 /cache/symcaches/
 /cache/cficaches/
 /cache/object_meta/
+
+# mkdocs
+site

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ test-integration: .venv/bin/python
 	@.venv/bin/pytest tests --reruns 5 -n12 -vv
 .PHONY: test-integration
 
+# Documentation
+
+doc: .venv/bin/python
+	.venv/bin/pip install -U mkdocs
+	.venv/bin/mkdocs serve
+
 # Style checking
 
 style: style-rust style-python

--- a/docs/background-and-principles.md
+++ b/docs/background-and-principles.md
@@ -1,0 +1,74 @@
+# Background and Principles
+
+This page describes reasoning behind the design of Symbolicator.
+
+## Issues Before Symbolicator
+
+There were a couple of general issues with native event processing:
+
+- Matching of system symbol paths sometimes yields false positives
+- SymbolServer only handles iOS system symbols and cannot resolve line numbers
+- Handling of DIFs in Sentry causes a lot of overhead in the blob storage and is prone to race conditions
+- Customers are starting to hit the maximum file size limit of 2GB
+- DIFs always need to be uploaded before events, whether they are used or not
+- Minidump processing requires multiple debug files at once, which required hacks in Sentry.
+
+Additionally, there were issues around the upload of debug information files.
+
+1. SymCaches and CFI caches are computed ahead of time and persisted. This creates inherent race conditions and also requires computation, even if the symbols are never used.
+2. Debug file models only store the debug identifier. This works for Breakpad minidumps and custom SDKs, but will never be compatible to native debuggers or other systems.
+3. The current logic for choosing a file based on debug ids is based on the upload time. This was done to reduce the amount of fetching from the file storage onto workers. However, this might choose a suboptimal file.
+4. During symbol upload, older "redundant" files are deleted. A file is considered redundant, if it only provides a subset of the features of all newer files combined. Since this does not consider the file type, this might throw away better debug information in favor of a newer, worse file (e.g. when a breakpad file is uploaded after the original debug file). 
+
+## Symbolicator Principles
+
+Symbolizer is a service that unifies symbolication for all kinds of native frames and allows us to add more features or improve performance more easily than in the former setup. Goals of the Symbolizer are:
+
+- **Symbolize entire stack traces at once**, referencing both system- and customer images. Thanks to this, heuristics for detecting system images are no longer necessary.
+- **Fetch DIFs from external sources.** These could be third-party servers like the online Microsoft Symbol Server or buckets of DIFs hosted by our customers. This removes the need to proactively upload files to Sentry that will never be used.
+- **Treat SymCaches and Debug Files as transient.** All files are put in a local file system cache for faster access, but there is no persistent storage for symcaches or files retrieved from an external resources. This also simplifies upgrades (simply wipe the cache).
+- **Avoid one-hit wonders.** SymCaches only need to be generated for debug files that are hit multiple times within a time frame. For all other symbols, using the original debug file is sufficiently fast — especially since it only needs to be loaded once per symbolication request.
+- **Improve processing of minidumps.** Potentially use multiple debug files or cache files at once to run stackwalking and symbolication in a single run. This reduces resource allocation and gets rid of our hacks in the breakpad processor.
+
+## Terminology
+
+### Sentry Symbol Server
+
+The Sentry Symbol Server was created to provide symbolicated stack frames iOS system libraries without forcing our users to upload them to each project after every iOS release. Instead, Sentry detects these frames and initially skip searching for debug files in its own database. 
+
+Symbol Server is an internal service. It can only handle dSYM files, thus constraining it to macOS and iOS. Every time Apple releases a new iOS version, the SDK team pulls new debug files from an updated device and re-uploads them to an S3 bucked. This bucked is scanned by the Symbol Server in regular intervals.
+
+Internally, Symbol Server uses a binary format for symbolication. It only contains file names, but not line numbers.
+
+Since sometimes images are wrongfully classified as system symbols, there is always a fallback to search for uploaded debug information files in Sentry's database.
+
+**We deprecated this service with [PR #72](https://github.com/getsentry/symbolicator/pull/72) and instead use a simple GCS bucket that we point Symbolicator to**
+
+
+### Debug Information Files
+
+**DIFs** contain "debug information" to resolve function names and file locations from raw memory addresses in native crash reports. These files can get quite large, and we have encountered first customers with files over 2GB.
+
+Additionally, DIFs come in various different formats depending on the operating system and build process. In some scenarios, a combination of multiple files might be needed to successfully symbolicate a native crash. This has first been encountered in minidumps, which require the executable to extract stack traces, but a separate debug file to symbolicate its addresses.
+
+To mitigate issues with file size and platform differences, we created **SymCaches**. These are custom binary files that store an essential subset of the original debug information in a uniform format. The file format is optimized for direct mapping into memory and fast lookups of addresses. SymCaches are created for every DIF uploaded by customers that contains valid debug information.
+
+### Reprocessing
+
+Fundamentally, Sentry cannot reprocess Events. Put simply, the "Reprocessing" feature defers processing of events until all required DIFs have been uploaded by the customer. 
+
+Whether a DIF is required mostly depends on our classification as system image. Unless an image is a system image, it is always required. Since this metric is only reliable for iOS, reprocessing is effectively broken for all other platforms.
+
+### Symbol Storage in Sentry
+
+Symbols in Sentry are stored in the main file store ("Blob Storage", on GCS in production but generally configurable) split into deduplicated 1MB chunks. This is governed by a table in the main Postgres database (`sentry_fileblobowner`), which also controls access authorization per organization. To retrieve a file, one has to query all blobs for a file with a database query first, and then manually assemble them into one continuous file on the disk. This logic is implemented in the [`File` model](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/models/file.py#L366) in the main Sentry codebase.
+
+Debug files abstract this in the `ProjectDebugFile` model. It contains a reference to a file in the blob store, as well as meta data on the debugging file such as its architecture or name. Debug files are always **associated to projects** and keyed by their **debug id**. There might be multiple files files for each debug id with complementary **features** (such as unwind information or symbol tables).
+
+There are several high-level abstractions that expose this to other parts of the Sentry code base and even to HTTP endpoints. These are:
+
+- `[find_by_checksum](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/models/debugfile.py#L111)`: Resolves debug file models by their content checksum. This is used to deduplicate entire files, for example to skip redundant symbol uploads.
+- `[find_by_debug_ids](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/models/debugfile.py#L117)`: Resolves debug file models for a list of debug_ids in a project. For each debug id, the *latest* file is returned if there are multiple. Optionally, a set of required *features* can be declared, by which the files will be filtered. This is used to resolve the best match for symbolication or stackwalking.
+- `[fetch_difs](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/models/debugfile.py#L611)`: Downloads a list of debug files specified by their debug ids and optional features to a local file system cache. This uses `find_by_debug_ids` internally.
+- `[generate_caches](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/models/debugfile.py#L596)`: Generates SymCaches and CFI caches for a debug file. Either, the file is already on the file system, or otherwise it will be downloaded. This is performed immediately after uploading; or on demand in case symcaches are missing.
+- `[DebugFilesEndpoint](https://github.com/getsentry/sentry/blob/2b4a785b4ebd9d874a339c3ba9741a4cd307faf5/src/sentry/api/endpoints/debug_files.py#L71-L76)`: Lists or searches debug files by a set of meta data, including the debug id. Also offers a download, which assembles the file from its chunks and then streams it to the client.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,66 @@
+# Internal Caching
+
+This page describes how Symbolicator uses file system caches.
+
+Conceptionally, Symbolicator does not store debug information files but treats them as transient caches. Symbolicator caches two types of files: Raw debug information files and symbolication caches.
+
+## Cache Files
+
+Symbolicator caches two kinds of files: original Debug Information Files and derived caches which comprise SymCaches and CFI caches. 
+
+- **Debug Information Files (Object Files)** (original): The original debug files as they are stored on external sources. They are cached to allow for faster recomputation of the derived caches, especially when after an update the format of the derived caches change. Otherwise, all original files would have to be downloaded again which could incur significant performance impact. DIFs are platform dependent and usually large in size, up to multiple GB. Their internal structure is platform dependent.
+- **Object Meta Files** (derived): Important attributes of a Object File used to determine which Object File is the best one. This information is persisted separately from Object Files because we want to delete Object Files a few days after download for disk we want to delete Object Files a few days after download for disk space while still knowing some information about them.
+- **Symbolication Caches** (derived): A platform-independent representation of function and line information to symbolicate instruction addresses. Those files are usually significantly smaller than native DIFs. However, endianness of the file contents depends on the host so these files cannot be transferred between systems with different endianness.
+- **CFI Caches** (derived): A platform-independent representation of stack unwind information to allow stackwalking. This currently uses the Breakpad ASCII format.
+
+## Cache Rules
+
+In addition to caching DIFs and derived caches, the Symbolicator also stores placeholders to indicate the absence of or errors when retrieving or computing those files. The cache adheres to the following rules:
+
+1. DIFs are cached until they have not been used for *7 days* but may be deleted earlier when disk space is running out. A DIF is used when a derived cache is computed from it.
+2. Derived caches that were successfully created from preferred DIFs are cached until they have not been used for *at least 7 days*.
+3. Derived caches that were successfully created from fallback DIFs are treated equally but *at most once per hour* an upgrade attempt is started to search for better DIFs.
+4. The absence of a DIF is cached for *1 hour*, after that another fetch attempt from all sources is started.
+5. Failed conversions (due to malformed or unsupported debug files) are cached for *24 hours* but only up to the *next restart*. After that, another conversion is attempted. The restart constraint serves the purpose to allow immediate bug fixes.
+
+Derived caches can continue to be stored independently of the DIFs they were created from. Because they are smaller than the originals, this contributes to a better use of the available disk space. All timeouts mentioned above are configurable:
+
+    caches:
+      downloaded:
+        max_unused_for:
+          days: 7   # unused DIFs, rule 1
+        retry_misses_after:
+          hours: 1  # absence of a DIF, rule 4
+      derived:
+        max_unused_for:
+          days: 7   # unused caches, rule 2
+        retry_misses_after:
+          hours: 1  # also necessary for rule 4
+
+For more information on which DIFs are preferred to create a specific cache format, see this document:
+
+[Symbol Lookup Strategy](symbol-lookup.md)
+
+## Cache Enforcement
+
+In order to enforce the desired cache behavior, Symbolicator uses file system meta data and information stored in the files themselves to determine when to evict items from the cache.
+
+1. **Last use of derived cache**: The time when a derived cache was last used in a symbolication request. This allows to prune cold caches from the system, even from an external service. This value is stored in the *mtime* of the symbolication file and updated at most *once per hour*. 
+2. **Last attempt to fetch dependencies of a cache:** The time when the a derived cache could not be constructed because no debug files were available. Instead, a placeholder cache file is created and its *mtime* indicates the attempt. If this file is older than the threshold (default *1 hour*), another fetch attempt can be started and the file is recreated or replaced. **NOTE**: The placeholder is created for the derived cache only, because otherwise too many placeholders would be created.
+3. **Last failed cache conversion**: The time when deriving a cache from a native DIF failed due to an error. A placeholder file is created and its *mtime* indicates the attempt. If a file is older than the threshold (default *24 hours*), conversion is repeated. If the debug files have been deleted in between, this causes another fetch from external sources.
+4. **DIFs used for derived cache**: The kind of debug information that was used to compute a derived cache. SymCaches store this in their header, so this can be retrieved inexpensively by opening the file. CFI caches currently do not contain this information, although all DIFs offer equal quality of unwind information.
+5. **Last cache upgrade:** The last time when an upgrade of an existing derived cache was attempted since it was not computed from a preferred source. This also uses the file’s *mtime* and attempts an update every time the modification time exceeds the threshold. 
+
+## Scopes
+
+Cached files are associated to a scope, which is given by the symbolication request. The default is a “global” scope, which implicitly makes the files accessible to any request (scoped and not scoped). Otherwise, the scope needs to match for caches to be used. Note that there is no verification of the scope number, so users of the Symbolicator are required to ensure the soundness of scope values.
+
+Scoping is achieved by encoding the scope identifier into the cache paths, thus creating separate cache directories for each scope.
+
+## Pruning Caches
+
+The `symbolicator cleanup` command removes stale caches. This command needs to be run manually and periodically, or at least when disk space is about to run out.
+
+Symbolicator operates under the assumption that files may be removed by an external actor at any time (one such actor is `symbolicator cleanup` itself which does not really attempt to synchronize with the main symbolicator service).
+
+Symbolicator assumes a fully POSIX-compliant filesystem to be able to serve requests without interruptions while files are being deleted. **Using a network share for the cache folder will not work.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Symbolicator
+
+## Table of contents
+
+- [Background and Principles](background-and-principles.md)
+- [System Architecture](system-architecture.md)
+- [Symbol lookup strategy](symbol-lookup.md)
+- [Symbol Server Compatibility](symbol-server-compatibility.md)
+- [Caching](caching.md)

--- a/docs/symbol-lookup.md
+++ b/docs/symbol-lookup.md
@@ -1,0 +1,106 @@
+# Symbol lookup strategy
+
+This page describes how Symbolicator resolves debug files.
+
+Symbolicator queries a list of external sources for debug information files which it uses to process minidumps and symbolicate stack traces. Based on availability, the CPU architecture and the operating system, it may determine the "best" file to use:
+
+1. Compute the code and debug identifiers for the modules to load.
+2. Look up available files in all sources
+3. Choose the best available file
+
+## Identifiers
+
+Symbol servers use native identifiers to locate files. Usually, they put them in a directory hierarchy for easier retrieval. For more information on specific formats, see:
+
+[Symbol Server Compatibility](symbol-server-compatibility.md)
+
+There are two kinds of identifiers:
+
+- **Code Id:** Native identifier of the actual binary (library or executable). Usually, this is a value stored in the header or computed from its contents.
+- **Debug Id:** Identifier of the associated debug file on some platforms, or a mangled version of the code identifier on other platforms.
+
+To look up different symbol kinds, the symbol server uses the following process to determine the ID (see below for exact conversion algorithms):
+
+- **MachO:** Use the UUID which is stored interchangeably in `debug_id` and `code_id`. If one of these values is missing, it can be computed from the other. Primarily, the `code_id` should be used.
+- **ELF:** Use the GNU build id which is given in the `code_id`. The `debug_id` can be computed from this `code_id`, but not the other way around. Thus, if the `code_id` is missing, lookups may not be possible.
+- **PE**: Windows executables use a combination of timestamp and size fields to compute a `code_id`. It is mandatory, as it cannot be derived from the `debug_id`.
+- **PDB**: Windows PDBs have their own `debug_id`, which can be read from the PDB or PE header. It is mandatory, as it cannot be derived from the `code_id`.
+- **Breakpad**: Google Breakpad uses `debug_id` for all symbol kinds. If it is missing, it can be computed from the `code_id` if this is possible using the above rules.
+
+## Symbol Precedence
+
+Depending on the desired information and type of image, the Symbolicator
+requests several files and chooses the best one. Note that the image type
+depends on the platform, but there are multiple formats for debug information
+files available.
+
+The following is a table of what we initially deemed as ideal lookup strategy.
+How we deviate from this in practice is documented separately.
+
+### Symbol Table
+
+Platform | 1. Choice    | 2. Choice    | 3. Choice
+--------------------------------------------------
+MachO    | MachO (dSYM) | MachO (code) | Breakpad
+ELF      | ELF (debug)  | ELF (code)   | Breakpad
+PE       | PDB          | PE           | Breakpad
+
+### Debug Information
+
+Platform | 1. Choice    | 2. Choice    | 3. Choice
+--------------------------------------------------
+MachO    | MachO (dSYM) | Breakpad     | 
+ELF      | ELF (debug)  | ELF (code)   | Breakpad
+PE       | PDB          | Breakpad     | 
+
+
+### Unwind Information
+
+Platform    | 1. Choice    | 2. Choice  
+--------------------------------------
+MachO       | MachO (code) | Breakpad
+ELF         | ELF (code)   | Breakpad
+PE (32-bit) | PDB          | Breakpad
+PE (64-bit) | PE           | Breakpad
+
+
+### Notes on implementation
+
+* Symbolicator downloads *all* filetypes in parallel and filters by whether
+  symbolic says that a file has debug/unwind information. There is no special
+  codepath for each table presented here, and especially not for each
+  platform/filetype.
+  
+  This creates a few more downloads than what would be necessary for a specific
+  task, but those should not matter considering that you e.g. will likely look
+  into debug information very soon if you already look for unwind information.
+
+* As a result of the previous point, Symbolicator does not differentiate
+  between 32-bit and 64-bit platforms, meaning that even on 64-bit Windows it
+  will attempt to look into the PDB to find relevant information. Again this
+  should not matter in terms of correctness as it will still also
+  unconditionally look into the PE and pick that if it's deemed to be be of
+  better quality.
+
+## Conversion Algorithms
+
+Some identifiers may be computed from others. See the following list for allowed non-lossy conversions in pseudocode:
+
+* **MachO `code_id` ←→ `debug_id`**
+
+      *identity*
+
+  **Implementation note:** Symbolicator implements this by using the code ID everywhere.
+
+
+* **ELF `code_id` → `debug_id`**
+
+     debug_id = code_id[0..16]
+      
+      if object.little_endian {
+        debug_id[0..4].reverse(); // uuid field 1
+        debug_id[4..6].reverse(); // uuid field 2
+        debug_id[6..8].reverse(); // uuid field 3
+      }
+
+  **Implementation note:** This is not yet implemented (TODO)

--- a/docs/symbol-server-compatibility.md
+++ b/docs/symbol-server-compatibility.md
@@ -1,0 +1,129 @@
+# Symbol Server Compatibility
+
+This page describes external sources supported by Symbolicator.
+
+The layout of external sources intends to be compatible to several symbol server implementations that have been used historically by different platforms. We commit to provide compatibility to the following services or directory structures:
+
+- Microsoft Symbol Server
+- Breakpad Symbol Repositories
+- LLDB File Mapped UUID Directories
+- GDB Build ID Directories
+
+## Identifiers
+
+There are two fundamentally different identifiers. Their semantics fundamentally depend on the symbol type, but follow certain rules:
+
+- **Code Identifier:** Identifies the actual executable or library file (e.g. EXE or DLL)
+- **Debug Identifier:** Identifies a debug companion file (e.g. PDB)
+
+On all platforms other than Windows, binaries and debug companion files use the same file type and share the same container. The Breakpad library has thus changed the semantics of those identifiers for all other platforms to:
+
+- **Code Identifier:** The original platform-specific identifier
+- **Debug Identifier:** A potentially lossy transformation of the code identifier into a unified format similar to the PDB debug identifiers.
+
+Specifically, the code and debug identifiers are defined as follows:
+
+- **ELF**
+- **MachO**
+- **PE** / **PDB**
+- **Breakpad**
+
+## A Note on Case Sensitivity
+
+Most symbol servers explicitly define **case insensitive** lookup semantics. This goes in particular for the Microsoft Public Symbol Server. However, the canonical representation on the file system is not necessarily case insensitive, for example when the files are stored on an Amazon S3 bucket. Since this is a hard restriction, the case for lookups is explicitly defined for each source below. Please pay attention to the casing rules!
+
+## Breakpad
+
+Breakpad always computes a "Breakpad ID" for each symbol. This is a lossy process depending on the file type. Sentry stores a bidirectionally compatible version of this in the `debug_id` field.
+
+The name of the symbol file is platform dependent. On Windows, the file extension (Either *.exe*, *.dll* or *.pdb*) is replaced with *.sym*. On all other platforms, the *.sym* extension is **appended** to the full file name including potential extensions.
+
+Casing rules are mixed:
+
+- The file name is **as given**
+- The signature part of the id (first 32 characters) are **uppercase**
+- The age part of the id (remaining characters) are **lowercase**
+
+- **Schema**: `<debug_name>/<breakpad-id>/<sym_name>`
+
+## Microsoft Symbol Server
+
+The public symbol server provided by Microsoft used to only host PDBs for the Windows platform. These use a *signature-age* debug identifier in addition to the file name to locate symbols. For .NET, this specification was amended by a schema for ELF and MachO-symbols, which is specified as [SSQP Key Conventions](https://github.com/dotnet/symstore/blob/master/docs/specs/SSQP_Key_Conventions.md). This means all non windows platforms are following SSQP rules except for casing.
+
+Casing rules for Symbol Server are mixed:
+
+- Filenames are **as given**
+- Identifiers are generally **lowercase**, except:
+- The signature and age of a PDB identifier is **uppercase**.
+- The timestamp of a PE identifier is **uppercase** except the size is **lowercase**
+
+- **PE**: `<code_name>/<Timestamp><SizeOfImage>/<code_name>`
+- **PDB**: `<debug_name>/<Signature><Age>/<debug_name>`
+- **ELF** (binary, potentially stripped): `<code_name>/elf-buildid-<note_byte_sequence>/<code_name>`
+- **ELF** (debug info): `_.debug/elf-buildid-sym-<note_byte_sequence>/_.debug`
+- **MachO** (binary): `<code_name>/mach-uuid-<uuid_bytes>/<code_name>`
+- **MachO** (dSYM): `_.dwarf/mach-uuid-sym-<uuid_bytes>/_.dwarf`
+
+The presence of a `index2.txt` in the root indicates two tier structure where the first two characters are prepended to the path as an additional folder. So `foo.exe/542D5742000f2000/foo.exe` is stored as `fo/foo.exe/542D5742000f2000/foo.exe`.
+
+## Microsoft SSQP Symbol Server
+
+Casing rules for SSQP are mixed:
+
+- Filenames are **lowercased**
+- Identifiers are generally **lowercase**, except:
+- The age of a PDB identifier is **uppercase**.
+
+- **PE**: `<code_name>/<Timestamp><SizeOfImage>/<code_name>`
+- **PDB**: `<debug_name>/<Signature><Age>/<debug_name>`
+- **ELF** (binary, potentially stripped): `<code_name>/elf-buildid-<note_byte_sequence>/<code_name>`
+- **ELF** (debug info): `_.debug/elf-buildid-sym-<note_byte_sequence>/_.debug`
+- **MachO** (binary): `<code_name>/mach-uuid-<uuid_bytes>/<code_name>`
+- **MachO** (dSYM): `_.dwarf/mach-uuid-sym-<uuid_bytes>/_.dwarf`
+
+Additionally, SSQP supports a lookup by SHA1 checksum over the file contents, commonly used for source file lookups. This will not be supported.
+
+## LLDB Debugger (macOS)
+
+The LLDB debugger on macOS can read debug symbols from [File Mapped UUID Directories](http://lldb.llvm.org/use/symbols.html#file-mapped-uuid-directories) (scroll down to the second last section). The UUID is broken up by splitting the first 20 hex digits into 4 character chunks, and a directory is created for each chunk. In the final directory, LLDB usually expects a symlink named by the last 12 hex digits, which it follows to the actual dSYM file. 
+
+**Note**: this is not actually an LLVM feature. This is in fact a feature of `CoreFoundation` and exclusively implemented on macOS on top of spotlight. Spotlight indexes these paths and the private `DBGCopyFullDSYMURLForUUID` API is used by lldb to locate the symbols. macOS uses the symlinks of those locations.
+
+Since the executable or library shares the same UUID as the dSYM file, the former are distinguished with a `.app` suffix.
+
+The hex digits are **uppercase**, the app suffix is **lowercase**.
+
+- **MachO** (binary): `XXXX/XXXX/XXXX/XXXX/XXXX/XXXXXXXXXXXX.app`
+- **MachO** (dSYM): `XXXX/XXXX/XXXX/XXXX/XXXX/XXXXXXXXXXXX`
+
+## GDB
+
+GDB supports multiple lookup methods, depending on the way the debug info file is specified. However, not all of these methods are applicable to a symbol server:
+
+- **Debug Link Method:** GDB looks up the name or relative path specified in the `.gnu.debuglink` section. This requires the debug file to be in a relative position to the actual executable, and does not provide any means to distinguish by a unique identifier.
+- **Build ID Method:** Assuming that a GNU build ID note or section have been written to the ELF file, this specifies a unique identifier for the executable which is also retained in the debug file. This method is applicable to a symbol server, but only if the Build ID is present.
+
+The GNU build ID is a variable-length binary string, usually consisting of a 20-byte SHA1 hash of the code section (`.text`). The lookup path is *nn/nnnnnnnn.debug*, where *nn* are the first 2 hex characters of the build ID bit string, and *nnnnnnnn* are the rest of the bit string. To look up executables, the `.debug` suffix is omitted.
+
+The build-id hex representation is always provided in **lowercase**.
+
+[https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html](https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html)
+
+- **ELF** (binary, potentially stripped)
+- **ELF** (debug info)
+
+## Other servers
+
+The following additional sources were considered but are not implemented right now:
+
+### Fedora Darkserver
+
+In 2010, Fedora launched a project called "Darkserver" that aimed to provide a symbol server for various libraries. In 2012, it seemed to have contained symbols for Debian and Ubuntu as well.
+
+However, this projects seems to have been abandoned since and there is only little information available. For now, there is no intention to support Darkserver.
+
+### Mozilla Tecken
+
+Tecken is the symbol server implementation used at Mozilla. The symbol file paths are compatible to Google's Breakpad symbol server. An example of available symbols can be viewed here: [https://symbols.mozilla.org/downloads/missing](https://symbols.mozilla.org/downloads/missing).
+
+Tecken internally implements a client for the Microsoft Symbol Server to forward downloads for missing symbols. While doing that, it attempts to replace the last character in the URL with an underscore to look up compressed symbols. In any case Tecken tries both variants. Example: `foo.exe/<id>/foo.ex_`. Microsoft Symbol Server no longer supports this.

--- a/docs/symbolication-api.md
+++ b/docs/symbolication-api.md
@@ -1,0 +1,200 @@
+# Symbolication API
+
+This page describes the public web API of the [Native Symbolicator](https://www.notion.so/9ce2a7da-ad06-44d0-8563-a963aa9e390f).
+
+Symbolicator exposes a HTTP API to allow symbolication of raw native stack traces and minidumps. All information necessary for symbolication needs to be part of the request, such as external buckets and their auth tokens or full stack traces. There are the following endpoints:
+
+- `POST /symbolicate`: Symbolicate raw native stacktrace
+- `POST /minidump`: Symbolicate a minidump and extract information
+- `GET /requests/:id`: Status update on running symbolication jobs
+- `GET /health`: System status and health monitoring
+
+## Symbolication Request
+
+    POST /symbolicate?timeout=123&scope=123
+    
+    {
+      "signal": 11,
+      "sources": [
+        {
+          "id": "<uuid>",
+          "type": "http",
+          ... // see "External Buckets"
+        },
+        ...
+      ],
+      "threads": [
+        {
+          "frames": [
+            {
+              "instruction_addr": "0xfeedbeef" // can also be a number
+            },
+            ...
+          ],
+          "registers": {
+            "rip": "0xfeedbeef",
+            "rsp": "0xfeedface"
+          }
+        }
+      ],
+      "modules": [
+        {
+          "type": "macho",
+          "debug_id": "some-debug-id",
+          "code_id": "some-debug-id",
+          "debug_file": "/path/to/image.so",
+          "image_addr": "0xfeedbeef",
+          "image_size": "0xbeef"
+        },
+        ...
+      ]
+    }
+
+### Query Parameters
+
+- `demangle[=true]`: Tries to demangle the mangled symbol and puts the result in the `"name"` field.
+- `timeout`: If given, a response status of `pending` might be sent by the server.
+- `scope`: An optional scope which will be used to isolate cached files from each other
+
+### Request Body
+
+A JSON payload describing the stack traces and code modules for symbolication, as well as external sources to pull symbols from:
+
+- `sources`: A list of descriptors for internal or external symbol sources. See *External Sources*.
+- `modules`: A list of code modules (aka debug images) that were loaded into the process. All attributes other than `type` are required. The Symbolicator may optimize lookups based on the `type` if present.
+Valid types are `macho`, `pe`, `elf`. Invalid types are silently ignored. The Symbolicator still works if the type is invalid, but less efficiently. However, a schematically valid but *wrong* type is fatal for finding symbols.
+- `threads`: A list of process threads to symbolicate.
+    - `registers`: Optional register values aiding symbolication heuristics. For example, register values may be used to perform correction heuristics on the instruction address of the top frame.
+    - `frames`: A list of frames with addresses. Arbitrary additional properties may be passed with frames, but are discarded.
+
+### Response
+
+See *Symbolication Response*
+
+## Minidump Request
+
+    POST /minidump?timeout=5&scope=123
+    Content-Type: multipart/form-data; boundary=xxx
+    
+    --xxx
+    Content-Disposition: form-data; name="upload_file_minidump"
+    [binary blob]
+    
+    --xxx
+    Content-Disposition: form-data; name="sources"
+    [
+      {
+        "id": "<uuid>",
+        "type": "http",
+        ... // see "External Buckets"
+      },
+      ...
+    ]
+
+### Query Parameters
+
+- `demangle[=true]`: Tries to demangle the mangled symbol and puts the result in the `"name"` field.
+- `timeout`: If given, a response status of `pending` might be sent by the server.
+- `scope`: An optional scope which will be used to isolate cached files from each other
+
+### Request Body
+
+A multipart form data body containing the minidump, as well as the external sources to pull symbols from.
+
+- `sources`: A list of descriptors for internal or external symbol sources. See *External Sources*.
+- `upload_file_minidump`: The minidump file to be analyzed.
+
+### Response
+
+See *Symbolication Response*.
+
+## Symbolication Response
+
+The response to a symbolication request is a JSON object which contains different data depending on the status of the symbolication job:
+
+- `pending`: Symbolication has not finished yet. Try again later.
+- `complete`: The symbolication request has been processed and results are ready. This status is only reported once, after which the job is cleaned up.
+- `error`: Something went wrong during symbolication, and details are in the payload.
+
+### Success Response
+
+Symbol server responds with *200 OK* and the response payload listed below if symbolication succeeds within a configured timeframe (around 20 seconds): 
+
+    {
+      "status": "complete",                   // TODO: Describe all status
+    
+      // Symbolicated stack traces
+      "stacktraces": [
+        {                                     // Only frames, no registers
+          "frames": [
+            {
+              // symbolication meta data
+              "status": "symbolicated",       // TODO: Describe all statuses
+              "original_index": 0,
+    
+              // frame information
+              "instruction_addr": "0xfeedbeef",
+              "package": "/path/to/module.so",
+              "function": "memset",           // demangled short version of symbol
+              "lang": "cpp",                  // TODO: List all languages
+              "symbol": "__1cGmemset6FpviI_0_",
+              "sym_addr": "0xfeed0000",
+              "filename": "../src/file.c",    // Relative to compilation dir
+              "abs_path": "/path/to/src/file.c",
+              "lineno": 22,
+              "line_addr": "0xfeedbe00",      // This does not exist in Sentry
+            },
+            ...
+          ],
+          "registers": { ... }
+        }
+      ],
+    
+      // Modules completed with information read from object files
+      "modules": [
+        {
+          "status": "found", 
+          ...
+        }
+      ],
+    
+      // Additional information read from crash report
+      "arch": "x86_64",
+      "signal": 11,
+      "os": {
+        "name": "Windows NT",
+        "version": "8.1.2700"
+      }
+    }
+
+The symbolicated frames are returned in the same order as provided in the request. Additional properties passed in the request are discarded. Errors that occurred during symbolication, such as missing symbol files or unresolvable addresses within symbols are reported as values for `status` in both modules and frames.
+
+### Backoff Response
+
+If symbolication takes longer than the threshold `timeout`, the server instead responds with a backoff response. It will then continue to fetch symbols and symbolication. The response indicates the estimated time for symbol retrieval, after which the symbolication request can be expected to succeed:
+
+    {
+      "status": "pending",
+      "request_id": "deadbeef",
+      "retry_after": 300,   // 5 minutes
+    }
+
+The symbolication server must not send a backoff response if no timeout was sent by the client.
+
+Note that the `retry_after` value is just an estimation and does not give any guarantee. The request may be repeated at any time:
+
+    GET /requests/deadbeef?timeout=123
+
+### Invalid Request Response
+
+If the user provided a non-existent request ID, the server responds with *404 Not Found*.
+
+Requests should always be treated transient as they might disappear during a deploy. Clients must expect that 404 is returned even for valid request IDs and then re-schedule symbolication
+
+On a related note, generally state on the server is ephemeral.
+
+## External Sources
+
+The service loads symbol files from external buckets as specified in the symbolication request. Access to these buckets may occur via one of the following protocols.
+
+Refer to `README.md` for the possible source types.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,0 +1,65 @@
+# System Architecture
+
+This page describes the internal structure and processes of Symbolicator.
+
+## Looking up debug/unwind information
+
+When finding an object file for a image in a symbolication request, we do the following:
+
+1. We generate all possible file downloads for each source, based on platform
+  information and source filters. See [Symbol Lookup](symbol-lookup.md).
+
+2. We download all files we can get and cache them keyed by source ID and
+   filepath (`ObjectFile`).
+
+3. Then we rank all downloaded files:
+
+  1. Objects with debug or unwind information (depending on what we want to use the object for) are ranked at the top.
+  2. Objects with a symbol table are ranked second.
+  3. Unparseable objects are ranked somewhere at the bottom together with empty files, 404s etc.
+
+3. Then we generate a symcache or cficache from the best file, save it also keyed by source ID and filepath. In the cache dir, a symcache file now basically has the same filename as an object file, just in a different folder.
+
+### `ObjectMeta`
+
+The issue with the above setup is that one would have to have all objects permanently persisted on disk to be able to decide which symcache to use, which is only feasible in a world with infinite disk space.
+
+For this purpose we have the concept of an `ObjectMeta` cache, which stores information about the quality of an `ObjectFile` and is persisted for much longer. `ObjectFile`s are deleted just a few days after download while `ObjectMeta`s stick around for as long as the symcache/cficache does.
+
+### The object cache key
+
+As mentioned earlier, `ObjectFile`s, symcaches/cficaches (and `ObjectMeta`s) are cached by source ID and filepath. What this actually means depends on the source type:
+
+* For the HTTP source type (Microsoft SymStore etc) this is just the source ID
+  as given in the symbolication request + the filepath of the download URL.
+* For S3 and GCS buckets this is the source ID and the object key/path (object
+  as in S3 object).
+* For the Sentry source type this is the source ID and the numeric "Debug File
+  Id".
+
+In summary, the cache key is just whatever is necessary to uniquely identify a file
+within a source.
+
+
+### Generating all possible file downloads for a source
+
+In step 1, we mentioned that we generate all possible file downloads. For most filesystem-like source types this is a simple computation that takes an `ObjectId` (really a quintuple of debug and code ID + debug name + code name) and generates possible filepaths. The logic for this lives in `src/utils/paths.rs`.
+
+For the Sentry source type, this looks a bit different. Since Sentry already builds some sort of index based on debug and code ID, we first have to issue an HTTP request to Sentry to search for files based on those IDs. We get back a list of numeric "Debug File Ids" (those are just the integer PK in Postgres) that we then can download one by one.
+
+Since this step is quite expensive for Sentry, it is cached separately. This part is currently WIP.
+
+### Example
+
+The logic for looking up debug information for an image looks as follows (simplified, conflating code_name vs debug_name + code_id vs debug_id):
+
+* Lookup of object `name=wkernel32.pdb, id=0xdeadbeef` (uncached, parallelized):
+  * (cached) Fetching sentry index for `id=0xdeadbeef` (uncached) -> returns `[123456]`
+  * (cached) lookup of object *metadata* `[sentry, 123456]` -> returns `has_debug_info=true, ...`
+    * (cached) lookup of object *file* `[sentry, 123456]`
+  * (cached) lookup of object *metadata* `[microsoft, /wkernel32.pdb/deadbeef/wkernel32.pdb]` -> returns `has_debug_info=false, ...`
+    * (cached) lookup of object *file* `[microsoft, /wkernel32.pdb/deadbeef/wkernel32.pdb]`
+  * Sentry project symbol wins, because it has more than symbol table
+* (cached) lookup of symcache `[sentry, 123456]`
+
+All steps that are behind a caching layer are prefixed with `(cached)`. If a cache hit occurs, the sub-bulletpoints are not executed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,2 @@
+site_name: Symbolicator
+theme: readthedocs


### PR DESCRIPTION
Use mkdocs because it's quite close to raw markdown files. Intending to host this on either readthedocs or github pages.

This is most of the stuff copied from Notion, quickly skimmed over for correctness (but not for good structure or clarity)