### PR TITLE
feat: Add metrics for debug_status, unwind_status, modules count, frames count

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -598,7 +598,7 @@ impl SymbolicationActor {
             .and_then(move |object_lookup| {
                 threadpool.spawn_handle(
                     future::lazy(move || {
-                        let stacktraces = stacktraces
+                        let stacktraces: Vec<_> = stacktraces
                             .into_iter()
                             .map(|thread| symbolize_thread(thread, &object_lookup, signal))
                             .collect();
@@ -613,6 +613,8 @@ impl SymbolicationActor {
                             .collect();
 
                         metric!(time_raw("symbolication.num_modules") = modules.len() as u64);
+                        metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
+                        metric!(time_raw("symbolication.num_frames") = stacktraces.iter().map(|s| s.frames.len() as u64).sum());
 
                         Ok(CompletedSymbolicationResponse {
                             signal,

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -607,7 +607,7 @@ impl SymbolicationActor {
                             .inner
                             .into_iter()
                             .map(|(object_info, _)| {
-                                metric!(counter("symbolication.debug_status") += 1, "status" => object_info.debug_status.as_ref());
+                                metric!(counter("symbolication.debug_status") += 1, "status" => object_info.debug_status.name());
                                 object_info
                             })
                             .collect();
@@ -848,7 +848,7 @@ impl SymbolicationActor {
                                         .cloned()
                                         .unwrap_or(ObjectFileStatus::Unused);
 
-                                metric!(counter("symbolication.unwind_status") += 1, "status" => status.as_ref());
+                                metric!(counter("symbolication.unwind_status") += 1, "status" => status.name());
                                 info.unwind_status = Some(status);
 
                                 Some(info)

--- a/src/types.rs
+++ b/src/types.rs
@@ -546,10 +546,10 @@ pub enum ObjectFileStatus {
     Other,
 }
 
-impl AsRef<str> for ObjectFileStatus {
-    fn as_ref(&self) -> &str {
+impl ObjectFileStatus {
+    pub fn name(self) -> &'static str {
         // used for metrics
-        match *self {
+        match self {
             ObjectFileStatus::Found => "found",
             ObjectFileStatus::Unused => "unused",
             ObjectFileStatus::Missing => "missing",

--- a/src/types.rs
+++ b/src/types.rs
@@ -546,6 +546,21 @@ pub enum ObjectFileStatus {
     Other,
 }
 
+impl AsRef<str> for ObjectFileStatus {
+    fn as_ref(&self) -> &str {
+        // used for metrics
+        match *self {
+            ObjectFileStatus::Found => "found",
+            ObjectFileStatus::Unused => "unused",
+            ObjectFileStatus::Missing => "missing",
+            ObjectFileStatus::Malformed => "malformed",
+            ObjectFileStatus::FetchingFailed => "fetching_failed",
+            ObjectFileStatus::Timeout => "timeout",
+            ObjectFileStatus::Other => "other",
+        }
+    }
+}
+
 impl Default for ObjectFileStatus {
     fn default() -> Self {
         ObjectFileStatus::Unused


### PR DESCRIPTION
We are seeing CPU load patterns that we cannot correlate to much of the other metrics that we currently have. Maybe CPU goes up because the requests have more frames/images on average?