### PR TITLE
fix: Touch cache files more often

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -252,7 +252,7 @@ impl Cache {
 
         Ok(!is_negative
             && !is_malformed
-            && mtime.map(|x| x > Duration::from_secs(3600)).unwrap_or(true))
+            && mtime.map(|x| x > Duration::from_secs(1200)).unwrap_or(true))
     }
 
     /// Validate cachefile against expiration config and open a byteview on it. Takes care of


### PR DESCRIPTION
Since we have some cache expiration set to one hour, maybe cache items
expire too often because the mtime doesn't get bumped in time. Just
deploy and see I would say.