### PR TITLE
Fix breakpad symbol path

### DIFF
--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_linux-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_linux-2.snap
@@ -1,0 +1,18 @@
+---
+created: "2019-06-28T09:52:52.206310Z"
+creator: insta@0.8.1
+source: src/actors/symbolication.rs
+expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+---
+- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f_debug
+- local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so_sym
+- local_f1_c3bcc0279865fe3058404b2831d9e64135386c_debug
+- local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5_debug
+- local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so_sym
+- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f
+- local_b5_381a457906d279073822a5ceb24c4bfef94ddb
+- local_linux-gate_so_75185F6C04B9B48FB8DFD832E74AD31A0_linux-gate_so_sym
+- local_f1_c3bcc0279865fe3058404b2831d9e64135386c
+- local_b5_381a457906d279073822a5ceb24c4bfef94ddb_debug
+- local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5
+- local_crash_C0BCC3F19827FE653058404B2831D9E60_crash_sym

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_linux-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_linux-2.snap
@@ -1,18 +1,18 @@
 ---
-created: "2019-06-28T09:52:52.206310Z"
+created: "2019-06-28T10:55:27.198215Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
-expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+expression: "{\n    let mut cache_entries: Vec<_> =\n        fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                            x.unwrap().file_name().into_string().unwrap()).collect();\n    cache_entries.sort();\n    cache_entries\n}"
 ---
-- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f_debug
-- local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so_sym
-- local_f1_c3bcc0279865fe3058404b2831d9e64135386c_debug
-- local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5_debug
-- local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so_sym
-- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f
-- local_b5_381a457906d279073822a5ceb24c4bfef94ddb
-- local_linux-gate_so_75185F6C04B9B48FB8DFD832E74AD31A0_linux-gate_so_sym
-- local_f1_c3bcc0279865fe3058404b2831d9e64135386c
-- local_b5_381a457906d279073822a5ceb24c4bfef94ddb_debug
 - local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5
+- local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5_debug
+- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f
+- local_6c_5f1875b9048fb4b8dfd832e74ad31a9aafb38f_debug
+- local_b5_381a457906d279073822a5ceb24c4bfef94ddb
+- local_b5_381a457906d279073822a5ceb24c4bfef94ddb_debug
 - local_crash_C0BCC3F19827FE653058404B2831D9E60_crash_sym
+- local_f1_c3bcc0279865fe3058404b2831d9e64135386c
+- local_f1_c3bcc0279865fe3058404b2831d9e64135386c_debug
+- local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so_sym
+- local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so_sym
+- local_linux-gate_so_75185F6C04B9B48FB8DFD832E74AD31A0_linux-gate_so_sym

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_macos-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_macos-2.snap
@@ -1,0 +1,12 @@
+---
+created: "2019-06-28T09:52:52.193621Z"
+creator: insta@0.8.1
+source: src/actors/symbolication.rs
+expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+---
+- local_9B2A_C56D_107C_3541_A127_9094A751F2C9_app
+- local_crash_67E9247C814E392BA027DBDE6748FCBF0_crash_sym
+- local_67E9_247C_814E_392B_A027_DBDE6748FCBF_app
+- local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dylib_sym
+- local_9B2A_C56D_107C_3541_A127_9094A751F2C9
+- local_67E9_247C_814E_392B_A027_DBDE6748FCBF

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_macos-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_macos-2.snap
@@ -1,12 +1,12 @@
 ---
-created: "2019-06-28T09:52:52.193621Z"
+created: "2019-06-28T10:55:27.188093Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
-expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+expression: "{\n    let mut cache_entries: Vec<_> =\n        fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                            x.unwrap().file_name().into_string().unwrap()).collect();\n    cache_entries.sort();\n    cache_entries\n}"
 ---
+- local_67E9_247C_814E_392B_A027_DBDE6748FCBF
+- local_67E9_247C_814E_392B_A027_DBDE6748FCBF_app
+- local_9B2A_C56D_107C_3541_A127_9094A751F2C9
 - local_9B2A_C56D_107C_3541_A127_9094A751F2C9_app
 - local_crash_67E9247C814E392BA027DBDE6748FCBF0_crash_sym
-- local_67E9_247C_814E_392B_A027_DBDE6748FCBF_app
 - local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dylib_sym
-- local_9B2A_C56D_107C_3541_A127_9094A751F2C9
-- local_67E9_247C_814E_392B_A027_DBDE6748FCBF

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows-2.snap
@@ -1,31 +1,31 @@
 ---
-created: "2019-06-28T09:52:52.279925Z"
+created: "2019-06-28T10:55:27.269322Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
-expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+expression: "{\n    let mut cache_entries: Vec<_> =\n        fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                            x.unwrap().file_name().into_string().unwrap()).collect();\n    cache_entries.sort();\n    cache_entries\n}"
 ---
-- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pd_
-- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dl_
-- local_kernel32_dll_590285E9e0000_kernel32_dl_
-- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pdb
-- local_crash_exe_5AB380779000_crash_exe
-- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_sym
-- local_ntdll_dll_59B0D8F3183000_ntdll_dl_
-- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_sym
-- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pd_
-- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pdb
-- local_dbgcore_dll_57898DAB25000_dbgcore_dll
-- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pd_
-- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_sym
-- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pdb
-- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dll
-- local_kernel32_dll_590285E9e0000_kernel32_dll
 - local_crash_exe_5AB380779000_crash_ex_
-- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pd_
-- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_sym
-- local_ntdll_dll_59B0D8F3183000_ntdll_dll
+- local_crash_exe_5AB380779000_crash_exe
+- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pd_
 - local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pdb
-- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pd_
-- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pdb
+- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_sym
 - local_dbgcore_dll_57898DAB25000_dbgcore_dl_
+- local_dbgcore_dll_57898DAB25000_dbgcore_dll
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pd_
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pdb
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_sym
+- local_kernel32_dll_590285E9e0000_kernel32_dl_
+- local_kernel32_dll_590285E9e0000_kernel32_dll
+- local_ntdll_dll_59B0D8F3183000_ntdll_dl_
+- local_ntdll_dll_59B0D8F3183000_ntdll_dll
+- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dl_
+- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dll
+- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pd_
+- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pdb
 - local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_sym
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pd_
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pdb
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_sym
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pd_
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pdb
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_sym

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows-2.snap
@@ -1,0 +1,31 @@
+---
+created: "2019-06-28T09:52:52.279925Z"
+creator: insta@0.8.1
+source: src/actors/symbolication.rs
+expression: "fs::read_dir(state.config.cache_dir.as_ref().unwrap().join(\"object_meta/global/\")).unwrap().map(|x|\n                                                                                                    x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()"
+---
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pd_
+- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dl_
+- local_kernel32_dll_590285E9e0000_kernel32_dl_
+- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pdb
+- local_crash_exe_5AB380779000_crash_exe
+- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_sym
+- local_ntdll_dll_59B0D8F3183000_ntdll_dl_
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_sym
+- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pd_
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pdb
+- local_dbgcore_dll_57898DAB25000_dbgcore_dll
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pd_
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_sym
+- local_wntdll_pdb_971F98E5CE6041FFB2D7235BBEB345781_wntdll_pdb
+- local_rpcrt4_dll_5A49BB75c1000_rpcrt4_dll
+- local_kernel32_dll_590285E9e0000_kernel32_dll
+- local_crash_exe_5AB380779000_crash_ex_
+- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_pd_
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_sym
+- local_ntdll_dll_59B0D8F3183000_ntdll_dll
+- local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pdb
+- local_dbgcore_pdb_AEC7EF2FDF4B4642A4714C3E5FE8760A1_dbgcore_pd_
+- local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pdb
+- local_dbgcore_dll_57898DAB25000_dbgcore_dl_
+- local_wkernel32_pdb_D347455996F747D6BF43C176B2171E681_wkernel32_sym

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1215,9 +1215,9 @@ impl From<&SymCacheError> for ObjectFileStatus {
 mod tests {
     use super::*;
 
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::{Once, ONCE_INIT};
-    use std::fs;
 
     use failure::Error;
 
@@ -1274,11 +1274,17 @@ mod tests {
 
         let response = get_symbolication_response(&mut sys, &state, request_id)?;
         insta::assert_yaml_snapshot_matches!(response);
-        insta::assert_yaml_snapshot_matches!(
-            fs::read_dir(state.config.cache_dir.as_ref().unwrap().join("object_meta/global/"))
-            .unwrap()
-            .map(|x| x.unwrap().file_name().into_string().unwrap()).collect::<Vec<_>>()
-        );
+        insta::assert_yaml_snapshot_matches!(fs::read_dir(
+            state
+                .config
+                .cache_dir
+                .as_ref()
+                .unwrap()
+                .join("object_meta/global/")
+        )
+        .unwrap()
+        .map(|x| x.unwrap().file_name().into_string().unwrap())
+        .collect::<Vec<_>>());
         Ok(())
     }
 

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1274,17 +1274,23 @@ mod tests {
 
         let response = get_symbolication_response(&mut sys, &state, request_id)?;
         insta::assert_yaml_snapshot_matches!(response);
-        insta::assert_yaml_snapshot_matches!(fs::read_dir(
-            state
-                .config
-                .cache_dir
-                .as_ref()
-                .unwrap()
-                .join("object_meta/global/")
-        )
-        .unwrap()
-        .map(|x| x.unwrap().file_name().into_string().unwrap())
-        .collect::<Vec<_>>());
+
+        insta::assert_yaml_snapshot_matches!({
+            let mut cache_entries: Vec<_> = fs::read_dir(
+                state
+                    .config
+                    .cache_dir
+                    .as_ref()
+                    .unwrap()
+                    .join("object_meta/global/"),
+            )
+            .unwrap()
+            .map(|x| x.unwrap().file_name().into_string().unwrap())
+            .collect();
+
+            cache_entries.sort();
+            cache_entries
+        });
         Ok(())
     }
 

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -133,10 +133,10 @@ fn get_native_path(filetype: FileType, identifier: &ObjectId) -> Option<String> 
             };
 
             Some(format!(
-                "{}.sym/{}/{}",
-                new_debug_file,
+                "{}/{}/{}.sym",
+                debug_file,
                 debug_id.breakpad(),
-                debug_file
+                new_debug_file
             ))
         }
     }


### PR DESCRIPTION
A proper path looks like this: Qt5Core.pdb/6CA082053866490D87E82C42650B67F71/Qt5Core.sym
Before this change a path like this was generated:  Qt5Core.sym/6CA082053866490D87E82C42650B67F71/Qt5Core.pdb