### PR TITLE
ref: Allow to ingest partially symbolicated requests

### DIFF
--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_add_bucket-2.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_add_bucket-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-14T11:25:20.322175Z"
+created: "2019-07-02T13:48:39.151403Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -9,6 +9,7 @@ stacktraces:
   - frames:
       - status: symbolicated
         original_index: 0
+        instruction_addr: 0x100000fa0
         lang: c
         symbol: main
         sym_addr: 0x100000fa0
@@ -16,7 +17,6 @@ stacktraces:
         filename: hello.c
         abs_path: /tmp/hello.c
         lineno: 1
-        instruction_addr: 0x100000fa0
 modules:
   - debug_status: found
     arch: x86_64

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_minidump_windows.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-14T08:44:54.969696Z"
+created: "2019-07-02T13:48:39.243365Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -32,25 +32,25 @@ stacktraces:
     frames:
       - status: symbolicated
         original_index: 0
+        instruction_addr: 0x2a2a3d
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         symbol: main
         sym_addr: 0x2a2910
         function: main
         filename: main.cpp
         abs_path: "c:\\projects\\breakpad-tools\\windows\\crash\\main.cpp"
         lineno: 35
-        instruction_addr: 0x2a2a3d
-        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         trust: context
       - status: symbolicated
         original_index: 1
+        instruction_addr: 0x2a2d96
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         symbol: __scrt_common_main_seh
         sym_addr: 0x2a2c9e
         function: __scrt_common_main_seh
         filename: exe_common.inl
         abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl"
         lineno: 283
-        instruction_addr: 0x2a2d96
-        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         trust: cfi
       - status: missing
         original_index: 2

--- a/src/actors/snapshots/tests__actors::symbolication::tests::test_remove_bucket.snap
+++ b/src/actors/snapshots/tests__actors::symbolication::tests::test_remove_bucket.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-14T08:44:54.885835Z"
+created: "2019-07-02T13:48:39.142460Z"
 creator: insta@0.8.1
 source: src/actors/symbolication.rs
 expression: response
@@ -9,6 +9,7 @@ stacktraces:
   - frames:
       - status: symbolicated
         original_index: 0
+        instruction_addr: 0x100000fa0
         lang: c
         symbol: main
         sym_addr: 0x100000fa0
@@ -16,7 +17,6 @@ stacktraces:
         filename: hello.c
         abs_path: /tmp/hello.c
         lineno: 1
-        instruction_addr: 0x100000fa0
 modules:
   - debug_status: found
     arch: x86_64

--- a/src/types.rs
+++ b/src/types.rs
@@ -374,6 +374,9 @@ impl fmt::Display for Scope {
     }
 }
 
+/// A map of register values.
+pub type Registers = BTreeMap<String, HexValue>;
+
 /// An unsymbolicated frame from a symbolication request.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct RawFrame {
@@ -385,16 +388,51 @@ pub struct RawFrame {
     #[serde(default)]
     pub package: Option<String>,
 
+    /// The language of the symbol (function) this frame is located in.
+    #[serde(skip_serializing_if = "is_default")]
+    pub lang: Option<Language>,
+
+    /// The mangled name of the function this frame is located in.
+    #[serde(skip_serializing_if = "is_default")]
+    pub symbol: Option<String>,
+
+    /// Start address of the function this frame is located in (lower or equal to instruction_addr).
+    #[serde(skip_serializing_if = "is_default")]
+    pub sym_addr: Option<HexValue>,
+
+    /// The demangled function name.
+    #[serde(skip_serializing_if = "is_default")]
+    pub function: Option<String>,
+
+    /// Source file path relative to the compilation directory.
+    #[serde(skip_serializing_if = "is_default")]
+    pub filename: Option<String>,
+
+    /// Absolute source file path.
+    #[serde(skip_serializing_if = "is_default")]
+    pub abs_path: Option<String>,
+
+    /// The line number within the source file, starting at 1 for the first line.
+    #[serde(skip_serializing_if = "is_default")]
+    pub lineno: Option<u32>,
+
     /// Information about how the raw frame was created.
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
     pub trust: FrameTrust,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct RawStacktrace {
     #[serde(default)]
-    pub registers: BTreeMap<String, HexValue>,
+    pub thread_id: Option<u64>,
+
+    #[serde(default)]
+    pub is_requesting: Option<bool>,
+
+    #[serde(default)]
+    pub registers: Registers,
+
     pub frames: Vec<RawFrame>,
 }
 
@@ -464,6 +502,7 @@ impl Default for FrameStatus {
 pub struct SymbolicatedFrame {
     /// Symbolication status of this frame.
     pub status: FrameStatus,
+
     /// The index of this frame in the request.
     ///
     /// This is relevant for two reasons:
@@ -472,28 +511,6 @@ pub struct SymbolicatedFrame {
     ///  2. Frames might expand to multiple inline frames at the same instruction address. However,
     ///     this might occur within recursion, so the instruction address is not a good
     pub original_index: Option<usize>,
-
-    /// The language of the symbol (function) this frame is located in.
-    #[serde(skip_serializing_if = "is_default")]
-    pub lang: Option<Language>,
-    /// The mangled name of the function this frame is located in.
-    #[serde(skip_serializing_if = "is_default")]
-    pub symbol: Option<String>,
-    /// Start address of the function this frame is located in (lower or equal to instruction_addr).
-    #[serde(skip_serializing_if = "is_default")]
-    pub sym_addr: Option<HexValue>,
-    /// The demangled function name.
-    #[serde(skip_serializing_if = "is_default")]
-    pub function: Option<String>,
-    /// Source file path relative to the compilation directory.
-    #[serde(skip_serializing_if = "is_default")]
-    pub filename: Option<String>,
-    /// Absolute source file path.
-    #[serde(skip_serializing_if = "is_default")]
-    pub abs_path: Option<String>,
-    /// The line number within the source file, starting at 1 for the first line.
-    #[serde(skip_serializing_if = "is_default")]
-    pub lineno: Option<u32>,
 
     #[serde(flatten)]
     pub raw: RawFrame,
@@ -520,7 +537,7 @@ pub struct CompleteStacktrace {
     /// Registers, only useful when returning a processed minidump.
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
-    pub registers: BTreeMap<String, HexValue>,
+    pub registers: Registers,
 
     /// Frames of this stack trace.
     pub frames: Vec<SymbolicatedFrame>,


### PR DESCRIPTION
This allows to ingest partially symbolicated stacktraces. The main reason for this are apple crash reports, which already contain function and file names. However, this now also works for JSON payloads (for consistency).

As part of this PR, I restructured the minidump symbolication path. It is still functionally equivalent to what was there before, but split into smaller functions with a clear defined interface. We can take further refactoring from there.