### PR TITLE
fix: Set a hard limit on amount of stacktrace frames

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -899,6 +899,11 @@ impl SymbolicationActor {
                                             package: frame.module().map(CodeModule::code_file),
                                             trust: frame.trust(),
                                         })
+                                        // Trim infinite recursions explicitly because those do not
+                                        // correlate to minidump size. Every other kind of bloated
+                                        // input data we know is already trimmed/rejected by raw
+                                        // byte size alone.
+                                        .take(20000)
                                         .collect(),
                                 }
                             })


### PR DESCRIPTION
We do not have concerns about Symbolicator performance, but Sentry has
issues handling infinitely large responses.