### PR TITLE
fix(timeout): Disable timeouts for all web requests

### DIFF
--- a/src/service/objects/gcs.rs
+++ b/src/service/objects/gcs.rs
@@ -96,6 +96,10 @@ fn request_new_token(
         // for some inexplicable reason we otherwise get gzipped data back that actix-web client has
         // no idea what to do with.
         .header(header::ACCEPT_ENCODING, "identity")
+        // Disable timeouts. The timeout wraps the entire client response future, and
+        // thus also counts the request waiting for getting queued in the connector.
+        // Instead, rely on the outer future's timeout to cancel the request.
+        .timeout(std::time::Duration::from_secs(9999))
         .send_form(&OAuth2Grant {
             grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".into(),
             assertion: auth_jwt,
@@ -181,6 +185,10 @@ pub(super) fn download_from_source(
                         header::AUTHORIZATION,
                         format!("Bearer {}", token.access_token),
                     )
+                    // Disable timeouts. The timeout wraps the entire client response future, and
+                    // thus also counts the request waiting for getting queued in the connector.
+                    // Instead, rely on the outer future's timeout to cancel the request.
+                    .timeout(std::time::Duration::from_secs(9999))
                     .send()
                     .map_err(ObjectError::io)
             })

--- a/src/service/objects/http.rs
+++ b/src/service/objects/http.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use actix_web::http::header;
 use futures::{future, Future, IntoFuture, Stream};
@@ -54,9 +55,12 @@ pub(super) fn download_from_source(
                     }
                 }
 
-                request.header(header::USER_AGENT, USER_AGENT)
-                // TODO(ja): Timeout is only until receiving the response, but not reading the
-                // body. Verify this.
+                request
+                    .header(header::USER_AGENT, USER_AGENT)
+                    // Disable timeouts. The timeout wraps the entire client response future, and
+                    // thus also counts the request waiting for getting queued in the connector.
+                    // Instead, rely on the outer future's timeout to cancel the request.
+                    .timeout(Duration::from_secs(9999))
             }),
         )
     });

--- a/src/service/objects/sentry.rs
+++ b/src/service/objects/sentry.rs
@@ -80,6 +80,10 @@ fn perform_search(
             .get(index_url.as_str())
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::AUTHORIZATION, format!("Bearer {}", token.clone()))
+            // Disable timeouts. The timeout wraps the entire client response future, and
+            // thus also counts the request waiting for getting queued in the connector.
+            // Instead, rely on the outer future's timeout to cancel the request.
+            .timeout(Duration::from_secs(9999))
             .send()
             .map_err(ObjectError::io)
             .and_then(move |mut response| {
@@ -169,8 +173,10 @@ pub(super) fn download_from_source(
             .get(download_url.as_str())
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::AUTHORIZATION, format!("Bearer {}", token))
-            // TODO(ja): Timeout is only until receiving the response, but not reading the
-            // body. Verify this.
+            // Disable timeouts. The timeout wraps the entire client response future, and
+            // thus also counts the request waiting for getting queued in the connector.
+            // Instead, rely on the outer future's timeout to cancel the request.
+            .timeout(Duration::from_secs(9999))
             .send()
     });
 


### PR DESCRIPTION
Fixes a (potential) regression in #106.

The new actix web client no longer wraps the payload stream in the timeout, but the timeout still runs while the request might be pending in the outgoing connector queue. The default timeout is 5s, which would mean that all systems would have to respond within 5s minus the time that it takes for a queued request to be sent. 

We can consider adding a slightly higher timeout of 10s, but I'm currently torn between our options.