### PR TITLE
fix: Avoid panics and improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ name = "actix-files"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
+ "actix-http 0.2.9 (git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,8 +53,8 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "0.2.8"
-source = "git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2#211f1f77bf3bd61629d71b081480a0bc08fe2d9f"
+version = "0.2.9"
+source = "git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0#192dfff6805a9360ee1858419f98f98066ff87c0"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,7 +249,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
+ "actix-http 0.2.9 (git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0)",
  "actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-server 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,7 +365,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
+ "actix-http 0.2.9 (git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2676,7 +2676,7 @@ version = "0.1.0"
 dependencies = [
  "actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-files 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
+ "actix-http 0.2.9 (git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0)",
  "actix-http-test 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-multipart 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3400,7 +3400,7 @@ dependencies = [
 "checksum actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
 "checksum actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "646be02316c497d1cb8b1ed82eb723b052d6b3e2462c94bd52d0ac2d4a29a165"
 "checksum actix-files 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f1e4640b28cd96059541c932f6f350c63c76688e43d68305cdb88e0004da12b5"
-"checksum actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)" = "<none>"
+"checksum actix-http 0.2.9 (git+https://github.com/actix/actix-web?rev=192dfff6805a9360ee1858419f98f98066ff87c0)" = "<none>"
 "checksum actix-http-test 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "beafa31d71c8fa8204ede1602a3dd221e5cf30ff354180f8ee87274ab81cf607"
 "checksum actix-multipart 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cc84406506d76ecb5572f020ee1e529f411c95b579b6ba515f0a52fee0343"
 "checksum actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "23224bb527e204261d0291102cb9b52713084def67d94f7874923baefe04ccf7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ name = "actix-files"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix-http 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 name = "actix-http"
 version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2#211f1f77bf3bd61629d71b081480a0bc08fe2d9f"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -65,7 +65,6 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -250,7 +249,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
  "actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-server 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -366,7 +365,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
  "actix-service 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2677,7 +2676,7 @@ version = "0.1.0"
 dependencies = [
  "actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-files 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-http 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)",
  "actix-http-test 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-multipart 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3401,7 +3400,7 @@ dependencies = [
 "checksum actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
 "checksum actix-connect 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "646be02316c497d1cb8b1ed82eb723b052d6b3e2462c94bd52d0ac2d4a29a165"
 "checksum actix-files 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f1e4640b28cd96059541c932f6f350c63c76688e43d68305cdb88e0004da12b5"
-"checksum actix-http 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4d45d3f033fb7ff73467dad0ef1d12afb532b39953d50f4124f4d89451670583"
+"checksum actix-http 0.2.8 (git+https://github.com/actix/actix-web?branch=bugfix/open-waiting-connection-h2)" = "<none>"
 "checksum actix-http-test 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "beafa31d71c8fa8204ede1602a3dd221e5cf30ff354180f8ee87274ab81cf607"
 "checksum actix-multipart 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cc84406506d76ecb5572f020ee1e529f411c95b579b6ba515f0a52fee0343"
 "checksum actix-router 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "23224bb527e204261d0291102cb9b52713084def67d94f7874923baefe04ccf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ actix-files = "0.1.4"
 actix-http = "0.2.8"
 actix-http-test = "0.2.4"
 insta = "0.10.1"
+
+[patch.crates-io]
+actix-http = { git = "https://github.com/actix/actix-web", branch = "bugfix/open-waiting-connection-h2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,5 @@ actix-http-test = "0.2.4"
 insta = "0.10.1"
 
 [patch.crates-io]
-actix-http = { git = "https://github.com/actix/actix-web", branch = "bugfix/open-waiting-connection-h2" }
+# Waiting for actix-http 0.2.9
+actix-http = { git = "https://github.com/actix/actix-web", rev = "192dfff6805a9360ee1858419f98f98066ff87c0" }

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,28 @@ fn emit_version_var() -> Result<(), io::Error> {
     Ok(())
 }
 
+fn emit_release_var() -> Result<(), io::Error> {
+    let cmd = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .stderr(Stdio::inherit())
+        .output()?;
+
+    if !cmd.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("`git rev-parse' failed: {}", cmd.status),
+        ));
+    }
+
+    let ver = String::from_utf8_lossy(&cmd.stdout);
+
+    println!("cargo:rustc-env=SYMBOLICATOR_RELEASE={}", ver);
+    println!("cargo:rerun-if-changed=.git/index");
+
+    Ok(())
+}
+
 fn main() {
     emit_version_var().ok();
+    emit_release_var().ok();
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ pub fn execute() -> Result<(), CliError> {
 
     let _sentry = sentry::init(sentry::ClientOptions {
         dsn: config.sentry_dsn.clone(),
-        release: Some(env!("SYMBOLICATOR_GIT_VERSION").into()),
+        release: Some(env!("SYMBOLICATOR_RELEASE").into()),
         ..Default::default()
     });
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,7 +82,12 @@ pub fn execute() -> Result<(), CliError> {
     let cli = Cli::from_args();
     let config = Config::get(cli.config())?;
 
-    let _sentry = sentry::init(config.sentry_dsn.clone());
+    let _sentry = sentry::init(sentry::ClientOptions {
+        dsn: config.sentry_dsn.clone(),
+        release: Some(env!("SYMBOLICATOR_GIT_VERSION").into()),
+        ..Default::default()
+    });
+
     logging::init_logging(&config);
     sentry::integrations::panic::register_panic_handler();
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,7 @@ use std::io::{self, Write};
 use chrono::{DateTime, Utc};
 use failure::AsFail;
 use log::{Level, LevelFilter};
-use sentry::integrations::log as sentry_log;
+use sentry::integrations::log::{breadcrumb_from_record, event_from_record};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{Config, LogFormat};
@@ -86,6 +86,42 @@ fn json_logger() -> env_logger::Builder {
     builder
 }
 
+/// A delegating logger that also logs breadcrumbs.
+pub struct BreadcrumbLogger<L> {
+    inner: L,
+}
+
+impl<L> BreadcrumbLogger<L> {
+    /// Initializes a new breadcrumb logger.
+    pub fn new(inner: L) -> Self {
+        Self { inner }
+    }
+}
+
+impl<L> log::Log for BreadcrumbLogger<L>
+where
+    L: log::Log,
+{
+    fn enabled(&self, md: &log::Metadata<'_>) -> bool {
+        self.inner.enabled(md)
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.inner.enabled(record.metadata()) {
+            if record.level() == log::Level::Error {
+                sentry::capture_event(event_from_record(record, false));
+            }
+
+            sentry::add_breadcrumb(|| breadcrumb_from_record(record));
+            self.inner.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
 /// Initializes logging for the symbolicator.
 ///
 /// This considers the `RUST_LOG` environment variable and defaults it to the level specified in the
@@ -112,16 +148,11 @@ pub fn init_logging(config: &Config) {
         Err(_) => builder.filter_level(config.logging.level),
     };
 
-    let logger = Box::new(builder.build());
-    let global_filter = logger.filter();
+    let logger = builder.build();
+    log::set_max_level(logger.filter());
 
-    sentry_log::init(
-        Some(logger),
-        sentry_log::LoggerOptions {
-            global_filter: Some(global_filter),
-            ..Default::default()
-        },
-    );
+    let breadcrumb_logger = Box::new(BreadcrumbLogger::new(logger));
+    log::set_boxed_logger(breadcrumb_logger).unwrap();
 }
 
 /// Returns whether backtrace printing is enabled.

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,7 @@ use crate::metrics;
 use crate::middleware;
 use crate::service::Service;
 
-/// Errors t
+/// Variants of `ServerError`.
 #[derive(Clone, Copy, Debug, Fail)]
 pub enum ServerErrorKind {
     /// Failed to bind to a port.

--- a/src/service/cache.rs
+++ b/src/service/cache.rs
@@ -5,10 +5,10 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
-use futures::future::{lazy, Future, IntoFuture, Shared};
+use futures::future::{self, Future, Shared};
 use futures::sync::oneshot;
 use parking_lot::RwLock;
-use sentry::{configure_scope, Hub};
+use sentry::Hub;
 use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 
@@ -90,18 +90,22 @@ pub trait CacheItemRequest: 'static + Send {
 }
 
 impl<T: CacheItemRequest> Cacher<T> {
-    fn lookup_cache(&self, request: &T) -> Result<Option<T::Item>, T::Error> {
+    /// Look up an item in the file system cache and load it if available.
+    fn lookup_cache(
+        &self,
+        request: &T,
+        key: &CacheKey,
+        path: &Path,
+    ) -> Result<Option<T::Item>, T::Error> {
         let name = self.config.name();
-        let key = request.get_cache_key();
+        sentry::configure_scope(|scope| {
+            scope.set_extra(
+                &format!("cache.{}.cache_path", name),
+                format!("{:?}", path).into(),
+            );
+        });
 
-        let path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
-
-        let path = match path {
-            Some(x) => x,
-            None => return Ok(None),
-        };
-
-        let byteview = match self.config.open_cachefile(&path)? {
+        let byteview = match self.config.open_cachefile(path)? {
             Some(x) => x,
             None => return Ok(None),
         };
@@ -116,135 +120,137 @@ impl<T: CacheItemRequest> Cacher<T> {
         // This is also reported for "negative cache hits": When we cached the 404 response from a
         // server as empty file.
         metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
-
         metric!(
             time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
             "hit" => "true"
         );
 
-        configure_scope(|scope| {
-            scope.set_extra(
-                &format!("cache.{}.cache_path", name),
-                format!("{:?}", path).into(),
-            );
-        });
-
         log::trace!("Loading {} at path {:?}", name, path);
-
-        let item = request.load(key.scope, status, byteview);
+        let item = request.load(key.scope.clone(), status, byteview);
         Ok(Some(item))
     }
 
+    /// Compute an item.
+    ///
+    /// If the item is in the file system cache, it is returned immediately. Otherwise, it is
+    /// computed using `T::compute`, and then persisted to the cache.
+    fn compute(
+        &self,
+        request: T,
+        key: CacheKey,
+    ) -> Box<dyn Future<Item = T::Item, Error = T::Error>> {
+        let cache_path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
+        if let Some(ref path) = cache_path {
+            if let Some(item) = tryf!(self.lookup_cache(&request, &key, &path)) {
+                return Box::new(future::ok(item));
+            }
+        }
+
+        let name = self.config.name();
+        let key = request.get_cache_key();
+
+        // A file was not found. If this spikes, it's possible that the filesystem cache
+        // just got pruned.
+        metric!(counter(&format!("caches.{}.file.miss", name)) += 1);
+
+        let temp_file = if let Some(ref path) = cache_path {
+            let dir = path.parent().unwrap();
+            tryf!(fs::create_dir_all(dir));
+            tryf!(NamedTempFile::new_in(dir))
+        } else {
+            tryf!(NamedTempFile::new())
+        };
+
+        let future = request.compute(temp_file.path()).and_then(move |status| {
+            if let Some(ref cache_path) = cache_path {
+                sentry::configure_scope(|scope| {
+                    scope.set_extra(
+                        &format!("cache.{}.cache_path", name),
+                        cache_path.to_string_lossy().into(),
+                    );
+                });
+
+                log::trace!("Creating {} at path {:?}", name, cache_path);
+            }
+
+            let byteview = ByteView::open(temp_file.path())?;
+
+            metric!(
+                counter(&format!("caches.{}.file.write", name)) += 1,
+                "status" => status.as_ref(),
+            );
+            metric!(
+                time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
+                "hit" => "false"
+            );
+
+            let item = request.load(key.scope.clone(), status, byteview);
+            if let Some(ref cache_path) = cache_path {
+                status.persist_item(cache_path, temp_file)?;
+            }
+
+            Ok(item)
+        });
+
+        Box::new(future)
+    }
+
+    /// Creates a shareable channel that computes an item.
+    fn create_channel(&self, request: T, key: CacheKey) -> ComputationChannel<T::Item, T::Error> {
+        let (sender, receiver) = oneshot::channel();
+
+        let slf = self.clone();
+        let current_computations = self.current_computations.clone();
+
+        // Run the computation and wrap the result in Arcs to make them clonable.
+        let channel = future::lazy(clone!(key, || slf.compute(request, key)))
+            .then(move |result| {
+                current_computations.write().remove(&key);
+                sender
+                    .send(match result {
+                        Ok(item) => Ok(Arc::new(item)),
+                        Err(error) => Err(Arc::new(error)),
+                    })
+                    .map_err(|_| ())
+            })
+            .bind_hub(Hub::new_from_top(Hub::main()));
+
+        actix_rt::spawn(channel);
+        receiver.shared()
+    }
+
+    /// Computes an item by loading from or populating the cache.
+    ///
+    /// The actual computation is deduplicated between concurrent requests. Finally, the result is
+    /// inserted into the cache and all subsequent calls fetch from the cache.
     pub fn compute_memoized(
         &self,
         request: T,
     ) -> Box<dyn Future<Item = Arc<T::Item>, Error = Arc<T::Error>>> {
         let key = request.get_cache_key();
         let name = self.config.name();
-        let current_computations = &self.current_computations;
 
-        if let Some(channel) = current_computations.read().get(&key) {
+        let current_computations = &self.current_computations;
+        let channel_opt = current_computations.read().get(&key).cloned();
+
+        let channel = if let Some(channel) = channel_opt {
             // A concurrent cache lookup was deduplicated.
             metric!(counter(&format!("caches.{}.channel.hit", name)) += 1);
+            channel.clone()
+        } else {
+            // A concurrent cache lookup is considered new. This does not imply a cache miss.
+            metric!(counter(&format!("caches.{}.channel.miss", name)) += 1);
+            let channel = self.create_channel(request, key.clone());
+            current_computations
+                .write()
+                .insert(key.clone(), channel.clone());
+            channel
+        };
 
-            let future = channel
-                .clone()
-                .map_err(|_| {
-                    panic!("Oneshot channel cancelled! Race condition or system shutting down")
-                })
-                .and_then(|result| (*result).clone());
+        let future = channel
+            .map_err(move |_| panic!("{} computation channel dropped", name))
+            .and_then(|shared| (*shared).clone());
 
-            return Box::new(future);
-        }
-
-        // A concurrent cache lookup is considered new. This does not imply a full cache miss.
-        metric!(counter(&format!("caches.{}.channel.miss", name)) += 1);
-
-        let (tx, rx) = oneshot::channel();
-
-        let slf = (*self).clone();
-
-        let compute_future = lazy(clone!(key, || {
-            if let Some(item) = tryf!(slf.lookup_cache(&request)) {
-                return Box::new(Ok(item).into_future());
-            }
-
-            // A file was not found. If this spikes, it's possible that the filesystem cache
-            // just got pruned.
-            metric!(counter(&format!("caches.{}.file.miss", name)) += 1);
-
-            let cache_path = get_scope_path(slf.config.cache_dir(), &key.scope, &key.cache_key);
-
-            let temp_file = if let Some(ref path) = cache_path {
-                let dir = path.parent().unwrap();
-                tryf!(fs::create_dir_all(dir));
-                tryf!(NamedTempFile::new_in(dir))
-            } else {
-                tryf!(NamedTempFile::new())
-            };
-
-            let future = request.compute(temp_file.path()).and_then(move |status| {
-                if let Some(ref cache_path) = cache_path {
-                    configure_scope(|scope| {
-                        scope.set_extra(
-                            &format!("cache.{}.cache_path", name),
-                            format!("{:?}", cache_path).into(),
-                        );
-                    });
-
-                    log::trace!("Creating {} at path {:?}", name, cache_path);
-                }
-
-                let byteview = tryf!(ByteView::open(temp_file.path()));
-
-                metric!(
-                    counter(&format!("caches.{}.file.write", name)) += 1,
-                    "status" => status.as_ref(),
-                );
-
-                metric!(
-                    time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
-                    "hit" => "false"
-                );
-
-                let item = request.load(key.scope.clone(), status, byteview);
-
-                if let Some(ref cache_path) = cache_path {
-                    tryf!(status.persist_item(cache_path, temp_file));
-                }
-
-                Box::new(Ok(item).into_future())
-            });
-
-            Box::new(future) as Box<dyn Future<Item = T::Item, Error = T::Error>>
-        }));
-
-        let compute_future = compute_future
-            .then(clone!(key, current_computations, |result| {
-                current_computations.write().remove(&key);
-                tx.send(match result {
-                    Ok(x) => Ok(Arc::new(x)),
-                    Err(e) => Err(Arc::new(e)),
-                })
-                .map_err(|_| ())
-                .into_future()
-            }))
-            .bind_hub(Hub::new_from_top(Hub::main()));
-
-        actix_rt::spawn(compute_future);
-
-        let channel = rx.shared();
-
-        self.current_computations
-            .write()
-            .insert(key.clone(), channel.clone());
-
-        let item_future = channel
-            .map_err(|_| {
-                panic!("Oneshot channel cancelled! Race condition or system shutting down")
-            })
-            .and_then(|result| (*result).clone());
-
-        Box::new(item_future)
+        Box::new(future)
     }
 }

--- a/src/service/cficaches.rs
+++ b/src/service/cficaches.rs
@@ -5,10 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::{
-    future::{Either, IntoFuture},
-    Future,
-};
+use futures::{future, future::Either, Future};
 use sentry::integrations::failure::capture_fail;
 use sentry::{configure_scope, Hub};
 use symbolic::{common::ByteView, minidump::cfi::CfiCache};
@@ -207,16 +204,13 @@ impl CfiCacheActor {
                     }))
                 })
                 .unwrap_or_else(move || {
-                    Either::B(
-                        Ok(Arc::new(CfiCacheFile {
-                            object_type,
-                            identifier,
-                            scope,
-                            data: ByteView::from_slice(b""),
-                            status: CacheStatus::Negative,
-                        }))
-                        .into_future(),
-                    )
+                    Either::B(future::ok(Arc::new(CfiCacheFile {
+                        object_type,
+                        identifier,
+                        scope,
+                        data: ByteView::from_slice(b""),
+                        status: CacheStatus::Negative,
+                    })))
                 })
         })
     }

--- a/src/service/objects/filesystem.rs
+++ b/src/service/objects/filesystem.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io;
 use std::sync::Arc;
 
-use futures::{Future, IntoFuture};
+use futures::{future, Future};
 
 use crate::service::objects::common::{prepare_download_paths, DownloadPath};
 use crate::service::objects::{DownloadStream, FileId, ObjectError, ObjectErrorKind};
@@ -22,7 +22,7 @@ pub(super) fn prepare_downloads(
     .map(|download_path| FileId::Filesystem(source.clone(), download_path))
     .collect();
 
-    Box::new(Ok(ids).into_future())
+    Box::new(future::ok(ids))
 }
 
 pub(super) fn download_from_source(
@@ -40,5 +40,5 @@ pub(super) fn download_from_source(
         },
     };
 
-    Box::new(res.into_future())
+    Box::new(future::result(res))
 }

--- a/src/service/objects/http.rs
+++ b/src/service/objects/http.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use actix_web::http::header;
-use futures::{future, Future, IntoFuture, Stream};
+use futures::{future, Future, Stream};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 
@@ -27,7 +27,7 @@ pub(super) fn prepare_downloads(
     .map(|download_path| FileId::Http(source.clone(), download_path))
     .collect();
 
-    Box::new(Ok(ids).into_future())
+    Box::new(future::ok(ids))
 }
 
 pub(super) fn download_from_source(

--- a/src/service/objects/s3.rs
+++ b/src/service/objects/s3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::BytesMut;
-use futures::{future::IntoFuture, Future, Stream};
+use futures::{future, Future, Stream};
 use parking_lot::Mutex;
 use rusoto_s3::S3;
 use tokio::codec::{BytesCodec, FramedRead};
@@ -62,7 +62,7 @@ pub(super) fn prepare_downloads(
     )
     .map(|download_path| FileId::S3(source.clone(), download_path))
     .collect();
-    Box::new(Ok(ids).into_future())
+    Box::new(future::ok(ids))
 }
 
 pub(super) fn download_from_source(

--- a/src/service/symbolication.rs
+++ b/src/service/symbolication.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use apple_crash_report_parser::AppleCrashReport;
 use failure::Fail;
-use futures::future::{self, join_all, Either, Future, IntoFuture, Shared, SharedError};
+use futures::future::{self, join_all, Either, Future, IntoFuture, Shared};
 use futures::sync::oneshot;
 use parking_lot::RwLock;
 use sentry::integrations::failure::capture_fail;
@@ -143,12 +143,9 @@ impl SymbolicationActor {
         timeout: Option<u64>,
         channel: ComputationChannel,
     ) -> impl Future<Item = SymbolicationResponse, Error = SymbolicationError> {
-        let rv =
-            channel
-                .map(|item| (*item).clone())
-                .map_err(|_: SharedError<oneshot::Canceled>| {
-                    SymbolicationErrorKind::CanceledChannel.into()
-                });
+        let rv = channel
+            .map(|item| (*item).clone())
+            .map_err(|_| SymbolicationErrorKind::CanceledChannel.into());
 
         let requests = &self.requests;
 

--- a/src/service/symcaches.rs
+++ b/src/service/symcaches.rs
@@ -5,10 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::{
-    future::{Either, IntoFuture},
-    Future,
-};
+use futures::{future, future::Either, Future};
 use sentry::integrations::failure::capture_fail;
 use sentry::{configure_scope, Hub};
 use symbolic::common::{Arch, ByteView};
@@ -220,17 +217,14 @@ impl SymCacheActor {
                     }))
                 })
                 .unwrap_or_else(move || {
-                    Either::B(
-                        Ok(Arc::new(SymCacheFile {
-                            object_type,
-                            identifier,
-                            scope,
-                            data: ByteView::from_slice(b""),
-                            status: CacheStatus::Negative,
-                            arch: Arch::Unknown,
-                        }))
-                        .into_future(),
-                    )
+                    Either::B(future::ok(Arc::new(SymCacheFile {
+                        object_type,
+                        identifier,
+                        scope,
+                        data: ByteView::from_slice(b""),
+                        status: CacheStatus::Negative,
+                        arch: Arch::Unknown,
+                    })))
                 })
         })
     }

--- a/src/utils/multipart.rs
+++ b/src/utils/multipart.rs
@@ -3,7 +3,7 @@ use std::io::{Seek, SeekFrom, Write};
 
 use actix_multipart::Field;
 use actix_web::{error, Error};
-use futures::{future, Future, IntoFuture, Stream};
+use futures::{future, Future, Stream};
 use sentry::Hub;
 
 use crate::types::SourceConfig;
@@ -32,8 +32,7 @@ pub fn read_multipart_file(
     field: Field,
     threadpool: ThreadPool,
 ) -> impl Future<Item = File, Error = Error> {
-    tempfile::tempfile()
-        .into_future()
+    future::result(tempfile::tempfile())
         .map_err(Error::from)
         .and_then(clone!(threadpool, |file| {
             field


### PR DESCRIPTION
Fixes a bunch of issues:

 - **Fix panics in HTTP2 connections**
 - Replaces the `sentry` log integration logger with a custom one to capture breadcrumbs only for logs that pass `RUST_LOG`.
 - Fixes race conditions in deduplication channels in the symbolication service and cacher.
 - Fixes hub propagation for symbolication requests
 - Logs errors in the symbolication error with stack traces.