### PR TITLE
feat(config): Default cache_dir to /data on Docker

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,15 +29,15 @@ settings in this case.
 Write this to a file (`config.yml`):
 
 ```yaml
-cache_dir: '/tmp/symbolicator'
-bind: '0.0.0.0:3021'
+cache_dir: "/tmp/symbolicator"
+bind: "0.0.0.0:3021"
 logging:
-  level: 'info'
-  format: 'pretty'
+  level: "info"
+  format: "pretty"
   enable_backtraces: true
 metrics:
-  statsd: '127.0.0.1:8125'
-  prefix: 'symbolicator'
+  statsd: "127.0.0.1:8125"
+  prefix: "symbolicator"
 ```
 
 - `cache_dir`: Path to a directory to cache downloaded files and symbolication
@@ -46,18 +46,18 @@ metrics:
   strictly recommended to configure caches in production!**
 - `bind`: Host and port for HTTP interface.
 - `logging`: Command line logging behavior.
-  - `level`: Log level, defaults to `info`. Can be one of `off`, `error`,
-    `warn`, `info`, `debug`, or `trace`.
-  - `format`: The format with which to print logs. Defaults to `auto`. Can be
-    one of: `json`, `simplified`, `pretty`, or `auto` (pretty on console,
-    simplified on tty).
-  - `enable_backtraces`: Whether backtraces for errors should be computed. This
-    causes a slight performance hit but improves debuggability. Defaults to
-    `true`.
+    - `level`: Log level, defaults to `info`. Can be one of `off`, `error`,
+      `warn`, `info`, `debug`, or `trace`.
+    - `format`: The format with which to print logs. Defaults to `auto`. Can be
+      one of: `json`, `simplified`, `pretty`, or `auto` (pretty on console,
+      simplified on tty).
+    - `enable_backtraces`: Whether backtraces for errors should be computed. This
+      causes a slight performance hit but improves debuggability. Defaults to
+      `true`.
 - `metrics`: Configure a statsd server to send metrics to.
-  - `statsd`: The host and port to send metrics to. Defaults to `null`, which
-    disables metric submission.
-  - `prefix`: A prefix for every metric, defaults to `symbolicator`.
+    - `statsd`: The host and port to send metrics to. Defaults to `null`, which
+      disables metric submission.
+    - `prefix`: A prefix for every metric, defaults to `symbolicator`.
 - `sentry_dsn`: DSN to a Sentry project for internal error reporting. Defaults
   to `null`, which disables reporting to Sentry.
 - `sources`: An optional list of preconfigured sources. If these are configured

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,34 +29,35 @@ settings in this case.
 Write this to a file (`config.yml`):
 
 ```yaml
-cache_dir: "/tmp/symbolicator"
-bind: "0.0.0.0:3021"
+cache_dir: '/tmp/symbolicator'
+bind: '0.0.0.0:3021'
 logging:
-  level: "info"
-  format: "pretty"
+  level: 'info'
+  format: 'pretty'
   enable_backtraces: true
 metrics:
-  statsd: "127.0.0.1:8125"
-  prefix: "symbolicator"
+  statsd: '127.0.0.1:8125'
+  prefix: 'symbolicator'
 ```
 
 - `cache_dir`: Path to a directory to cache downloaded files and symbolication
-  caches. Defaults to `null`, which disables caching. **It is strictly
-  recommended to configure caches in production!**
+  caches. Defaults to `/data` inside Docker which is already defined as a
+  persistent volume, and `null` otherwise, which disables caching. **It is
+  strictly recommended to configure caches in production!**
 - `bind`: Host and port for HTTP interface.
 - `logging`: Command line logging behavior.
-    - `level`: Log level, defaults to `info`. Can be one of `off`, `error`,
-      `warn`, `info`, `debug`, or `trace`.
-    - `format`: The format with which to print logs. Defaults to `auto`. Can be
-      one of: `json`, `simplified`, `pretty`, or `auto` (pretty on console,
-      simplified on tty).
-    - `enable_backtraces`: Whether backtraces for errors should be computed. This
-      causes a slight performance hit but improves debuggability. Defaults to
-      `true`.
+  - `level`: Log level, defaults to `info`. Can be one of `off`, `error`,
+    `warn`, `info`, `debug`, or `trace`.
+  - `format`: The format with which to print logs. Defaults to `auto`. Can be
+    one of: `json`, `simplified`, `pretty`, or `auto` (pretty on console,
+    simplified on tty).
+  - `enable_backtraces`: Whether backtraces for errors should be computed. This
+    causes a slight performance hit but improves debuggability. Defaults to
+    `true`.
 - `metrics`: Configure a statsd server to send metrics to.
-    - `statsd`: The host and port to send metrics to. Defaults to `null`, which
-      disables metric submission.
-    - `prefix`: A prefix for every metric, defaults to `symbolicator`.
+  - `statsd`: The host and port to send metrics to. Defaults to `null`, which
+    disables metric submission.
+  - `prefix`: A prefix for every metric, defaults to `symbolicator`.
 - `sentry_dsn`: DSN to a Sentry project for internal error reporting. Defaults
   to `null`, which disables reporting to Sentry.
 - `sources`: An optional list of preconfigured sources. If these are configured

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,10 +191,10 @@ fn default_bind() -> String {
 }
 
 /// Default value for the "cache_dir" configuration.
-fn default_cache_dir() -> String {
+fn default_cache_dir() -> Option<PathBuf> {
     if is_docker() {
         // Docker image alread defines /data as a persistent volume
-        "/data".to_owned()
+        Some(PathBuf::from("/data"))
     } else {
         None
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,7 +193,7 @@ fn default_bind() -> String {
 /// Default value for the "cache_dir" configuration.
 fn default_cache_dir() -> Option<PathBuf> {
     if is_docker() {
-        // Docker image alread defines /data as a persistent volume
+        // Docker image already defines `/data` as a persistent volume
         Some(PathBuf::from("/data"))
     } else {
         None

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,10 +190,20 @@ fn default_bind() -> String {
     }
 }
 
+/// Default value for the "cache_dir" configuration.
+fn default_cache_dir() -> String {
+    if is_docker() {
+        // Docker image alread defines /data as a persistent volume
+        "/data".to_owned()
+    } else {
+        None
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Config {
-            cache_dir: None,
+            cache_dir: default_cache_dir(),
             bind: default_bind(),
             logging: Logging::default(),
             metrics: Metrics::default(),


### PR DESCRIPTION
On our Docker images, we already define `/data` as a persistent volume, even more, it is quite tricky to mount a new cache directory as a volume with the right symbolicator user so make that the default on Docker. This also allows us to run symbolicator with the default config in getsentry/onpremise#220.