### PR TITLE
feat: Extract proper reason from Apple Crash Reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -153,7 +153,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -269,7 +269,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -314,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -600,7 +600,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -615,7 +615,7 @@ dependencies = [
  "encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -787,7 +787,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -798,7 +798,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -822,7 +822,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -961,7 +961,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1965,7 +1965,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2187,18 +2187,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2307,7 +2307,7 @@ dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2445,7 +2445,7 @@ dependencies = [
  "libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry-types 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2693,7 +2693,7 @@ dependencies = [
  "pdb 0.5.0 (git+https://github.com/jan-auer/pdb?rev=ae705e37355c794b844a12f6ceaf9ed12cb17114)",
  "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2721,7 +2721,7 @@ dependencies = [
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "symbolic-common 6.1.4 (git+https://github.com/getsentry/symbolic?rev=cbba9e6c3288d3a5c2ac9e60944c2bf9dacb5d0a)",
  "symbolic-debuginfo 6.1.4 (git+https://github.com/getsentry/symbolic?rev=cbba9e6c3288d3a5c2ac9e60944c2bf9dacb5d0a)",
@@ -2771,6 +2771,7 @@ dependencies = [
  "lru 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3702,8 +3703,8 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
-"checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
-"checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
+"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ jsonwebtoken = { git = "https://github.com/Keats/jsonwebtoken", rev = "b8627260b
 base64 = "0.10.1"
 ipnetwork = "0.14.0"
 smallvec = "0.6.10"
+regex = "1.3.1"
 
 [dev-dependencies]
 actix-files = "0.1.4"

--- a/src/service/snapshots/tests__apple_crash_report.snap
+++ b/src/service/snapshots/tests__apple_crash_report.snap
@@ -5,13 +5,14 @@ expression: response
 status: completed
 timestamp: 1547055742
 system_info:
-  os_name: Mac OS X 10.14.0 (18A391)
-  os_version: ""
-  os_build: ""
+  os_name: macOS
+  os_version: 10.14.0
+  os_build: 18A391
   cpu_arch: x86_64
   device_model: "MacBookPro14,3"
 crashed: true
-crash_reason: "objc_msgSend() selector name: respondsToSelector:\n  more information here"
+crash_reason: SIGSEGV
+crash_details: "objc_msgSend() selector name: respondsToSelector:\n  more information here"
 stacktraces:
   - thread_id: 0
     is_requesting: false

--- a/src/service/symbolication.rs
+++ b/src/service/symbolication.rs
@@ -1131,7 +1131,6 @@ impl SymbolicationActor {
                 slf.stackwalk_minidump_with_cfi(scope, minidump, sources, cfi_caches)
             })
             .timeout(Duration::from_secs(1200), || {
-                println!("do stackwalk timeout");
                 SymbolicationErrorKind::Timeout
             })
             .measure("minidump_stackwalk");

--- a/src/service/symbolication.rs
+++ b/src/service/symbolication.rs
@@ -10,6 +10,7 @@ use failure::Fail;
 use futures::future::{self, join_all, Either, Future, Shared};
 use futures::sync::oneshot;
 use parking_lot::Mutex;
+use regex::Regex;
 use sentry::integrations::failure::capture_fail;
 use sentry::Hub;
 use symbolic::common::{Arch, ByteView, CodeId, DebugId, InstructionInfo, Language, SelfCell};
@@ -46,6 +47,11 @@ const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions {
 
 /// The maximum delay we allow for polling a finished request before dropping it.
 const MAX_POLL_DELAY: Duration = Duration::from_secs(90);
+
+lazy_static::lazy_static! {
+    /// Format sent by Unreal Engine on macOS
+    static ref OS_MACOS_REGEX: Regex = Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap();
+}
 
 /// Variants of `SymbolicationError`.
 #[derive(Debug, Fail)]
@@ -1170,7 +1176,8 @@ impl SymbolicationActor {
 struct AppleCrashReportState {
     timestamp: Option<u64>,
     system_info: SystemInfo,
-    app_info: Option<String>,
+    crash_reason: Option<String>,
+    crash_details: Option<String>,
 }
 
 impl AppleCrashReportState {
@@ -1186,7 +1193,8 @@ impl AppleCrashReportState {
 
         response.timestamp = self.timestamp;
         response.system_info = Some(self.system_info);
-        response.crash_reason = self.app_info;
+        response.crash_reason = self.crash_reason;
+        response.crash_details = self.crash_details;
         response.crashed = Some(true);
     }
 }
@@ -1218,7 +1226,8 @@ impl SymbolicationActor {
         file: Bytes,
         sources: Vec<SourceConfig>,
     ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), SymbolicationError> {
-        let mut report = AppleCrashReport::from_reader(&file[..])?;
+        let report = AppleCrashReport::from_reader(&file[..])?;
+        let mut metadata = report.metadata;
 
         let arch = report
             .code_type
@@ -1269,15 +1278,38 @@ impl SymbolicationActor {
             stacktraces,
         };
 
+        let mut system_info = SystemInfo {
+            os_name: metadata.remove("OS Version").unwrap_or_default(),
+            device_model: metadata.remove("Hardware Model").unwrap_or_default(),
+            cpu_arch: arch,
+            ..SystemInfo::default()
+        };
+
+        if let Some(captures) = OS_MACOS_REGEX.captures(&system_info.os_name) {
+            system_info.os_version = captures
+                .name("version")
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            system_info.os_build = captures
+                .name("build")
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            system_info.os_name = "macOS".to_string();
+        }
+
+        // https://developer.apple.com/library/archive/technotes/tn2151/_index.html
+        let crash_reason = metadata.remove("Exception Type");
+        let crash_details = report
+            .application_specific_information
+            .or_else(|| metadata.remove("Exception Message"))
+            .or_else(|| metadata.remove("Exception Subtype"))
+            .or_else(|| metadata.remove("Exception Codes"));
+
         let state = AppleCrashReportState {
             timestamp: report.timestamp.map(|t| t.timestamp() as u64),
-            system_info: SystemInfo {
-                os_name: report.metadata.remove("OS Version").unwrap_or_default(),
-                device_model: report.metadata.remove("Hardware Model").unwrap_or_default(),
-                cpu_arch: arch,
-                ..SystemInfo::default()
-            },
-            app_info: report.application_specific_information,
+            system_info,
+            crash_reason,
+            crash_details,
         };
 
         Ok((request, state))

--- a/src/types.rs
+++ b/src/types.rs
@@ -717,6 +717,11 @@ pub struct CompletedSymbolicationResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub crash_reason: Option<String>,
 
+    /// A detailed explanation of the crash, potentially in human readable form. This may
+    /// include a string representation of the crash reason or application-specific info.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crash_details: Option<String>,
+
     /// If there was an assertion that was hit, a textual representation of that assertion,
     /// possibly including the file and line at which it occurred.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/integration/test_applecrashreport.py
+++ b/tests/integration/test_applecrashreport.py
@@ -1,7 +1,8 @@
 import json
 
 APPLE_CRASH_REPORT_SUCCESS = {
-    "crash_reason": "objc_msgSend() selector name: respondsToSelector:\n"
+    "crash_reason": "SIGSEGV",
+    "crash_details": "objc_msgSend() selector name: respondsToSelector:\n"
     "  more information here",
     "crashed": True,
     "modules": [
@@ -215,9 +216,9 @@ APPLE_CRASH_REPORT_SUCCESS = {
     "system_info": {
         "cpu_arch": "x86_64",
         "device_model": "MacBookPro14,3",
-        "os_build": "",
-        "os_name": "Mac OS X 10.14.0 (18A391)",
-        "os_version": "",
+        "os_build": "18A391",
+        "os_name": "macOS",
+        "os_version": "10.14.0",
     },
     "timestamp": 1547055742,
 }


### PR DESCRIPTION
Many AppleCrashReports do not have application specific information, but they specify an exception type and subdata. We can leverage this to populate the crash reason and details.
