### PR TITLE
fix(sentry): Set the correct sentry release

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,28 @@ fn emit_version_var() -> Result<(), io::Error> {
     Ok(())
 }
 
+fn emit_release_var() -> Result<(), io::Error> {
+    let cmd = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .stderr(Stdio::inherit())
+        .output()?;
+
+    if !cmd.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("`git rev-parse' failed: {}", cmd.status),
+        ));
+    }
+
+    let ver = String::from_utf8_lossy(&cmd.stdout);
+
+    println!("cargo:rustc-env=SYMBOLICATOR_RELEASE={}", ver);
+    println!("cargo:rerun-if-changed=.git/index");
+
+    Ok(())
+}
+
 fn main() {
     emit_version_var().ok();
+    emit_release_var().ok();
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,7 +118,12 @@ fn execute() -> Result<(), CliError> {
     let cli = Cli::from_args();
     let config = Config::get(cli.config())?;
 
-    let _sentry = sentry::init(config.sentry_dsn.clone());
+    let _sentry = sentry::init(sentry::ClientOptions {
+        dsn: config.sentry_dsn.clone(),
+        release: Some(env!("SYMBOLICATOR_RELEASE").into()),
+        ..Default::default()
+    });
+
     logging::init_logging(&config);
     sentry::integrations::panic::register_panic_handler();
 


### PR DESCRIPTION
Release information is currently not available in Sentry. This ensures that the release field is properly set to the commit hash.