### PR TITLE
ci(travis): Fix Rust caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ before_install:
   - export PATH=~/.cargo/bin/:$PATH
 
 cache:
-  cargo: true
+  directories:
+    - $HOME/.cargo
+    - $TRAVIS_BUILD_DIR/target
 
 git:
   depth: 1


### PR DESCRIPTION
Caches were not working for symbolicator on Travis. 

I believe `cache: cargo` only works if the language is set to `rust`. In our case, we use `python` so that we can run integration tests. Build times are around 11 minutes for tests at the moment, and I believe we can bring them down to roughly 4 minutes with caches.

Example: https://travis-ci.com/getsentry/symbolicator/jobs/242364591