### PR TITLE
build(docker): Revert to debian stretch-slim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ branches:
   only:
     - master
     - /^release\/[\d.]+$/
+    - /^deploy\/.*$/
 
 matrix:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM rust:slim-buster AS symbolicator-build
+FROM rust:slim-stretch AS symbolicator-build
 
 WORKDIR /work
 
@@ -30,7 +30,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:buster-slim
+FROM debian:stretch-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There is a suspected regression in OpenSSL `1.1.1c` used on Debian buster-slim that might cause a memory leak. We suspect that this might have to do with HTTP2 connections, but it has not been confirmed yet.

cc @BYK 