### PR TITLE
feat: Added debuginfod and unified support

### DIFF
--- a/docs/advanced/symbol-server-compatibility.md
+++ b/docs/advanced/symbol-server-compatibility.md
@@ -12,6 +12,7 @@ structures:
 - LLDB File Mapped UUID Directories
 - GDB Build ID Directories
 - debuginfod
+- Unified Symbol Server Layout
 
 ## Prerequisites
 
@@ -218,6 +219,29 @@ compatible servers for ELF and Macho.
 - **ELF** (debug info): `<code_note_byte_sequence>/debuginfo`
 - **MachO** (binary): `<uuid_bytes>/executable`
 - **MachO** (dSYM): `<uuid_bytes>/debuginfo`
+
+### unified
+
+If you have no requirements to be compatible with another system you can also
+use the "unified" directory layout structure. This has the advantage that it's
+unified across all platforms and thus easier to manage. It can store breakpad
+files, PDBs, PEs and everything else.
+
+**Schema**:
+
+The debug id is in all cases lowercase in hex format and computed as follows:
+
+- **PE**: `<Signature><Age>` (age in hex, not padded)
+- **PDB**: `<Signature><Age>` (age in hex, not padded)
+- **ELF**: `<code_note_byte_sequence>`
+- **MachO**: `<uuid_bytes>`
+
+The path format is then as follows:
+
+- binary: `<DebugIdFirstTwo>/<DebugIdRest>/executable`
+- debug info: `<DebugIdFirstTwo>/<DebugIdRest>/debuginfo`
+- breakpad: `<DebugIdFirstTwo>/<DebugIdRest>/breakpad`
+- source bundle: `<DebugIdFirstTwo>/<DebugIdRest>/sourcebundle`
 
 ## Other Servers
 

--- a/docs/advanced/symbol-server-compatibility.md
+++ b/docs/advanced/symbol-server-compatibility.md
@@ -11,6 +11,7 @@ structures:
 - Breakpad Symbol Repositories
 - LLDB File Mapped UUID Directories
 - GDB Build ID Directories
+- debuginfod
 
 ## Prerequisites
 
@@ -204,6 +205,19 @@ The build-id hex representation is always provided in **lowercase**.
 
 - **ELF** (binary, potentially stripped)
 - **ELF** (debug info)
+
+### debuginfod
+
+Symbolicator also supports talking to
+[debuginfod]()https://sourceware.org/git/?p=elfutils.git;a=shortlog;h=refs/heads/debuginfod
+compatible servers for ELF and Macho.
+
+**Schema**:
+
+- **ELF** (binary, potentially stripped): `<code_note_byte_sequence>/executable`
+- **ELF** (debug info): `<code_note_byte_sequence>/debuginfo`
+- **MachO** (binary): `<uuid_bytes>/executable`
+- **MachO** (dSYM): `<uuid_bytes>/debuginfo`
 
 ## Other Servers
 

--- a/docs/advanced/symbol-server-compatibility.md
+++ b/docs/advanced/symbol-server-compatibility.md
@@ -210,15 +210,13 @@ The build-id hex representation is always provided in **lowercase**.
 ### debuginfod
 
 Symbolicator also supports talking to
-[debuginfod]()https://sourceware.org/git/?p=elfutils.git;a=shortlog;h=refs/heads/debuginfod
+[debuginfod](https://sourceware.org/git/?p=elfutils.git;a=shortlog;h=refs/heads/debuginfod)
 compatible servers for ELF and Macho.
 
 **Schema**:
 
 - **ELF** (binary, potentially stripped): `<code_note_byte_sequence>/executable`
 - **ELF** (debug info): `<code_note_byte_sequence>/debuginfo`
-- **MachO** (binary): `<uuid_bytes>/executable`
-- **MachO** (dSYM): `<uuid_bytes>/debuginfo`
 
 ### unified
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -306,6 +306,9 @@ pub enum DirectoryLayoutType {
     /// Uses Microsoft SSQP server conventions.
     #[serde(rename = "ssqp")]
     SSQP,
+    /// debuginfod conventions.
+    #[serde(rename = "debuginfod")]
+    Debuginfod,
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -309,6 +309,9 @@ pub enum DirectoryLayoutType {
     /// debuginfod conventions.
     #[serde(rename = "debuginfod")]
     Debuginfod,
+    /// unified sentry propriertary bucket format
+    #[serde(rename = "unified")]
+    Unified,
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -233,6 +233,9 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
             Some(format!("{}/debuginfo", code_id))
         }
 
+        // Mach is not supported
+        FileType::MachCode | FileType::MachDebug => None,
+
         // PDB and PE are not supported
         FileType::Pdb | FileType::Pe => None,
 

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -222,6 +222,28 @@ fn get_symstore_index2_path(filetype: FileType, identifier: &ObjectId) -> Option
     Some(rv)
 }
 
+fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<String> {
+    match filetype {
+        FileType::ElfCode | FileType::MachCode => {
+            let code_id = identifier.code_id.as_ref()?.as_str();
+            Some(format!("{}/executable", code_id))
+        }
+        FileType::ElfDebug | FileType::MachDebug => {
+            let code_id = identifier.code_id.as_ref()?.as_str();
+            Some(format!("{}/debuginfo", code_id))
+        }
+
+        // PDB and PE are not supported
+        FileType::Pdb | FileType::Pe => None,
+
+        // Breakpad is not supported
+        FileType::Breakpad => None,
+
+        // not available
+        FileType::SourceBundle => None,
+    }
+}
+
 /// Determines the path for an object file in the given layout.
 pub fn get_directory_path(
     directory_layout: DirectoryLayout,
@@ -233,6 +255,7 @@ pub fn get_directory_path(
         DirectoryLayoutType::Symstore => get_symstore_path(filetype, identifier, false)?,
         DirectoryLayoutType::SymstoreIndex2 => get_symstore_index2_path(filetype, identifier)?,
         DirectoryLayoutType::SSQP => get_symstore_path(filetype, identifier, true)?,
+        DirectoryLayoutType::Debuginfod => get_debuginfod_path(filetype, identifier)?,
     };
 
     match directory_layout.casing {

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -224,11 +224,11 @@ fn get_symstore_index2_path(filetype: FileType, identifier: &ObjectId) -> Option
 
 fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<String> {
     match filetype {
-        FileType::ElfCode | FileType::MachCode => {
+        FileType::ElfCode => {
             let code_id = identifier.code_id.as_ref()?.as_str();
             Some(format!("{}/executable", code_id))
         }
-        FileType::ElfDebug | FileType::MachDebug => {
+        FileType::ElfDebug => {
             let code_id = identifier.code_id.as_ref()?.as_str();
             Some(format!("{}/debuginfo", code_id))
         }

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -252,8 +252,9 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
         FileType::SourceBundle => "sourcebundle",
     };
 
-    // for PEs we want to use signature+age that also breakpad uses
-    let id = if filetype == FileType::Pe {
+    // for PEs we want to use signature+age that also breakpad uses.  We also use
+    // the debug id if the query did not provide a code id.
+    let id = if filetype == FileType::Pe || identifier.code_id.is_none() {
         Cow::Owned(identifier.debug_id?.breakpad().to_string().to_lowercase())
     } else {
         Cow::Borrowed(identifier.code_id.as_ref()?.as_str())


### PR DESCRIPTION
This adds support for the debuginfod and deived debug information file path structure.

What's nice about debuginfod is that they also have a format for how to find sources.
This let us use a dialect of the debuginfod format (dubbed unified) as a recommended
standard for linux/mac where users currently do not have a good default naming scheme.

Refs #141