### PR TITLE
ci(travis): Remove caches to improve build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable}
   - export PATH=~/.cargo/bin/:$PATH
 
-cache:
-  directories:
-    - $HOME/.cargo
-    - $TRAVIS_BUILD_DIR/target
-
 git:
   depth: 1
 


### PR DESCRIPTION
Sad but true; Caching is slower than downloading and recompiling. 