### PR TITLE
feat: Add an option to collect core dumps

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -eu
 
+# Enable core dumps. Requires privileged mode.
+if [[ "$SYMBOLICATOR_DEBUG" == "1" ]]; then
+  echo '/data/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
+  ulimit -c unlimited
+fi
+
 if [ "$(id -u)" == "0" ]; then
   # Prepare default data directory
   # WARNING(BYK): This should be done for the cache_dir mounted by any means, otherwise it is not

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -eu
 
 # Enable core dumps. Requires privileged mode.
 if [[ "$SYMBOLICATOR_DEBUG" == "1" ]]; then
+  mkdir -p /data/tmp
   echo '/data/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
   ulimit -c unlimited
 fi


### PR DESCRIPTION
To enable this functionality, the container has to be run in the privileged mode, and `SYMBOLICATOR_DEBUG` environment variable must be set to "1".