### PR TITLE
ci: Split tests into separate jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ matrix:
       script: make -e lint
 
     - name: "test"
-      script: make -e test
+      script: make -e test-rust
+
+    - name: "e2e"
+      script: make -e test-integration
 
     - name: "docs"
       before_script: npm install -g @zeus-ci/cli


### PR DESCRIPTION
The old test job first builds the test target and then rebuilds the binary target to run integration tests. Since this is running serially, it might take longer than needed. By running two jobs, we might speed up builds slightly.