### PR TITLE
build: Rename futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ actix = "0.7.9"
 apple-crash-report-parser = "0.3.1"
 failure = "0.1.5"
 serde = { version = "1.0.101", features = ["derive", "rc"] }
-futures03 = { version = "0.3", package = "futures", features = ["compat"] }
-futures = "0.1.29"
+futures = { version = "0.3", features = ["compat"] }
+futures01 = { version = "0.1.29", package = "futures" }
 bytes = "0.4.12"
 url = "1.7.2"
 derive_more = "0.15.0"

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::future::{Either, Future, IntoFuture};
-use futures03::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures01::future::{Either, Future, IntoFuture};
 use sentry::configure_scope;
 use sentry::integrations::failure::capture_fail;
 use symbolic::{common::ByteView, minidump::cfi::CfiCache};
@@ -120,7 +120,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
 
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
-            let future = futures::lazy(move || {
+            let future = futures01::lazy(move || {
                 if object.status() != CacheStatus::Positive {
                     return Ok(object.status());
                 }

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -5,8 +5,8 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
-use futures::future::{lazy, Future, IntoFuture, Shared};
-use futures::sync::oneshot;
+use futures01::future::{lazy, Future, IntoFuture, Shared};
+use futures01::sync::oneshot;
 use parking_lot::RwLock;
 use sentry::configure_scope;
 use symbolic::common::ByteView;

--- a/src/actors/objects/filesystem.rs
+++ b/src/actors/objects/filesystem.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io;
 use std::sync::Arc;
 
-use futures::{Future, IntoFuture};
+use futures01::{Future, IntoFuture};
 
 use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{DownloadPath, DownloadStream, FileId, ObjectError, ObjectErrorKind};

--- a/src/actors/objects/gcs.rs
+++ b/src/actors/objects/gcs.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use actix_web::{client, HttpMessage};
 use chrono::{DateTime, Duration, Utc};
 use failure::{Fail, ResultExt};
-use futures::{Future, IntoFuture, Stream};
+use futures01::{Future, IntoFuture, Stream};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};

--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use actix_web::http::header;
 use actix_web::{client, HttpMessage};
 use failure::Fail;
-use futures::{Future, IntoFuture, Stream};
+use futures01::{Future, IntoFuture, Stream};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -13,8 +13,8 @@ use ::sentry::integrations::failure::capture_fail;
 
 use bytes::Bytes;
 use failure::{Fail, ResultExt};
-use futures::{future, Future, IntoFuture, Stream};
-use futures03::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures01::{future, Future, IntoFuture, Stream};
 use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::{tempfile_in, NamedTempFile};

--- a/src/actors/objects/s3.rs
+++ b/src/actors/objects/s3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::BytesMut;
-use futures::{future::IntoFuture, Future, Stream};
+use futures01::{future::IntoFuture, Future, Stream};
 use parking_lot::Mutex;
 use rusoto_s3::S3;
 use tokio::codec::{BytesCodec, FramedRead};

--- a/src/actors/objects/sentry.rs
+++ b/src/actors/objects/sentry.rs
@@ -7,8 +7,8 @@ use actix_web::{client, HttpMessage};
 use actix::{Actor, Addr};
 
 use failure::Fail;
-use futures::future::Either;
-use futures::{Future, IntoFuture, Stream};
+use futures01::future::Either;
+use futures01::{Future, IntoFuture, Stream};
 use parking_lot::Mutex;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -8,9 +8,9 @@ use actix::ResponseFuture;
 use apple_crash_report_parser::AppleCrashReport;
 use bytes::{Bytes, IntoBuf};
 use failure::Fail;
-use futures::future::{self, join_all, Either, Future, IntoFuture, Shared};
-use futures::sync::oneshot;
-use futures03::{compat::Future01CompatExt, FutureExt as _, TryFutureExt};
+use futures::{compat::Future01CompatExt, FutureExt as _, TryFutureExt};
+use futures01::future::{self, join_all, Either, Future, IntoFuture, Shared};
+use futures01::sync::oneshot;
 use parking_lot::RwLock;
 use regex::Regex;
 use sentry::integrations::failure::capture_fail;
@@ -345,7 +345,7 @@ impl SourceLookup {
         }
 
         Ok(SourceLookup {
-            inner: futures03::future::join_all(futures).await,
+            inner: futures::future::join_all(futures).await,
         })
     }
 
@@ -532,7 +532,7 @@ impl SymCacheLookup {
         }
 
         Ok(SymCacheLookup {
-            inner: futures03::future::join_all(futures).await,
+            inner: futures::future::join_all(futures).await,
         })
     }
 
@@ -1212,9 +1212,8 @@ impl SymbolicationActor {
         scope: Scope,
         minidump: Bytes,
         sources: Vec<SourceConfig>,
-    ) -> impl futures03::future::Future<
-        Output = Result<(SymbolicateStacktraces, MinidumpState), SymbolicationError>,
-    > {
+    ) -> impl futures::Future<Output = Result<(SymbolicateStacktraces, MinidumpState), SymbolicationError>>
+    {
         future_metrics!(
             "minidump_stackwalk",
             Some((

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Fail, ResultExt};
-use futures::future::{Either, Future, IntoFuture};
-use futures03::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use futures01::future::{Either, Future, IntoFuture};
 use sentry::configure_scope;
 use sentry::integrations::failure::capture_fail;
 use symbolic::common::{Arch, ByteView};
@@ -127,7 +127,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
 
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
-            let future = futures::lazy(move || {
+            let future = futures01::lazy(move || {
                 if object.status() != CacheStatus::Positive {
                     return Ok(object.status());
                 }

--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -4,7 +4,7 @@ use actix_web::{
     State,
 };
 use bytes::Bytes;
-use futures::{future, Future, Stream};
+use futures01::{future, Future, Stream};
 use sentry::{configure_scope, Hub};
 use sentry_actix::ActixWebHubExt;
 

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -4,7 +4,7 @@ use actix_web::{
     State,
 };
 use bytes::Bytes;
-use futures::{future, Future, Stream};
+use futures01::{future, Future, Stream};
 use sentry::{configure_scope, Hub};
 use sentry_actix::ActixWebHubExt;
 

--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -4,7 +4,7 @@ use actix::ResponseFuture;
 use actix_web::{http::Method, pred, HttpRequest, HttpResponse, Path, State};
 use bytes::BytesMut;
 use failure::{Error, Fail};
-use futures::{future::Either, Future, IntoFuture, Stream};
+use futures01::{future::Either, Future, IntoFuture, Stream};
 use sentry::Hub;
 use sentry_actix::ActixWebHubExt;
 use tokio::codec::{BytesCodec, FramedRead};

--- a/src/endpoints/requests.rs
+++ b/src/endpoints/requests.rs
@@ -1,7 +1,7 @@
 use actix::ResponseFuture;
 use actix_web::{http::Method, HttpResponse, Path, Query, State};
 use failure::Error;
-use futures::Future;
+use futures01::Future;
 use serde::Deserialize;
 
 use crate::actors::symbolication::GetSymbolicationStatus;

--- a/src/endpoints/symbolicate.rs
+++ b/src/endpoints/symbolicate.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use actix::ResponseFuture;
 use actix_web::{http::Method, HttpRequest, Json, Query, State};
 use failure::Error;
-use futures::Future;
+use futures01::Future;
 use sentry::{configure_scope, Hub};
 use sentry_actix::ActixWebHubExt;
 use serde::Deserialize;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! tryf {
         match $e {
             Ok(value) => value,
             Err(e) => {
-                return Box::new(::futures::future::err(::std::convert::From::from(e)))
+                return Box::new(::futures01::future::err(::std::convert::From::from(e)))
                     as Box<dyn Future<Item = _, Error = _>>;
             }
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -126,7 +126,7 @@ macro_rules! future_metrics {
     // Collect generic metrics about a future
     ($task_name:expr, $timeout:expr, $future:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use std::time::Instant;
-        use futures::future::{self, Either};
+        use futures01::future::{self, Either};
         use tokio::prelude::FutureExt;
 
         let creation_time = Instant::now();

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use actix::{System, SystemRunner};
 use actix_web::fs::StaticFiles;
-use futures::{future, IntoFuture};
+use futures01::{future, IntoFuture};
 use log::LevelFilter;
 
 use crate::types::{FilesystemSourceConfig, HttpSourceConfig, SourceConfig};

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -2,8 +2,8 @@ use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use futures03::channel::oneshot;
-use futures03::{FutureExt, TryFutureExt};
+use futures::channel::oneshot;
+use futures::{FutureExt, TryFutureExt};
 use tokio::runtime::Runtime as TokioRuntime;
 
 static IS_TEST: AtomicBool = AtomicBool::new(false);

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -7,7 +7,7 @@ use actix::actors::resolver::{Connect, Resolve, Resolver, ResolverError};
 use actix::{clock, Actor, Addr, Context, Handler, ResponseFuture, System};
 use actix_web::client::{ClientConnector, ClientRequest, ClientResponse, SendRequestError};
 use actix_web::{http::header, HttpMessage};
-use futures::{future, future::Either, Async, Future, IntoFuture, Poll};
+use futures01::{future, future::Either, Async, Future, IntoFuture, Poll};
 use ipnetwork::Ipv4Network;
 use tokio::net::{tcp::ConnectFuture, TcpStream};
 use tokio::timer::Delay;

--- a/src/utils/multipart.rs
+++ b/src/utils/multipart.rs
@@ -1,7 +1,7 @@
 use actix::ResponseFuture;
 use actix_web::{dev::Payload, error, multipart, Error};
 use bytes::{Bytes, BytesMut};
-use futures::{Future, Stream};
+use futures01::{Future, Stream};
 
 use crate::types::SourceConfig;
 

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use futures::future::Future;
-use futures::Poll;
+use futures01::future::Future;
+use futures01::Poll;
 
 use sentry::{Hub, Scope};
 


### PR DESCRIPTION
This is required so that we can enable the `async-await` feature on `futures` and then use macros like `select!`.