### PR TITLE
ref(futures): Migrate symbolication actor to futures 0.3

### DIFF
--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -1,152 +1,73 @@
-use actix::ResponseFuture;
-use actix_web::{
-    dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
-    State,
-};
-use bytes::Bytes;
-use futures01::{future, Future, Stream};
-use sentry::{configure_scope, Hub};
-use sentry_actix::ActixWebHubExt;
+use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
+use futures::{compat::Stream01CompatExt, StreamExt};
+use sentry::configure_scope;
 
-use crate::actors::symbolication::{GetSymbolicationStatus, SymbolicationActor};
 use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::types::{RequestId, Scope, SourceConfig, SymbolicationResponse};
-use crate::utils::futures::ThreadPool;
+use crate::types::SymbolicationResponse;
 use crate::utils::multipart::{read_multipart_file, read_multipart_sources};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
-#[derive(Debug, Default)]
-struct AppleCrashReportRequest {
-    sources: Option<Vec<SourceConfig>>,
-    apple_crash_report: Option<Bytes>,
-}
-
-fn handle_multipart_item(
-    threadpool: ThreadPool,
-    mut request: AppleCrashReportRequest,
-    item: multipart::MultipartItem<Payload>,
-) -> ResponseFuture<AppleCrashReportRequest, Error> {
-    let field = match item {
-        multipart::MultipartItem::Field(field) => field,
-        multipart::MultipartItem::Nested(nested) => {
-            return handle_multipart_stream(threadpool, request, nested);
-        }
-    };
-
-    match field
-        .content_disposition()
-        .as_ref()
-        .and_then(|d| d.get_name())
-    {
-        Some("sources") => {
-            let future = read_multipart_sources(field).map(move |sources| {
-                request.sources = Some(sources);
-                request
-            });
-            Box::new(future)
-        }
-        Some("apple_crash_report") => {
-            let future = read_multipart_file(field).map(move |apple_crash_report| {
-                request.apple_crash_report = Some(apple_crash_report);
-                request
-            });
-            Box::new(future)
-        }
-        _ => {
-            let error = error::ErrorBadRequest("unknown formdata field");
-            Box::new(future::err(error))
-        }
-    }
-}
-
-fn handle_multipart_stream(
-    threadpool: ThreadPool,
-    request: AppleCrashReportRequest,
-    stream: multipart::Multipart<Payload>,
-) -> ResponseFuture<AppleCrashReportRequest, Error> {
-    let future = stream
-        .map_err(Error::from)
-        .fold(request, move |request, item| {
-            handle_multipart_item(threadpool.clone(), request, item)
-        });
-
-    Box::new(future)
-}
-
-fn parse_apple_crash_report(
-    symbolication: &SymbolicationActor,
-    request: AppleCrashReportRequest,
-    scope: Scope,
-) -> Result<RequestId, Error> {
-    let report = request
-        .apple_crash_report
-        .ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
-
-    let sources = request
-        .sources
-        .ok_or_else(|| error::ErrorBadRequest("missing sources"))?;
-
-    symbolication
-        .process_apple_crash_report(scope, report, sources)
-        .map_err(error::ErrorInternalServerError)
-}
-
-fn handle_apple_crash_report_request(
+async fn handle_apple_crash_report_request(
     state: State<ServiceState>,
     params: Query<SymbolicationRequestQueryParams>,
     request: HttpRequest<ServiceState>,
-) -> ResponseFuture<Json<SymbolicationResponse>, Error> {
-    let hub = Hub::from_request(&request);
+) -> Result<Json<SymbolicationResponse>, Error> {
+    let params = params.into_inner();
+    configure_scope(|scope| {
+        params.write_sentry_scope(scope);
+    });
 
-    Hub::run(hub, || {
-        let default_sources = state.config().default_sources();
+    let mut report = None;
+    let mut sources = None;
 
-        let params = params.into_inner();
-        configure_scope(|scope| {
-            params.write_sentry_scope(scope);
-        });
+    let mut stream = request.multipart().compat();
+    while let Some(item) = stream.next().await {
+        let field = match item? {
+            multipart::MultipartItem::Field(field) => field,
+            _ => return Err(error::ErrorBadRequest("unsupported nested formdata")),
+        };
 
-        let request_future = handle_multipart_stream(
-            state.io_pool(),
-            AppleCrashReportRequest::default(),
-            request.multipart(),
-        );
+        let content_disposition = field.content_disposition();
+        match content_disposition.as_ref().and_then(|d| d.get_name()) {
+            Some("sources") => sources = Some(read_multipart_sources(field).await?),
+            Some("apple_crash_report") => report = Some(read_multipart_file(field).await?),
+            _ => return Err(error::ErrorBadRequest("unknown formdata field")),
+        }
+    }
 
-        let SymbolicationRequestQueryParams { scope, timeout } = params;
-        let symbolication = state.symbolication();
+    let report = match report {
+        Some(report) => report,
+        None => return Err(error::ErrorBadRequest("missing apple crash report")),
+    };
 
-        let response_future = request_future
-            .and_then(clone!(symbolication, |mut request| {
-                if request.sources.is_none() {
-                    request.sources = Some((*default_sources).clone());
-                }
+    let sources = match sources {
+        Some(sources) => sources,
+        None => (*state.config().default_sources()).clone(),
+    };
 
-                parse_apple_crash_report(&symbolication, request, scope)
-            }))
-            .and_then(move |request_id| {
-                symbolication
-                    .get_symbolication_status(GetSymbolicationStatus {
-                        request_id,
-                        timeout,
-                    })
-                    .then(|result| match result {
-                        Ok(Some(response)) => Ok(Json(response)),
-                        Ok(None) => Err(error::ErrorInternalServerError(
-                            "symbolication request did not start",
-                        )),
-                        Err(error) => Err(error::ErrorInternalServerError(error)),
-                    })
-                    .map_err(Error::from)
-            });
+    let request_id = state
+        .symbolication()
+        .process_apple_crash_report(params.scope, report, sources)
+        .map_err(error::ErrorInternalServerError)?;
 
-        Box::new(response_future.sentry_hub_current())
-    })
+    let result = state
+        .symbolication()
+        .get_response(request_id, params.timeout)
+        .await;
+
+    match result {
+        Ok(Some(response)) => Ok(Json(response)),
+        Ok(None) => Err(error::ErrorInternalServerError(
+            "symbolication request did not start",
+        )),
+        Err(error) => Err(error::ErrorInternalServerError(error)),
+    }
 }
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/applecrashreport", |r| {
-        r.method(Method::POST)
-            .with(handle_apple_crash_report_request);
+        let handler = compat_handler!(handle_apple_crash_report_request, s, p, r);
+        r.post().with_async(handler);
     })
 }

--- a/src/endpoints/healthcheck.rs
+++ b/src/endpoints/healthcheck.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::Method, HttpRequest};
+use actix_web::HttpRequest;
 
 use crate::app::{ServiceApp, ServiceState};
 
@@ -8,6 +8,6 @@ fn healthcheck(_req: HttpRequest<ServiceState>) -> &'static str {
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/healthcheck", |r| {
-        r.method(Method::GET).with(healthcheck);
+        r.get().with(healthcheck);
     })
 }

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -1,158 +1,73 @@
-use actix::ResponseFuture;
-use actix_web::{
-    dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
-    State,
-};
-use bytes::Bytes;
-use futures01::{future, Future, Stream};
-use sentry::{configure_scope, Hub};
-use sentry_actix::ActixWebHubExt;
+use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
+use futures::{compat::Stream01CompatExt, StreamExt};
+use sentry::configure_scope;
 
-use crate::actors::symbolication::{GetSymbolicationStatus, SymbolicationActor};
 use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::types::{RequestId, Scope, SourceConfig, SymbolicationResponse};
-use crate::utils::futures::ThreadPool;
+use crate::types::SymbolicationResponse;
 use crate::utils::multipart::{read_multipart_file, read_multipart_sources};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
-#[derive(Debug, Default)]
-struct MinidumpRequest {
-    sources: Option<Vec<SourceConfig>>,
-    minidump: Option<Bytes>,
-}
-
-fn handle_multipart_item(
-    threadpool: ThreadPool,
-    mut request: MinidumpRequest,
-    item: multipart::MultipartItem<Payload>,
-) -> ResponseFuture<MinidumpRequest, Error> {
-    let field = match item {
-        multipart::MultipartItem::Field(field) => field,
-        multipart::MultipartItem::Nested(nested) => {
-            return handle_multipart_stream(threadpool, request, nested);
-        }
-    };
-
-    match field
-        .content_disposition()
-        .as_ref()
-        .and_then(|d| d.get_name())
-    {
-        Some("sources") => {
-            let future = read_multipart_sources(field).map(move |sources| {
-                request.sources = Some(sources);
-                request
-            });
-            Box::new(future)
-        }
-        Some("upload_file_minidump") => {
-            let future = read_multipart_file(field).map(move |minidump| {
-                request.minidump = Some(minidump);
-                request
-            });
-            Box::new(future)
-        }
-        _ => {
-            let error = error::ErrorBadRequest("unknown formdata field");
-            Box::new(future::err(error))
-        }
-    }
-}
-
-fn handle_multipart_stream(
-    threadpool: ThreadPool,
-    request: MinidumpRequest,
-    stream: multipart::Multipart<Payload>,
-) -> ResponseFuture<MinidumpRequest, Error> {
-    let future = stream
-        .map_err(Error::from)
-        .fold(request, move |request, item| {
-            handle_multipart_item(threadpool.clone(), request, item)
-        });
-
-    Box::new(future)
-}
-
-fn process_minidump(
-    symbolication: &SymbolicationActor,
-    request: MinidumpRequest,
-    scope: Scope,
-) -> Result<RequestId, Error> {
-    let minidump = request
-        .minidump
-        .ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
-
-    sentry::configure_scope(|scope| {
-        let mut hasher = crc32fast::Hasher::new();
-        hasher.update(&minidump);
-        scope.set_extra("minidump_crc32", hasher.finalize().into());
-        scope.set_extra("minidump_len", minidump.len().into());
-    });
-
-    let sources = request
-        .sources
-        .ok_or_else(|| error::ErrorBadRequest("missing sources"))?;
-
-    symbolication
-        .process_minidump(scope, minidump, sources)
-        .map_err(error::ErrorInternalServerError)
-}
-
-fn handle_minidump_request(
+async fn handle_minidump_request(
     state: State<ServiceState>,
     params: Query<SymbolicationRequestQueryParams>,
     request: HttpRequest<ServiceState>,
-) -> ResponseFuture<Json<SymbolicationResponse>, Error> {
-    let hub = Hub::from_request(&request);
+) -> Result<Json<SymbolicationResponse>, Error> {
+    let params = params.into_inner();
+    configure_scope(|scope| {
+        params.write_sentry_scope(scope);
+    });
 
-    Hub::run(hub, || {
-        let default_sources = state.config().default_sources();
+    let mut minidump = None;
+    let mut sources = None;
 
-        let params = params.into_inner();
-        configure_scope(|scope| {
-            params.write_sentry_scope(scope);
-        });
+    let mut stream = request.multipart().compat();
+    while let Some(item) = stream.next().await {
+        let field = match item? {
+            multipart::MultipartItem::Field(field) => field,
+            _ => return Err(error::ErrorBadRequest("unsupported nested formdata")),
+        };
 
-        let request_future = handle_multipart_stream(
-            state.io_pool(),
-            MinidumpRequest::default(),
-            request.multipart(),
-        );
+        let content_disposition = field.content_disposition();
+        match content_disposition.as_ref().and_then(|d| d.get_name()) {
+            Some("sources") => sources = Some(read_multipart_sources(field).await?),
+            Some("upload_file_minidump") => minidump = Some(read_multipart_file(field).await?),
+            _ => return Err(error::ErrorBadRequest("unknown formdata field")),
+        }
+    }
 
-        let SymbolicationRequestQueryParams { scope, timeout } = params;
-        let symbolication = state.symbolication();
+    let minidump = match minidump {
+        Some(minidump) => minidump,
+        None => return Err(error::ErrorBadRequest("missing minidump")),
+    };
 
-        let response_future = request_future
-            .and_then(clone!(symbolication, |mut request| {
-                if request.sources.is_none() {
-                    request.sources = Some((*default_sources).clone());
-                }
+    let sources = match sources {
+        Some(sources) => sources,
+        None => (*state.config().default_sources()).clone(),
+    };
 
-                process_minidump(&symbolication, request, scope)
-            }))
-            .and_then(move |request_id| {
-                symbolication
-                    .get_symbolication_status(GetSymbolicationStatus {
-                        request_id,
-                        timeout,
-                    })
-                    .then(|result| match result {
-                        Ok(Some(response)) => Ok(Json(response)),
-                        Ok(None) => Err(error::ErrorInternalServerError(
-                            "symbolication request did not start",
-                        )),
-                        Err(error) => Err(error::ErrorInternalServerError(error)),
-                    })
-                    .map_err(Error::from)
-            });
+    let request_id = state
+        .symbolication()
+        .process_minidump(params.scope, minidump, sources)
+        .map_err(error::ErrorInternalServerError)?;
 
-        Box::new(response_future.sentry_hub_current())
-    })
+    let result = state
+        .symbolication()
+        .get_response(request_id, params.timeout)
+        .await;
+
+    match result {
+        Ok(Some(response)) => Ok(Json(response)),
+        Ok(None) => Err(error::ErrorInternalServerError(
+            "symbolication request did not start",
+        )),
+        Err(error) => Err(error::ErrorInternalServerError(error)),
+    }
 }
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/minidump", |r| {
-        r.method(Method::POST).with(handle_minidump_request);
+        let handler = compat_handler!(handle_minidump_request, s, p, r);
+        r.post().with_async(handler);
     })
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,3 +39,10 @@ macro_rules! clone {
         }
     );
 }
+
+macro_rules! compat_handler {
+    ($func:ident , $($param:ident),*) => {{
+        use ::futures::{FutureExt, TryFutureExt};
+        |$($param),*| $func ( $($param),* ).boxed_local().compat()
+    }};
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -173,30 +173,6 @@ macro_rules! future_metrics {
     }};
 }
 
-macro_rules! measure2 {
-    ($task:literal, $future:expr, |$result:pat| $status:expr $(, $k:ident = $v:expr)* $(,)?) => {{
-        use std::time::Instant;
-        let start_time = Instant::now();
-
-        async move {
-            let result = $future.await;
-            let elapsed = start_time.elapsed();
-            let status = match result {
-                $result => $status,
-            };
-
-            metric!(
-                timer("futures.done") = elapsed,
-                "task_name" => $task,
-                "status" => status,
-                $(stringify!($k) => $v,)*
-            );
-
-            result
-        }
-    }};
-}
-
 macro_rules! measure {
     ($task:literal, $future:expr, $status:expr $(, $k:ident = $v:expr)* $(,)?) => {{
         use std::time::Instant;
@@ -217,18 +193,4 @@ macro_rules! measure {
             result
         }
     }};
-}
-
-fn test_measure() {
-    let future = async {
-        // if true {
-        //     Ok(1)
-        // } else {
-        //     Err(1)
-        // }
-        1
-    };
-
-    // let stuff = measure!("test", future, |_| "foo");
-    let stuff = measure!("test", future, |_| "foo",);
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -172,3 +172,63 @@ macro_rules! future_metrics {
         })
     }};
 }
+
+macro_rules! measure2 {
+    ($task:literal, $future:expr, |$result:pat| $status:expr $(, $k:ident = $v:expr)* $(,)?) => {{
+        use std::time::Instant;
+        let start_time = Instant::now();
+
+        async move {
+            let result = $future.await;
+            let elapsed = start_time.elapsed();
+            let status = match result {
+                $result => $status,
+            };
+
+            metric!(
+                timer("futures.done") = elapsed,
+                "task_name" => $task,
+                "status" => status,
+                $(stringify!($k) => $v,)*
+            );
+
+            result
+        }
+    }};
+}
+
+macro_rules! measure {
+    ($task:literal, $future:expr, $status:expr $(, $k:ident = $v:expr)* $(,)?) => {{
+        use std::time::Instant;
+        let start_time = Instant::now();
+
+        async move {
+            let result = $future.await;
+            let elapsed = start_time.elapsed();
+            let status = $status(&result);
+
+            metric!(
+                timer("futures.done") = elapsed,
+                "task_name" => $task,
+                "status" => status,
+                $(stringify!($k) => $v,)*
+            );
+
+            result
+        }
+    }};
+}
+
+fn test_measure() {
+    let future = async {
+        // if true {
+        //     Ok(1)
+        // } else {
+        //     Err(1)
+        // }
+        1
+    };
+
+    // let stuff = measure!("test", future, |_| "foo");
+    let stuff = measure!("test", future, |_| "foo",);
+}

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -89,15 +89,3 @@ where
         _ = delay.compat().fuse() => Err(Elapsed),
     }
 }
-
-pub async fn timeout_with<F, T, E, R, O>(duration: Duration, future: F, or_else: O) -> Result<T, E>
-where
-    F: Future<Output = Result<T, E>>,
-    O: FnOnce() -> R,
-    R: Into<E>,
-{
-    match timeout(duration, future).await {
-        Ok(result) => result,
-        Err(_) => Err(or_else().into()),
-    }
-}

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -199,12 +199,12 @@ pub fn start_safe_connector() {
 mod tests {
     use super::*;
 
-    use actix_web::Error;
+    use futures::compat::Future01CompatExt;
 
     use crate::test;
 
     #[test]
-    fn test_local_connection() -> Result<(), Error> {
+    fn test_local_connection() {
         test::setup();
         start_safe_connector();
 
@@ -212,9 +212,9 @@ mod tests {
             app.resource("/", |resource| resource.f(|_| "OK"));
         });
 
-        let response = test::block_fn(|| server.get().finish().unwrap().send());
-        assert!(response.is_err());
-
-        Ok(())
+        test::block_on(async {
+            let response = server.get().finish().unwrap().send().compat().await;
+            assert!(response.is_err());
+        })
     }
 }

--- a/src/utils/multipart.rs
+++ b/src/utils/multipart.rs
@@ -1,48 +1,41 @@
-use actix::ResponseFuture;
-use actix_web::{dev::Payload, error, multipart, Error};
+use actix_web::{dev::Payload, error, multipart::Field, Error};
 use bytes::{Bytes, BytesMut};
-use futures01::{Future, Stream};
+use futures::{compat::Stream01CompatExt, StreamExt};
 
 use crate::types::SourceConfig;
 
 const MAX_SOURCES_SIZE: usize = 1_000_000;
 
-pub fn read_multipart_data(
-    field: multipart::Field<Payload>,
-    max_size: usize,
-) -> ResponseFuture<Vec<u8>, Error> {
-    let future =
-        field
-            .map_err(Error::from)
-            .fold(Vec::with_capacity(512), move |mut body, chunk| {
-                if (body.len() + chunk.len()) > max_size {
-                    Err(error::ErrorBadRequest("payload too large"))
-                } else {
-                    body.extend_from_slice(&chunk);
-                    Ok(body)
-                }
-            });
+pub async fn read_multipart_data(field: Field<Payload>, max_size: usize) -> Result<Vec<u8>, Error> {
+    let mut body = Vec::with_capacity(512);
+    let mut stream = field.compat();
 
-    Box::new(future)
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+
+        if (body.len() + chunk.len()) > max_size {
+            return Err(error::ErrorBadRequest("payload too large"));
+        }
+
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
 }
 
-pub fn read_multipart_file(
-    field: multipart::Field<Payload>,
-) -> impl Future<Item = Bytes, Error = Error> {
-    field
-        .map_err(Error::from)
-        .fold(BytesMut::new(), |mut bytes, chunk| {
-            bytes.extend_from_slice(&chunk);
-            Ok::<BytesMut, Error>(bytes)
-        })
-        .and_then(|bytes| Ok(bytes.freeze()))
+pub async fn read_multipart_file(field: Field<Payload>) -> Result<Bytes, Error> {
+    let mut bytes = BytesMut::new();
+    let mut stream = field.compat();
+
+    while let Some(chunk) = stream.next().await {
+        bytes.extend_from_slice(&chunk?);
+    }
+
+    Ok(bytes.freeze())
 }
 
-pub fn read_multipart_sources(
-    field: multipart::Field<Payload>,
-) -> ResponseFuture<Vec<SourceConfig>, Error> {
-    Box::new(
-        read_multipart_data(field, MAX_SOURCES_SIZE)
-            .and_then(|data| Ok(serde_json::from_slice(&data)?)),
-    )
+pub async fn read_multipart_sources(field: Field<Payload>) -> Result<Vec<SourceConfig>, Error> {
+    let data = read_multipart_data(field, MAX_SOURCES_SIZE).await?;
+    let sources = serde_json::from_slice(&data)?;
+    Ok(sources)
 }


### PR DESCRIPTION
A first pass over the symbolication "actor" to migrate it to futures 0.3 and async / await. The implementation is still quite messy and ugly, but can be cleaned up now.