### PR TITLE
Reduce the threadpool sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
+ "num_cpus",
  "parking_lot 0.10.0",
  "pretty_env_logger",
  "procspawn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ base64 = "0.11.0"
 ipnetwork = "0.16.0"
 regex = "1.3.3"
 crc32fast = "1.2.0"
+num_cpus = "1.12.0"
 
 [dev-dependencies]
 insta = "0.11.0"

--- a/src/endpoints/healthcheck.rs
+++ b/src/endpoints/healthcheck.rs
@@ -3,6 +3,7 @@ use actix_web::{http::Method, HttpRequest};
 use crate::app::{ServiceApp, ServiceState};
 
 fn healthcheck(_req: HttpRequest<ServiceState>) -> &'static str {
+    metric!(counter("healthcheck") += 1);
     "ok"
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use actix::System;
 use actix_web::{server::HttpServer, App};
 use failure::{Fail, ResultExt};
+use num_cpus;
 
 use crate::app::{ServiceApp, ServiceState};
 use crate::config::Config;
@@ -51,6 +52,7 @@ pub fn run(config: Config) -> Result<(), ServerError> {
 
     log::info!("Starting http server: {}", bind);
     HttpServer::new(move || create_app(service.clone()))
+        .workers(num_cpus::get() / 2)
         .bind(&bind)
         .context(ServerErrorKind::Bind)?
         .start();

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -36,7 +36,11 @@ pub struct ThreadPool {
 }
 
 impl ThreadPool {
-    /// Create a new `ThreadPool` with default values.
+    /// Create a new `ThreadPool`.
+    ///
+    /// Since we create a CPU-heavy and an IO-heavy pool we reduce the
+    /// number of threads used per pool so that the pools are less
+    /// likely to starve each other.
     pub fn new() -> Self {
         let inner = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
             None

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -41,7 +41,11 @@ impl ThreadPool {
         let inner = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
             None
         } else {
-            Some(Arc::new(TokioRuntime::new().unwrap()))
+            let runtime = tokio::runtime::Builder::new()
+                .core_threads(num_cpus::get() / 2)
+                .build()
+                .unwrap();
+            Some(Arc::new(runtime))
         };
 
         ThreadPool { inner }


### PR DESCRIPTION
The most important here is the CPU-intensive threadpool which is no
longer the same size all the CPUs available.  The IO-bound threadpools
are still overcommited in that there are two threads per CPU core.

The num_cpus crate was already an indirect dependency, now it is a
direct dependency under the same version number as before.

Lastly add a cude measure of the healthchecks in the form of a metrics
counter.  This is not ideal as it's the server's side point of view
but will give some indication.  I'm be tempted to add the timestamp as
a field but not sure this makes much sense in Datadog's model.