### PR TITLE
Propagate the spawn error from the process pool up at startup

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -137,17 +137,17 @@ impl SymbolicationActor {
         symcaches: SymCacheActor,
         cficaches: CfiCacheActor,
         threadpool: ThreadPool,
-    ) -> Self {
+    ) -> Result<Self, procspawn::SpawnError> {
         let requests = Arc::new(RwLock::new(BTreeMap::new()));
 
-        SymbolicationActor {
+        Ok(SymbolicationActor {
             objects,
             symcaches,
             cficaches,
             threadpool,
             requests,
-            spawnpool: Arc::new(procspawn::Pool::new(num_cpus::get()).expect("fixme")),
-        }
+            spawnpool: Arc::new(procspawn::Pool::new(num_cpus::get())?),
+        })
     }
 
     fn wrap_response_channel(
@@ -1671,7 +1671,7 @@ mod tests {
         let mut config = Config::default();
         config.cache_dir = Some(cache_dir.path().to_owned());
         config.connect_to_reserved_ips = true;
-        let service = ServiceState::create(config);
+        let service = ServiceState::create(config).unwrap();
 
         (service, cache_dir)
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use crate::utils::http;
 /// Variants of [ServiceStateError].
 #[derive(Clone, Copy, Debug, Fail)]
 pub enum ServiceStateErrorKind {
-    #[fail(display = "failed to create process pool")]
-    Spawn,
+    #[fail(display = "failed to create the symbolication service")]
+    SymbolicationService,
 }
 
 symbolic::common::derive_failure!(
@@ -65,7 +65,7 @@ impl ServiceState {
             cficaches,
             cpu_threadpool.clone(),
         )
-        .context(ServiceStateErrorKind::Spawn)?;
+        .context(ServiceStateErrorKind::SymbolicationService)?;
 
         Ok(Self {
             cpu_threadpool,

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,8 +13,8 @@ pub enum ServerErrorKind {
     /// Failed to bind to a port.
     #[fail(display = "failed to bind to the port")]
     Bind,
-    #[fail(display = "failed to create process pool")]
-    Spawn,
+    #[fail(display = "failed to create service state")]
+    ServiceCreation,
 }
 
 symbolic::common::derive_failure!(
@@ -44,7 +44,7 @@ pub fn run(config: Config) -> Result<(), ServerError> {
     metric!(counter("server.starting") += 1);
 
     let bind = config.bind.clone();
-    let service = ServiceState::create(config).context(ServerErrorKind::Spawn)?;
+    let service = ServiceState::create(config).context(ServerErrorKind::ServiceCreation)?;
 
     log::info!("Starting http server: {}", bind);
     HttpServer::new(move || create_app(service.clone()))

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,8 @@ pub enum ServerErrorKind {
     /// Failed to bind to a port.
     #[fail(display = "failed to bind to the port")]
     Bind,
+    #[fail(display = "failed to create process pool")]
+    Spawn,
 }
 
 symbolic::common::derive_failure!(
@@ -42,7 +44,7 @@ pub fn run(config: Config) -> Result<(), ServerError> {
     metric!(counter("server.starting") += 1);
 
     let bind = config.bind.clone();
-    let service = ServiceState::create(config);
+    let service = ServiceState::create(config).context(ServerErrorKind::Spawn)?;
 
     log::info!("Starting http server: {}", bind);
     HttpServer::new(move || create_app(service.clone()))


### PR DESCRIPTION
This newtypes the error in the ServiceState but doesn't bother in the
SymbolicationActor itself.  It's a bit more graceful compared to the
plain .expect() which is probably nice.