### PR TITLE
fix(download): Percent-encode HTTP paths with unicode names

### DIFF
--- a/src/actors/objects/http.rs
+++ b/src/actors/objects/http.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 use actix_web::http::header;
 use actix_web::{client, HttpMessage};
 use failure::Fail;
-use futures01::{Future, IntoFuture, Stream};
+use futures01::{future, Future, Stream};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
+use url::Url;
 
 use crate::actors::objects::common::prepare_download_paths;
 use crate::actors::objects::{
@@ -17,6 +18,24 @@ use crate::utils::http;
 
 /// The maximum number of redirects permitted by a remote symbol server.
 const MAX_HTTP_REDIRECTS: usize = 10;
+
+/// Joins the relative path to the given URL.
+///
+/// As opposed to `Url::join`, this only supports relative paths. Each segment of the path is
+/// percent-encoded. Empty segments are skipped, for example, `foo//bar` is collapsed to `foo/bar`.
+///
+/// The base URL is treated as directory. If it does not end with a slash, then a slash is
+/// automatically appended.
+///
+/// Returns `Err(())` if the URL is cannot-be-a-base.
+fn join_url_encoded(base: &Url, path: &str) -> Result<Url, ()> {
+    let mut joined = base.clone();
+    joined
+        .path_segments_mut()?
+        .pop_if_empty()
+        .extend(path.split('/').filter(|s| !s.is_empty()));
+    Ok(joined)
+}
 
 pub(super) fn prepare_downloads(
     source: &Arc<HttpSourceConfig>,
@@ -32,17 +51,17 @@ pub(super) fn prepare_downloads(
     .map(|download_path| FileId::Http(source.clone(), download_path))
     .collect();
 
-    Box::new(Ok(ids).into_future())
+    Box::new(future::ok(ids))
 }
 
 pub(super) fn download_from_source(
     source: Arc<HttpSourceConfig>,
     download_path: &DownloadPath,
 ) -> Box<dyn Future<Item = Option<DownloadStream>, Error = ObjectError>> {
-    // XXX: Probably should send an error if the URL turns out to be invalid
-    let download_url = match source.url.join(&download_path.0) {
+    // This can effectively never error since the URL is always validated to be a base URL.
+    let download_url = match join_url_encoded(&source.url, &download_path.0) {
         Ok(x) => x,
-        Err(_) => return Box::new(Ok(None).into_future()),
+        Err(_) => return Box::new(future::ok(None)),
     };
 
     log::debug!("Fetching debug file from {}", download_url);
@@ -108,4 +127,61 @@ pub(super) fn download_from_source(
     });
 
     Box::new(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_join_empty() {
+        let base = Url::parse("https://example.org/base").unwrap();
+        let joined = join_url_encoded(&base, "").unwrap();
+        assert_eq!(joined, "https://example.org/base".parse().unwrap());
+    }
+
+    #[test]
+    fn test_join_space() {
+        let base = Url::parse("https://example.org/base").unwrap();
+        let joined = join_url_encoded(&base, "foo bar").unwrap();
+        assert_eq!(
+            joined,
+            "https://example.org/base/foo%20bar".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_join_multiple() {
+        let base = Url::parse("https://example.org/base").unwrap();
+        let joined = join_url_encoded(&base, "foo/bar").unwrap();
+        assert_eq!(joined, "https://example.org/base/foo/bar".parse().unwrap());
+    }
+
+    #[test]
+    fn test_join_trailing_slash() {
+        let base = Url::parse("https://example.org/base/").unwrap();
+        let joined = join_url_encoded(&base, "foo").unwrap();
+        assert_eq!(joined, "https://example.org/base/foo".parse().unwrap());
+    }
+
+    #[test]
+    fn test_join_leading_slash() {
+        let base = Url::parse("https://example.org/base").unwrap();
+        let joined = join_url_encoded(&base, "/foo").unwrap();
+        assert_eq!(joined, "https://example.org/base/foo".parse().unwrap());
+    }
+
+    #[test]
+    fn test_join_multi_slash() {
+        let base = Url::parse("https://example.org/base").unwrap();
+        let joined = join_url_encoded(&base, "foo//bar").unwrap();
+        assert_eq!(joined, "https://example.org/base/foo/bar".parse().unwrap());
+    }
+
+    #[test]
+    fn test_join_absolute() {
+        let base = Url::parse("https://example.org/").unwrap();
+        let joined = join_url_encoded(&base, "foo").unwrap();
+        assert_eq!(joined, "https://example.org/foo".parse().unwrap());
+    }
 }


### PR DESCRIPTION
Some symbol server layouts, such as SSQP and Microsoft's SymStore, contain file names in the path. These paths do not necessarily have to be valid URL paths and may contain special characters. To join them, the path must be percent-encoded.

This switches from `Url::join`, which assumes a valid URL path, to `Url::path_segments_mut`, which percent-encodes the path properly.