### PR TITLE
ref: Report failed function demangling to Sentry

### DIFF
--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -35,8 +35,8 @@ where
     let state = (initial_url, max_redirects, true);
     Box::new(future::loop_fn(state, move |(url, redirects, trusted)| {
         let mut request = tryf!(make_request(url.as_str()).map_err(|err| {
-            let fail = failure::format_err!("Failed creating request: {} (URI: {})", err, url);
-            sentry::integrations::failure::capture_error(&fail);
+            let message = format!("Failed creating request: {} (URI: {})", err, url);
+            sentry::capture_message(&message, sentry::Level::Error);
             SendRequestError::Connector(ClientConnectorError::InvalidUrl)
         }));
 


### PR DESCRIPTION
Instead of silently ignoring when a function cannot be demangled, log it to Sentry. This only reports an error if the language can be explicitly detected to avoid false-positives in case there are unmangled names marked as some other language.