### PR TITLE
test: Show pytest report summary by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --tb=native --durations 5 -p no:warnings
+addopts = -ra --tb=native --durations 5 -p no:warnings


### PR DESCRIPTION
This shows a summary of tests which are skipped, failed etc at the end
of the test output.