### PR TITLE
fix(monitoring): Give this a unique task_name metric tag

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1564,7 +1564,7 @@ impl SymbolicationActor {
             .flatten();
 
         Box::new(future_metrics!(
-            "minidump_stackwalk",
+            "parse_apple_crash_report",
             Some((
                 Duration::from_secs(1200),
                 SymbolicationErrorKind::Timeout.into()


### PR DESCRIPTION
The future was being recorded as task_name=minidump_stackwalk even
though it has nothing to do with this.  This could account for thecase where the minidump_stackwalk duration graph looks a bit weird at times.