### PR TITLE
feat(minidump): Save minidumps which crash during processing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,26 @@ metrics:
   `true`.
 - `connect_to_reserved_ips`: Allow reserved IP addresses for requests to
   sources. See [Security](#security). Defaults to `false`.
+- `caches`: Fine-tune cache expiry.
+   - `downloaded`: Fine-tune caches for downloaded files.
+      - `max_unused_for`: Maximum duration to keep a file since last
+        use of it.
+      - `retry_misses_after`: Duration to wait before re-trying to
+        download a file which was not found.
+      - `retry_malformed_after`: Duration to wait before re-trying to
+        download a file which was malformed.
+    - `derived`: Fine-tune caches for files which are derived from
+      downloaded files.  These files are usually versions of the
+      downloaded files optimised for fast lookups.
+       - `max_unused_for`: Maximum duration to keep a file since last
+         use of it.
+       - `retry_misses_after`: Duration to wait before re-trying to
+         download a file which was not found.
+       - `retry_malformed_after`: Duration to wait before re-trying to
+         download a file which was malformed.
+    - `minidump`: This configures the duration minidumps which failed
+      to be processed correctly will be stored in the cache.
+       - `max_unused_for`: Duration a minidump will be kept in this cache.
 
 ## Security
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,9 +87,10 @@ metrics:
          download a file which was not found.
        - `retry_malformed_after`: Duration to wait before re-trying to
          download a file which was malformed.
-    - `minidump`: This configures the duration minidumps which failed
-      to be processed correctly will be stored in the cache.
-       - `max_unused_for`: Duration a minidump will be kept in this cache.
+    - `diagnostics`: This configures the duration diagnostics data
+      will be stored in cache.  E.g. minidumps which failed to be
+      processed correctly will be stored in this cache.
+       - `max_unused_for`: Duration a file will be kept in this cache.
 
 ## Security
 

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1123,11 +1123,12 @@ impl SymbolicationActor {
                 if let SymbolicationErrorKind::Canceled = kind {
                     Self::save_minidump(minidump, minidump_cache)
                         .map_err(|e| log::error!("Failed to save minidump {}", LogError(&e)))
-                        .map(|r| match r {
-                            Some(path) => sentry::configure_scope(|scope| {
-                                scope.set_tag("crashed_minidump", path.display());
-                            }),
-                            None => (),
+                        .map(|r| {
+                            if let Some(path) = r {
+                                sentry::configure_scope(|scope| {
+                                    scope.set_tag("crashed_minidump", path.display());
+                                });
+                            }
                         })
                         .ok();
                 }

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -132,7 +132,7 @@ pub struct SymbolicationActor {
     objects: ObjectsActor,
     symcaches: SymCacheActor,
     cficaches: CfiCacheActor,
-    minidump_cache: crate::cache::Cache,
+    diagnostics_cache: crate::cache::Cache,
     threadpool: ThreadPool,
     requests: ComputationMap,
     spawnpool: Arc<procspawn::Pool>,
@@ -143,7 +143,7 @@ impl SymbolicationActor {
         objects: ObjectsActor,
         symcaches: SymCacheActor,
         cficaches: CfiCacheActor,
-        minidump_cache: crate::cache::Cache,
+        diagnostics_cache: crate::cache::Cache,
         threadpool: ThreadPool,
         spawnpool: procspawn::Pool,
     ) -> Self {
@@ -153,7 +153,7 @@ impl SymbolicationActor {
             objects,
             symcaches,
             cficaches,
-            minidump_cache,
+            diagnostics_cache,
             threadpool,
             requests,
             spawnpool: Arc::new(spawnpool),
@@ -1031,7 +1031,7 @@ impl SymbolicationActor {
         minidump: Bytes,
     ) -> ResponseFuture<Vec<(CodeModuleId, RawObjectInfo)>, SymbolicationError> {
         let pool = self.spawnpool.clone();
-        let minidump_cache = self.minidump_cache.clone();
+        let diagnostics_cache = self.diagnostics_cache.clone();
         let lazy = future::lazy(move || {
             let spawn_time = std::time::SystemTime::now();
             let spawn_result = pool.spawn(
@@ -1068,7 +1068,7 @@ impl SymbolicationActor {
                 Duration::from_secs(20),
                 "minidump.modules.spawn.error",
                 minidump,
-                minidump_cache,
+                diagnostics_cache,
             )
         });
 
@@ -1229,7 +1229,7 @@ impl SymbolicationActor {
         }
 
         let pool = self.spawnpool.clone();
-        let minidump_cache = self.minidump_cache.clone();
+        let diagnostics_cache = self.diagnostics_cache.clone();
         let lazy = future::lazy(move || {
             let spawn_time = std::time::SystemTime::now();
             let spawn_result =
@@ -1388,7 +1388,7 @@ impl SymbolicationActor {
                 Duration::from_secs(60),
                 "minidump.stackwalk.spawn.error",
                 minidump,
-                minidump_cache,
+                diagnostics_cache,
             )?;
 
             let request = SymbolicateStacktraces {

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1126,7 +1126,12 @@ impl SymbolicationActor {
                         .map(|r| {
                             if let Some(path) = r {
                                 sentry::configure_scope(|scope| {
-                                    scope.set_tag("crashed_minidump", path.display());
+                                    scope.set_extra(
+                                        "crashed_minidump",
+                                        sentry::protocol::Value::String(
+                                            path.to_string_lossy().to_string(),
+                                        ),
+                                    );
                                 });
                             }
                         })

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,7 @@ impl ServiceState {
             objects.clone(),
             symcaches,
             cficaches,
+            caches.minidumps.clone(),
             cpu_threadpool.clone(),
             spawnpool,
         );

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,7 +65,7 @@ impl ServiceState {
             objects.clone(),
             symcaches,
             cficaches,
-            caches.minidumps,
+            caches.diagnostics,
             cpu_threadpool.clone(),
             spawnpool,
         );

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,7 +65,7 @@ impl ServiceState {
             objects.clone(),
             symcaches,
             cficaches,
-            caches.minidumps.clone(),
+            caches.minidumps,
             cpu_threadpool.clone(),
             spawnpool,
         );

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -314,7 +314,7 @@ pub struct Caches {
     pub object_meta: Cache,
     pub symcaches: Cache,
     pub cficaches: Cache,
-    pub minidumps: Cache,
+    pub diagnostics: Cache,
 }
 
 impl Caches {
@@ -336,9 +336,9 @@ impl Caches {
                 let path = config.cache_dir("cficaches");
                 Cache::new("cficaches", path, config.caches.derived)
             },
-            minidumps: {
-                let path = config.cache_dir("minidumps");
-                Cache::new("minidumps", path, config.caches.minidumps)
+            diagnostics: {
+                let path = config.cache_dir("diagnostics");
+                Cache::new("diagnostics", path, config.caches.diagnostics)
             },
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -314,6 +314,7 @@ pub struct Caches {
     pub object_meta: Cache,
     pub symcaches: Cache,
     pub cficaches: Cache,
+    pub minidumps: Cache,
 }
 
 impl Caches {
@@ -334,6 +335,10 @@ impl Caches {
             cficaches: {
                 let path = config.cache_dir("cficaches");
                 Cache::new("cficaches", path, config.caches.derived)
+            },
+            minidumps: {
+                let path = config.cache_dir("minidumps");
+                Cache::new("minidumps", path, config.caches.minidumps)
             },
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,7 @@ impl CacheConfig {
         }
     }
 
-    pub fn default_minidump() -> Self {
+    pub fn default_diagnostics() -> Self {
         CacheConfig {
             max_unused_for: Some(Duration::from_secs(3600 * 24)),
             retry_misses_after: None,
@@ -121,10 +121,12 @@ pub struct CacheConfigs {
     pub downloaded: CacheConfig,
     /// Configure how long caches derived from downloads are cached for.
     pub derived: CacheConfig,
-    /// How long failed minidumps are cached.
+    /// How long diagnostics data is cached.
+    ///
+    /// E.g. minidumps which caused a crash in symbolicator will be stored here.
     ///
     /// Only `max_unused_for` is used here, the others do not make sense.
-    pub minidumps: CacheConfig,
+    pub diagnostics: CacheConfig,
 }
 
 impl Default for CacheConfigs {
@@ -132,7 +134,7 @@ impl Default for CacheConfigs {
         CacheConfigs {
             downloaded: CacheConfig::default_downloaded(),
             derived: CacheConfig::default_derived(),
-            minidumps: CacheConfig::default_minidump(),
+            diagnostics: CacheConfig::default_diagnostics(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,14 @@ impl CacheConfig {
             retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
         }
     }
+
+    pub fn default_minidump() -> Self {
+        CacheConfig {
+            max_unused_for: Some(Duration::from_secs(3600 * 24)),
+            retry_misses_after: None,
+            retry_malformed_after: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -113,6 +121,10 @@ pub struct CacheConfigs {
     pub downloaded: CacheConfig,
     /// Configure how long caches derived from downloads are cached for.
     pub derived: CacheConfig,
+    /// How long failed minidumps are cached.
+    ///
+    /// Only `max_unused_for` is used here, the others do not make sense.
+    pub minidumps: CacheConfig,
 }
 
 impl Default for CacheConfigs {
@@ -120,6 +132,7 @@ impl Default for CacheConfigs {
         CacheConfigs {
             downloaded: CacheConfig::default_downloaded(),
             derived: CacheConfig::default_derived(),
+            minidumps: CacheConfig::default_minidump(),
         }
     }
 }


### PR DESCRIPTION
This adds a feature which saves minidumps when the process processing
them crashes.  It also improves the metrics reporting these failures
to contain more information about the failure.

The crashed minidumps are stored in the cache directory and have a
default cache timeout of 24h.

Todo:

- [ ] Testing


The way this is jammed into the symbolication "actor" is not ideal,
and as can be seen from `join_procspawn()` this is by far a nice API.
It could be worth splitting this off into a minidump service which
might be able to encapsulate this a bit better.

The other thing which isn't overly nice is how this pretends to be an
entirely normal cache directory, but it only uses one of the fields.
I could be better to create a new config struct for the minidumps
cache instead.  And perhaps it should not be an item in cache::Caches
at all and instead hooked up more manually into the cleanup.

----

#