### PR TITLE
fix: Create cache directories at startup

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1148,6 +1148,7 @@ impl SymbolicationActor {
         failed_cache: crate::cache::Cache,
     ) -> failure::Fallible<Option<PathBuf>> {
         if let Some(dir) = failed_cache.cache_dir() {
+            std::fs::create_dir_all(dir)?;
             let tmp = tempfile::NamedTempFile::new_in(dir)?;
             tmp.as_file().write_all(&*minidump)?;
             let (_file, path) = tmp.keep()?;

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1153,7 +1153,7 @@ impl SymbolicationActor {
             let (_file, path) = tmp.keep()?;
             Ok(Some(path))
         } else {
-            log::debug!("No minidump crash crash configured, not saving minidump");
+            log::debug!("No diagnostics retention configured, not saving minidump");
             Ok(None)
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,8 @@ use crate::utils::http;
 pub enum ServiceStateErrorKind {
     #[fail(display = "failed to create process pool")]
     Spawn,
+    #[fail(display = "failed to create local caches")]
+    Cache,
 }
 
 symbolic::common::derive_failure!(
@@ -58,7 +60,7 @@ impl ServiceState {
 
         let download_svc = Arc::new(DownloadService::new(io_thread));
 
-        let caches = Caches::new(&config);
+        let caches = Caches::new(&config).context(ServiceStateErrorKind::Cache)?;
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,

--- a/src/app.rs
+++ b/src/app.rs
@@ -60,7 +60,7 @@ impl ServiceState {
 
         let download_svc = Arc::new(DownloadService::new(io_thread));
 
-        let caches = Caches::new(&config).context(ServiceStateErrorKind::Cache)?;
+        let caches = Caches::from_config(&config).context(ServiceStateErrorKind::Cache)?;
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -321,7 +321,7 @@ pub struct Caches {
 }
 
 impl Caches {
-    pub fn new(config: &Config) -> io::Result<Self> {
+    pub fn from_config(config: &Config) -> io::Result<Self> {
         Ok(Self {
             objects: {
                 let path = config.cache_dir("objects");
@@ -359,7 +359,7 @@ impl Caches {
 ///
 /// This will clean up all caches based on configured cache retention.
 pub fn cleanup(config: Config) -> Result<(), CleanupError> {
-    Caches::new(&config)?.cleanup()
+    Caches::from_config(&config)?.cleanup()
 }
 
 #[cfg(test)]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -107,7 +107,7 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub fn new(
+    pub fn from_config(
         name: &'static str,
         cache_dir: Option<PathBuf>,
         cache_config: CacheConfig,
@@ -325,23 +325,23 @@ impl Caches {
         Ok(Self {
             objects: {
                 let path = config.cache_dir("objects");
-                Cache::new("objects", path, config.caches.downloaded.into())?
+                Cache::from_config("objects", path, config.caches.downloaded.into())?
             },
             object_meta: {
                 let path = config.cache_dir("object_meta");
-                Cache::new("object_meta", path, config.caches.derived.into())?
+                Cache::from_config("object_meta", path, config.caches.derived.into())?
             },
             symcaches: {
                 let path = config.cache_dir("symcaches");
-                Cache::new("symcaches", path, config.caches.derived.into())?
+                Cache::from_config("symcaches", path, config.caches.derived.into())?
             },
             cficaches: {
                 let path = config.cache_dir("cficaches");
-                Cache::new("cficaches", path, config.caches.derived.into())?
+                Cache::from_config("cficaches", path, config.caches.derived.into())?
             },
             diagnostics: {
                 let path = config.cache_dir("diagnostics");
-                Cache::new("diagnostics", path, config.caches.diagnostics.into())?
+                Cache::from_config("diagnostics", path, config.caches.diagnostics.into())?
             },
         })
     }
@@ -380,7 +380,7 @@ mod tests {
     fn test_cache_dir_created() {
         let basedir = tempdir().unwrap();
         let cachedir = basedir.path().join("cache");
-        let _cache = Cache::new(
+        let _cache = Cache::from_config(
             "test",
             Some(cachedir.clone()),
             CacheConfig::Downloaded(Default::default()),
@@ -394,7 +394,7 @@ mod tests {
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
-        let cache = Cache::new(
+        let cache = Cache::from_config(
             "test",
             Some(tempdir.path().to_path_buf()),
             CacheConfig::Derived(DerivedCacheConfig {
@@ -430,7 +430,7 @@ mod tests {
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
-        let cache = Cache::new(
+        let cache = Cache::from_config(
             "test",
             Some(tempdir.path().to_path_buf()),
             CacheConfig::Derived(DerivedCacheConfig {
@@ -475,7 +475,7 @@ mod tests {
         sleep(Duration::from_millis(10));
 
         // Creation of this struct == "process startup"
-        let cache = Cache::new(
+        let cache = Cache::from_config(
             "test",
             Some(tempdir.path().to_path_buf()),
             CacheConfig::Derived(Default::default()),


### PR DESCRIPTION
The diagnostics cache directory was not created.  It seems all the
cache directories are created on the fly at runtime.  This changes
this to create all the cache directories at startup, ensuring the
application fails to start when it can not create one of the caches.