### PR TITLE
ref: Remote thread timeout

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1799,7 +1799,7 @@ mod tests {
         let (service, _cache_dir) = setup_service();
         let (_symsrv, source) = test::symbol_server();
 
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let request = get_symbolication_request(vec![source]);
             let request_id = service.symbolication().symbolicate_stacktraces(request);
             service.symbolication().get_response(request_id, None)
@@ -1807,7 +1807,7 @@ mod tests {
 
         insta::assert_yaml_snapshot!(response);
 
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let request = get_symbolication_request(vec![]);
             let request_id = service.symbolication().symbolicate_stacktraces(request);
             service.symbolication().get_response(request_id, None)
@@ -1826,7 +1826,7 @@ mod tests {
         let (service, _cache_dir) = setup_service();
         let (_symsrv, source) = test::symbol_server();
 
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let request = get_symbolication_request(vec![]);
             let request_id = service.symbolication().symbolicate_stacktraces(request);
             service.symbolication().get_response(request_id, None)
@@ -1834,7 +1834,7 @@ mod tests {
 
         insta::assert_yaml_snapshot!(response);
 
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let request = get_symbolication_request(vec![source]);
             let request_id = service.symbolication().symbolicate_stacktraces(request);
             service.symbolication().get_response(request_id, None)
@@ -1850,7 +1850,7 @@ mod tests {
         let (_symsrv, source) = test::symbol_server();
 
         let minidump = Bytes::from(fs::read(path)?);
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let symbolication = service.symbolication();
             let request_id = symbolication.process_minidump(Scope::Global, minidump, vec![source]);
             service.symbolication().get_response(request_id, None)
@@ -1890,7 +1890,7 @@ mod tests {
         let (_symsrv, source) = test::symbol_server();
 
         let report_file = Bytes::from(fs::read("./tests/fixtures/apple_crash_report.txt")?);
-        let response = test::block_fn(|| {
+        let response = test::block_fn01(|| {
             let request_id = service.symbolication().process_apple_crash_report(
                 Scope::Global,
                 report_file,

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -144,7 +144,7 @@ mod tests {
         };
         let loc = SourceLocation::new("hello.txt");
 
-        let ret = test::block_fn(|| download_source(http_source, loc, dest.clone()));
+        let ret = test::block_fn01(|| download_source(http_source, loc, dest.clone()));
         assert_eq!(ret.unwrap(), DownloadStatus::Completed);
         let content = std::fs::read_to_string(dest).unwrap();
         assert_eq!(content, "hello world\n");
@@ -164,7 +164,7 @@ mod tests {
         };
         let loc = SourceLocation::new("i-do-not-exist");
 
-        let ret = test::block_fn(|| download_source(http_source, loc, dest.clone()));
+        let ret = test::block_fn01(|| download_source(http_source, loc, dest.clone()));
         assert_eq!(ret.unwrap(), DownloadStatus::NotFound);
     }
 

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -85,35 +85,40 @@ impl DownloadService {
         source: SourceFileId,
         destination: PathBuf,
     ) -> Box<dyn Future<Item = DownloadStatus, Error = DownloadError> + Send + 'static> {
-        let fut03 = self.worker.spawn(|| async move {
-            match source {
-                SourceFileId::Sentry(source, loc) => {
-                    sentry::download_source(source, loc, destination)
-                        .compat()
-                        .await
+        let fut03 = self.worker.spawn(
+            "service.download",
+            std::time::Duration::from_secs(3600),
+            || async move {
+                match source {
+                    SourceFileId::Sentry(source, loc) => {
+                        sentry::download_source(source, loc, destination)
+                            .compat()
+                            .await
+                    }
+                    SourceFileId::Http(source, loc) => {
+                        http::download_source(source, loc, destination)
+                            .compat()
+                            .await
+                    }
+                    SourceFileId::S3(source, loc) => {
+                        s3::download_source(source, loc, destination).compat().await
+                    }
+                    SourceFileId::Gcs(source, loc) => {
+                        gcs::download_source(source, loc, destination)
+                            .compat()
+                            .await
+                    }
+                    SourceFileId::Filesystem(source, loc) => {
+                        filesystem::download_source(source, loc, destination)
+                    }
                 }
-                SourceFileId::Http(source, loc) => {
-                    http::download_source(source, loc, destination)
-                        .compat()
-                        .await
-                }
-                SourceFileId::S3(source, loc) => {
-                    s3::download_source(source, loc, destination).compat().await
-                }
-                SourceFileId::Gcs(source, loc) => {
-                    gcs::download_source(source, loc, destination)
-                        .compat()
-                        .await
-                }
-                SourceFileId::Filesystem(source, loc) => {
-                    filesystem::download_source(source, loc, destination)
-                }
-            }
-        });
+            },
+        );
         let fut01 = fut03
             .map(|spawn_ret| spawn_ret.unwrap_or_else(|_| Err(DownloadErrorKind::Canceled.into())))
             .boxed()
             .compat();
+        // TODO: remote future_metrics! macro
         Box::new(future_metrics!(
             "service.download",
             Some((

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -114,19 +114,13 @@ impl DownloadService {
                 }
             },
         );
+
+        // Map all SpawnError variants into DownloadErrorKind::Canceled.
         let fut01 = fut03
             .map(|spawn_ret| spawn_ret.unwrap_or_else(|_| Err(DownloadErrorKind::Canceled.into())))
             .boxed()
             .compat();
-        // TODO: remote future_metrics! macro
-        Box::new(future_metrics!(
-            "service.download",
-            Some((
-                std::time::Duration::from_secs(3600),
-                DownloadErrorKind::Canceled.into()
-            )),
-            fut01
-        ))
+        Box::new(fut01)
     }
 }
 

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -188,7 +188,7 @@ mod tests {
         };
 
         let svc = DownloadService::new(RemoteThread::new_threaded());
-        let ret = test::block_fn(|| svc.download(source_id, dest.clone()));
+        let ret = test::block_fn01(|| svc.download(source_id, dest.clone()));
         assert_eq!(ret.unwrap(), DownloadStatus::Completed);
         let content = std::fs::read_to_string(dest).unwrap();
         assert_eq!(content, "hello world\n")

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use actix::{System, SystemRunner};
 use actix_web::fs::StaticFiles;
+use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, IntoFuture};
 use log::LevelFilter;
 
@@ -104,9 +105,13 @@ pub(crate) fn tempdir() -> TempDir {
 /// error. The result of the future is then returned from this function
 /// call.
 ///
+/// This is provided rather than a `block_on()`-like interface to avoid accidentally calling
+/// a function which spawns before creating a future, which would attempt to spawn before
+/// actix is initialised.
+///
 /// Note that this function is intended to be used only for testing purpose.
 /// This function panics on nested call.
-pub fn block_fn<F, R>(f: F) -> Result<R::Item, R::Error>
+pub fn block_fn01<F, R>(f: F) -> Result<R::Item, R::Error>
 where
     F: FnOnce() -> R,
     R: IntoFuture,
@@ -118,22 +123,18 @@ where
     })
 }
 
-/// Run the std::future::Future until completion.
-///
-/// Block the current thread and run the std::future::Future aka futures03 future to
-/// completion, returning the output it resolves to.
-pub fn block_on<F, T>(f: F) -> T
+/// Version of `block_fn` which works with std::future aka futures03.
+pub fn block_fn<F, R, T>(f: F) -> T
 where
-    F: std::future::Future<Output = T>,
+    F: FnOnce() -> R,
+    R: std::future::Future<Output = T>,
 {
-    use futures::future::{FutureExt, TryFutureExt};
-
     SYSTEM.with(|cell| {
         let mut inner = cell.borrow_mut();
         inner.set_current();
         inner
             .runner()
-            .block_on(f.then(futures::future::ok::<T, ()>).boxed_local().compat())
+            .block_on(async move { f().await }.unit_error().boxed_local().compat())
             .unwrap()
     })
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -129,11 +129,7 @@ where
         inner.set_current();
         inner
             .runner()
-            .block_on(
-                f.then(|o| futures::future::ok::<T, ()>(o))
-                    .boxed_local()
-                    .compat(),
-            )
+            .block_on(f.then(futures::future::ok::<T, ()>).boxed_local().compat())
             .unwrap()
     })
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -118,6 +118,10 @@ where
     })
 }
 
+/// Run the std::future::Future until completion.
+///
+/// Block the current thread and run the std::future::Future aka futures03 future to
+/// completion, returning the output it resolves to.
 pub fn block_on<F, T>(f: F) -> T
 where
     F: std::future::Future<Output = T>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 
 use actix::{System, SystemRunner};
 use actix_web::fs::StaticFiles;
-use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, IntoFuture};
 use log::LevelFilter;
 
@@ -105,10 +104,6 @@ pub(crate) fn tempdir() -> TempDir {
 /// error. The result of the future is then returned from this function
 /// call.
 ///
-/// This is provided rather than a `block_on()`-like interface to avoid accidentally calling
-/// a function which spawns before creating a future, which would attempt to spawn before
-/// actix is initialised.
-///
 /// Note that this function is intended to be used only for testing purpose.
 /// This function panics on nested call.
 pub fn block_fn<F, R>(f: F) -> Result<R::Item, R::Error>
@@ -123,22 +118,6 @@ where
     })
 }
 
-/// Version of `block_fn` which works with std::future aka futures03.
-pub fn block_fn03<F, R, T>(f: F) -> T
-where
-    F: FnOnce() -> R,
-    R: std::future::Future<Output = T>,
-{
-    SYSTEM.with(|cell| {
-        let mut inner = cell.borrow_mut();
-        inner.set_current();
-        inner
-            .runner()
-            .block_on(async move { f().await }.unit_error().boxed_local().compat())
-            .unwrap()
-    })
-}
-
 /// Run the std::future::Future until completion.
 ///
 /// Block the current thread and run the std::future::Future aka futures03 future to
@@ -147,12 +126,14 @@ pub fn block_on<F, T>(f: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
+    use futures::future::{FutureExt, TryFutureExt};
+
     SYSTEM.with(|cell| {
         let mut inner = cell.borrow_mut();
         inner.set_current();
         inner
             .runner()
-            .block_on(f.unit_error().boxed_local().compat())
+            .block_on(f.then(futures::future::ok::<T, ()>).boxed_local().compat())
             .unwrap()
     })
 }

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -196,8 +196,12 @@ impl RemoteThread {
                                 ChannelMsg::Timeout
                             }
                         };
-                        // TODO: Should send failures be logged?  Panic?
-                        tx.send(msg).ok();
+                        tx.send(msg).unwrap_or_else(|_| {
+                            log::info!(
+                                "Failed to send result of {} task, caller dropped",
+                                task_name
+                            )
+                        });
                         futures01::future::ok(())
                     })
             });

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -145,11 +145,12 @@ impl RemoteThread {
 
     /// Create a future in the remote thread and run it.
     ///
-    /// The returned future resolves when the spawned future has completed
-    /// execution.  The output type of the spawned future is wrapped in a
-    /// `Result`, normally the output is returned in an `Ok` but when the remote
-    /// future is dropped because the thread is shut down or restarted for any
-    /// reason it returns `Err(oneshot::Canceled)`.
+    /// The returned future resolves when the spawned future has completed execution.  The
+    /// output type of the spawned future is wrapped in a `Result`, normally the output is
+    /// returned in an `Ok`.
+    ///
+    /// Then the future takes too long `SpawnError::Timeout` is returned, ifthe
+    /// `RemoteThread` it is running on is dropped `SpawnError::Canceled` is returned.
     pub fn spawn<F, R, T>(
         &self,
         task_name: &'static str,

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -192,7 +192,7 @@ impl RemoteThread {
                 );
                 let start_time = Instant::now();
                 factory()
-                    .then(future::ok)
+                    .unit_error()
                     .boxed_local()
                     .compat()
                     .timeout(timeout)
@@ -205,10 +205,11 @@ impl RemoteThread {
                         let msg = match r {
                             Ok(o) => ChannelMsg::Output(o),
                             Err(_) => {
-                                // Because we wrapped our T into future::ok() above to make a
-                                // TryFuture, we know the <Timeout as Future>::Error will only
-                                // occur if the error is actually because of a timeout, so we do
-                                // not need to check with .is_timer() or .is_inner().
+                                // Because we wrapped our T into Ok() above using
+                                // .unit_error() to make a TryFuture, we know the <Timeout
+                                // as Future>::Error will only occur if the error is
+                                // actually because of a timeout, so we do not need to check
+                                // with .is_timer() or .is_inner().
                                 ChannelMsg::Timeout
                             }
                         };

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -149,7 +149,7 @@ impl RemoteThread {
     /// output type of the spawned future is wrapped in a `Result`, normally the output is
     /// returned in an `Ok`.
     ///
-    /// Then the future takes too long `SpawnError::Timeout` is returned, ifthe
+    /// When the future takes too long `SpawnError::Timeout` is returned, if the
     /// `RemoteThread` it is running on is dropped `SpawnError::Canceled` is returned.
     pub fn spawn<F, R, T>(
         &self,
@@ -321,7 +321,6 @@ mod tests {
         });
         std::mem::drop(remote);
         let ret = test::block_on(fut);
-        println!("{:?}", ret);
         assert_eq!(ret, Err(SpawnError::Canceled));
     }
 }

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -288,7 +288,7 @@ mod tests {
     fn test_remote_thread() {
         let remote = setup_remote_thread();
         let fut = remote.spawn("task", Duration::from_secs(10), || future::ready(42));
-        let ret = test::block_on(fut);
+        let ret = test::block_fn(|| fut);
         assert_eq!(ret, Ok(42));
     }
 
@@ -304,7 +304,7 @@ mod tests {
             });
             rx
         });
-        let ret = test::block_on(fut);
+        let ret = test::block_fn(|| fut);
         assert_eq!(ret, Err(SpawnError::Timeout));
     }
 
@@ -321,7 +321,7 @@ mod tests {
             rx
         });
         std::mem::drop(remote);
-        let ret = test::block_on(fut);
+        let ret = test::block_fn(|| fut);
         assert_eq!(ret, Err(SpawnError::Canceled));
     }
 
@@ -332,7 +332,7 @@ mod tests {
         let remote1 = remote0.clone();
         std::mem::drop(remote0);
         let fut = remote1.spawn("task", Duration::from_secs(10), || future::ready(42));
-        let ret = test::block_on(fut);
+        let ret = test::block_fn(|| fut);
         assert_eq!(ret, Ok(42));
     }
 }

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::channel::oneshot;
-use futures::{future, FutureExt, TryFutureExt};
-use futures01::future::Future as Future01;
+use futures::compat::Future01CompatExt;
+use futures::{FutureExt, TryFutureExt};
 use tokio::prelude::FutureExt as TokioFutureExt;
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -21,8 +21,8 @@ pub fn enable_test_mode() {
     IS_TEST.store(true, Ordering::Relaxed);
 }
 
-/// Error returned from a `SpawnHandle` when the thread pool restarts.
-pub use oneshot::Canceled as RemoteCanceled;
+/// Error returned when the spawned future was canceled.
+use oneshot::Canceled as RemoteCanceled;
 
 /// Handle returned from `ThreadPool::spawn_handle`.
 ///
@@ -82,6 +82,98 @@ impl ThreadPool {
     }
 }
 
+/// A plain remote thread which can execute non-send futures.
+///
+/// When the global `IS_TEST` is set by calling [`enable_test_mode`] this will
+/// not create a new thread and instead spawn any executions in the current
+/// thread.  This is a workaround for the stdout and panic capturing not being
+/// exposed properly to the test framework users which stops us from enabling
+/// these things in spawned threads during tests.
+///
+/// [`enable_test_mode`]: func.enable_test_mode.html
+#[derive(Debug, Clone)]
+struct BareRemoteThread {
+    inner: Arc<InnerBareRemoteThread>,
+}
+
+/// Inner `BareRemoteThread` struct to get correct clone behaviour.
+///
+/// We only have an `actix::Addr` to the arbiter, which itself can be cloned.  Dropping this
+/// does not terminate the arbiter, but we wan the `RemoteThread` to stop when dropped.  So
+/// we need to implement `Drop`, but only want to actually trigger this drop when all clones
+/// of our `RemoteThread` are dropped.  Hence the need to put the drop on an inner struct
+/// which is wrapped in an Arc.
+#[derive(Debug)]
+struct InnerBareRemoteThread {
+    arbiter: Option<actix::Addr<actix::Arbiter>>,
+}
+
+/// Dropping terminates the BareRemoteThread, cancelling all futures.
+impl Drop for InnerBareRemoteThread {
+    fn drop(&mut self) {
+        // Without sending the StopArbiter message the arbiter thread keeps running even if
+        // you drop the arbiter.
+        if let Some(ref addr) = self.arbiter {
+            addr.do_send(actix::msgs::StopArbiter(0));
+        }
+    }
+}
+
+impl BareRemoteThread {
+    /// Create a new instance, spawning the thread.
+    fn new() -> Self {
+        let arbiter = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
+            None
+        } else {
+            Some(actix::Arbiter::new("RemoteThread"))
+        };
+        Self {
+            inner: Arc::new(InnerBareRemoteThread { arbiter }),
+        }
+    }
+
+    /// Create a new instance, even when running in test mode.
+    ///
+    /// Some tests actually need to test this stuff works, support that.
+    #[cfg(test)]
+    pub fn new_threaded() -> Self {
+        Self {
+            inner: Arc::new(InnerBareRemoteThread {
+                arbiter: Some(actix::Arbiter::new("RemoteThread")),
+            }),
+        }
+    }
+
+    /// Create a future in the remote thread and run it.
+    ///
+    /// The returned future resolves when the spawned future has completed execution.  The
+    /// output type of the spawned future is wrapped in a `Result`, normally the output is
+    /// returned in an `Ok`.
+    // TODO: Dropping the returned future should cancel the spawned future.
+    pub fn spawn<F, R, T>(&self, factory: F) -> impl Future<Output = Result<T, RemoteCanceled>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Future<Output = T> + 'static,
+        T: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        let msg = actix::msgs::Execute::new(move || -> Result<(), ()> {
+            let fut = factory().map(|output| tx.send(output).or(Err(())));
+            let fut01 = fut.boxed_local().compat();
+            actix::spawn(fut01);
+            Ok(())
+        });
+        match self.inner.arbiter {
+            Some(ref arbiter) => arbiter.do_send(msg),
+            None => {
+                let arbiter = actix::Arbiter::current();
+                arbiter.do_send(msg);
+            }
+        }
+        rx
+    }
+}
+
 /// A remote thread which can run non-sendable futures.
 ///
 /// This can be used to implement any services which internally need to use
@@ -93,22 +185,13 @@ impl ThreadPool {
 /// exposed properly to the test framework users which stops us from enabling
 /// these things in spawned threads during tests.
 ///
+/// NOTE: This implementation will still change to not handle the timeout and instead
+///    support cancellation on dropping of the returned future.
+///
 /// [`enable_test_mode`]: func.enable_test_mode.html
 #[derive(Clone, Debug)]
 pub struct RemoteThread {
-    inner: Arc<InnerRemoteThread>,
-}
-
-/// Inner `RemoteThread` struct to get correct clone behaviour.
-///
-/// We only have an `actix::Addr` to the arbiter, which itself can be cloned.  Dropping this
-/// does not terminate the arbiter, but we wan the `RemoteThread` to stop when dropped.  So
-/// we need to implement `Drop`, but only want to actually trigger this drop when all clones
-/// of our `RemoteThread` are dropped.  Hence the need to put the drop on an inner struct
-/// which is wrapped in an Arc.
-#[derive(Debug)]
-struct InnerRemoteThread {
-    arbiter: Option<actix::Addr<actix::Arbiter>>,
+    remote: BareRemoteThread,
 }
 
 /// Spawning the future on the remote failed.
@@ -123,27 +206,11 @@ pub enum SpawnError {
     Timeout,
 }
 
-/// Dropping terminates the RemoteThread, cancelling all futures.
-impl Drop for InnerRemoteThread {
-    fn drop(&mut self) {
-        // Without sending the StopArbiter message the arbiter thread keeps running even if
-        // you drop the arbiter.
-        if let Some(ref addr) = self.arbiter {
-            addr.do_send(actix::msgs::StopArbiter(0));
-        }
-    }
-}
-
 impl RemoteThread {
     /// Create a new instance, spawning the thread.
     pub fn new() -> Self {
-        let arbiter = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
-            None
-        } else {
-            Some(actix::Arbiter::new("RemoteThread"))
-        };
         Self {
-            inner: Arc::new(InnerRemoteThread { arbiter }),
+            remote: BareRemoteThread::new(),
         }
     }
 
@@ -153,9 +220,7 @@ impl RemoteThread {
     #[cfg(test)]
     pub fn new_threaded() -> Self {
         Self {
-            inner: Arc::new(InnerRemoteThread {
-                arbiter: Some(actix::Arbiter::new("RemoteThread")),
-            }),
+            remote: BareRemoteThread::new_threaded(),
         }
     }
 
@@ -167,6 +232,7 @@ impl RemoteThread {
     ///
     /// When the future takes too long `SpawnError::Timeout` is returned, if the
     /// `RemoteThread` it is running on is dropped `SpawnError::Canceled` is returned.
+    // TODO: rename to spawn_task?
     pub fn spawn<F, R, T>(
         &self,
         task_name: &'static str,
@@ -182,60 +248,46 @@ impl RemoteThread {
             Output(T),
             Timeout,
         };
-        let (tx, rx) = oneshot::channel();
         let creation_time = Instant::now();
-        let msg = actix::msgs::Execute::new(move || -> Result<(), ()> {
-            let fut01 = futures01::future::lazy(move || {
-                metric!(
-                    timer("futures.wait_time") = creation_time.elapsed(),
-                    "task_name" => task_name,
-                );
-                let start_time = Instant::now();
-                factory()
-                    .then(future::ok)
-                    .boxed_local()
-                    .compat()
-                    .timeout(timeout)
-                    .then(move |r: Result<T, tokio::timer::timeout::Error<()>>| {
-                        metric!(
-                            timer("futures.done") = start_time.elapsed(),
-                            "task_name" => task_name,
-                            "status" => if r.is_ok() {"done"} else {"timeout"},
-                        );
-                        let msg = match r {
-                            Ok(o) => ChannelMsg::Output(o),
-                            Err(_) => {
-                                // Because we wrapped our T into future::ok() above to make a
-                                // TryFuture, we know the <Timeout as Future>::Error will only
-                                // occur if the error is actually because of a timeout, so we do
-                                // not need to check with .is_timer() or .is_inner().
-                                ChannelMsg::Timeout
-                            }
-                        };
-                        tx.send(msg).unwrap_or_else(|_| {
-                            log::info!(
-                                "Failed to send result of {} task, caller dropped",
-                                task_name
-                            )
-                        });
-                        futures01::future::ok(())
-                    })
-            });
-            actix::spawn(fut01);
-            Ok(())
+        let spawn_rx = self.remote.spawn(move || async move {
+            metric!(
+                timer("futures.wait_time") = creation_time.elapsed(),
+                "task_name" => task_name,
+            );
+            let start_time = Instant::now();
+            let timeout_output = factory()
+                .unit_error()
+                .boxed_local()
+                .compat()
+                .timeout(timeout)
+                .compat()
+                .await;
+            metric!(
+                timer("futures.done") = start_time.elapsed(),
+                "task_name" => task_name,
+                "status" => if timeout_output.is_ok() {"done"} else {"timeout"},
+            );
+            match timeout_output {
+                Ok(output) => ChannelMsg::Output(output),
+                // Because we wrapped the original future in Ok with .unit_error() we know
+                // any error here is from the timeout and not from the future.  So we do not
+                // need to check using with .is_timer() or .is_inner().
+                Err(_) => ChannelMsg::Timeout,
+            }
         });
-        match self.inner.arbiter {
-            Some(ref arbiter) => arbiter.do_send(msg),
-            None => {
-                let arbiter = actix::Arbiter::current();
-                arbiter.do_send(msg);
+        async move {
+            match spawn_rx.await {
+                Ok(ChannelMsg::Output(output)) => Ok(output),
+                Ok(ChannelMsg::Timeout) => Err(SpawnError::Timeout),
+                Err(RemoteCanceled) => {
+                    metric!(
+                        counter("futures.canceled") += 1,
+                        "task_name" => task_name,
+                    );
+                    Err(SpawnError::Canceled)
+                }
             }
         }
-        rx.then(|oneshot_result| match oneshot_result {
-            Ok(ChannelMsg::Output(o)) => future::ready(Ok(o)),
-            Ok(ChannelMsg::Timeout) => future::ready(Err(SpawnError::Timeout)),
-            Err(oneshot::Canceled) => future::ready(Err(SpawnError::Canceled)),
-        })
     }
 }
 
@@ -268,7 +320,59 @@ impl Drop for CallOnDrop {
 mod tests {
     use super::*;
 
+    use futures::future;
+
     use crate::test;
+
+    fn setup() {
+        // Ensure actix is setup.
+        test::setup();
+
+        // test::setup() enables logging, but this test spawns a thread where
+        // logging is not captured.  For normal test runs we don't want to
+        // pollute the stdout so silence logs here.  When debugging this test
+        // you may want to temporarily remove this.
+        log::set_max_level(log::LevelFilter::Off);
+    }
+
+    #[test]
+    fn test_bare_remote_thread() {
+        setup();
+        let remote = BareRemoteThread::new_threaded();
+        let fut = remote.spawn(|| future::ready(42));
+        let ret = test::block_fn03(|| fut);
+        assert_eq!(ret, Ok(42));
+    }
+
+    #[test]
+    fn test_bare_remote_thread_canceled() {
+        setup();
+        let remote = BareRemoteThread::new_threaded();
+        let fut = remote.spawn(|| {
+            // Elaborate executor-neutral way of sleeping in a future.
+            let (tx, rx) = oneshot::channel();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_secs(10));
+                tx.send(42).ok();
+            });
+            rx
+        });
+        std::mem::drop(remote);
+        let ret = test::block_fn03(|| fut);
+        assert_eq!(ret, Err(RemoteCanceled));
+    }
+
+    #[test]
+    fn test_bare_remote_thread_clone_drop() {
+        // When dropping a clone of the BareRemoteThread the other one needs to keep working.
+        setup();
+        let remote0 = BareRemoteThread::new_threaded();
+        let remote1 = remote0.clone();
+        std::mem::drop(remote0);
+        let fut = remote1.spawn(|| future::ready(42));
+        let ret = test::block_on(fut);
+        assert_eq!(ret, Ok(42));
+    }
 
     /// Create a new RemoteThread for testing purposes.
     fn setup_remote_thread() -> RemoteThread {

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -220,7 +220,7 @@ mod tests {
             app.resource("/", |resource| resource.f(|_| "OK"));
         });
 
-        let response = test::block_fn(|| server.get().finish().unwrap().send());
+        let response = test::block_fn01(|| server.get().finish().unwrap().send());
         assert!(response.is_err());
 
         Ok(())


### PR DESCRIPTION
The `future_metrics!` macro is `futures v0.1` only and hinders adoption of `futures v0.3`. What it does should be part of the services interface so integrate it into the `RemoteThread::spawn` call.