### PR TITLE
style: Deny clippy by default using code attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint-python: .venv/bin/python
 
 lint-rust:
 	@rustup component add clippy --toolchain stable 2> /dev/null
-	cargo +stable clippy --all-features --all --tests --examples -- -D clippy::all
+	cargo +stable clippy --all-features --all --tests --examples
 .PHONY: lint-rust
 
 # Formatting

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@
 //! Symbolicator can act as a proxy to symbol servers supporting multiple formats, such as
 //! Microsoft's symbol server or Breakpad symbol repositories.
 
-#![deny(missing_debug_implementations, missing_docs, clippy::all)]
+#![deny(clippy::all)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 #[macro_use]
 mod macros;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@
 //! Symbolicator can act as a proxy to symbol servers supporting multiple formats, such as
 //! Microsoft's symbol server or Breakpad symbol repositories.
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![deny(missing_debug_implementations, missing_docs, clippy::all)]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This replaces the -D option on the command line, so running lints are
more consistent.