### PR TITLE
Convert inner implementation of HTTP downloader to async fn code

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! tryf {
             Ok(value) => value,
             Err(e) => {
                 return Box::new(::futures01::future::err(::std::convert::From::from(e)))
-                    as Box<dyn Future<Item = _, Error = _>>;
+                    as Box<dyn ::futures01::future::Future<Item = _, Error = _>>;
             }
         }
     };

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -82,6 +82,7 @@ pub async fn download_source(
         Err(_) => return Ok(DownloadStatus::NotFound),
     };
     log::debug!("Fetching debug file from {}", download_url);
+
     let mut backoff = ExponentialBackoff::from_millis(10).map(jitter).take(3);
     let response = loop {
         let result = start_request(&source, download_url.clone()).await;
@@ -90,6 +91,7 @@ pub async fn download_source(
             _ => break result,
         }
     };
+
     match response {
         Ok(response) => {
             if response.status().is_success() {

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -48,7 +48,7 @@ fn join_url_encoded(base: &Url, path: &SourceLocation) -> Result<Url, ()> {
 /// This initiates the request, when the future resolves the headers will have been
 /// retrieved but not the entire payload.
 async fn start_request(
-    source: Arc<HttpSourceConfig>,
+    source: &HttpSourceConfig,
     url: Url,
 ) -> Result<client::ClientResponse, client::SendRequestError> {
     http::follow_redirects(url, MAX_HTTP_REDIRECTS, move |url| {
@@ -84,7 +84,7 @@ pub async fn download_source(
     log::debug!("Fetching debug file from {}", download_url);
     let mut backoff = ExponentialBackoff::from_millis(10).map(jitter).take(3);
     let response = loop {
-        let result = start_request(source.clone(), download_url.clone()).await;
+        let result = start_request(&source, download_url.clone()).await;
         match backoff.next() {
             Some(duration) if result.is_err() => delay(duration).await,
             _ => break result,

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -210,7 +210,7 @@ async fn download_stream(
     log::trace!("Downloading from {}", source);
     let mut file =
         std::fs::File::create(&destination).context(DownloadErrorKind::BadDestination)?;
-    let mut stream = Box::pin(stream);
+    futures::pin_mut!(stream);
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -202,6 +202,9 @@ fn download_future_stream(
     Box::new(ret)
 }
 
+/// Download the source from a stream.
+///
+/// This is common functionality used by all many downloaders.
 async fn download_stream(
     source: SourceFileId,
     stream: impl Stream<Item = Result<Bytes, DownloadError>>,

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::channel::oneshot;
+use futures::compat::Future01CompatExt;
 use futures::{future, FutureExt, TryFutureExt};
 use futures01::future::Future as Future01;
 use tokio::prelude::FutureExt as TokioFutureExt;
@@ -269,6 +270,14 @@ impl Drop for CallOnDrop {
             f();
         }
     }
+}
+
+/// Delay aka sleep for a given duration
+pub async fn delay(duration: Duration) {
+    tokio::timer::Delay::new(Instant::now() + duration)
+        .compat()
+        .await
+        .ok();
 }
 
 #[cfg(test)]

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -9,7 +9,8 @@ use actix_web::client::{
     ClientConnector, ClientConnectorError, ClientRequest, ClientResponse, SendRequestError,
 };
 use actix_web::{http::header, HttpMessage};
-use futures01::{future, future::Either, Async, Future, IntoFuture, Poll};
+use futures::compat::Future01CompatExt;
+use futures01::{future::Either, Async, Future, IntoFuture, Poll};
 use ipnetwork::Ipv4Network;
 use tokio::net::{tcp::ConnectFuture, TcpStream};
 use tokio::timer::Delay;
@@ -24,57 +25,51 @@ lazy_static::lazy_static! {
     ].into_iter().map(|x| x.parse().unwrap()).collect();
 }
 
-pub fn follow_redirects<F>(
+pub async fn follow_redirects<F>(
     initial_url: Url,
     max_redirects: usize,
     make_request: F,
-) -> ResponseFuture<ClientResponse, SendRequestError>
+) -> Result<ClientResponse, SendRequestError>
 where
     F: Fn(&str) -> Result<ClientRequest, actix_web::error::Error> + Send + 'static,
 {
-    let state = (initial_url, max_redirects, true);
-    Box::new(future::loop_fn(state, move |(url, redirects, trusted)| {
-        let mut request = tryf!(make_request(url.as_str()).map_err(|err| {
+    let mut url = initial_url;
+    let mut redirects = max_redirects;
+    let mut trusted = true;
+
+    let response = loop {
+        let mut request = make_request(url.as_str()).map_err(|err| {
             let message = format!("Failed creating request: {} (URI: {})", err, url);
             sentry::capture_message(&message, sentry::Level::Error);
             SendRequestError::Connector(ClientConnectorError::InvalidUrl)
-        }));
-
+        })?;
         if !trusted {
             let headers = request.headers_mut();
             headers.remove(header::AUTHORIZATION);
             headers.remove(header::COOKIE);
         }
-
-        let resp_fut = request.send().and_then(move |response| {
-            if response.status().is_redirection() && redirects > 0 {
-                let location = response
-                    .headers()
-                    .get(header::LOCATION)
-                    .and_then(|l| l.to_str().ok());
-
-                if let Some(location) = location {
-                    let redirect_url = url.join(location).map_err(|e| {
-                        let message = format!("bad request uri: {}", e);
-                        SendRequestError::Io(io::Error::new(io::ErrorKind::InvalidData, message))
-                    })?;
-
-                    log::trace!("Following redirect: {:?}", &redirect_url);
-                    let is_same_origin = redirect_url.origin() == url.origin();
-
-                    return Ok(future::Loop::Continue((
-                        redirect_url,
-                        redirects - 1,
-                        trusted && is_same_origin,
-                    )));
-                }
+        let response = request.send().compat().await?;
+        if response.status().is_redirection() && redirects > 0 {
+            let location = response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|l| l.to_str().ok());
+            if let Some(location) = location {
+                let redirect_url = url.join(location).map_err(|e| {
+                    let message = format!("bad request uri: {}", e);
+                    SendRequestError::Io(io::Error::new(io::ErrorKind::InvalidData, message))
+                })?;
+                log::trace!("Following redirect: {:?}", &redirect_url);
+                let is_same_origin = redirect_url.origin() == url.origin();
+                trusted = trusted && is_same_origin;
+                url = redirect_url;
+                redirects -= 1;
+                continue;
             }
-
-            Ok(future::Loop::Break(response))
-        });
-
-        Box::new(resp_fut)
-    }))
+        }
+        break response;
+    };
+    Ok(response)
 }
 
 /// A Resolver-like actor for the actix-web http client that refuses to resolve to reserved IP addresses.


### PR DESCRIPTION
This converts the HTTP downloader to futures03 using async fn code.
No functional change.