### PR TITLE
fix: Do not skip modules without debug id

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1055,7 +1055,7 @@ impl SymbolicationActor {
                             (
                                 code_module
                                     .id()
-                                    .unwrap_or_else(|| CodeModuleId::from(DebugId::nil())),
+                                    .unwrap_or_default(),
                                 object_info_from_minidump_module(object_type, code_module),
                             )
                         })

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1304,7 +1304,7 @@ impl SymbolicationActor {
                                     object_info_from_minidump_module(object_type, code_module)
                                         .into();
 
-                                let module_id: Option<CodeModuleId> = code_module.id();
+                                let module_id = code_module.id();
 
                                 let status = match module_id {
                                     Some(id) => unwind_statuses

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1299,7 +1299,7 @@ impl SymbolicationActor {
                         let modules = process_state
                             .modules()
                             .into_iter()
-                            .filter_map(|code_module| {
+                            .map(|code_module| {
                                 let mut info: CompleteObjectInfo =
                                     object_info_from_minidump_module(object_type, code_module)
                                         .into();
@@ -1329,7 +1329,7 @@ impl SymbolicationActor {
 
                                 info.features.merge(features);
 
-                                Some(info)
+                                info
                             })
                             .collect::<Vec<_>>();
 

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1169,10 +1169,6 @@ impl SymbolicationActor {
 
         let futures = requests
             .into_iter()
-            // .filter(|(code_module_id, _object_info)| {
-            //     println!("code module: {:?} {}", _object_info.code_id, code_module_id);
-            //     !code_module_id.uuid().is_nil()
-            // })
             .map(move |(code_module_id, object_info)| {
                 cficaches
                     .fetch(FetchCfiCache {

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1053,9 +1053,7 @@ impl SymbolicationActor {
                         .into_iter()
                         .map(|code_module| {
                             (
-                                code_module
-                                    .id()
-                                    .unwrap_or_default(),
+                                code_module.id().unwrap_or_default(),
                                 object_info_from_minidump_module(object_type, code_module),
                             )
                         })
@@ -1171,6 +1169,7 @@ impl SymbolicationActor {
 
         let futures = requests
             .into_iter()
+            .filter(|(code_module_id, _object_info)| !code_module_id.uuid().is_nil())
             .map(move |(code_module_id, object_info)| {
                 cficaches
                     .fetch(FetchCfiCache {

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1051,11 +1051,13 @@ impl SymbolicationActor {
                     let cfi_modules = state
                         .referenced_modules()
                         .into_iter()
-                        .filter_map(|code_module| {
-                            Some((
-                                code_module.id()?,
+                        .map(|code_module| {
+                            (
+                                code_module
+                                    .id()
+                                    .unwrap_or_else(|| CodeModuleId::from(DebugId::nil())),
                                 object_info_from_minidump_module(object_type, code_module),
-                            ))
+                            )
                         })
                         .collect();
 


### PR DESCRIPTION
Some minidumps are missing debug IDs and skipping them results in not
even all modules showing up which results in even more confusing crash
reporting.