### PR TITLE
ref: Update S3 downloader to async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 symbolic = { version = "7.3.2", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
 sentry = { version = "0.18.0", features = ["with_debug_meta"] }
 sentry-actix = "0.18.0"
+# rusoto >= 0.43 supports async/await natively, with tokio 0.2 under the hood
+# For now we will stick with an older version, until our downloader client / runtime is compatible with tokio 0.2
 rusoto_s3 = "0.40.0"
 rusoto_core = "0.40.0"
 rusoto_credential = "0.40.0"

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -76,9 +76,7 @@ async fn dispatch_download(
                 .await
         }
         SourceFileId::Http(source, loc) => http::download_source(source, loc, destination).await,
-        SourceFileId::S3(source, loc) => {
-            s3::download_source(source, loc, destination).compat().await
-        }
+        SourceFileId::S3(source, loc) => s3::download_source(source, loc, destination).await,
         SourceFileId::Gcs(source, loc) => {
             gcs::download_source(source, loc, destination)
                 .compat()

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -9,8 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::BytesMut;
-use futures::compat::Future01CompatExt;
-use futures::compat::Stream01CompatExt;
+use futures::compat::{Future01CompatExt, Stream01CompatExt};
 use futures01::Stream;
 use parking_lot::Mutex;
 use rusoto_s3::S3;


### PR DESCRIPTION
This is just a first step, as a newer rusoto has native support
for async/await, which we do not yet use.

A next step in this refactoring would probably be to directly stream
from an `AsyncRead` into an `AsyncWrite`, without manually dealing
with streams.