### PR TITLE
Refactor hitcounter fixture, disable pytest-rerunfailure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ test-rust:
 .PHONY: test-rust
 
 test-integration: .venv/bin/python
-	.venv/bin/pip install -U pytest pytest-rerunfailures pytest-localserver requests pytest-xdist pytest-icdiff boto3
+	.venv/bin/pip install -U pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
 	cargo build --locked
-	@.venv/bin/pytest tests --reruns 5 -n12 -vv
+	@.venv/bin/pytest tests -n12 -vv
 .PHONY: test-integration
 
 # Documentation

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = -ra --tb=native --durations 5 -p no:warnings
+testpaths = tests
 markers =
     extra_failure_checks: Marker which can add additional failure checks to
        a test.  It accepts the keyword argument `checks` which should be a

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 addopts = -ra --tb=native --durations 5 -p no:warnings
+markers =
+    extra_failure_checks: Marker which can add additional failure checks to
+       a test.  It accepts the keyword argument `checks` which should be a
+       list of functions to call after the test finished executing.  These
+       functions can fail the test by calling `pytest.fail()`.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,6 +65,7 @@ def background_process(request):
 
     The return value of the function is the subprocess.Popen object.
     """
+
     def inner(*args, **kwargs):
         p = subprocess.Popen(*args, **kwargs)
         request.addfinalizer(p.kill)
@@ -120,6 +121,7 @@ def symbolicator(tmpdir, request, random_port, background_process):
 
     The return value of the function is a :class:`Symbolicator` object.
     """
+
     def inner(**config_data):
         config = tmpdir.join("config")
         port = random_port()
@@ -207,14 +209,14 @@ class HitCounter:
             start_response("302 Found", [("Location", path)])
             return [b""]
         elif path.startswith("/msdl/"):
-            print(f'got requested: {path}')
+            print(f"got requested: {path}")
             path = path[len("/msdl/") :]
-            print(f'proxying {path}')
+            print(f"proxying {path}")
             with requests.get(
                 f"https://msdl.microsoft.com/download/symbols/{path}",
                 allow_redirects=False,  # test redirects with msdl
             ) as r:
-                print(f'status code: {r.status_code}')
+                print(f"status code: {r.status_code}")
                 start_response(f"{r.status_code} BOGUS", list(r.headers.items()))
                 return [r.content]
         elif path.startswith("/respond_statuscode/"):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,6 @@
+import collections
 import subprocess
+import traceback
 import uuid
 import time
 import socket
@@ -22,6 +24,24 @@ GCS_CLIENT_EMAIL = os.environ.get("SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL")
 session = requests.session()
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """This handles the extra_failure_checks mark to perform further assertions.
+
+    The mark can be added e.g. by a fixture that wants to run
+    something that can raise pytest.fail.Exception after the test has
+    completed.
+
+    Such checks will not be run when the test already failed, just
+    like multiple assertions within a test will stop the test
+    execution at the first failure.
+    """
+    yield
+    for marker in item.iter_markers("extra_failure_checks"):
+        for check_func in marker.kwargs.get("checks", []):
+            check_func()
+
+
 @pytest.fixture
 def random_port():
     def inner():
@@ -38,6 +58,13 @@ def random_port():
 
 @pytest.fixture
 def background_process(request):
+    """Function to run a process in the background.
+
+    All args and kwargs are passed to subprocess.Popen and the process is terminated in the
+    fixture finaliser.
+
+    The return value of the function is the subprocess.Popen object.
+    """
     def inner(*args, **kwargs):
         p = subprocess.Popen(*args, **kwargs)
         request.addfinalizer(p.kill)
@@ -73,9 +100,9 @@ class Service:
                 break
             except Exception:
                 time.sleep(backoff)
-                if backoff > 10:
+                if backoff > 100:  # 10s
                     raise
-                backoff *= 2
+                backoff += 0.1
 
     def wait_healthcheck(self):
         self.wait_http("/healthcheck")
@@ -87,6 +114,12 @@ class Symbolicator(Service):
 
 @pytest.fixture
 def symbolicator(tmpdir, request, random_port, background_process):
+    """Function to run a symbolicator instance.
+
+    All kwargs are written to the config file of the symbolicator instance.
+
+    The return value of the function is a :class:`Symbolicator` object.
+    """
     def inner(**config_data):
         config = tmpdir.join("config")
         port = random_port()
@@ -107,67 +140,120 @@ def symbolicator(tmpdir, request, random_port, background_process):
 
 
 class HitCounter:
-    def __init__(self, url, hits):
-        self.url = url
-        self.hits = hits
+    """A simple WSGI app which will count the number of times a URL path is served.
+
+    Several URL paths are recognised:
+
+    `/redirect/{tail}`: This redirects to `/{tail}`.
+
+    `/msdl/{tail}`: This proxies the request to
+       https://msdl.microsoft.com/download/symbols/{tail}.
+
+    `/respond_statuscode/{num}`: returns and empty response with the given status code.
+
+    `/garbage_data/{tail}`: returns 200 OK with some garbage data in the response body.
+
+    Any other request will return 500 Internal Server Error and will be stored in
+    self.errors.
+
+    This object itself is a context manager, when entered the WSGI server will start serving,
+    when exited it will stop serving.
+
+    Attributes:
+
+    :ivar url: The URL to reach the server, only available while the server is running.
+    :ivar hits: Dictionary of URL paths to hit counters.
+    :ivar before_request: Can be optionally set to execute a function before the request is
+       handled.
+    """
+
+    def __init__(self):
+        self.url = None
+        self.hits = collections.defaultdict(lambda: 0)
         self.before_request = None
+        self._lock = threading.Lock()
+        self.errors = []
+        self._server = WSGIServer(application=self._app, threaded=True)
 
+    def __enter__(self):
+        self._server.start()
+        self.url = self._server.url
 
-@pytest.fixture
-def hitcounter():
-    errors = []
-    hits = {}
-    hitlock = threading.Lock()
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._server.stop()
+        self.url = None
 
-    rv = None
-
-    def app(environ, start_response):
-        if rv.before_request:
-            rv.before_request()
+    def _app(self, environ, start_response):
+        """The WSGI app."""
+        if self.before_request:
+            self.before_request()
 
         try:
             path = environ["PATH_INFO"]
-            with hitlock:
-                hits.setdefault(path, 0)
-                hits[path] += 1
-
-            if path.startswith("/redirect/"):
-                path = path[len("/redirect") :]
-                start_response("302 Found", [("Location", path)])
-                return [b""]
-            elif path.startswith("/msdl/"):
-                path = path[len("/msdl/") :]
-
-                with requests.get(
-                    f"https://msdl.microsoft.com/download/symbols/{path}",
-                    allow_redirects=False,  # test redirects with msdl
-                ) as r:
-                    start_response(f"{r.status_code} BOGUS", list(r.headers.items()))
-                    return [r.content]
-            elif path.startswith("/respond_statuscode/"):
-                statuscode = int(path.split("/")[2])
-                start_response(f"{statuscode} BOGUS", [])
-                return [b""]
-
-            elif path.startswith("/garbage_data/"):
-                start_response("200 OK", [])
-                return [b"bogus"]
-            else:
-                raise AssertionError("Bad path: {}".format(path))
+            with self._lock:
+                self.hits[path] += 1
+            body = self._handle_path(path, start_response)
         except Exception as e:
-            errors.append(e)
+            self.errors.append(e)
             start_response("500 Internal Server Error", [])
             return [b"error"]
+        else:
+            return body
 
-    server = WSGIServer(application=app, threaded=True)
-    server.start()
+    @staticmethod
+    def _handle_path(path, start_response):
+        if path.startswith("/redirect/"):
+            path = path[len("/redirect") :]
+            start_response("302 Found", [("Location", path)])
+            return [b""]
+        elif path.startswith("/msdl/"):
+            print(f'got requested: {path}')
+            path = path[len("/msdl/") :]
+            print(f'proxying {path}')
+            with requests.get(
+                f"https://msdl.microsoft.com/download/symbols/{path}",
+                allow_redirects=False,  # test redirects with msdl
+            ) as r:
+                print(f'status code: {r.status_code}')
+                start_response(f"{r.status_code} BOGUS", list(r.headers.items()))
+                return [r.content]
+        elif path.startswith("/respond_statuscode/"):
+            statuscode = int(path.split("/")[2])
+            start_response(f"{statuscode} BOGUS", [])
+            return [b""]
 
-    rv = HitCounter(url=server.url, hits=hits)
-    yield rv
+        elif path.startswith("/garbage_data/"):
+            start_response("200 OK", [])
+            return [b"bogus"]
+        else:
+            raise AssertionError("Bad path: {}".format(path))
 
-    server.stop()
-    for error in errors:
-        raise error
+
+@pytest.fixture
+def hitcounter(request):
+    """Running HitCounter server.
+
+    This fixture sets up a running hitcounter server and will fail the test if there was any
+    error in it's request handling.
+    """
+    app = HitCounter()
+
+    def fail_on_errors():
+        if app.errors:
+            tracebacks = [
+                "".join(traceback.format_exception(type(exc), exc, None))
+                for exc in app.errors
+            ]
+            pytest.fail(
+                "{n} errors in hitcounter server:\n\n{failures}".format(
+                    n=len(app.errors), failures="\n\n".join(tracebacks)
+                )
+            )
+
+    mark = pytest.mark.extra_failure_checks(checks=[fail_on_errors])
+    request.node.add_marker(mark)
+    with app:
+        yield app
 
 
 @pytest.fixture

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -322,7 +322,7 @@ def test_timeouts(symbolicator, hitcounter):
             request_id = response["request_id"]
         else:
             assert False
-        time.sleep(0.3)         # 0.3 * 10 iterations = 3s => expect timeout on 4th iteration
+        time.sleep(0.3)  # 0.3 * 10 iterations = 3s => expect timeout on 4th iteration
 
     for response in responses[:-1]:
         assert response["status"] == "pending"


### PR DESCRIPTION
The hitcounter is refactored to be more modular.  It is now more
encapsulated in an object rather than have a free closure variable
bound to itself.  This work also adds some more docstrings so that
pytest --fixtures shows more useful output.

The hitcounter now also avoids raising failures in the teardown,
instead using a mechanism to raise them during the call step of the
testrun protocol.

test_timeouts gets an explicit sleep step.  Its 10 iterations need to
take longer than its 1s timeout.  This should reduce flakyness and
hopefully remove the need for pytest-rerunfailures.

test_reserved_ip_addresses gets a more readable variable name and also
an additional assert to ensure the local proxy is (not) hit.

The Service fixute helper just does linear backoff instead of
exponential.  There is no point is sparing the server, we just want to
test to start being useful as quickly as possible and exponential
backoff adds needless delays.