### PR TITLE
fix: Exclude irrelevant modules from minidumps

### DIFF
--- a/src/utils/hex.rs
+++ b/src/utils/hex.rs
@@ -83,7 +83,7 @@ macro_rules! impl_hex_serde {
     };
 }
 
-#[derive(Clone, Default, Debug, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct HexValue(pub u64);
 
 impl_hex_serde!(HexValue, u64);


### PR DESCRIPTION
Follow-up to #247. Minidumps can specify shared memory regions in the module list. These are undesired for symbolication purposes. The only exception is when a stack frame references an address from such a module.

This PR introduces `CodeModulesBuilder` which allows to track valid modules and references into them. In the end, only modules with valid identifiers or with references are kept.