### PR TITLE
Improve S3 logging output

### DIFF
--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -100,7 +100,7 @@ pub async fn download_source(
             // - To fetch existing objects, `GetObject` is required.
             // - If `ListBucket` is premitted, a 404 is returned for missing objects.
             // - Otherwise, a 403 ("access denied") is returned.
-            log::debug!("Skipping response from s3:{}{}: {}", bucket, &key, err);
+            log::debug!("Skipping response from s3://{}/{}: {}", bucket, &key, err);
             Ok(DownloadStatus::NotFound)
         }
     }


### PR DESCRIPTION
This shows the S3 object in the same format as aws cli uses.