### PR TITLE
fix: Lower log levels to reduce verbose output

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1274,7 +1274,7 @@ impl SymbolicationActor {
             let cache_file = match result {
                 Ok(x) => x,
                 Err(e) => {
-                    log::info!(
+                    log::debug!(
                         "Error while fetching cficache: {}",
                         LogError(&ArcFail(e.clone()))
                     );

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -169,7 +169,7 @@ impl Cache {
         log::trace!("Checking {}", path.display());
         if path.is_file() {
             if catch_not_found(|| self.check_expiry(path))?.is_none() {
-                log::info!("Removing {}", path.display());
+                log::debug!("Removing {}", path.display());
                 catch_not_found(|| remove_file(path))?;
             }
 

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -216,7 +216,7 @@ impl RemoteThread {
                             }
                         };
                         tx.send(msg).unwrap_or_else(|_| {
-                            log::info!(
+                            log::debug!(
                                 "Failed to send result of {} task, caller dropped",
                                 task_name
                             )


### PR DESCRIPTION
Especially the cache cleanup tasks emit very verbose log output. INFO logs are
supposed to give consumers a high level insight into current operations, and as
such some of the current messages should be made DEBUG, instead.

