### PR TITLE
fix(sentry): Change cleanup error message for grouping

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use failure::Fail;
-use sentry::integrations::failure::capture_fail;
 use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -156,8 +156,10 @@ impl Cache {
                 if path.is_dir() {
                     directories.push(path.to_owned());
                 } else if let Err(e) = self.try_cleanup_path(&path) {
-                    log::error!("Failed to clean up {}: {}", path.display(), LogError(&e));
-                    capture_fail(&e);
+                    sentry::with_scope(
+                        |scope| scope.set_extra("path", path.display().to_string().into()),
+                        || log::error!("Failed to clean cache file: {}", LogError(&e)),
+                    );
                 }
             }
         }


### PR DESCRIPTION
Removes the file path from the message to allow Sentry to group all errors
together. Additionally, the error was reported twice.
