### PR TITLE
meta(gha): Add a danger lint for changelog entries

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,15 @@
+name: "Danger"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  build:
+    name: Changelogs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npx danger@9.1.8 ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,3 @@
-const files = danger.git.modified_files;
-const hasChangelog = files.indexOf("CHANGELOG.md") !== -1;
-
 const ERROR_MESSAGE =
   "Please consider adding a changelog entry for the next release.";
 
@@ -13,10 +10,13 @@ Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the fo
 If none of the above apply, you can opt out by adding _#skip-changelog_ to the PR description.
 `;
 
+const files = danger.git.modified_files;
+const hasChangelog = files.indexOf("CHANGELOG.md") !== -1;
+
 const skipChangelog =
   danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
 
-if (!skipChangelog && !hasChangelog && !hasPyChangelog) {
+if (!skipChangelog && !hasChangelog) {
   fail(ERROR_MESSAGE);
   markdown(DETAILS);
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,22 @@
+const files = danger.git.modified_files;
+const hasChangelog = files.indexOf("CHANGELOG.md") !== -1;
+
+const ERROR_MESSAGE =
+  "Please consider adding a changelog entry for the next release.";
+
+const DETAILS = `
+Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the following heading:
+ 1. **Features**: For new user-visible functionality.
+ 2. **Bug Fixes**: For user-visible bug fixes.
+ 3. **Internal**: For features and bug fixes in internal operation.
+
+If none of the above apply, you can opt out by adding _#skip-changelog_ to the PR description.
+`;
+
+const skipChangelog =
+  danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
+
+if (!skipChangelog && !hasChangelog && !hasPyChangelog) {
+  fail(ERROR_MESSAGE);
+  markdown(DETAILS);
+}


### PR DESCRIPTION
Creates the following comment when the changelog is missing:

![image](https://user-images.githubusercontent.com/1433023/92099681-1853fe80-eddb-11ea-854f-1a5c8d0c93e2.png)

---

#skip-changelog
