### PR TITLE
ci: Publish artifacts to GitHub and release registry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,33 @@
 ---
-minVersion: '0.5.1'
+minVersion: "0.11.0"
 github:
   owner: getsentry
   repo: symbolicator
-targets: 
+changelogPolicy: auto
+statusProvider:
+  name: github
+
+targets:
   - name: github
   - name: gh-pages
+  - name: registry
+    type: app
+    urlTemplate: "https://downloads.sentry-cdn.com/symbolicator/{{version}}/{{file}}"
+    includeNames: /^symbolicator-.*$/i
+    config:
+      canonical: "app:symbolicator"
+  - name: gcs
+    bucket: sentry-sdk-assets
+    includeNames: /^symbolicator-.*$/
+    paths:
+      - path: /symbolicator/{{version}}/
+        metadata:
+          cacheControl: "public, max-age=2592000"
+      - path: /symbolicator/latest/
+        metadata:
+          cacheControl: "public, max-age=600"
 
-changelog: CHANGELOG.md
-changelogPolicy: simple
+requireNames:
+  - /^gh-pages.zip$/
+  - /^symbolicator-Linux-x86_64$/
+  - /^symbolicator-Linux-x86_64-debug.zip$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ branches:
   only:
     - master
     - /^release\/[\d.]+$/
-    - /^deploy\/.*$/
 
 env:
   - CXX=clang
@@ -32,7 +31,17 @@ jobs:
     - name: "e2e"
       script: make -e test-integration
 
-    - name: "docs"
+    - name: "release: linux x86_64"
+      if: branch ~= /^release\/[\d.]+$/
+      before_script: npm install -g @zeus-ci/cli
+      script:
+        - make release
+        - zeus upload -t "application/octet-stream" -n symbolicator-Linux-x86_64 target/release/symbolicator
+        - zip symbolicator-debug.zip target/symbolicator/symbolicator.debug
+        - zeus upload -t "application/octet-stream" -n symbolicator-Linux-x86_64-debug.zip symbolicator-debug.zip
+
+    - name: "release: docs"
+      if: branch ~= /^release\/[\d.]+$/
       before_script: npm install -g @zeus-ci/cli
       script: make -e travis-upload-docs
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,19 @@ clean:
 	rm -rf .venv
 .PHONY: clean
 
+# Builds
+
+build:
+	cargo build
+.PHONY: build
+
+release:
+	cargo build --release
+	objcopy --only-keep-debug target/release/symbolicator{,.debug}
+	objcopy --strip-debug --strip-unneeded target/release/symbolicator
+	objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}
+.PHONY: release
+
 # Tests
 
 test: test-rust test-integration


### PR DESCRIPTION
Adds a release job to CI that builds a Linux GNU x86_64 binary, which is
subsequently uploaded to GitHub releases and the sentry release registry.
Release and docs builds only occur in the release branch, since they take
significant time compared to regular test builds.

Additionally, changelogs are required for releasing. See #263 for enforcement of
changelogs.

