### PR TITLE
ref: Replace failure with thiserror in the download service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "structopt",
  "symbolic",
  "tempfile",
+ "thiserror",
  "tokio 0.1.22",
  "tokio-retry",
  "url 1.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ actix = "0.7.9"
 anyhow = "1.0.32"
 apple-crash-report-parser = "0.4.2"
 failure = "0.1.6"
+thiserror = "1.0.20"
 serde = { version = "1.0.101", features = ["derive", "rc"] }
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { version = "0.1.29", package = "futures" }

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -19,7 +19,7 @@ use tempfile::{tempfile_in, NamedTempFile};
 use crate::actors::common::cache::{CacheItemRequest, CachePath, Cacher};
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::logging::LogError;
-use crate::services::download::{DownloadService, DownloadStatus};
+use crate::services::download::{DownloadError, DownloadService, DownloadStatus};
 use crate::sources::{FileType, SourceConfig, SourceFileId};
 use crate::types::{ArcFail, ObjectFeatures, ObjectId, Scope};
 use crate::utils::futures::ThreadPool;
@@ -59,12 +59,10 @@ impl From<io::Error> for ObjectError {
     }
 }
 
-impl From<crate::services::download::DownloadError> for ObjectError {
-    fn from(source: crate::services::download::DownloadError) -> Self {
-        match source.kind() {
-            crate::services::download::DownloadErrorKind::Canceled => {
-                source.context(ObjectErrorKind::Canceled).into()
-            }
+impl From<DownloadError> for ObjectError {
+    fn from(source: DownloadError) -> Self {
+        match source {
+            DownloadError::Canceled => source.context(ObjectErrorKind::Canceled).into(),
             _ => source.context(ObjectErrorKind::Io).into(),
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ impl ServiceState {
 
         let download_svc = Arc::new(DownloadService::new(io_thread, config.clone()));
 
-        let caches = Caches::from_config(&config).context("Failed to create local caches")?;
+        let caches = Caches::from_config(&config).context("failed to create local caches")?;
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,
@@ -57,7 +57,7 @@ impl ServiceState {
         let cficaches =
             CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone());
         let spawnpool =
-            procspawn::Pool::new(num_cpus::get()).context("Failed to create process pool")?;
+            procspawn::Pool::new(num_cpus::get()).context("failed to create process pool")?;
 
         let symbolication = SymbolicationActor::new(
             objects.clone(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -120,7 +120,7 @@ impl Cache {
     pub fn cleanup(&self) -> Result<()> {
         log::info!("Cleaning up cache: {}", self.name);
         let cache_dir = self.cache_dir.clone().ok_or_else(|| {
-            anyhow!("No caching configured! Did you provide a path to your config file?")
+            anyhow!("no caching configured! Did you provide a path to your config file?")
         })?;
 
         let mut directories = vec![cache_dir];
@@ -154,7 +154,7 @@ impl Cache {
 
     fn try_cleanup_path(&self, path: &Path) -> Result<()> {
         log::trace!("Checking {}", path.display());
-        anyhow::ensure!(path.is_file(), "Not a file");
+        anyhow::ensure!(path.is_file(), "not a file");
         if catch_not_found(|| self.check_expiry(path))?.is_none() {
             log::debug!("Removing {}", path.display());
             catch_not_found(|| remove_file(path))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ impl Cli {
 /// Runs the main application.
 pub fn execute() -> Result<()> {
     let cli = Cli::from_args();
-    let config = Config::get(cli.config()).context("Failed loading config")?;
+    let config = Config::get(cli.config()).context("failed loading config")?;
 
     let _sentry = sentry::init(sentry::ClientOptions {
         dsn: config.sentry_dsn.clone(),
@@ -82,8 +82,8 @@ pub fn execute() -> Result<()> {
         .init();
 
     match cli.command {
-        Command::Run => server::run(config).context("Failed to start the server")?,
-        Command::Cleanup => cache::cleanup(config).context("Failed to clean up caches")?,
+        Command::Run => server::run(config).context("failed to start the server")?,
+        Command::Cleanup => cache::cleanup(config).context("failed to clean up caches")?,
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,14 +301,14 @@ impl Config {
     pub fn get(path: Option<&Path>) -> Result<Self> {
         match path {
             Some(path) => Self::from_reader(
-                fs::File::open(path).context("Failed to open configuration file")?,
+                fs::File::open(path).context("failed to open configuration file")?,
             ),
             None => Ok(Config::default()),
         }
     }
 
     fn from_reader(reader: impl std::io::Read) -> Result<Self> {
-        serde_yaml::from_reader(reader).context("Failed to parse YAML")
+        serde_yaml::from_reader(reader).context("failed to parse YAML")
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,12 +26,12 @@ pub fn run(config: Config) -> Result<()> {
     metric!(counter("server.starting") += 1);
 
     let bind = config.bind.clone();
-    let service = ServiceState::create(config).context("Failed to create service state")?;
+    let service = ServiceState::create(config).context("failed to create service state")?;
 
     log::info!("Starting http server: {}", bind);
     HttpServer::new(move || create_app(service.clone()))
         .bind(&bind)
-        .context("Failed to bind to the port")?
+        .context("failed to bind to the port")?
         .start();
 
     log::info!("Starting system");

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::{DownloadError, DownloadErrorKind, DownloadStatus};
+use super::{DownloadError, DownloadStatus};
 use crate::sources::{FileType, FilesystemSourceConfig, SourceFileId, SourceLocation};
 use crate::types::ObjectId;
 
@@ -28,7 +28,7 @@ pub fn download_source(
         Ok(_) => Ok(DownloadStatus::Completed),
         Err(e) => match e.kind() {
             io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),
-            _ => Err(DownloadError::from(DownloadErrorKind::Io)),
+            _ => Err(DownloadError::Io(e)),
         },
     }
 }

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -62,13 +62,13 @@ struct GcsToken {
 
 #[derive(Debug, Error)]
 pub enum GcsError {
-    #[error("Failed decoding key")]
+    #[error("failed decoding key")]
     Base64(#[from] base64::DecodeError),
-    #[error("Failed encoding JWT")]
+    #[error("failed encoding JWT")]
     Jwt(#[from] jsonwebtoken::errors::Error),
-    #[error("Failed to parse JSON response")]
+    #[error("failed to parse JSON response")]
     Json(#[from] failure::Compat<JsonPayloadError>),
-    #[error("Failed to send authentication request")]
+    #[error("failed to send authentication request")]
     Auth(#[from] failure::Compat<SendRequestError>),
 }
 

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -7,17 +7,20 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use actix_web::error::JsonPayloadError;
 use actix_web::{client, HttpMessage};
 use chrono::{DateTime, Duration, Utc};
-use failure::{Fail, ResultExt};
+use client::SendRequestError;
+use failure::Fail;
 use futures::compat::{Future01CompatExt, Stream01CompatExt};
 use futures::prelude::*;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use url::percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
-use super::{DownloadError, DownloadErrorKind, DownloadStatus};
+use super::{DownloadError, DownloadStatus};
 use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey, SourceFileId, SourceLocation};
 use crate::types::ObjectId;
 use crate::utils::futures::delay;
@@ -57,7 +60,19 @@ struct GcsToken {
     expires_at: DateTime<Utc>,
 }
 
-fn key_from_string(mut s: &str) -> Result<Vec<u8>, DownloadError> {
+#[derive(Debug, Error)]
+pub enum GcsError {
+    #[error("Failed decoding key")]
+    Base64(#[from] base64::DecodeError),
+    #[error("Failed encoding JWT")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("Failed to parse JSON response")]
+    Json(#[from] failure::Compat<JsonPayloadError>),
+    #[error("Failed to send authentication request")]
+    Auth(#[from] failure::Compat<SendRequestError>),
+}
+
+fn key_from_string(mut s: &str) -> Result<Vec<u8>, GcsError> {
     if s.starts_with("-----BEGIN PRIVATE KEY-----") {
         s = s.splitn(5, "-----").nth(2).unwrap();
     }
@@ -69,10 +84,10 @@ fn key_from_string(mut s: &str) -> Result<Vec<u8>, DownloadError> {
         .filter(|b| !b.is_ascii_whitespace())
         .collect::<Vec<u8>>();
 
-    Ok(base64::decode(bytes).context(DownloadErrorKind::Io)?)
+    Ok(base64::decode(bytes)?)
 }
 
-fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, DownloadError> {
+fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, GcsError> {
     let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
 
     let jwt_claims = JwtClaims {
@@ -86,10 +101,10 @@ fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, Do
     let key = key_from_string(&source_key.private_key)?;
     let pkcs8 = jsonwebtoken::Key::Pkcs8(&key);
 
-    Ok(jsonwebtoken::encode(&header, &jwt_claims, pkcs8).context(DownloadErrorKind::Io)?)
+    Ok(jsonwebtoken::encode(&header, &jwt_claims, pkcs8)?)
 }
 
-async fn request_new_token(source_key: &GcsSourceKey) -> Result<GcsToken, DownloadError> {
+async fn request_new_token(source_key: &GcsSourceKey) -> Result<GcsToken, GcsError> {
     let expires_at = Utc::now() + Duration::minutes(58);
     let auth_jwt = get_auth_jwt(source_key, expires_at.timestamp() + 30)?;
 
@@ -107,20 +122,20 @@ async fn request_new_token(source_key: &GcsSourceKey) -> Result<GcsToken, Downlo
 
     let response = response.compat().await.map_err(|err| {
         log::debug!("Failed to authenticate against gcs: {}", err);
-        DownloadError::from(DownloadErrorKind::Io)
+        err.compat()
     })?;
     let token = response
         .json::<GcsTokenResponse>()
         .compat()
         .await
-        .map_err(|e| e.context(DownloadErrorKind::Io))?;
+        .map_err(Fail::compat)?;
     Ok(GcsToken {
         access_token: token.access_token,
         expires_at,
     })
 }
 
-async fn get_token(source_key: &Arc<GcsSourceKey>) -> Result<Arc<GcsToken>, DownloadError> {
+async fn get_token(source_key: &Arc<GcsSourceKey>) -> Result<Arc<GcsToken>, GcsError> {
     if let Some(token) = GCS_TOKENS.lock().get(source_key) {
         if token.expires_at >= Utc::now() {
             metric!(counter("source.gcs.token.cached") += 1);
@@ -177,7 +192,7 @@ pub async fn download_source(
                 let stream = response
                     .payload()
                     .compat()
-                    .map(|i| i.map_err(|e| e.context(DownloadErrorKind::Io).into()));
+                    .map(|i| i.map_err(DownloadError::stream));
                 super::download_stream(
                     SourceFileId::Gcs(source, download_path),
                     stream,

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -10,12 +10,11 @@ use std::time::Duration;
 
 use actix_web::http::header;
 use actix_web::{client, HttpMessage};
-use failure::Fail;
 use futures::compat::Stream01CompatExt;
 use futures::prelude::*;
 use url::Url;
 
-use super::{DownloadError, DownloadErrorKind, DownloadStatus, USER_AGENT};
+use super::{DownloadError, DownloadStatus, USER_AGENT};
 use crate::sources::{FileType, HttpSourceConfig, SourceFileId, SourceLocation};
 use crate::types::ObjectId;
 use crate::utils::futures as future_utils;
@@ -90,7 +89,7 @@ pub async fn download_source(
                 let stream = response
                     .payload()
                     .compat()
-                    .map(|i| i.map_err(|e| e.context(DownloadErrorKind::Io).into()));
+                    .map(|i| i.map_err(DownloadError::stream));
                 super::download_stream(
                     SourceFileId::Http(source, download_path),
                     stream,

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -38,19 +38,19 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 /// Errors happening while downloading from sources.
 #[derive(Debug, Error)]
 pub enum DownloadError {
-    #[error("Failed to download")]
+    #[error("failed to download")]
     Io(#[source] std::io::Error),
-    #[error("Failed to download stream")]
+    #[error("failed to download stream")]
     Stream(#[source] failure::Compat<PayloadError>),
-    #[error("Bad file destination")]
+    #[error("bad file destination")]
     BadDestination(#[source] std::io::Error),
-    #[error("Failed writing the downloaded file")]
+    #[error("failed writing the downloaded file")]
     Write(#[source] std::io::Error),
-    #[error("Download was cancelled")]
+    #[error("download was cancelled")]
     Canceled,
-    #[error("Failed to fetch data from GCS")]
+    #[error("failed to fetch data from GCS")]
     Gcs(#[from] gcs::GcsError),
-    #[error("Failed to fetch data from Sentry")]
+    #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
 }
 

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -10,9 +10,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ::sentry::Hub;
+use actix_web::error::PayloadError;
 use bytes::Bytes;
-use failure::{Fail, ResultExt};
+use failure::Fail;
 use futures::prelude::*;
+use thiserror::Error;
 
 use crate::utils::futures::RemoteThread;
 use crate::utils::paths::get_directory_paths;
@@ -34,25 +36,30 @@ pub use crate::types::ObjectId;
 /// HTTP User-Agent string to use.
 const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 
-#[derive(Debug, Fail, Clone)]
-pub enum DownloadErrorKind {
-    #[fail(display = "failed to download")]
-    Io,
-    #[fail(display = "bad file destination")]
-    BadDestination,
-    #[fail(display = "failed writing the downloaded file")]
-    Write,
-    #[fail(display = "download was cancelled")]
+/// Errors happening while downloading from sources.
+#[derive(Debug, Error)]
+pub enum DownloadError {
+    #[error("Failed to download")]
+    Io(#[source] std::io::Error),
+    #[error("Failed to download stream")]
+    Stream(#[source] failure::Compat<PayloadError>),
+    #[error("Bad file destination")]
+    BadDestination(#[source] std::io::Error),
+    #[error("Failed writing the downloaded file")]
+    Write(#[source] std::io::Error),
+    #[error("Download was cancelled")]
     Canceled,
-    #[fail(display = "failed to fetch data from Sentry")]
-    Sentry,
+    #[error("Failed to fetch data from GCS")]
+    Gcs(#[from] gcs::GcsError),
+    #[error("Failed to fetch data from Sentry")]
+    Sentry(#[from] sentry::SentryError),
 }
 
-symbolic::common::derive_failure!(
-    DownloadError,
-    DownloadErrorKind,
-    doc = "Errors happening while downloading from sources."
-);
+impl DownloadError {
+    pub fn stream(err: PayloadError) -> Self {
+        Self::Stream(err.compat())
+    }
+}
 
 /// Completion status of a successful download request.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -118,8 +125,8 @@ impl DownloadService {
             .spawn("service.download", Duration::from_secs(300), move || {
                 dispatch_download(source, destination).bind_hub(hub)
             })
-            // Map all SpawnError variants into DownloadErrorKind::Canceled.
-            .map(|o| o.unwrap_or_else(|_| Err(DownloadErrorKind::Canceled.into())))
+            // Map all SpawnError variants into DownloadError::Canceled.
+            .map(|o| o.unwrap_or_else(|_| Err(DownloadError::Canceled)))
     }
 
     pub fn list_files(
@@ -141,8 +148,8 @@ impl DownloadService {
                     worker
                         .spawn("service.download.list_files", Duration::from_secs(30), job)
                         .await
-                        // Map all SpawnError variants into DownloadErrorKind::Canceled
-                        .unwrap_or_else(|_| Err(DownloadErrorKind::Canceled.into()))
+                        // Map all SpawnError variants into DownloadError::Canceled
+                        .unwrap_or_else(|_| Err(DownloadError::Canceled))
                 }
                 SourceConfig::Http(cfg) => Ok(http::list_files(cfg, filetypes, object_id)),
                 SourceConfig::S3(cfg) => Ok(s3::list_files(cfg, filetypes, object_id)),
@@ -165,13 +172,13 @@ async fn download_stream(
 ) -> Result<DownloadStatus, DownloadError> {
     // All file I/O in this function is blocking!
     log::trace!("Downloading from {}", source);
-    let mut file = File::create(&destination).context(DownloadErrorKind::BadDestination)?;
+    let mut file = File::create(&destination).map_err(DownloadError::BadDestination)?;
     futures::pin_mut!(stream);
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
         file.write_all(chunk.as_ref())
-            .context(DownloadErrorKind::Write)?;
+            .map_err(DownloadError::Write)?;
     }
     Ok(DownloadStatus::Completed)
 }

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -15,7 +15,7 @@ use parking_lot::Mutex;
 use rusoto_s3::S3;
 use tokio::codec::{BytesCodec, FramedRead};
 
-use super::{DownloadError, DownloadErrorKind, DownloadStatus};
+use super::{DownloadError, DownloadStatus};
 use crate::sources::{FileType, S3SourceConfig, S3SourceKey, SourceFileId, SourceLocation};
 use crate::types::ObjectId;
 
@@ -88,7 +88,7 @@ pub async fn download_source(
 
             let stream = FramedRead::new(body_read, BytesCodec::new())
                 .map(BytesMut::freeze)
-                .map_err(|_err| DownloadError::from(DownloadErrorKind::Io))
+                .map_err(DownloadError::Io)
                 .compat();
 
             super::download_stream(SourceFileId::S3(source, download_path), stream, destination)

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -103,13 +103,13 @@ struct SearchQuery {
 /// Errors happening while fetching data from Sentry.
 #[derive(Debug, Error)]
 pub enum SentryError {
-    #[error("Failed parsing JSON response from Sentry")]
+    #[error("failed parsing JSON response from Sentry")]
     Parsing(#[from] failure::Compat<JsonPayloadError>),
 
-    #[error("Failed sending request to Sentry")]
+    #[error("failed sending request to Sentry")]
     SendRequest(#[from] failure::Compat<SendRequestError>),
 
-    #[error("Bad status code from Sentry: {0}")]
+    #[error("bad status code from Sentry: {0}")]
     BadStatusCode(StatusCode),
 }
 

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -11,14 +11,17 @@ use std::time::{Duration, Instant};
 
 use actix::{Actor, Addr};
 use actix_web::client::{ClientConnector, ClientResponse, SendRequestError};
+use actix_web::error::JsonPayloadError;
+use actix_web::http::StatusCode;
 use actix_web::{client, HttpMessage};
 use failure::Fail;
 use futures::compat::{Future01CompatExt, Stream01CompatExt};
 use futures::prelude::*;
 use parking_lot::Mutex;
+use thiserror::Error;
 use url::Url;
 
-use super::{DownloadError, DownloadErrorKind, DownloadStatus, USER_AGENT};
+use super::{DownloadError, DownloadStatus, USER_AGENT};
 use crate::config::Config;
 use crate::sources::{FileType, SentryFileId, SentrySourceConfig, SourceFileId};
 use crate::types::ObjectId;
@@ -66,7 +69,7 @@ pub async fn download_source(
                 let stream = response
                     .payload()
                     .compat()
-                    .map(|i| i.map_err(|e| e.context(DownloadErrorKind::Io).into()));
+                    .map(|i| i.map_err(DownloadError::stream));
                 super::download_stream(SourceFileId::Sentry(source, file_id), stream, destination)
                     .await
             } else {
@@ -85,18 +88,6 @@ pub async fn download_source(
     }
 }
 
-#[derive(Debug, Fail, Clone, Copy)]
-pub enum SentryErrorKind {
-    #[fail(display = "failed parsing JSON response from Sentry")]
-    Parsing,
-
-    #[fail(display = "bad status code from Sentry")]
-    BadStatusCode,
-
-    #[fail(display = "failed sending request to Sentry")]
-    SendRequest,
-}
-
 #[derive(Clone, Debug, serde::Deserialize)]
 struct SearchResult {
     id: String,
@@ -109,11 +100,18 @@ struct SearchQuery {
     token: String,
 }
 
-symbolic::common::derive_failure!(
-    SentryError,
-    SentryErrorKind,
-    doc = "Errors happening while fetching data from Sentry"
-);
+/// Errors happening while fetching data from Sentry.
+#[derive(Debug, Error)]
+pub enum SentryError {
+    #[error("Failed parsing JSON response from Sentry")]
+    Parsing(#[from] failure::Compat<JsonPayloadError>),
+
+    #[error("Failed sending request to Sentry")]
+    SendRequest(#[from] failure::Compat<SendRequestError>),
+
+    #[error("Bad status code from Sentry: {0}")]
+    BadStatusCode(StatusCode),
+}
 
 /// Make a request to sentry, parse the result as a JSON SearchResult list.
 async fn fetch_sentry_json(query: &SearchQuery) -> Result<Vec<SearchResult>, SentryError> {
@@ -127,17 +125,17 @@ async fn fetch_sentry_json(query: &SearchQuery) -> Result<Vec<SearchResult>, Sen
         .send()
         .compat()
         .await
-        .map_err(|e| SentryError::from(e.context(SentryErrorKind::SendRequest)))?;
+        .map_err(Fail::compat)?;
     if response.status().is_success() {
         log::trace!("Success fetching index from Sentry");
         response
             .json()
             .compat()
             .await
-            .map_err(|e| e.context(SentryErrorKind::Parsing).into())
+            .map_err(|e| Fail::compat(e).into())
     } else {
         log::warn!("Sentry returned status code {}", response.status());
-        Err(SentryError::from(SentryErrorKind::BadStatusCode))
+        Err(SentryError::BadStatusCode(response.status()))
     }
 }
 
@@ -169,9 +167,7 @@ async fn cached_sentry_search(
         "Fetching list of Sentry debug files from {}",
         &query.index_url
     );
-    let entries = future_utils::retry(|| fetch_sentry_json(&query))
-        .await
-        .map_err(|e| DownloadError::from(e.context(DownloadErrorKind::Sentry)))?;
+    let entries = future_utils::retry(|| fetch_sentry_json(&query)).await?;
 
     if cache_duration > Duration::from_secs(0) {
         SENTRY_SEARCH_RESULTS


### PR DESCRIPTION
I think @jan-auer had a few ideas about making these errors better, especially around authentication errors on upstream services (gcs, s3), so this might be a good idea to figure out what we want to do here.

#skip-changelog