### PR TITLE
ci(craft): Add docker target to craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -26,6 +26,9 @@ targets:
       - path: /symbolicator/latest/
         metadata:
           cacheControl: "public, max-age=600"
+  - name: docker
+    source: us.gcr.io/sentryio/symbolicator
+    target: getsentry/symbolicator
 
 requireNames:
   - /^gh-pages.zip$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
+- Publish Docker containers to DockerHub at `getsentry/symbolicator`. ([#271](https://github.com/getsentry/symbolicator/pull/271))
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,17 @@
 
 ## Unreleased
 
-* Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
+- Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
 
 ## 0.2.0
 
-* This changelog is entirely incomplete, future releases will try to
-  improve this.
+- This changelog is entirely incomplete, future releases will try to improve this.
 
 ### Breaking Changes
 
-* The configuration file is stricter on which fields can be present,
-  unknown fields will no longer be accepted and cause an error.
-* Configuring cache durations is now done using
-  (humantime)[https://docs.rs/humantime/latest/humantime/fn.parse_duration.html].
-
+- The configuration file is stricter on which fields can be present, unknown fields will no longer be accepted and cause an error.
+- Configuring cache durations is now done using (humantime)[https://docs.rs/humantime/latest/humantime/fn.parse_duration.html].
 
 ## 0.1.0
 
-* Initial version of symbolicator
+- Initial version of symbolicator


### PR DESCRIPTION
`symbolicator:0.2.0` was missing from Docker Hub as it was not defined in Craft as a publish target. This PR adds it. Whoever releases Symbolicator will now need write access to https://hub.docker.com/r/getsentry/symbolicator
