### PR TITLE
feat: Add an option to configure subprocess pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
 - Publish Docker containers to DockerHub at `getsentry/symbolicator`. ([#271](https://github.com/getsentry/symbolicator/pull/271))
+- Add `processing_pool_size` configuration option that allows to set the size of the processing pool ()
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
 - Publish Docker containers to DockerHub at `getsentry/symbolicator`. ([#271](https://github.com/getsentry/symbolicator/pull/271))
-- Add `processing_pool_size` configuration option that allows to set the size of the processing pool ()
+- Add `processing_pool_size` configuration option that allows to set the size of the processing pool. ([#273](https://github.com/getsentry/symbolicator/pull/273))
 
 ## 0.2.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,8 @@ metrics:
   `true`.
 - `connect_to_reserved_ips`: Allow reserved IP addresses for requests to
   sources. See [Security](#security). Defaults to `false`.
+- `processing_pool_size`: The number of subprocesses in Symbolicator's internal
+  processing pool. Defaults to the total number of logical CPUs on the machine.
 - `caches`: Fine-tune cache expiry.
   All time units can be either a time expression like `1s`.  Units
   can be `s`, `seconds`, `m`, `minutes`, `h`, `hours`, `d`, `days`,

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,8 +56,8 @@ impl ServiceState {
             SymCacheActor::new(caches.symcaches, objects.clone(), cpu_threadpool.clone());
         let cficaches =
             CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone());
-        let spawnpool =
-            procspawn::Pool::new(num_cpus::get()).context("failed to create process pool")?;
+        let spawnpool = procspawn::Pool::new(config.processing_pool_size)
+            .context("failed to create process pool")?;
 
         let symbolication = SymbolicationActor::new(
             objects.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,7 +236,7 @@ pub struct Config {
     /// Allow reserved IP addresses for requests to sources.
     pub connect_to_reserved_ips: bool,
 
-    /// Size of internal processing pool.
+    /// Number of subprocesses in the internal processing pool.
     pub processing_pool_size: usize,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,6 +235,9 @@ pub struct Config {
 
     /// Allow reserved IP addresses for requests to sources.
     pub connect_to_reserved_ips: bool,
+
+    /// Size of internal processing pool.
+    pub processing_pool_size: usize,
 }
 
 impl Config {
@@ -293,6 +296,7 @@ impl Default for Config {
             symstore_proxy: true,
             sources: Arc::new(vec![]),
             connect_to_reserved_ips: false,
+            processing_pool_size: num_cpus::get(),
         }
     }
 }


### PR DESCRIPTION
This can be useful when Symbolicator is not the only service running on the machine (e.g. in Kubernetes environment).