### PR TITLE
fix(objects): Make sure returned files can be used for purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
-- Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
+### Features
+
 - Publish Docker containers to DockerHub at `getsentry/symbolicator`. ([#271](https://github.com/getsentry/symbolicator/pull/271))
 - Add `processing_pool_size` configuration option that allows to set the size of the processing pool. ([#273](https://github.com/getsentry/symbolicator/pull/273))
 - Use a dedicated `tmp` sub-directory in the cache directory to write temporary files into. ([#265](https://github.com/getsentry/symbolicator/pull/265))
+
+### Bug Fixes
+
+- Fix a bug where Sentry requests were cached even though caches were disabled. ([#260](https://github.com/getsentry/symbolicator/pull/260))
+- Fix CFI cache status in cases where the PDB file was found but not the PE file. ([#279](https://github.com/getsentry/symbolicator/pull/279))
 
 ## 0.2.0
 

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -106,6 +106,10 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         self.object_meta.cache_key()
     }
 
+    /// Extracts the Call Frame Information (CFI) from an object file.
+    ///
+    /// The extracted CFI is written to `path` in symbolic's
+    /// [symbolic::minidump::cfi::CfiCache] format.
     fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
         let path = path.to_owned();
         let object = self
@@ -185,6 +189,12 @@ pub struct FetchCfiCache {
 }
 
 impl CfiCacheActor {
+    /// Fetches the CFI cache file for a given code module.
+    ///
+    /// The code object can be identified by a combination of the code-id, debug-id and
+    /// debug filename (the basename).  To do this it looks in the existing cache with the
+    /// given scope and if it does not yet exist in cached form will fetch the required DIFs
+    /// and compute the required CFI cache file.
     pub fn fetch(
         &self,
         request: FetchCfiCache,
@@ -236,6 +246,10 @@ impl CfiCacheActor {
     }
 }
 
+/// Extracts the CFI from an object file, writing it to a CFI file.
+///
+/// The source file is probably an executable or so, the resulting file is in the format of
+/// [symbolic::minidump::cfi::CfiCache].
 fn write_cficache(path: &Path, object_file: &ObjectFile) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_cficache"));

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -195,6 +195,7 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// This method does not take care of ensuring the computation only happens once even
     /// for concurrent requests, see the public [Cacher::compute_memoized] for this.
     fn compute(&self, request: T, key: CacheKey) -> ResponseFuture<T::Item, T::Error> {
+        // cache_path is None when caching is disabled.
         let cache_path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
         if let Some(ref path) = cache_path {
             if let Some(item) = tryf!(self.lookup_cache(&request, &key, &path)) {
@@ -211,39 +212,41 @@ impl<T: CacheItemRequest> Cacher<T> {
 
         let temp_file = tryf!(self.tempfile());
 
-        let future = request.compute(temp_file.path()).and_then(move |status| {
-            if let Some(ref cache_path) = cache_path {
-                sentry::configure_scope(|scope| {
-                    scope.set_extra(
-                        &format!("cache.{}.cache_path", name),
-                        cache_path.to_string_lossy().into(),
-                    );
-                });
+        let future = request
+            .compute(temp_file.path())
+            .and_then(move |status: CacheStatus| {
+                if let Some(ref cache_path) = cache_path {
+                    sentry::configure_scope(|scope| {
+                        scope.set_extra(
+                            &format!("cache.{}.cache_path", name),
+                            cache_path.to_string_lossy().into(),
+                        );
+                    });
 
-                log::trace!("Creating {} at path {:?}", name, cache_path);
-            }
-
-            let byteview = ByteView::open(temp_file.path())?;
-
-            metric!(
-                counter(&format!("caches.{}.file.write", name)) += 1,
-                "status" => status.as_ref(),
-            );
-            metric!(
-                time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
-                "hit" => "false"
-            );
-
-            let path = match cache_path {
-                Some(ref cache_path) => {
-                    status.persist_item(cache_path, temp_file)?;
-                    CachePath::Cached(cache_path.to_path_buf())
+                    log::trace!("Creating {} at path {:?}", name, cache_path);
                 }
-                None => CachePath::Temp(temp_file.into_temp_path()),
-            };
 
-            Ok(request.load(key.scope.clone(), status, byteview, path))
-        });
+                let byteview = ByteView::open(temp_file.path())?;
+
+                metric!(
+                    counter(&format!("caches.{}.file.write", name)) += 1,
+                    "status" => status.as_ref(),
+                );
+                metric!(
+                    time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
+                    "hit" => "false"
+                );
+
+                let path = match cache_path {
+                    Some(ref cache_path) => {
+                        status.persist_item(cache_path, temp_file)?;
+                        CachePath::Cached(cache_path.to_path_buf())
+                    }
+                    None => CachePath::Temp(temp_file.into_temp_path()),
+                };
+
+                Ok(request.load(key.scope.clone(), status, byteview, path))
+            });
 
         Box::new(future)
     }

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -189,7 +189,7 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// Compute an item.
     ///
     /// If the item is in the file system cache, it is returned immediately. Otherwise, it
-    /// is computed using `T::compute` (CacheItemRequest::compute], and then persisted to
+    /// is computed using `T::compute` ([CacheItemRequest::compute]), and then persisted to
     /// the cache.
     ///
     /// This method does not take care of ensuring the computation only happens once even

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -521,7 +521,7 @@ impl ObjectsActor {
     ///
     /// Asking for the objects metadata from the data cache also triggers a download of each
     /// object, which will then be cached in the data cache.  The metadata itself is cached
-    /// in the meta cach which usually lives longer.
+    /// in the metadata cache which usually lives longer.
     pub fn find(
         &self,
         request: FindObject,

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -296,7 +296,7 @@ impl CacheItemRequest for FetchFileDataRequest {
                         let object = match object_opt {
                             Some(object) => object,
                             None => {
-                                if archive.objects().all(|r| r.is_err()) {
+                                if archive.objects().any(|r| r.is_err()) {
                                     return Ok(CacheStatus::Malformed);
                                 } else {
                                     return Ok(CacheStatus::Negative);

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -519,7 +519,7 @@ impl ObjectsActor {
     /// object metadata of each matching object in the metadata cache.  These are then
     /// ranked and the best matching object metadata is returned.
     ///
-    /// Asking the objects metdata from the data cache also triggers a download of each
+    /// Asking for the objects metadata from the data cache also triggers a download of each
     /// object, which will then be cached in the data cache.  The metadata itself is cached
     /// in the meta cach which usually lives longer.
     pub fn find(

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1306,7 +1306,10 @@ impl SymbolicationActor {
                                     cfi.insert(code_module_id, cache);
                                 }
                                 Err(e) => {
-                                    log::warn!("Error while parsing cficache: {}", LogError(&e));
+                                    // This mostly never happens since we already checked
+                                    // the files after downloading and they would have been
+                                    // with tagged CacheStatus::Malformed.
+                                    log::warn!("Error while reading cficache: {}", LogError(&e));
                                     unwind_statuses.insert(code_module_id, (&e).into());
                                 }
                             }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -58,6 +58,11 @@ impl CacheStatus {
         }
     }
 
+    /// Persist the operation in the cache.
+    ///
+    /// If the status was [CacheStatus::Positive] this copies the data from the temporary
+    /// file to the final cache location.  Otherwise it writes corresponding marker in the
+    /// cache location.
     pub fn persist_item(self, path: &Path, file: NamedTempFile) -> Result<(), io::Error> {
         let dir = path.parent().ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "no parent directory to persist item")

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -128,6 +128,13 @@ impl DownloadService {
             .map(|o| o.unwrap_or_else(|_| Err(DownloadError::Canceled)))
     }
 
+    /// Returns all objects matching the [ObjectId] at the source.
+    ///
+    /// Some sources, namely all the symbol servers, simply return the locations at which a
+    /// download attempt should be made without any guarantee the object is actually there.
+    ///
+    /// If the source needs to be contacted to get matching objects this may fail and
+    /// returns a [DownloadError].
     pub fn list_files(
         &self,
         source: SourceConfig,


### PR DESCRIPTION
When the objects actor downloads files it ranks them and chooses the
highest ranking file.  However before returning we must make sure the
file can actually be used for the requested purpose.

In particular this avoids asking for CFI but only getting a (64-bit)
PDB but no PE file.  This file does not actually provide the requested
info, which then confuses the CfiActor because it tries to use it as a
CFI file, even though the file does not have CFI.