### PR TITLE
ci: Check rust doc comments on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install rust stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           profile: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
         run: pytest --ci -n12 -vv tests/integration
 
+
   doc-comments:
     name: Rust doc comments
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -74,8 +72,6 @@ jobs:
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -99,8 +95,6 @@ jobs:
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
 
       - name: Build rust
         run: cargo build --locked
@@ -120,7 +114,6 @@ jobs:
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
         run: pytest --ci -n12 -vv tests/integration
-
 
   doc-comments:
     name: Rust doc comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
   pull_request:
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   lints:
     name: Lints
@@ -117,6 +120,32 @@ jobs:
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
         run: pytest --ci -n12 -vv tests/integration
+
+  doc-comments:
+    name: Rust doc comments
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust stable toolchain
+        with:
+          toolchain: nightly
+          profile: minimal
+          components: rust-docs
+          override: true
+
+      - name: Cache rust cargo artifacts
+        uses: swatinem/rust-cache@v1
+        with:
+          key: ${{ github.job }}
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --all-features --document-private-items --no-deps
 
   docs:
     name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,6 @@ jobs:
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v1
-        with:
-          key: ${{ github.job }}
 
       - uses: actions-rs/cargo@v1
         with:

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -583,7 +583,7 @@ impl ObjectsActor {
 /// Decompresses an object file.
 ///
 /// Some compression methods are implemented by spawning an external tool and can only
-/// process from a named pathname, hence we need a [NamedTemporaryFile] as source.
+/// process from a named pathname, hence we need a [NamedTempFile] as source.
 fn decompress_object_file(src: &NamedTempFile, mut dst: fs::File) -> io::Result<fs::File> {
     // Ensure that both meta data and file contents are available to the
     // subsequent reads of the file metadata and reads from other threads.

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,7 +8,7 @@
 //! CPU-intensive workloads from those with IO-heavy workloads..
 //!
 //! In general services are created once in the
-//! [crate::app:ServiceState] and accessed via this state.
+//! [crate::app::ServiceState] and accessed via this state.
 //!
 //! [`ThreadPool`]: ../utils/futures/struct.ThreadPool.html
 


### PR DESCRIPTION
This adds a check to ensure the rust doc comments are correct and can
be used to internally document the application.

#skip-changelog