### PR TITLE
ref: Use a more strongly-typed timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,14 +434,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1114,7 +1116,7 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1586,9 +1588,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "linked-hash-map"
@@ -3355,12 +3357,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "redox_syscall",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.8",
 ]
 
@@ -3958,6 +3960,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,56 +8,56 @@ include = ["src/**/*", "Cargo.toml", "README.md"]
 readme = "README.md"
 
 [dependencies]
-actix-web = { version = "0.7.19", features = ["tls"], default-features = false }
 actix = "0.7.9"
+actix-web = { version = "0.7.19", features = ["tls"], default-features = false }
 anyhow = "1.0.32"
 apple-crash-report-parser = "0.4.2"
 backtrace = "0.3.53"
+base64 = "0.11.0"
+bytes = { version = "0.4.12", features = ["serde"] }
+cadence = "0.18.0"
+chrono = { version = "0.4.19", features = ["serde"] }
+console = "0.10.0"
+crc32fast = "1.2.0"
+derive_more = "0.15.0"
+env_logger = "0.7.1"
 failure = "0.1.6"
-thiserror = "1.0.20"
-serde = { version = "1.0.101", features = ["derive", "rc"] }
+flate2 = "1.0.14"
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { version = "0.1.29", package = "futures" }
-bytes = { version = "0.4.12", features = ["serde"] }
-procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
-url = "1.7.2"
-derive_more = "0.15.0"
-url_serde = "0.2.0"
-log = { version = "0.4.8", features = ["serde"] }
-tempfile = "3.1.0"
-env_logger = "0.7.1"
-structopt = "0.3.2"
-serde_yaml = "0.8.11"
-cadence = "0.18.0"
-lazy_static = "1.4.0"
-parking_lot = "0.10.0"
-tokio = "0.1.22"
-uuid = { version = "0.8.1", features = ["v4", "serde"] }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
-sentry = { version = "0.20.1", features = ["debug-images", "log"] }
-sentry-actix = "0.20.1"
-# rusoto >= 0.43 supports async/await natively, with tokio 0.2 under the hood
-# For now we will stick with an older version, until our downloader client / runtime is compatible with tokio 0.2
-rusoto_s3 = "0.40.0"
-rusoto_core = "0.40.0"
-rusoto_credential = "0.40.0"
-lru = "0.4.3"
-pretty_env_logger = "0.4.0"
-console = "0.10.0"
-serde_json = "1.0.45"
-chrono = "0.4.9"
-zstd = "0.5.1"
-flate2 = "1.0.14"
 glob = "0.3.0"
-tokio-retry = "0.2.0"
+humantime-serde = "1.0.0"
+ipnetwork = "0.16.0"
 # needed for gcs, see https://github.com/Keats/jsonwebtoken/pull/89
 jsonwebtoken = { git = "https://github.com/Keats/jsonwebtoken", rev = "b8627260b2902a1ab4fdda83083be3e0b0fb9b7f" }
-base64 = "0.11.0"
-ipnetwork = "0.16.0"
-regex = "1.3.3"
-crc32fast = "1.2.0"
+lazy_static = "1.4.0"
+log = { version = "0.4.8", features = ["serde"] }
+lru = "0.4.3"
 num_cpus = "1.12.0"
-humantime-serde = "1.0.0"
+parking_lot = "0.10.0"
+pretty_env_logger = "0.4.0"
+procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
+regex = "1.3.3"
+# rusoto >= 0.43 supports async/await natively, with tokio 0.2 under the hood
+# For now we will stick with an older version, until our downloader client / runtime is compatible with tokio 0.2
+rusoto_core = "0.40.0"
+rusoto_credential = "0.40.0"
+rusoto_s3 = "0.40.0"
+sentry = { version = "0.20.1", features = ["debug-images", "log"] }
+sentry-actix = "0.20.1"
+serde = { version = "1.0.101", features = ["derive", "rc"] }
+serde_json = "1.0.45"
+serde_yaml = "0.8.11"
+structopt = "0.3.2"
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
+tempfile = "3.1.0"
+thiserror = "1.0.20"
+tokio = "0.1.22"
+tokio-retry = "0.2.0"
+url = "1.7.2"
+url_serde = "0.2.0"
+uuid = { version = "0.8.1", features = ["v4", "serde"] }
+zstd = "0.5.1"
 
 [dev-dependencies]
 insta = "0.11.0"

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use actix::ResponseFuture;
 use apple_crash_report_parser::AppleCrashReport;
 use bytes::{Bytes, IntoBuf};
+use chrono::{DateTime, TimeZone, Utc};
 use futures::{compat::Future01CompatExt, FutureExt as _, TryFutureExt};
 use futures01::future::{self, join_all, Future, IntoFuture, Shared};
 use futures01::sync::oneshot;
@@ -1035,7 +1036,7 @@ type CfiCacheResult = (CodeModuleId, Result<Arc<CfiCacheFile>, Arc<CfiCacheError
 
 #[derive(Debug, Serialize, Deserialize)]
 struct MinidumpState {
-    timestamp: u64,
+    timestamp: DateTime<Utc>,
     system_info: SystemInfo,
     crashed: bool,
     crash_reason: String,
@@ -1372,7 +1373,8 @@ impl SymbolicationActor {
                             .collect::<CodeModulesBuilder>();
 
                         let minidump_state = MinidumpState {
-                            timestamp: process_state.timestamp(),
+                            timestamp: Utc
+                                .timestamp(process_state.timestamp().try_into().unwrap(), 0),
                             system_info: SystemInfo {
                                 os_name: normalize_minidump_os_name(&os_name).to_owned(),
                                 os_version,
@@ -1532,7 +1534,7 @@ impl SymbolicationActor {
 
 #[derive(Debug)]
 struct AppleCrashReportState {
-    timestamp: Option<u64>,
+    timestamp: Option<DateTime<Utc>>,
     system_info: SystemInfo,
     crash_reason: Option<String>,
     crash_details: Option<String>,
@@ -1665,7 +1667,7 @@ impl SymbolicationActor {
                 .or_else(|| metadata.remove("Exception Codes"));
 
             let state = AppleCrashReportState {
-                timestamp: report.timestamp.map(|t| t.timestamp() as u64),
+                timestamp: report.timestamp,
                 system_info,
                 crash_reason,
                 crash_details,

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1373,8 +1373,10 @@ impl SymbolicationActor {
                             .collect::<CodeModulesBuilder>();
 
                         let minidump_state = MinidumpState {
-                            timestamp: Utc
-                                .timestamp(process_state.timestamp().try_into().unwrap(), 0),
+                            timestamp: Utc.timestamp(
+                                process_state.timestamp().try_into().unwrap_or_default(),
+                                0,
+                            ),
                             system_info: SystemInfo {
                                 os_name: normalize_minidump_os_name(&os_name).to_owned(),
                                 os_version,

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -1,7 +1,7 @@
 //! Service which handles all downloading from multiple kinds of sources.
 //!
 //! The sources are described on
-//! [https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/](https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/)
+//! <https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/>
 
 use std::fs::File;
 use std::io::Write;

--- a/src/types.rs
+++ b/src/types.rs
@@ -477,7 +477,7 @@ pub enum SymbolicationResponse {
 ///
 /// This object is the main type containing the symblicated crash as returned by the
 /// `/minidump`, `/symbolicate` and `/applecrashreport` endpoints.  It is publicly
-/// documented at https://getsentry.github.io/symbolicator/api/response/.  For the actual
+/// documented at <https://getsentry.github.io/symbolicator/api/response/>.  For the actual
 /// HTTP response this is further wrapped in [SymbolicationResponse] which can also return a
 /// pending or failed state etc instead of a result.
 #[derive(Debug, Default, Clone, Serialize)]


### PR DESCRIPTION
This avoids duck-typing an integer as a timestamp.

Additionally this upgrades chrono and sorts dependencies in cargo.toml
alphabetically.


----

#skip-changelog