### PR TITLE
test: Move conftest.py to repo toplevel

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,49 @@
+"""Project-wide pytest customisation.
+
+This module is a symbolicator-specific plugin to pytest, which is used by the integration
+tests.  Customisations to the global pytest process should be done here to ensure they are
+loaded before any test collection happens.
+"""
+
+import resource
+
+import pytest
+
+
+@pytest.hookimpl
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ci",
+        action="store_true",
+        help="Indicate the tests are being run on CI, "
+        "this e.g. prefers to fail tests instead of skipping them.",
+    )
+
+
+@pytest.hookimpl
+def pytest_sessionstart(session):
+    no_fds_soft, no_fds_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if no_fds_soft < 2028:
+        session.warn(
+            pytest.PytestWarning(
+                f"Too low open filedescriptor limit: {no_fds_soft} (try `ulimit -n 4096`)"
+            )
+        )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """This handles the extra_failure_checks mark to perform further assertions.
+
+    The mark can be added e.g. by a fixture that wants to run
+    something that can raise pytest.fail.Exception after the test has
+    completed.
+
+    Such checks will not be run when the test already failed, just
+    like multiple assertions within a test will stop the test
+    execution at the first failure.
+    """
+    yield
+    for marker in item.iter_markers("extra_failure_checks"):
+        for check_func in marker.kwargs.get("checks", []):
+            check_func()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 import collections
 import json
 import os
-import resource
 import socket
 import subprocess
 import threading
@@ -23,45 +22,6 @@ GCS_PRIVATE_KEY = os.environ.get("SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY")
 GCS_CLIENT_EMAIL = os.environ.get("SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL")
 
 session = requests.session()
-
-
-@pytest.hookimpl
-def pytest_addoption(parser):
-    parser.addoption(
-        "--ci",
-        action="store_true",
-        help="Indicate the tests are being run on CI, "
-        "this e.g. prefers to fail tests instead of skipping them.",
-    )
-
-
-@pytest.hookimpl
-def pytest_sessionstart(session):
-    no_fds_soft, no_fds_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    if no_fds_soft < 2028:
-        session.warn(
-            pytest.PytestWarning(
-                f"Too low open filedescriptor limit: {no_fds_soft} (try `ulimit -n 4096`)"
-            )
-        )
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item):
-    """This handles the extra_failure_checks mark to perform further assertions.
-
-    The mark can be added e.g. by a fixture that wants to run
-    something that can raise pytest.fail.Exception after the test has
-    completed.
-
-    Such checks will not be run when the test already failed, just
-    like multiple assertions within a test will stop the test
-    execution at the first failure.
-    """
-    yield
-    for marker in item.iter_markers("extra_failure_checks"):
-        for check_func in marker.kwargs.get("checks", []):
-            check_func()
 
 
 @pytest.fixture


### PR DESCRIPTION
Because this does things globally to the pytest process it needs to be
loaded before any test collection.  Thus it should be in the topmost
conftest.py, in this case the toplevel of the repo.

This currently works on CI because it invokes pytest with the path to
the integration tests, triggering the peculiarities of pytest plugin
loading which will now load a conftest in this directory before
collecting tests.  However when you interactively run pytest you might
not want to bother passing this argument all the time, let alone
realise this is the problem why pytest mysteriously fails.


----

#skip-changelog