### PR TITLE
ref: Upgrade to upcoming sentry SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,9 +956,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fragile"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2765,8 +2765,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "sentry"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e85b28d129f056ef91664fe2b985eade906d2838752c2f61c9f233cd98e4a"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -2780,23 +2779,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-actix"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f534ff69609cdb84413cea364545d9318a02dccd629a5786cceff2604480f85f"
-dependencies = [
- "actix-web",
- "failure",
- "fragile",
- "sentry",
- "sentry-failure",
-]
-
-[[package]]
 name = "sentry-backtrace"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92dabd890482f152fb6d261fe2034a193facc2c99c0c571bbf7687c356fcb2e8"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2807,8 +2792,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039ac50d2d740d51c5d376c2e9e93725eea662fa3acdcbcfe1b8b93a3b30c478"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -2822,8 +2806,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe4fe890b12416701f838c702898a9c5e574c333cfbbee9fb7855a14e6490a3"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "im",
  "lazy_static",
@@ -2836,8 +2819,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3d5f2b7822a6e54a7711cc49a92e2bab023198fb1a7342b8d1768d4987ec6a"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "findshlibs 0.7.0",
  "lazy_static",
@@ -2847,8 +2829,7 @@ dependencies = [
 [[package]]
 name = "sentry-failure"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead35e7019f77a79ed0345b3f3c28427139100f87f318c1c3e2788db2cdea8b7"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "failure",
  "sentry-backtrace",
@@ -2858,19 +2839,16 @@ dependencies = [
 [[package]]
 name = "sentry-log"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecacbaff50702c1028124ac834a25040bf13b6fbd720156fb817eafaea2c0e9"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "log",
- "sentry-backtrace",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8a3ac989339a76efd6155f9d02675ce4b04419cd8083ca58d083c222554147"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2879,8 +2857,7 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8124f0e9bc1113ecbcc8c3746e0e590943cf23e7d09c70a088c116869bb12e3"
+source = "git+https://github.com/getsentry/sentry-rust#bb3b777251ae53c7d413306334703c14dc7de51b"
 dependencies = [
  "chrono",
  "debugid",
@@ -3205,6 +3182,7 @@ dependencies = [
  "env_logger",
  "failure",
  "flate2",
+ "fragile",
  "futures 0.1.29",
  "futures 0.3.4",
  "glob",
@@ -3224,7 +3202,6 @@ dependencies = [
  "rusoto_credential",
  "rusoto_s3",
  "sentry",
- "sentry-actix",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = "0.15.0"
 env_logger = "0.7.1"
 failure = "0.1.6"
 flate2 = "1.0.14"
+fragile = "1.0.0" # used for vendoring sentry-actix
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { version = "0.1.29", package = "futures" }
 glob = "0.3.0"
@@ -43,8 +44,7 @@ regex = "1.3.3"
 rusoto_core = "0.40.0"
 rusoto_credential = "0.40.0"
 rusoto_s3 = "0.40.0"
-sentry = { version = "0.20.1", features = ["debug-images", "log"] }
-sentry-actix = "0.20.1"
+sentry = { git = "https://github.com/getsentry/sentry-rust", features = ["debug-images", "failure", "log"] }
 serde = { version = "1.0.101", features = ["derive", "rc"] }
 serde_json = "1.0.45"
 serde_yaml = "0.8.11"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use log::LevelFilter;
-use sentry::internals::Dsn;
+use sentry::types::Dsn;
 use serde::Deserialize;
 
 use crate::sources::SourceConfig;

--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -6,7 +6,6 @@ use actix_web::{
 use bytes::Bytes;
 use futures01::{future, Future, Stream};
 use sentry::{configure_scope, Hub};
-use sentry_actix::ActixWebHubExt;
 
 use crate::actors::symbolication::SymbolicationActor;
 use crate::app::{ServiceApp, ServiceState};
@@ -15,7 +14,7 @@ use crate::sources::SourceConfig;
 use crate::types::{RequestId, Scope, SymbolicationResponse};
 use crate::utils::futures::ThreadPool;
 use crate::utils::multipart::{read_multipart_file, read_multipart_sources};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
 
 #[derive(Debug, Default)]
 struct AppleCrashReportRequest {

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -6,7 +6,6 @@ use actix_web::{
 use bytes::Bytes;
 use futures01::{future, Future, Stream};
 use sentry::{configure_scope, Hub};
-use sentry_actix::ActixWebHubExt;
 
 use crate::actors::symbolication::SymbolicationActor;
 use crate::app::{ServiceApp, ServiceState};
@@ -15,7 +14,7 @@ use crate::sources::SourceConfig;
 use crate::types::{RequestId, Scope, SymbolicationResponse};
 use crate::utils::futures::ThreadPool;
 use crate::utils::multipart::{read_multipart_file, read_multipart_sources};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
 
 #[derive(Debug, Default)]
 struct MinidumpRequest {

--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -6,14 +6,13 @@ use bytes::BytesMut;
 use failure::{Error, Fail};
 use futures01::{future::Either, Future, IntoFuture, Stream};
 use sentry::Hub;
-use sentry_actix::ActixWebHubExt;
 use tokio::codec::{BytesCodec, FramedRead};
 
 use crate::actors::objects::{FindObject, ObjectFileBytes, ObjectPurpose};
 use crate::app::{ServiceApp, ServiceState};
 use crate::types::Scope;
 use crate::utils::paths::parse_symstore_path;
-use crate::utils::sentry::SentryFutureExt;
+use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt};
 
 fn proxy_symstore_request(
     state: State<ServiceState>,

--- a/src/endpoints/symbolicate.rs
+++ b/src/endpoints/symbolicate.rs
@@ -5,14 +5,13 @@ use actix_web::{http::Method, HttpRequest, Json, Query, State};
 use failure::Error;
 use futures01::Future;
 use sentry::{configure_scope, Hub};
-use sentry_actix::ActixWebHubExt;
 use serde::Deserialize;
 
 use crate::actors::symbolication::SymbolicateStacktraces;
 use crate::app::{ServiceApp, ServiceState};
 use crate::sources::SourceConfig;
 use crate::types::{RawObjectInfo, RawStacktrace, Scope, Signal, SymbolicationResponse};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
 
 /// Query parameters of the symbolication request.
 #[derive(Deserialize)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -108,7 +108,7 @@ where
     fn log(&self, record: &log::Record<'_>) {
         if self.inner.enabled(record.metadata()) {
             if record.level() == log::Level::Error {
-                sentry::capture_event(event_from_record(record, false));
+                sentry::capture_event(event_from_record(record));
             }
 
             sentry::add_breadcrumb(|| breadcrumb_from_record(record));
@@ -154,7 +154,7 @@ pub fn init_logging(config: &Config) {
     log::set_boxed_logger(breadcrumb_logger).unwrap();
 }
 
-/// A wrapper around a `Fail` that prints its causes.
+/// A wrapper around a `std::error::Error` that prints its causes.
 pub struct LogError<'a>(pub &'a dyn std::error::Error);
 
 impl<'a> fmt::Display for LogError<'a> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,7 @@ use crate::app::{ServiceApp, ServiceState};
 use crate::config::Config;
 use crate::endpoints;
 use crate::middlewares;
+use crate::utils::sentry::SentryMiddleware;
 
 /// Creates the Actix web application with all middlewares.
 #[inline]
@@ -13,7 +14,7 @@ fn create_app(state: ServiceState) -> ServiceApp {
     App::with_state(state)
         .middleware(middlewares::Metrics)
         .middleware(middlewares::ErrorHandlers)
-        .middleware(sentry_actix::SentryMiddleware::new())
+        .middleware(SentryMiddleware::new())
         .configure(endpoints::configure)
 }
 

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -1,9 +1,19 @@
-use std::sync::Arc;
+#![allow(deprecated)]
 
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
+
+use actix_web::middleware::{Finished, Middleware, Response, Started};
+use actix_web::{Error, HttpRequest, HttpResponse};
+use failure::Fail;
 use futures01::future::Future;
 use futures01::Poll;
 
-use sentry::{Hub, Scope};
+use sentry::integrations::failure::exception_from_single_fail;
+use sentry::protocol::{ClientSdkPackage, Event};
+use sentry::{Hub, Level, Scope, ScopeGuard};
+use uuid::Uuid;
 
 pub struct SentryFuture<F> {
     pub(crate) hub: Arc<Hub>,
@@ -66,4 +76,211 @@ impl<F> SentryFutureExt for F where F: futures01::future::Future {}
 /// for this.
 pub trait WriteSentryScope {
     fn write_sentry_scope(&self, scope: &mut Scope);
+}
+
+/// Reports certain failures to sentry.
+pub struct SentryMiddleware {
+    emit_header: bool,
+    capture_server_errors: bool,
+}
+
+struct HubWrapper {
+    hub: Arc<Hub>,
+    root_scope: RefCell<Option<ScopeGuard>>,
+}
+
+impl SentryMiddleware {
+    /// Creates a new sentry middleware.
+    pub fn new() -> SentryMiddleware {
+        SentryMiddleware {
+            emit_header: false,
+            capture_server_errors: true,
+        }
+    }
+
+    fn new_hub(&self) -> Arc<Hub> {
+        Arc::new(Hub::new_from_top(Hub::main()))
+    }
+}
+
+impl Default for SentryMiddleware {
+    fn default() -> Self {
+        SentryMiddleware::new()
+    }
+}
+
+fn extract_request<S: 'static>(
+    req: &HttpRequest<S>,
+    with_pii: bool,
+) -> (Option<String>, sentry::protocol::Request) {
+    let resource = req.resource();
+    let transaction = if let Some(rdef) = resource.rdef() {
+        Some(rdef.pattern().to_string())
+    } else if resource.name() != "" {
+        Some(resource.name().to_string())
+    } else {
+        None
+    };
+    let mut sentry_req = sentry::protocol::Request {
+        url: format!(
+            "{}://{}{}",
+            req.connection_info().scheme(),
+            req.connection_info().host(),
+            req.uri()
+        )
+        .parse()
+        .ok(),
+        method: Some(req.method().to_string()),
+        headers: req
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str().into(), v.to_str().unwrap_or("").into()))
+            .collect(),
+        ..Default::default()
+    };
+
+    if with_pii {
+        if let Some(remote) = req.connection_info().remote() {
+            sentry_req.env.insert("REMOTE_ADDR".into(), remote.into());
+        }
+    };
+
+    (transaction, sentry_req)
+}
+
+impl<S: 'static> Middleware<S> for SentryMiddleware {
+    fn start(&self, req: &HttpRequest<S>) -> Result<Started, Error> {
+        let hub = self.new_hub();
+        let outer_req = req;
+        let req = outer_req.clone();
+        let client = hub.client();
+
+        let req = fragile::SemiSticky::new(req);
+        let cached_data = Arc::new(Mutex::new(None));
+
+        let root_scope = hub.push_scope();
+        hub.configure_scope(move |scope| {
+            scope.add_event_processor(Box::new(move |mut event| {
+                let mut cached_data = cached_data.lock().unwrap();
+                if cached_data.is_none() && req.is_valid() {
+                    let with_pii = client
+                        .as_ref()
+                        .map_or(false, |x| x.options().send_default_pii);
+                    *cached_data = Some(extract_request(&req.get(), with_pii));
+                }
+
+                if let Some((ref transaction, ref req)) = *cached_data {
+                    if event.transaction.is_none() {
+                        event.transaction = transaction.clone();
+                    }
+                    if event.request.is_none() {
+                        event.request = Some(req.clone());
+                    }
+                }
+
+                if let Some(sdk) = event.sdk.take() {
+                    let mut sdk = sdk.into_owned();
+                    sdk.packages.push(ClientSdkPackage {
+                        name: "sentry-actix".into(),
+                        version: env!("CARGO_PKG_VERSION").into(),
+                    });
+                    event.sdk = Some(Cow::Owned(sdk));
+                }
+
+                Some(event)
+            }));
+        });
+
+        outer_req.extensions_mut().insert(HubWrapper {
+            hub,
+            root_scope: RefCell::new(Some(root_scope)),
+        });
+        Ok(Started::Done)
+    }
+
+    fn response(&self, req: &HttpRequest<S>, mut resp: HttpResponse) -> Result<Response, Error> {
+        if self.capture_server_errors && resp.status().is_server_error() {
+            let event_id = if let Some(error) = resp.error() {
+                Some(Hub::from_request(req).capture_actix_error(error))
+            } else {
+                None
+            };
+            match event_id {
+                Some(event_id) if self.emit_header => {
+                    resp.headers_mut().insert(
+                        "x-sentry-event",
+                        event_id.to_simple_ref().to_string().parse().unwrap(),
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(Response::Done(resp))
+    }
+
+    fn finish(&self, req: &HttpRequest<S>, _resp: &HttpResponse) -> Finished {
+        // if we make it to the end of the request we want to first drop the root
+        // scope before we drop the entire hub.  This will first drop the closures
+        // on the scope which in turn will release the circular dependency we have
+        // with the hub via the request.
+        if let Some(hub_wrapper) = req.extensions().get::<HubWrapper>() {
+            if let Ok(mut guard) = hub_wrapper.root_scope.try_borrow_mut() {
+                guard.take();
+            }
+        }
+        Finished::Done
+    }
+}
+
+/// Hub extensions for actix.
+pub trait ActixWebHubExt {
+    /// Returns the hub from a given http request.
+    ///
+    /// This requires that the `SentryMiddleware` middleware has been enabled or the
+    /// call will panic.
+    fn from_request<S>(req: &HttpRequest<S>) -> Arc<Hub>;
+    /// Captures an actix error on the given hub.
+    fn capture_actix_error(&self, err: &Error) -> Uuid;
+}
+
+impl ActixWebHubExt for Hub {
+    fn from_request<S>(req: &HttpRequest<S>) -> Arc<Hub> {
+        req.extensions()
+            .get::<HubWrapper>()
+            .expect("SentryMiddleware middleware was not registered")
+            .hub
+            .clone()
+    }
+
+    fn capture_actix_error(&self, err: &Error) -> Uuid {
+        let mut exceptions = vec![];
+        let mut ptr: Option<&dyn Fail> = Some(err.as_fail());
+        let mut idx = 0;
+        while let Some(fail) = ptr {
+            // Check whether the failure::Fail held by err is a failure::Error wrapped in Compat
+            // If that's the case, we should be logging that error and its fail instead of the wrapper's construction in actix_web
+            // This wouldn't be necessary if failure::Compat<failure::Error>'s Fail::backtrace() impl was not "|| None",
+            // that is however impossible to do as of now because it conflicts with the generic implementation of Fail also provided in failure.
+            // Waiting for update that allows overlap, (https://github.com/rust-lang/rfcs/issues/1053), but chances are by then failure/std::error will be refactored anyway
+            let compat: Option<&failure::Compat<failure::Error>> = fail.downcast_ref();
+            let failure_err = compat.map(failure::Compat::get_ref);
+            let fail = failure_err.map_or(fail, |x| x.as_fail());
+            exceptions.push(exception_from_single_fail(
+                fail,
+                if idx == 0 {
+                    Some(failure_err.map_or_else(|| err.backtrace(), |err| err.backtrace()))
+                } else {
+                    fail.backtrace()
+                },
+            ));
+            ptr = fail.cause();
+            idx += 1;
+        }
+        exceptions.reverse();
+        self.capture_event(Event {
+            exception: exceptions.into(),
+            level: Level::Error,
+            ..Default::default()
+        })
+    }
 }


### PR DESCRIPTION
This is vendoring in the old sentry-actix integration, as the new SDK only supports actix-web 3

#skip-changelog