### PR TITLE
ref(stackwalk): simplify MinidumpState creation

### DIFF
--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1281,8 +1281,8 @@ impl SymbolicationActor {
     /// This processes the minidump to stackwalk all the threads found in the minidump.
     ///
     /// The `cfi_results` must contain all modules found in the minidump (extracted using
-    /// [SymbolicationActor::get_referenced_modules]) and the result of trying to fetch the
-    /// Call Frame Information (CFI) for them from the [CfiCacheActor].
+    /// [SymbolicationActor::get_referenced_modules_from_minidump]) and the result of trying
+    /// to fetch the Call Frame Information (CFI) for them from the [CfiCacheActor].
     ///
     /// This function will load the CFI files and ask breakpad to stackwalk the minidump.
     /// Once it has stacktraces it creates the list of used modules and returns the


### PR DESCRIPTION
This moves the creation of MinidumpState into a std::convert::From
impl which simplifies the stackwalking code itself by moving boring
stuff out of the way.

It also removes get_object_type_from_minidump() completely forcing the
get_referenced_modules() code to build a full MinidumpState to get
this information.  That's a few wasteful allocations but avoids more
special purpose code matching strings.


----

#skip-changelog