### PR TITLE
test: Be more liberal when skipping credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
-        run: pytest --ci -n12 -vv tests/integration
+        run: pytest -n12 -vv tests/integration
 
   doc-comments:
     name: Rust doc comments

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-rust:
 test-integration: .venv/bin/python
 	.venv/bin/pip install -U pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
 	cargo build --locked
-	@.venv/bin/pytest $(CI_ARGS) tests/integration -n12 -vv
+	@.venv/bin/pytest tests/integration -n12 -vv
 .PHONY: test-integration
 
 # Documentation

--- a/conftest.py
+++ b/conftest.py
@@ -11,16 +11,6 @@ import pytest
 
 
 @pytest.hookimpl
-def pytest_addoption(parser):
-    parser.addoption(
-        "--ci",
-        action="store_true",
-        help="Indicate the tests are being run on CI, "
-        "this e.g. prefers to fail tests instead of skipping them.",
-    )
-
-
-@pytest.hookimpl
 def pytest_sessionstart(session):
     no_fds_soft, no_fds_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     if no_fds_soft < 2028:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -242,9 +242,16 @@ def hitcounter(request):
 
 @pytest.fixture
 def s3(pytestconfig):
+    """AWS S3 credentials for testing S3 buckets.
+
+    This will skip if the secrets are not in the environment, unless we are running on CI in
+    the getsentry team, in which case it will fail.  When running CI not as part of the
+    getsentry team you do not automatically get access to the configured secrets so skipping
+    is allowed.
+    """
     if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
         msg = "No AWS credentials"
-        if pytestconfig.getoption("ci"):
+        if os.getenv("CI") and os.getenv("GITHUB_REPOSITORY").startswith("getsentry/"):
             pytest.fail(msg)
         else:
             pytest.skip(msg)
@@ -274,9 +281,16 @@ def s3_bucket_config(s3):
 
 @pytest.fixture
 def ios_bucket_config(pytestconfig):
+    """Google cloud storage bucket for ios symbols.
+
+    This will skip if the secrets are not in the environment, unless we are running on CI in
+    the getsentry team, in which case it will fail.  When running CI not as part of the
+    getsentry team you do not automatically get access to the configured secrets so skipping
+    is allowed.
+    """
     if not GCS_PRIVATE_KEY or not GCS_CLIENT_EMAIL:
         msg = "No GCS credentials"
-        if pytestconfig.getoption("ci"):
+        if os.getenv("CI") and os.getenv("GITHUB_REPOSITORY").startswith("getsentry/"):
             pytest.fail(msg)
         else:
             pytest.skip(msg)


### PR DESCRIPTION
When an external person makes a PR they do not get access to the
credentials in the environment variables and the tests will fail.  So
we now check we're actually running as getsentry to still allow
skipping for external contributors.

This also removes the --ci flag, as we are now depending on Github
Actions environment variables we might as well depend on them to
detect running in CI in general.

#skip-changelog
