### PR TITLE
ci(gha): Publish artifacts to GHA

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,10 +1,13 @@
 ---
-minVersion: "0.11.0"
+minVersion: "0.13.2"
 github:
   owner: getsentry
   repo: symbolicator
 changelogPolicy: auto
+
 statusProvider:
+  name: github
+artifactProvider:
   name: github
 
 targets:
@@ -34,7 +37,7 @@ targets:
     name: docker
     source: us.gcr.io/sentryio/symbolicator
     target: getsentry/symbolicator
-    targetFormat: '{{{target}}}:latest'
+    targetFormat: "{{{target}}}:latest"
 
 requireNames:
   - /^gh-pages.zip$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
           objcopy --strip-debug --strip-unneeded target/release/symbolicator
           objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}
           zip symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
-          mv target/release/{symbolicator,symbolicator-Linux-x86_64}
+          mv target/release/symbolicator symbolicator-Linux-x86_64
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
-          path: target/release/symbolicator-Linux-*
+          path: symbolicator-Linux-*
 
   docs:
     name: Build Docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           objcopy --only-keep-debug target/release/symbolicator{,.debug}
           objcopy --strip-debug --strip-unneeded target/release/symbolicator
           objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}
-          zip symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
+          zip -j symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
           mv target/release/symbolicator symbolicator-Linux-x86_64
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,21 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Install rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --locked
+
       - name: Build symbolicator
         run: |
-          cargo build --release
           objcopy --only-keep-debug target/release/symbolicator{,.debug}
           objcopy --strip-debug --strip-unneeded target/release/symbolicator
           objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,7 @@ name: Release build
 on:
   push:
     branches:
-      - master
       - release/**
-
-  pull_request:
 
 jobs:
   binary:
@@ -30,7 +27,7 @@ jobs:
           command: build
           args: --release --locked
 
-      - name: Build symbolicator
+      - name: Split and archive debug info
         run: |
           objcopy --only-keep-debug target/release/symbolicator{,.debug}
           objcopy --strip-debug --strip-unneeded target/release/symbolicator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ on:
       - release/**
 
 jobs:
-  docs:
-    name: Build and upload Linux release and docs
+  binary:
+    name: Build Binary
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +20,21 @@ jobs:
           objcopy --only-keep-debug target/release/symbolicator{,.debug}
           objcopy --strip-debug --strip-unneeded target/release/symbolicator
           objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}
-          zip symbolicator-debug.zip target/release/symbolicator.debug
+          zip symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
+          mv target/release/{symbolicator,symbolicator-Linux-x86_64}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.sha }}
+          path: target/release/symbolicator-Linux-*
+
+  docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -36,16 +50,7 @@ jobs:
           touch site/.nojekyll
           cd site && zip -r gh-pages .
 
-      - name: Setup node
-        uses: actions/setup-node@v1
-
-      - name: Upload to Zeus
-        env:
-          ZEUS_HOOK_BASE: ${{ secrets.ZEUS_HOOK_BASE }}
-        run: |
-          npm install -D @zeus-ci/cli
-          npx zeus job update -b ${{ github.run_id }} -j ${{ github.job }} -r ${{ github.sha }}
-          npx zeus upload -b ${{ github.run_id }} -j ${{ github.job }} -t "application/octet-stream" -n symbolicator-Linux-x86_64 target/release/symbolicator
-          npx zeus upload -b ${{ github.run_id }} -j ${{ github.job }} -t "application/zip" -n symbolicator-Linux-x86_64-debug.zip symbolicator-debug.zip
-          npx zeus upload -b ${{ github.run_id }} -j ${{ github.job }} -t "application/zip+docs" site/gh-pages.zip
-          npx zeus job update --status=passed -b ${{ github.run_id }} -j ${{ github.job }} -r ${{ github.sha }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.sha }}
+          path: site/gh-pages.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,10 @@ name: Release build
 on:
   push:
     branches:
+      - master
       - release/**
+
+  pull_request:
 
 jobs:
   binary:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 .PHONY: build
 
 release:
-	cargo build --release
+	cargo build --release --locked
 	objcopy --only-keep-debug target/release/symbolicator{,.debug}
 	objcopy --strip-debug --strip-unneeded target/release/symbolicator
 	objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}


### PR DESCRIPTION
Uses Craft's GitHub artifact provider instead of Zeus.

#skip-changelog