### PR TITLE
ci(danger): Improve danger warnings

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,7 +1,7 @@
 name: "Danger"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   build:

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -50,10 +50,7 @@ function getSnapshotDetails() {
 <details>
 <summary><b>Instructions for snapshot changes</b></summary>
 
-Sentry contains a separate symbolicator integration test suite located at
-[\`tests/symbolicator/\`](https://github.com/getsentry/sentry/tree/master/tests/symbolicator).
-Changes in this PR will likely result in snapshot diffs in Sentry, which will break the master
-branch and in-progress PRs.
+Sentry runs a symbolicator integration test suite located at [\`tests/symbolicator/\`](https://github.com/getsentry/sentry/tree/master/tests/symbolicator). Changes in this PR will likely result in snapshot diffs in Sentry, which will break the master branch and in-progress PRs.
 
 Follow these steps to update snapshots in Sentry:
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -8,7 +8,7 @@ async function checkChangelog(path) {
   return contents.includes(prLink);
 }
 
-function getChangelogMessage() {
+function getChangelogDetails() {
   const prNumber = danger.github.pr.number;
   const prUrl = danger.github.pr.html_url;
   const prLink = `[#${prNumber}](${prUrl})`;
@@ -41,8 +41,31 @@ function checkChangelog() {
 
   if (!skipChangelog && !hasChangelog) {
     fail("Please consider adding a changelog entry for the next release.");
-    markdown(getChangelogMessage());
+    markdown(getChangelogDetails());
   }
+}
+
+function getSnapshotDetails() {
+  return `
+<details>
+<summary><b>Instructions for snapshot changes</b></summary>
+
+Sentry contains a separate symbolicator integration test suite located at
+[\`tests/symbolicator/\`](https://github.com/getsentry/sentry/tree/master/tests/symbolicator).
+Changes in this PR will likely result in snapshot diffs in Sentry, which will break the master
+branch and in-progress PRs.
+
+Follow these steps to update snapshots in Sentry:
+
+1. Check out latest Sentry \`master\` and enable the virtualenv.
+2. Stop the symbolicator devservice using \`sentry devservices down symbolicator\`.
+3. Run your development symbolicator on port ``3021``.
+4. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` and run symbolicator tests with pytest.
+5. Review snapshot changes locally, then create a PR to Sentry.
+6. Merge the Symbolicator PR, then merge the Sentry PR.
+
+</details>
+  `;
 }
 
 function checkSnapshots() {
@@ -55,6 +78,7 @@ function checkSnapshots() {
       "Snapshot changes likely affect Sentry tests. Please check the symbolicator test suite in " +
         "Sentry and update snapshots as needed."
     );
+    markdown(getSnapshotDetails());
   }
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -70,8 +70,9 @@ Follow these steps to update snapshots in Sentry:
 
 function checkSnapshots() {
   const SNAPSHOT_LOCATION = "src/actors/snapshots/";
-  const changesSnapshots =
-    danger.git.modified_files.indexOf(SNAPSHOT_LOCATION) !== -1;
+  const changesSnapshots = danger.git.modified_files.some((f) =>
+    f.startsWith(SNAPSHOT_LOCATION)
+  );
 
   if (changesSnapshots) {
     warn(

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,22 +1,65 @@
-const ERROR_MESSAGE =
-  "Please consider adding a changelog entry for the next release.";
+function getCleanTitle() {
+  const title = danger.github.pr.title;
+  return title.split(": ").slice(-1)[0].trim().replace(/\.+$/, "");
+}
 
-const DETAILS = `
+async function checkChangelog(path) {
+  const contents = await danger.github.utils.fileContents(path);
+  return contents.includes(prLink);
+}
+
+function getChangelogMessage() {
+  const prNumber = danger.github.pr.number;
+  const prUrl = danger.github.pr.html_url;
+  const prLink = `[#${prNumber}](${prUrl})`;
+
+  return `
 Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the following heading:
  1. **Features**: For new user-visible functionality.
  2. **Bug Fixes**: For user-visible bug fixes.
  3. **Internal**: For features and bug fixes in internal operation.
 
+To the changelog entry, please add a link to this PR (consider a more descriptive message):
+
+\`\`\`md
+- ${getCleanTitle()}. (${prLink})
+\`\`\`
+
 If none of the above apply, you can opt out by adding _#skip-changelog_ to the PR description.
 `;
-
-const files = danger.git.modified_files;
-const hasChangelog = files.indexOf("CHANGELOG.md") !== -1;
-
-const skipChangelog =
-  danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
-
-if (!skipChangelog && !hasChangelog) {
-  fail(ERROR_MESSAGE);
-  markdown(DETAILS);
 }
+
+function checkChangelog() {
+  const hasChangelog = danger.git.modified_files.indexOf("CHANGELOG.md") !== -1;
+  const skipChangelog =
+    danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
+
+  if (!skipChangelog && !hasChangelog) {
+    fail("Please consider adding a changelog entry for the next release.");
+    markdown(getChangelogMessage());
+  }
+}
+
+function checkSnapshots() {
+  const SNAPSHOT_LOCATION = "src/actors/snapshots/";
+  const changesSnapshots =
+    danger.git.modified_files.indexOf(SNAPSHOT_LOCATION) !== -1;
+
+  if (changesSnapshots) {
+    warn(
+      "Snapshot changes likely affect Sentry tests. Please check the symbolicator test suite in " +
+        "Sentry and update snapshots as needed."
+    );
+  }
+}
+
+function checkAll() {
+  const isDraft = danger.github && danger.github.pr.mergeable_state === "draft";
+
+  if (!isDraft) {
+    checkChangelog();
+    checkSnapshots();
+  }
+}
+
+checkAll();

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -15,7 +15,7 @@ function getChangelogMessage() {
 
   return `
 <details>
-<summary>Instructions and example for changelog.</summary>
+<summary><b>Instructions and example for changelog</b></summary>
 
 Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the following heading:
  1. **Features**: For new user-visible functionality.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -14,6 +14,9 @@ function getChangelogMessage() {
   const prLink = `[#${prNumber}](${prUrl})`;
 
   return `
+<details>
+<summary>Instructions and example for changelog.</summary>
+
 Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the following heading:
  1. **Features**: For new user-visible functionality.
  2. **Bug Fixes**: For user-visible bug fixes.
@@ -26,6 +29,8 @@ To the changelog entry, please add a link to this PR (consider a more descriptiv
 \`\`\`
 
 If none of the above apply, you can opt out by adding _#skip-changelog_ to the PR description.
+
+</details>
 `;
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -59,7 +59,7 @@ Follow these steps to update snapshots in Sentry:
 
 1. Check out latest Sentry \`master\` and enable the virtualenv.
 2. Stop the symbolicator devservice using \`sentry devservices down symbolicator\`.
-3. Run your development symbolicator on port ``3021``.
+3. Run your development symbolicator on port \`3021\`.
 4. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` and run symbolicator tests with pytest.
 5. Review snapshot changes locally, then create a PR to Sentry.
 6. Merge the Symbolicator PR, then merge the Sentry PR.

--- a/src/actors/snapshots/tests__add_bucket.snap
+++ b/src/actors/snapshots/tests__add_bucket.snap
@@ -1,6 +1,6 @@
 ---
 source: src/actors/symbolication.rs
-expression: response
+expression: responseCHANGECHANGE
 ---
 status: completed
 stacktraces:

--- a/src/actors/snapshots/tests__add_bucket.snap
+++ b/src/actors/snapshots/tests__add_bucket.snap
@@ -1,6 +1,6 @@
 ---
 source: src/actors/symbolication.rs
-expression: responseCHANGECHANGE
+expression: response
 ---
 status: completed
 stacktraces:


### PR DESCRIPTION
Makes several improvements to Danger checks:

- Skips danger checks on draft PRs entirely.
- Shows a suggestion for the changelog entry for simple copy-paste.
- Warns when snapshots change that Sentry tests probably need updating.

#skip-changelog