### PR TITLE
ref(minidump): Consolidate building of module info

### DIFF
--- a/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -154,7 +154,7 @@ stacktraces:
         trust: context
 modules:
   - debug_status: found
-    unwind_status: unused
+    unwind_status: found
     features:
       has_debug_info: true
       has_unwind_info: true

--- a/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -154,7 +154,7 @@ stacktraces:
         trust: context
 modules:
   - debug_status: found
-    unwind_status: found
+    unwind_status: unused
     features:
       has_debug_info: true
       has_unwind_info: true


### PR DESCRIPTION
The minidump stack unwiding starts the building of the module info
which is eventually sent back in the symbolication response.  This
consolidates this code by introducing a few more helpers making the
main stackwalking code smaller and separating concerns a bit better.

This makes one change:

- The unwind_status field is now marked as "unused" even when CFI for
  the module was found, before it was only marked as unsued if the
  CFI was missing.  This behaviour is more correct, the features map
  still indicates the presence of the CFI for the module.

#skip-changelog

No snapshot updates required in sentry