### PR TITLE
build: Skip debug information in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,5 +63,12 @@ zstd = "0.5.1"
 insta = "1.3.0"
 procspawn = { version = "0.9.0", features = ["test-support"] }
 
+[profile.dev]
+# Debug information slows down the build and increases caches in the
+# target folder, but we don't require stack traces in most cases.
+debug = false
+
 [profile.release]
+# In release, however, we do want full debug information to report
+# panic and error stack traces to Sentry.
 debug = true


### PR DESCRIPTION
Speeds up compilation of debug builds by removing debug information, which we usually don't require during development and testing. In cases where stack traces and debug information are required, they can be enabled by setting `debug = true` locally.

#skip-changelog