### PR TITLE
doc: Use intra doc links consistently

### DIFF
--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -109,7 +109,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     /// Extracts the Call Frame Information (CFI) from an object file.
     ///
     /// The extracted CFI is written to `path` in symbolic's
-    /// [symbolic::minidump::cfi::CfiCache] format.
+    /// [`CfiCache`](symbolic::minidump::cfi::CfiCache) format.
     fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
         let path = path.to_owned();
         let object = self

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -29,7 +29,7 @@ type ComputationMap<T, E> = Arc<Mutex<BTreeMap<CacheKey, ComputationChannel<T, E
 /// - Symcaches
 /// - CFI caches
 ///
-/// Transparently performs cache lookups, downloads and cache stores via the `CacheItemRequest`
+/// Transparently performs cache lookups, downloads and cache stores via the [`CacheItemRequest`]
 /// trait and associated types.
 ///
 /// Internally deduplicates concurrent cache lookups (in-memory).
@@ -189,11 +189,11 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// Compute an item.
     ///
     /// If the item is in the file system cache, it is returned immediately. Otherwise, it
-    /// is computed using `T::compute` ([CacheItemRequest::compute]), and then persisted to
+    /// is computed using [`T::compute`](CacheItemRequest::compute), and then persisted to
     /// the cache.
     ///
     /// This method does not take care of ensuring the computation only happens once even
-    /// for concurrent requests, see the public [Cacher::compute_memoized] for this.
+    /// for concurrent requests, see the public [`Cacher::compute_memoized`] for this.
     fn compute(&self, request: T, key: CacheKey) -> ResponseFuture<T::Item, T::Error> {
         // cache_path is None when caching is disabled.
         let cache_path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
@@ -284,8 +284,8 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// The actual computation is deduplicated between concurrent requests. Finally, the result is
     /// inserted into the cache and all subsequent calls fetch from the cache.
     ///
-    /// The computation itself is done by the [CacheItemRequest::compute] (`T::compute` or
-    /// `request.compute`) function, but only if it was not already in the cache.
+    /// The computation itself is done by [`T::compute`](CacheItemRequest::compute), but only if it
+    /// was not already in the cache.
     pub fn compute_memoized(&self, request: T) -> ResponseFuture<Arc<T::Item>, Arc<T::Error>> {
         let key = request.get_cache_key();
         let name = self.config.name();

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -157,7 +157,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
     /// the data cache has probably also expired.
     ///
     /// This returns an error if the download failed.  If the data cache has a
-    /// [CacheStatus::Negative] or [CacheStatus::Malformed] status the same status is
+    /// [`CacheStatus::Negative`] or [`CacheStatus::Malformed`] status the same status is
     /// returned.
     fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
         let cache_key = self.get_cache_key();
@@ -195,10 +195,10 @@ impl CacheItemRequest for FetchFileMetaRequest {
         serde_json::from_slice::<ObjectFeatures>(data).is_ok()
     }
 
-    /// Returns the [ObjectFileMeta] at the given cache key.
+    /// Returns the [`ObjectFileMeta`] at the given cache key.
     ///
-    /// If the `status` is [CacheStatus::Malformed] or [CacheStatus::Negative] the metadata
-    /// returned will contain the default [ObjectFileMeta::features].
+    /// If the `status` is [`CacheStatus::Malformed`] or [`CacheStatus::Negative`] the metadata
+    /// returned will contain the default [`ObjectFileMeta::features`].
     fn load(
         &self,
         scope: Scope,
@@ -233,10 +233,10 @@ impl CacheItemRequest for FetchFileDataRequest {
     /// symbolic to ensure it is not malformed.
     ///
     /// If there is an error with downloading or decompression then an `Err` of
-    /// [ObjectError] is returned.  However if only the final object file parsing failed
-    /// then an `Ok` with [CacheStatus::Malformed] is returned.
+    /// [`ObjectError`] is returned.  However if only the final object file parsing failed
+    /// then an `Ok` with [`CacheStatus::Malformed`] is returned.
     ///
-    /// If the object file did not exist on the source a [CacheStatus::Negative] will be
+    /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
     /// returned.
     fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
         let cache_key = self.get_cache_key();
@@ -650,7 +650,7 @@ impl ObjectsActor {
 /// Decompresses an object file.
 ///
 /// Some compression methods are implemented by spawning an external tool and can only
-/// process from a named pathname, hence we need a [NamedTempFile] as source.
+/// process from a named pathname, hence we need a [`NamedTempFile`] as source.
 fn decompress_object_file(src: &NamedTempFile, mut dst: fs::File) -> io::Result<fs::File> {
     // Ensure that both meta data and file contents are available to the
     // subsequent reads of the file metadata and reads from other threads.

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -107,12 +107,11 @@ pub struct SymCacheLookupResult<'a> {
 }
 
 impl<'a> SymCacheLookupResult<'a> {
-    /// The preferred addr mode for this lookup.
+    /// The preferred [`AddrMode`] for this lookup.
     ///
-    /// for the symbolicated frame we generally switch to absolute reporting of
-    /// addresses.  This is not done for images mounted at `0x0`.  This is done
-    /// because for instance WASM does not have a unified address space and so
-    /// it's not possible for us to absolutize addresses.
+    /// For the symbolicated frame, we generally switch to absolute reporting of addresses. This is
+    /// not done for images mounted at `0` because, for instance, WASM does not have a unified
+    /// address space and so it is not possible for us to absolutize addresses.
     pub fn preferred_addr_mode(&self) -> AddrMode {
         if self.object_info.supports_absolute_addresses() {
             AddrMode::Abs
@@ -121,7 +120,7 @@ impl<'a> SymCacheLookupResult<'a> {
         }
     }
 
-    /// Exposes an address consistent with `preferred_addr_mode`.
+    /// Exposes an address consistent with [`preferred_addr_mode`](Self::preferred_addr_mode).
     pub fn expose_preferred_addr(&self, addr: u64) -> u64 {
         if self.object_info.supports_absolute_addresses() {
             self.object_info.rel_to_abs_addr(addr).unwrap_or(0)
@@ -989,17 +988,17 @@ pub struct SymbolicateStacktraces {
 
     /// A list of images that were loaded into the process.
     ///
-    /// This list must cover the instruction addresses of the frames in `threads`. If a frame is not
-    /// covered by any image, the frame cannot be symbolicated as it is not clear which debug file
-    /// to load.
+    /// This list must cover the instruction addresses of the frames in
+    /// [`stacktraces`](Self::stacktraces). If a frame is not covered by any image, the frame cannot
+    /// be symbolicated as it is not clear which debug file to load.
     pub modules: Vec<CompleteObjectInfo>,
 }
 
 /// Run future with a timeout, instrumented with metrics.
 ///
-/// This runs the future `future` and exports the duration as the `futures.done` metric
-/// using `task_name` as metric field.  The future will be cancelled if it runs for longer
-/// than `duration` with this status also being represented in the metric.
+/// This polls the [`Future`] to completion and exposes the duration as the `"futures.done"` metric
+/// using `"task_name"` as metric tag. The future will be cancelled if it runs for longer than
+/// `duration` with this status also being represented in the metric.
 async fn measure_task_timeout<T, F>(task_name: &str, future: F, duration: Duration) -> F::Output
 where
     F: Future<Output = Result<T, SymbolicationError>>,
@@ -1142,7 +1141,8 @@ impl SymbolicationActor {
 
     /// Polls the status for a started symbolication task.
     ///
-    /// If the timeout is set and no result is ready within the given time, a `pending` status is
+    /// If the timeout is set and no result is ready within the given time,
+    /// [`SymbolicationResponse::Pending`] is returned.
     pub fn get_response(
         &self,
         request_id: RequestId,
@@ -1169,8 +1169,8 @@ type CfiCacheResult = (CodeModuleId, Result<Arc<CfiCacheFile>, Arc<CfiCacheError
 
 /// Contains some meta-data about a minidump.
 ///
-/// The minidump meta-data contained here is extracted in a [procspawn] subprocess so needs
-/// to be (de)serialisable to/from JSON.  It is only a way to get this metadata out of the
+/// The minidump meta-data contained here is extracted in a [`procspawn`] subprocess, so needs
+/// to be (de)serialisable to/from JSON. It is only a way to get this metadata out of the
 /// subprocess and merged into the final symbolication result.
 ///
 /// A few more convenience methods exist to help with building the symbolication results.
@@ -1310,7 +1310,7 @@ impl SymbolicationActor {
     ///
     /// This handles the procspawn result, makes sure to appropriately log any failures and
     /// save the minidump for debugging.  Returns a simple result converted to the
-    /// `SymbolicationError`.
+    /// [`SymbolicationError`].
     fn join_procspawn<T, E>(
         handle: procspawn::JoinHandle<Result<procspawn::serde::Json<T>, E>>,
         timeout: Duration,
@@ -1416,8 +1416,8 @@ impl SymbolicationActor {
     /// This processes the minidump to stackwalk all the threads found in the minidump.
     ///
     /// The `cfi_results` must contain all modules found in the minidump (extracted using
-    /// [SymbolicationActor::get_referenced_modules_from_minidump]) and the result of trying
-    /// to fetch the Call Frame Information (CFI) for them from the [CfiCacheActor].
+    /// [`SymbolicationActor::get_referenced_modules_from_minidump`]) and the result of trying
+    /// to fetch the Call Frame Information (CFI) for them from the [`CfiCacheActor`].
     ///
     /// This function will load the CFI files and ask breakpad to stackwalk the minidump.
     /// Once it has stacktraces it creates the list of used modules and returns the
@@ -1991,7 +1991,7 @@ mod tests {
     /// Setup tests and create a test service.
     ///
     /// This function returns a tuple containing the service to test, and a temporary cache
-    /// directory. The directory is cleaned up when the `TempDir` instance is dropped. Keep it as
+    /// directory. The directory is cleaned up when the [`TempDir`] instance is dropped. Keep it as
     /// guard until the test has finished.
     ///
     /// The service is configured with `connect_to_reserved_ips = True`. This allows to use a local

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -22,7 +22,7 @@ use crate::types::Scope;
 /// The malformed state is useful for failed computations that are unlikely to succeed before the
 /// next deploy. For example, symcache writing may fail due to an object file symbolic can't parse
 /// yet.
-const MALFORMED_MARKER: &[u8] = b"malformed";
+pub const MALFORMED_MARKER: &[u8] = b"malformed";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CacheStatus {
@@ -33,7 +33,7 @@ pub enum CacheStatus {
     /// trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache. See
-    /// docs for `MALFORMED_MARKER`.
+    /// docs for [`MALFORMED_MARKER`].
     Malformed,
 }
 
@@ -60,7 +60,7 @@ impl CacheStatus {
 
     /// Persist the operation in the cache.
     ///
-    /// If the status was [CacheStatus::Positive] this copies the data from the temporary
+    /// If the status was [`CacheStatus::Positive`] this copies the data from the temporary
     /// file to the final cache location.  Otherwise it writes corresponding marker in the
     /// cache location.
     pub fn persist_item(self, path: &Path, file: NamedTempFile) -> Result<(), io::Error> {
@@ -100,7 +100,7 @@ pub struct Cache {
     ///
     /// When writing a new file into the cache it is best to write it to a temporary file in
     /// a sibling directory, once fully written it can then be atomically moved to the
-    /// actual location withing the `cache_dir`.
+    /// actual location withing the [`cache_dir`](Self::cache_dir).
     ///
     /// Just like for `cache_dir` when this cache is disabled this will be `None`.
     tmp_dir: Option<PathBuf>,
@@ -186,10 +186,10 @@ impl Cache {
     }
 
     /// Validate cache expiration of path. If cache should not be used,
-    /// `Err(io::ErrorKind::NotFound)` is returned.  If cache is usable, `Ok(x)` is returned, where
+    /// `Err(io::ErrorKind::NotFound)` is returned. If cache is usable, `Ok(x)` is returned, where
     /// `x` indicates whether the file should be touched before using.
     fn check_expiry(&self, path: &Path) -> io::Result<bool> {
-        // We use mtime to keep track of both "cache last used" and "cache created" depending on
+        // We use `mtime` to keep track of both "cache last used" and "cache created" depending on
         // whether the file is a negative cache item or not, because literally every other
         // filesystem attribute is unreliable.
         //
@@ -311,7 +311,7 @@ pub fn get_scope_path(cache_dir: Option<&Path>, scope: &Scope, cache_key: &str) 
 }
 
 fn safe_path_segment(s: &str) -> String {
-    s.replace(".", "_") // protect against ..
+    s.replace(".", "_") // protect against ".."
         .replace("/", "_") // protect against absolute paths
         .replace(":", "_") // not a threat on POSIX filesystems, but confuses OS X Finder
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ impl Default for Metrics {
 
 /// Fine-tuning downloaded cache expiry.
 ///
-/// These differ from `DerivedCacheConfig` in the `Default::default` implementation.
+/// These differ from [`DerivedCacheConfig`] in the [`Default`] implementation.
 #[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq)]
 #[serde(default)]
 pub struct DownloadedCacheConfig {
@@ -100,7 +100,7 @@ impl Default for DownloadedCacheConfig {
 
 /// Fine-tuning derived cache expiry.
 ///
-/// These differ from `DownloadedCacheConfig` in the `Default::default` implementation.
+/// These differ from [`DownloadedCacheConfig`] in the [`Default`] implementation.
 #[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq)]
 #[serde(default)]
 pub struct DerivedCacheConfig {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -124,8 +124,10 @@ where
 /// Initializes logging for the symbolicator.
 ///
 /// This considers the `RUST_LOG` environment variable and defaults it to the level specified in the
-/// configuration. Additionally, this toggles `RUST_BACKTRACE` based on the `enable_stacktraces`
+/// configuration. Additionally, this toggles `RUST_BACKTRACE` based on the [`enable_stacktraces`]
 /// config value.
+///
+/// [`enable_stacktraces`]: crate::config::Logging::enable_backtraces
 pub fn init_logging(config: &Config) {
     if config.logging.enable_backtraces {
         env::set_var("RUST_BACKTRACE", "1");
@@ -154,7 +156,7 @@ pub fn init_logging(config: &Config) {
     log::set_boxed_logger(breadcrumb_logger).unwrap();
 }
 
-/// A wrapper around a `std::error::Error` that prints its causes.
+/// A wrapper around an [`Error`](std::error::Error) that prints its causes.
 pub struct LogError<'a>(pub &'a dyn std::error::Error);
 
 impl<'a> fmt::Display for LogError<'a> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-/// Same as `try` but to be used in functions that return `Box<dyn Future>` instead of `Result`.
+/// Same as [`try!`] but to be used in functions that return `Box<dyn Future>` instead of `Result`.
 ///
 /// Useful when calling synchronous (but cheap enough) functions in async code.
 #[macro_export]
@@ -14,8 +14,9 @@ macro_rules! tryf {
     };
 }
 
-/// Declare a closure that clone specific values before moving them into their bodies. Mainly
-/// useful when using combinator functions such as `Future::and_then` or `Future::map`.
+/// Declare a closure that clone specific values before moving them into their bodies. Mainly useful
+/// when using combinator functions such as [`Future::and_then`](futures01::Future::and_then) or
+/// [`Future::map`](futures01::Future::map).
 #[macro_export]
 macro_rules! clone {
     ($($n:ident),+ , || $body:expr) => (

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -41,8 +41,8 @@ pub fn configure_statsd<A: ToSocketAddrs>(prefix: &str, host: A) {
 
 /// Invoke a callback with the current statsd client.
 ///
-/// If statsd is not configured the callback is not invoked.  For the most part
-/// the `metric!` macro should be used instead.
+/// If statsd is not configured the callback is not invoked. For the most part
+/// the [`metric!`] macro should be used instead.
 #[inline(always)]
 pub fn with_client<F, R>(f: F) -> R
 where

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -3,8 +3,6 @@
 //! Specifically this supports the [`FilesystemSourceConfig`] source.  It allows
 //! sources to be present on the local filesystem, usually only used for
 //! testing.
-//!
-//! [`FilesystemSourceConfig`]: ../../../sources/struct.S3SourceConfig.html
 
 use std::fs;
 use std::io;

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -1,8 +1,6 @@
 //! Support to download from Google Cloud Storage buckets.
 //!
 //! Specifically this supports the [`GcsSourceConfig`] source.
-//!
-//! [`GcsSourceConfig`]: ../../../sources/struct.GcsSourceConfig.html
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -1,8 +1,6 @@
 //! Support to download from HTTP sources.
 //!
 //! Specifically this supports the [`HttpSourceConfig`] source.
-//!
-//! [`HttpSourceConfig`]: ../../../sources/struct.HttpSourceConfig.html
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -25,7 +23,7 @@ const MAX_HTTP_REDIRECTS: usize = 10;
 
 /// Joins the relative path to the given URL.
 ///
-/// As opposed to `Url::join`, this only supports relative paths. Each segment of the path is
+/// As opposed to [`Url::join`], this only supports relative paths. Each segment of the path is
 /// percent-encoded. Empty segments are skipped, for example, `foo//bar` is collapsed to `foo/bar`.
 ///
 /// The base URL is treated as directory. If it does not end with a slash, then a slash is

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -91,8 +91,6 @@ async fn dispatch_download(
 ///
 /// The service is rather simple on the outside but will one day control
 /// rate limits and the concurrency it uses.
-///
-/// [`SourceConfig`]: ../../types/enum.SourceConfig.html
 #[derive(Debug, Clone)]
 pub struct DownloadService {
     worker: RemoteThread,
@@ -107,12 +105,11 @@ impl DownloadService {
 
     /// Download a file from a source and store it on the local filesystem.
     ///
-    /// This does not do any deduplication of requests, every requested file is
-    /// freshly downloaded.
+    /// This does not do any deduplication of requests, every requested file is freshly downloaded.
     ///
-    /// The downloaded file is saved into `destination`.  The file will be created if it
-    /// does not exist and truncated if it does.  In case of any error the file's contents
-    /// is considered garbage.
+    /// The downloaded file is saved into `destination`. The file will be created if it does not
+    /// exist and truncated if it does. In case of any error, the file's contents is considered
+    /// garbage.
     pub fn download(
         &self,
         source: SourceFileId,
@@ -128,13 +125,13 @@ impl DownloadService {
             .map(|o| o.unwrap_or(Err(DownloadError::Canceled)))
     }
 
-    /// Returns all objects matching the [ObjectId] at the source.
+    /// Returns all objects matching the [`ObjectId`] at the source.
     ///
     /// Some sources, namely all the symbol servers, simply return the locations at which a
     /// download attempt should be made without any guarantee the object is actually there.
     ///
     /// If the source needs to be contacted to get matching objects this may fail and
-    /// returns a [DownloadError].
+    /// returns a [`DownloadError`].
     pub fn list_files(
         &self,
         source: SourceConfig,
@@ -189,18 +186,22 @@ async fn download_stream(
     Ok(DownloadStatus::Completed)
 }
 
-/// Iterator to generate a list of filepaths to try downloading from.
-///
-///  - `object_id`: Information about the image we want to download.
-///  - `filetypes`: Limit search to these filetypes.
-///  - `filters`: Filters from a `SourceConfig` to limit the amount of generated paths.
-///  - `layout`: Directory from `SourceConfig` to define what kind of paths we generate.
+/// Iterator to generate a list of [`SourceLocation`]s to attempt downloading.
 #[derive(Debug)]
 struct SourceLocationIter<'a> {
+    /// Limits search to a set of filetypes.
     filetypes: std::slice::Iter<'a, FileType>,
+
+    /// Filters from a `SourceConfig` to limit the amount of generated paths.
     filters: &'a SourceFilters,
+
+    /// Information about the object file to be downloaded.
     object_id: &'a ObjectId,
+
+    /// Directory from `SourceConfig` to define what kind of paths we generate.
     layout: DirectoryLayout,
+
+    /// Remaining locations to iterate.
     next: Vec<String>,
 }
 

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -1,8 +1,6 @@
 //! Support to download from S3 buckets.
 //!
 //! Specifically this supports the [`S3SourceConfig`] source.
-//!
-//! [`S3SourceConfig`]: ../../../sources/struct.S3SourceConfig.html
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -2,8 +2,6 @@
 //!
 //! Specifically this supports the [`SentrySourceConfig`] source, which allows
 //! to fetch files which were directly uploaded to Sentry itself.
-//!
-//! [`SentrySourceConfig`]: ../../../sources/struct.SentrySourceConfig.html
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,15 +1,14 @@
 //! Internal services.
 //!
-//! These services all operate independently from their caller.  Therefore they
-//! are all created with a [`ThreadPool`] to operate on so that they can spawn
-//! work without the caller having to worry about how calling is going to affect
-//! it's own executor.  It is common for threadpools to be shared by multiple
-//! services and the application wants to generally separate services with
-//! CPU-intensive workloads from those with IO-heavy workloads..
+//! These services all operate independently from their caller. Therefore they are all created with
+//! a [`ThreadPool`] to operate on so that they can spawn work without the caller having to worry
+//! about how calling is going to affect it's own executor. It is common for threadpools to be
+//! shared by multiple services and the application wants to generally separate services with
+//! CPU-intensive workloads from those with IO-heavy workloads.
 //!
-//! In general services are created once in the
-//! [crate::app::ServiceState] and accessed via this state.
+//! In general, services are created once in the [`crate::app::ServiceState`] and accessed via this
+//! state.
 //!
-//! [`ThreadPool`]: ../utils/futures/struct.ThreadPool.html
+//! [`ThreadPool`]: crate::utils::futures::ThreadPool
 
 pub mod download;

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,4 +1,4 @@
-//! Download sources types and related `impl`s.
+//! Download sources types and related implementations.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -76,10 +76,8 @@ impl WriteSentryScope for SourceConfig {
 
 /// A location for a file retrievable from many source configs.
 ///
-/// It is essentially a `/`-separated string.  This is currently used by all
-/// sources other than [`SentrySourceConfig`].  This may change in the future.
-///
-/// [`SentrySourceConfig`]: struct.SentrySourceConfig.html
+/// It is essentially a `/`-separated string. This is currently used by all sources other than
+/// [`SentrySourceConfig`]. This may change in the future.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SourceLocation(String);
 
@@ -101,8 +99,6 @@ impl fmt::Display for SourceLocation {
 }
 
 /// An identifier for a file retrievable from a [`SentrySourceConfig`].
-///
-/// [`SentrySourceConfig`]: struct.SentrySourceConfig.html
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SentryFileId(String);
 
@@ -182,8 +178,6 @@ impl FilesystemSourceConfig {
 /// This is a combination of the [`SourceConfig`], which describes a download
 /// source and how to download rom it, with an identifier describing a single
 /// file in that source.
-///
-/// [`SourceConfig`]: enum.SourceConfig.html
 #[derive(Debug, Clone)]
 pub enum SourceFileId {
     Sentry(Arc<SentrySourceConfig>, SentryFileId),
@@ -413,10 +407,12 @@ pub struct DirectoryLayout {
     #[serde(rename = "type")]
     pub ty: DirectoryLayoutType,
 
-    /// Overwrite filename casing convention of `self.layout`. This is useful in the case of
-    /// DirectoryLayout::Symstore, where servers are supposed to handle requests
-    /// case-insensitively, but practically don't (in the case of S3 buckets it's not possible),
-    /// making this aspect not well-specified.
+    /// Overwrite the default filename casing convention of the [layout type](Self::ty).
+    ///
+    /// This is useful in the case of [`DirectoryLayoutType::Symstore`], where servers are supposed to
+    /// handle requests case-insensitively, but practically do not, making this aspect not
+    /// well-specified. For instance, in S3 buckets it is not possible to perform case-insensitive
+    /// queries.
     pub casing: FilenameCasing,
 }
 
@@ -429,7 +425,7 @@ impl Default for DirectoryLayout {
     }
 }
 
-/// Known conventions for `DirectoryLayout`
+/// Known conventions for [`DirectoryLayout`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 pub enum DirectoryLayoutType {
     /// Uses conventions of native debuggers.
@@ -444,10 +440,10 @@ pub enum DirectoryLayoutType {
     /// Uses Microsoft SSQP server conventions.
     #[serde(rename = "ssqp")]
     SSQP,
-    /// debuginfod conventions.
+    /// Uses [debuginfod](https://www.mankier.com/8/debuginfod) conventions.
     #[serde(rename = "debuginfod")]
     Debuginfod,
-    /// unified sentry propriertary bucket format
+    /// Unified sentry propriertary bucket format.
     #[serde(rename = "unified")]
     Unified,
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,18 +2,18 @@
 //!
 //! When writing tests, keep the following points in mind:
 //!
-//!  - In every test, call `test::setup`. This will set up the logger so that all console output is
-//!    captured by the test runner.
+//!  - In every test, call [`test::setup`]. This will set up the logger so that all console output
+//!    is captured by the test runner.
 //!
-//!  - When using `test::tempdir`, make sure that the handle to the temp directory is held for the
+//!  - When using [`test::tempdir`], make sure that the handle to the temp directory is held for the
 //!    entire lifetime of the test. When dropped too early, this might silently leak the temp
 //!    directory, since symbolicator will create it again lazily after it has been deleted. To avoid
 //!    this, assign it to a variable in the test function (e.g. `let _cache_dir = test::tempdir()`).
 //!
-//!  - When using `test::symbol_server`, make sure that the server is held until all requests to the
-//!    server have been made. If the server is dropped, the ports remain open and all connections
-//!    to it will time out. To avoid this, assign it to a variable: `let (_server, source) =
-//!    test::symbol_server();`. Alternatively, use `test::local_source()` to test without HTTP
+//!  - When using [`test::symbol_server`], make sure that the server is held until all requests to the
+//!    server have been made. If the server is dropped, the ports remain open and all connections to
+//!    it will time out. To avoid this, assign it to a variable: `let (_server, source) =
+//!    test::symbol_server();`. Alternatively, use [`test::local_source`] to test without HTTP
 //!    connections.
 
 use std::cell::RefCell;
@@ -91,26 +91,26 @@ pub(crate) fn setup() {
 
 /// Creates a temporary directory.
 ///
-/// The directory is deleted when the `TempDir` instance is dropped, unless `into_path()` is called.
-/// Use it as a guard to automatically clean up after tests.
+/// The directory is deleted when the [`TempDir`] instance is dropped, unless
+/// [`into_path`](TemptDir::into_path) is called. Use it as a guard to automatically clean up after
+/// tests.
 pub(crate) fn tempdir() -> TempDir {
     TempDir::new().unwrap()
 }
 
-/// Runs the provided function, blocking the current thread until the result
-/// future completes.
+/// Runs the provided function, blocking the current thread until the result **legacy**
+/// [`Future`](futures01::Future) completes.
 ///
-/// This function can be used to synchronously block the current thread
-/// until the provided `future` has resolved either successfully or with an
-/// error. The result of the future is then returned from this function
-/// call.
+/// This function can be used to synchronously block the current thread until the provided `Future`
+/// has resolved either successfully or with an error. The result of the future is then returned
+/// from this function call.
 ///
-/// This is provided rather than a `block_on()`-like interface to avoid accidentally calling
-/// a function which spawns before creating a future, which would attempt to spawn before
-/// actix is initialised.
+/// This is provided rather than a `block_on`-like interface to avoid accidentally calling a
+/// function which spawns before creating a future, which would attempt to spawn before actix is
+/// initialised.
 ///
-/// Note that this function is intended to be used only for testing purpose.
-/// This function panics on nested call.
+/// Note that this function is intended to be used only for testing purpose. This function panics on
+/// nested call.
 pub fn block_fn01<F, R>(f: F) -> Result<R::Item, R::Error>
 where
     F: FnOnce() -> R,
@@ -123,7 +123,19 @@ where
     })
 }
 
-/// Version of `block_fn` which works with std::future aka futures03.
+/// Runs the provided function, blocking the current thread until the result
+/// [`Future`](std::future::Future) completes.
+///
+/// This function can be used to synchronously block the current thread until the provided `Future`
+/// has resolved either successfully or with an error. The result of the future is then returned
+/// from this function call.
+///
+/// This is provided rather than a `block_on`-like interface to avoid accidentally calling a
+/// function which spawns before creating a future, which would attempt to spawn before actix is
+/// initialised.
+///
+/// Note that this function is intended to be used only for testing purpose. This function panics on
+/// nested call.
 pub fn block_fn<F, R, T>(f: F) -> T
 where
     F: FnOnce() -> R,
@@ -155,12 +167,12 @@ pub(crate) fn local_source() -> SourceConfig {
 /// Spawn an actual HTTP symbol server for local fixtures.
 ///
 /// The symbol server serves static files from the local symbols fixture location under the
-/// `/download` prefix. The layout of this folder is `Native`. This function returns the test server
-/// as well as a source configuration, which can be used to access the symbol server in
-/// symbolication requests.
+/// `/download` prefix. The layout of this folder is [`DirectoryLayoutType::Native`]. This function
+/// returns the test server as well as a source configuration, which can be used to access the
+/// symbol server in symbolication requests.
 ///
 /// **Note**: The symbol server runs on localhost. By default, connections to local host are not
-/// permitted, and need to be activated via `Config::connect_to_reserved_ips`.
+/// permitted, and need to be activated via [`Config::connect_to_reserved_ips`].
 pub(crate) fn symbol_server() -> (TestServer, SourceConfig) {
     let server = TestServer::new(|app| {
         app.resource("/download/{tail:.+}", |resource| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,19 +124,20 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 /// An unsymbolicated frame from a symbolication request.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct RawFrame {
-    /// Controls the addressing mode for `instruction_addr` and
-    /// `sym_addr`.  If not defined it defaults to "abs".  Can be
-    /// set to `"rel:INDEX"` to make the address relative to the
-    /// module at the given index.
+    /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
+    /// [`sym_addr`](Self::sym_addr).
+    ///
+    /// If not defined, it defaults to [`AddrMode::Abs`]. The mode can be set to `"rel:INDEX"` to
+    /// make the address relative to the module at the given index ([`AddrMode::Rel`]).
     #[serde(default, skip_serializing_if = "is_default_value")]
     pub addr_mode: AddrMode,
 
-    /// The instruction address of this frame.
+    /// The absolute instruction address of this frame.
     ///
-    /// See `addr_mode` for the exact behavior of addresses.
+    /// See [`addr_mode`](Self::addr_mode) for the exact behavior of addresses.
     pub instruction_addr: HexValue,
 
-    /// The path to the image this frame is located in.
+    /// The path to the [module](RawObjectInfo) this frame is located in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
 
@@ -148,9 +149,10 @@ pub struct RawFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol: Option<String>,
 
-    /// Start address of the function this frame is located in (lower or equal to instruction_addr).
+    /// Start address of the function this frame is located in (lower or equal to
+    /// [`instruction_addr`](Self::instruction_addr)).
     ///
-    /// See `addr_mode` for the exact behavior of addresses.
+    /// See [`addr_mode`](Self::addr_mode) for the exact behavior of addresses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sym_addr: Option<HexValue>,
 
@@ -162,15 +164,15 @@ pub struct RawFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
-    /// Absolute source file path.
+    /// Absolute path to the source file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abs_path: Option<String>,
 
-    /// The line number within the source file, starting at 1 for the first line.
+    /// The line number within the source file, starting at `1` for the first line.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lineno: Option<u32>,
 
-    /// Source context before the context line
+    /// Source context before the context line.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pre_context: Vec<String>,
 
@@ -187,21 +189,28 @@ pub struct RawFrame {
     pub trust: FrameTrust,
 }
 
+/// A stack trace containing unsymbolicated stack frames.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct RawStacktrace {
+    /// The OS-dependent identifier of the thread.
     #[serde(default)]
     pub thread_id: Option<u64>,
 
+    /// `true` if this thread triggered the report. Usually indicates that this trace crashed.
     #[serde(default)]
     pub is_requesting: Option<bool>,
 
+    /// Values of CPU registers in the top frame in the trace.
     #[serde(default)]
     pub registers: Registers,
 
+    /// A list of unsymbolicated stack frames.
+    ///
+    /// The first entry in the list is the active frame, with its callers below.
     pub frames: Vec<RawFrame>,
 }
 
-/// Specification of an image loaded into the process.
+/// Specification of a module loaded into the process.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct RawObjectInfo {
     /// Platform image file type (container format).
@@ -226,14 +235,15 @@ pub struct RawObjectInfo {
 
     /// Absolute address at which the image was mounted into virtual memory.
     ///
-    /// We do allow the image addr to be skipped if it's zero.  This is
-    /// because for instance systems like WASM do not actually require an
-    /// image to be mounted at a specific address.  Per definition an image
-    /// mounted at 0 does not support absolute addressing.
+    /// We do allow the `image_addr` to be skipped if it is zero. This is because systems like WASM
+    /// do not require modules to be mounted at a specific absolute address. Per definition, a
+    /// module mounted at `0` does not support absolute addressing.
     #[serde(default)]
     pub image_addr: HexValue,
 
     /// Size of the image in virtual memory.
+    ///
+    /// The size is infered from the module list if not specified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_size: Option<u64>,
 }
@@ -424,9 +434,9 @@ impl ObjectFeatures {
     }
 }
 
-/// Normalized [RawObjectInfo] with status attached.
+/// Normalized [`RawObjectInfo`] with status attached.
 ///
-/// [RawObjectInfo] is what the user sends and [CompleteObjectInfo] is what the user gets.
+/// `RawObjectInfo` is what the user sends and [`CompleteObjectInfo`] is what the user gets.
 #[derive(Debug, Clone, Serialize, Eq, PartialEq, Deserialize)]
 pub struct CompleteObjectInfo {
     /// Status for fetching the file with debug info.
@@ -530,7 +540,7 @@ pub enum SymbolicationResponse {
 /// This object is the main type containing the symblicated crash as returned by the
 /// `/minidump`, `/symbolicate` and `/applecrashreport` endpoints.  It is publicly
 /// documented at <https://getsentry.github.io/symbolicator/api/response/>.  For the actual
-/// HTTP response this is further wrapped in [SymbolicationResponse] which can also return a
+/// HTTP response this is further wrapped in [`SymbolicationResponse`] which can also return a
 /// pending or failed state etc instead of a result.
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct CompletedSymbolicationResponse {
@@ -596,9 +606,9 @@ pub struct SystemInfo {
     pub device_model: String,
 }
 
-/// Information to find a Object in external sources and also internal cache.
+/// Information to find an object in external sources and also internal cache.
 ///
-/// See [ObjectId::match_object] for how these can be compared.
+/// See [`ObjectId::match_object`] for how these can be compared.
 #[derive(Debug, Clone, Default)]
 pub struct ObjectId {
     /// Identifier of the code file.

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -23,15 +23,15 @@ pub fn enable_test_mode() {
     IS_TEST.store(true, Ordering::Relaxed);
 }
 
-/// Error returned from a `SpawnHandle` when the thread pool restarts.
+/// Error returned from a [`SpawnHandle`] when the thread pool restarts.
 pub use oneshot::Canceled as RemoteCanceled;
 
-/// Handle returned from `ThreadPool::spawn_handle`.
+/// Handle returned from [`ThreadPool::spawn_handle`].
 ///
 /// This handle is a future representing the completion of a different future spawned on to the
-/// thread pool. Created through the `ThreadPool::spawn_handle` function this handle will resolve
+/// thread pool. Created through the [`ThreadPool::spawn_handle`] function this handle will resolve
 /// when the future provided resolves on the thread pool. If the remote thread restarts due to
-/// panics, `SpawnError::Canceled` is returned.
+/// panics, [`SpawnError::Canceled`] is returned.
 pub use oneshot::Receiver as SpawnHandle;
 
 /// Work-stealing based thread pool for executing futures.
@@ -59,7 +59,7 @@ impl ThreadPool {
 
     /// Spawn a future on to the thread pool, return a future representing the produced value.
     ///
-    /// The `SpawnHandle` returned is a future that is a proxy for future itself. When future
+    /// The [`SpawnHandle`] returned is a future that is a proxy for future itself. When future
     /// completes on this thread pool then the SpawnHandle will itself be resolved.
     pub fn spawn_handle<F>(&self, future: F) -> SpawnHandle<F::Output>
     where
@@ -89,24 +89,22 @@ impl ThreadPool {
 /// This can be used to implement any services which internally need to use
 /// non-`Send`able futures and are sufficient with running on single thread.
 ///
-/// When the global `IS_TEST` is set by calling [`enable_test_mode`] this will
+/// When the global `IS_TEST` is set by calling `enable_test_mode`, this will
 /// not create a new thread and instead spawn any executions in the current
 /// thread.  This is a workaround for the stdout and panic capturing not being
 /// exposed properly to the test framework users which stops us from enabling
 /// these things in spawned threads during tests.
-///
-/// [`enable_test_mode`]: func.enable_test_mode.html
 #[derive(Clone, Debug)]
 pub struct RemoteThread {
     inner: Arc<InnerRemoteThread>,
 }
 
-/// Inner `RemoteThread` struct to get correct clone behaviour.
+/// Inner [`RemoteThread`] struct to get correct clone behaviour.
 ///
-/// We only have an `actix::Addr` to the arbiter, which itself can be cloned.  Dropping this
-/// does not terminate the arbiter, but we wan the `RemoteThread` to stop when dropped.  So
-/// we need to implement `Drop`, but only want to actually trigger this drop when all clones
-/// of our `RemoteThread` are dropped.  Hence the need to put the drop on an inner struct
+/// We only have an [`actix::Addr`] to the arbiter, which itself can be cloned. Dropping this
+/// does not terminate the arbiter, but we wan the [`RemoteThread`] to stop when dropped. So
+/// we need to implement [`Drop`], but only want to actually trigger this drop when all clones
+/// of our [`RemoteThread`] are dropped.  Hence the need to put the drop on an inner struct
 /// which is wrapped in an Arc.
 #[derive(Debug)]
 struct InnerRemoteThread {
@@ -125,7 +123,7 @@ pub enum SpawnError {
     Timeout,
 }
 
-/// Dropping terminates the RemoteThread, cancelling all futures.
+/// Dropping terminates the [`RemoteThread`], cancelling all futures.
 impl Drop for InnerRemoteThread {
     fn drop(&mut self) {
         // Without sending the StopArbiter message the arbiter thread keeps running even if
@@ -167,8 +165,8 @@ impl RemoteThread {
     /// output type of the spawned future is wrapped in a `Result`, normally the output is
     /// returned in an `Ok`.
     ///
-    /// When the future takes too long `SpawnError::Timeout` is returned, if the
-    /// `RemoteThread` it is running on is dropped `SpawnError::Canceled` is returned.
+    /// When the future takes too long [`SpawnError::Timeout`] is returned, if the
+    /// `RemoteThread` it is running on is dropped [`SpawnError::Canceled`] is returned.
     pub fn spawn<F, R, T>(
         &self,
         task_name: &'static str,

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -73,7 +73,8 @@ where
     }
 }
 
-/// A Resolver-like actor for the actix-web http client that refuses to resolve to reserved IP addresses.
+/// A [`Resolver`]-like actor for the actix-web http client that refuses to resolve to reserved IP
+/// addresses.
 pub struct SafeResolver(Addr<Resolver>);
 
 impl Default for SafeResolver {
@@ -142,8 +143,8 @@ impl Handler<Connect> for SafeResolver {
     }
 }
 
-/// Tcp stream connector, copied from `actix::actors::resolver::TcpConnector`. The only change is
-/// that this one implements `Future` while the original only implements ActorFuture.
+/// Tcp stream connector, copied from [`actix::actors::resolver::TcpConnector`]. The only change is
+/// that this one implements [`Future`] while the original only implements [`actix::ActorFuture`].
 struct TcpConnector {
     addrs: VecDeque<SocketAddr>,
     timeout: Delay,

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -71,9 +71,9 @@ pub trait SentryFutureExt: Sized {
 
 impl<F> SentryFutureExt for F where F: futures01::future::Future {}
 
-/// Write own data to Sentry scope, only the subset that is considered useful for debugging. Right
-/// now this could've been a simple method, but the idea is that one day we want a custom derive
-/// for this.
+/// Write own data to [`sentry::Scope`], only the subset that is considered useful for debugging.
+// Right now, this could have been a simple method, but the idea is that one day we want a custom
+// derive for this.
 pub trait WriteSentryScope {
     fn write_sentry_scope(&self, scope: &mut Scope);
 }
@@ -232,12 +232,11 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
     }
 }
 
-/// Hub extensions for actix.
+/// Hub extensions for [`actix_web`].
 pub trait ActixWebHubExt {
     /// Returns the hub from a given http request.
     ///
-    /// This requires that the `SentryMiddleware` middleware has been enabled or the
-    /// call will panic.
+    /// This requires that [`SentryMiddleware`] has been enabled or the call will panic.
     fn from_request<S>(req: &HttpRequest<S>) -> Arc<Hub>;
     /// Captures an actix error on the given hub.
     fn capture_actix_error(&self, err: &Error) -> Uuid;


### PR DESCRIPTION
Since intra-doc-links are stable now, this adopts them across the code base. There are still comments where code structures are referred to without links, which will be updated in the future.

#skip-changelog