### PR TITLE
feat(wasm-split): Retain all sections in debug companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Tools
+
+- `wasm-split` now retains all sections. ([#311](https://github.com/getsentry/symbolicator/pull/311))
+
 ## 0.3.1
 
 ### Features

--- a/tests/integration/test_wasm.py
+++ b/tests/integration/test_wasm.py
@@ -23,7 +23,7 @@ WASM_DATA = {
 SUCCESS_WASM = {
     "modules": [
         {
-            "arch": "wasm",
+            "arch": "wasm32",
             "code_id": "bda18fd85d4a4eb893022d6bfad846b1",
             "debug_file": "file://foo.invalid/demo.wasm",
             "debug_id": "bda18fd8-5d4a-4eb8-9302-2d6bfad846b1",

--- a/wasm-split/Cargo.lock
+++ b/wasm-split/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-split"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argh",


### PR DESCRIPTION
See comment in source for justification but in general we need to understand the original file layout to calculate the offset to the code section. This means we can't remove that information but need to retain it.

I filed an issue in the webassembly toolchain repo for discussions: https://github.com/WebAssembly/tool-conventions/issues/155