### PR TITLE
fix(procspawn): Ensure deserialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Buf Fixes
+
+- Ensure deserialisation. ([#314](https://github.com/getsentry/symbolicator/pull/314))
+
 ### Tools
 
 - `wasm-split` now retains all sections. ([#311](https://github.com/getsentry/symbolicator/pull/311))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Buf Fixes
+### Bug Fixes
 
 - Ensure deserialisation. ([#314](https://github.com/getsentry/symbolicator/pull/314))
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -443,7 +443,7 @@ pub struct CompleteObjectInfo {
     pub debug_status: ObjectFileStatus,
 
     /// Status for fetching the file with unwind info (for minidump stackwalking).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub unwind_status: Option<ObjectFileStatus>,
 
     /// Features available during symbolication.


### PR DESCRIPTION
If an object passed through procspawn can not correctly deserialise it
will just hang forever, probably triggering the overal symbolication
task timeout.