### PR TITLE
ci(clippy): Enable clippy::all all in source code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --workspace --tests --examples -- -D clippy::all
+          args: --all-features --workspace --tests --examples
 
   unit-test:
     name: Unit Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --workspace --tests --examples -- -D clippy::all
+          args: --all-features --workspace --tests --examples
 
       - uses: actions-rs/cargo@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ lint-python: .venv/bin/python
 
 lint-rust:
 	@rustup component add clippy --toolchain stable 2> /dev/null
-	cargo +stable clippy --all-features --workspace --tests --examples -- -D clippy::all
+	cargo +stable clippy --all-features --workspace --tests --examples
 .PHONY: lint-rust
 
 # Formatting

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@
 //! Symbolicator can act as a proxy to symbol servers supporting multiple formats, such as
 //! Microsoft's symbol server or Breakpad symbol repositories.
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, clippy::all)]
 
 #[macro_use]
 mod macros;

--- a/symsorter/Cargo.lock
+++ b/symsorter/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "symsorter"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/symsorter/src/main.rs
+++ b/symsorter/src/main.rs
@@ -1,3 +1,7 @@
+//! Sorts debug symbols into the right structure for symbolicator.
+
+#![warn(missing_docs, missing_debug_implementations, clippy::all)]
+
 #[macro_use]
 mod utils;
 

--- a/symsorter/src/utils.rs
+++ b/symsorter/src/utils.rs
@@ -72,6 +72,7 @@ pub fn create_source_bundle(path: &Path, unified_id: &str) -> Result<Option<Byte
     Ok(None)
 }
 
+/// Console logging for the symsorter app.
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {

--- a/wasm-split/src/main.rs
+++ b/wasm-split/src/main.rs
@@ -1,3 +1,7 @@
+//! Tool to split a WASM file into a binary and debug companion file.
+
+#![warn(missing_docs, missing_debug_implementations, clippy::all)]
+
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;


### PR DESCRIPTION
This makes sure everyone invokes clippy locally the same way as on CI
and doesn't get any surprises.

#skip-changelog