### PR TITLE
fix(endpoints): Always ignore unknown multipart fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 0.3.2
+## Unreleased
 
 ### Features
 
 - Symbolication responses include download information about all DIF object files which were looked up on the available object sources. ([#309](https://github.com/getsentry/symbolicator/pull/309))
+
+### Bug Fixes
+
+- Silently ignore unknown fields in minidump and apple crash report requests instead of responding with `400 Bad Request`. ([#321](https://github.com/getsentry/symbolicator/pull/321))
+
+## 0.3.2
 
 ### Bug Fixes
 

--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -64,8 +64,8 @@ fn handle_multipart_item(
             Box::new(future)
         }
         _ => {
-            let error = error::ErrorBadRequest("unknown formdata field");
-            Box::new(future::err(error))
+            // Always ignore unknown fields.
+            Box::new(future::ok(request))
         }
     }
 }

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -64,8 +64,8 @@ fn handle_multipart_item(
             Box::new(future)
         }
         _ => {
-            let error = error::ErrorBadRequest("unknown formdata field");
-            Box::new(future::err(error))
+            // Always ignore unknown fields.
+            Box::new(future::ok(request))
         }
     }
 }

--- a/tests/integration/test_applecrashreport.py
+++ b/tests/integration/test_applecrashreport.py
@@ -271,3 +271,20 @@ def test_basic(symbolicator, hitcounter):
     pprint(response.json())
 
     assert response.json() == APPLE_CRASH_REPORT_SUCCESS
+
+
+def test_unknown_field(symbolicator):
+    service = symbolicator()
+    service.wait_healthcheck()
+
+    with open("tests/fixtures/apple_crash_report.txt", "rb") as f:
+        response = service.post(
+            "/applecrashreport",
+            files={"apple_crash_report": f},
+            data={
+                "sources": "[]",
+                "unknown": "value",
+            },
+        )
+
+    assert response.status_code == 200

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -234,6 +234,20 @@ def test_no_sources(symbolicator, cache_dir_param):
         assert not cache_dir_param.join("symcaches/global").exists()
 
 
+def test_unknown_field(symbolicator, cache_dir_param):
+    service = symbolicator(cache_dir=cache_dir_param)
+    service.wait_healthcheck()
+
+    request = dict(
+        **WINDOWS_DATA,
+        sources=[],  # Disable for faster test result. We don't care about symbolication
+        unknown="value",  # Should be ignored
+    )
+
+    response = service.post("/symbolicate", json=request)
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize("is_public", [True, False])
 def test_lookup_deduplication(symbolicator, hitcounter, is_public):
     input = dict(


### PR DESCRIPTION
For forward compatibility, Symbolicator must always ignore unknown
fields in requests. This is the default for JSON payloads, but
multipart/form-data parsing used to emit an error for unknown field.

This PR adopts the leniency policy for multipart/form-data requests and
ignores all unknown fields.