### PR TITLE
ref(cache): Convert to futures 0.3

### DIFF
--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -14,14 +14,14 @@ use symbolic::{
 };
 use thiserror::Error;
 
-use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath, Cacher};
+use crate::actors::common::cache::{CacheItemRequest, CachePath, Cacher};
 use crate::actors::objects::{
     FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sources::{FileType, SourceConfig};
 use crate::types::{ObjectFeatures, ObjectId, ObjectType, Scope};
-use crate::utils::futures::ThreadPool;
+use crate::utils::futures::{BoxedFuture, ThreadPool};
 use crate::utils::sentry::WriteSentryScope;
 
 /// Errors happening while generating a cficache

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use futures::compat::Future01CompatExt;
 use futures::future::{self, Either};
 use futures::{Future, FutureExt, TryFutureExt};
-// use futures01::future::{Either, Future, IntoFuture};
 use sentry::{configure_scope, Hub, SentryFutureExt};
 use symbolic::{
     common::ByteView,

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -1,12 +1,15 @@
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
-use futures01::future::{Either, Future, IntoFuture};
-use sentry::configure_scope;
+use futures::compat::Future01CompatExt;
+use futures::future::{self, Either};
+use futures::{Future, FutureExt, TryFutureExt};
+// use futures01::future::{Either, Future, IntoFuture};
+use sentry::{configure_scope, Hub, SentryFutureExt};
 use symbolic::{
     common::ByteView,
     minidump::cfi::{self, CfiCache},
@@ -21,7 +24,7 @@ use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sources::{FileType, SourceConfig};
 use crate::types::{ObjectFeatures, ObjectId, ObjectType, Scope};
 use crate::utils::futures::ThreadPool;
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
 /// Errors happening while generating a cficache
 #[derive(Debug, Error)]
@@ -110,17 +113,19 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     ///
     /// The extracted CFI is written to `path` in symbolic's
     /// [`CfiCache`](symbolic::minidump::cfi::CfiCache) format.
-    fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
+    fn compute(
+        &self,
+        path: &Path,
+    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
         let path = path.to_owned();
         let object = self
             .objects_actor
             .fetch(self.object_meta.clone())
-            .compat()
             .map_err(CfiCacheError::Fetching);
 
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
-            let future = futures01::lazy(move || {
+            let future = future::lazy(move |_| {
                 if object.status() != CacheStatus::Positive {
                     return Ok(object.status());
                 }
@@ -138,21 +143,21 @@ impl CacheItemRequest for FetchCfiCacheInternal {
             });
 
             threadpool
-                .spawn_handle(future.sentry_hub_current().compat())
-                .boxed_local()
-                .compat()
-                .map_err(|_| CfiCacheError::Canceled)
-                .flatten()
+                .spawn_handle(future.bind_hub(Hub::current()))
+                .unwrap_or_else(|_| Err(CfiCacheError::Canceled))
         });
 
         let num_sources = self.request.sources.len();
 
-        Box::new(future_metrics!(
-            "cficaches",
-            Some((Duration::from_secs(1200), CfiCacheError::Timeout)),
-            result,
-            "num_sources" => &num_sources.to_string()
-        ))
+        Box::pin(
+            future_metrics!(
+                "cficaches",
+                Some((Duration::from_secs(1200), CfiCacheError::Timeout)),
+                result.compat(),
+                "num_sources" => &num_sources.to_string()
+            )
+            .compat(),
+        )
     }
 
     fn should_load(&self, data: &[u8]) -> bool {
@@ -199,7 +204,7 @@ impl CfiCacheActor {
     pub fn fetch(
         &self,
         request: FetchCfiCache,
-    ) -> impl Future<Item = Arc<CfiCacheFile>, Error = Arc<CfiCacheError>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<CfiCacheFile>, Arc<CfiCacheError>>>>> {
         let object = self
             .objects
             .clone()
@@ -220,20 +225,20 @@ impl CfiCacheActor {
         let identifier = request.identifier.clone();
         let scope = request.scope.clone();
 
-        object.boxed_local().compat().and_then(move |object| {
-            object
-                .meta
-                .map(move |object_meta| {
-                    Either::A(cficaches.compute_memoized(FetchCfiCacheInternal {
-                        request,
-                        objects_actor: objects,
-                        object_meta,
-                        threadpool,
-                    }))
-                })
-                .unwrap_or_else(move || {
-                    Either::B(
-                        Ok(Arc::new(CfiCacheFile {
+        object
+            .and_then(move |object| {
+                object
+                    .meta
+                    .map(move |object_meta| {
+                        Either::Left(cficaches.compute_memoized(FetchCfiCacheInternal {
+                            request,
+                            objects_actor: objects,
+                            object_meta,
+                            threadpool,
+                        }))
+                    })
+                    .unwrap_or_else(move || {
+                        Either::Right(future::ok(Arc::new(CfiCacheFile {
                             object_type,
                             identifier,
                             scope,
@@ -241,11 +246,10 @@ impl CfiCacheActor {
                             features: ObjectFeatures::default(),
                             status: CacheStatus::Negative,
                             path: CachePath::new(),
-                        }))
-                        .into_future(),
-                    )
-                })
-        })
+                        })))
+                    })
+            })
+            .boxed_local()
     }
 }
 

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -22,7 +22,7 @@ use crate::utils::futures::CallOnDrop;
 /// pretty boring but clippy quickly complains about type complexity without this.
 pub type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
-/// Result from [`CacheItemRequest::compute_memoised`].
+/// Result from [`Cacher::compute_memoized`].
 type CacheResult<T, E> = BoxedFuture<Result<Arc<T>, Arc<E>>>;
 
 // Inner result necessary because `futures::Shared` won't give us `Arc`s but its own custom

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 
 use futures::channel::oneshot;
 use futures::future::{self, Future, FutureExt, Shared, TryFutureExt};
-// use futures01::future::{self, Future, Shared};
-// use futures01::sync::oneshot;
 use parking_lot::Mutex;
 use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -288,6 +288,8 @@ impl<T: CacheItemRequest> Cacher<T> {
                 Ok(ok) => Ok(Arc::new(ok)),
                 Err(err) => Err(Arc::new(err)),
             };
+            // Drop the token first to evict from the map.  This ensures that callers either
+            // get a channel that will receive data, or they create a new channel.
             drop(remove_computation_token);
             sender.send(result).ok();
             Ok(())

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -2,11 +2,10 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::channel::oneshot;
-use futures::future::{self, Future, FutureExt, Shared, TryFutureExt};
+use futures::future::{self, FutureExt, Shared, TryFutureExt};
 use parking_lot::Mutex;
 use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
@@ -14,13 +13,7 @@ use tempfile::NamedTempFile;
 
 use crate::cache::{get_scope_path, Cache, CacheKey, CacheStatus};
 use crate::types::Scope;
-use crate::utils::futures::CallOnDrop;
-
-/// A pinned, boxed future.
-///
-/// This is the type of future that [`futures::FutureExt::boxed`] would return.  This is
-/// pretty boring but clippy quickly complains about type complexity without this.
-pub type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+use crate::utils::futures::{BoxedFuture, CallOnDrop};
 
 /// Result from [`Cacher::compute_memoized`].
 type CacheResult<T, E> = BoxedFuture<Result<Arc<T>, Arc<E>>>;

--- a/src/actors/objects/data_cache.rs
+++ b/src/actors/objects/data_cache.rs
@@ -10,18 +10,17 @@ use std::cmp;
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
-use std::pin::Pin;
 use std::process;
 use std::time::Duration;
 
 use futures::compat::Future01CompatExt;
-use futures::future::{Future, FutureExt, TryFutureExt};
+use futures::future::{FutureExt, TryFutureExt};
 use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::{tempfile_in, NamedTempFile};
 
-use crate::actors::common::cache::{CacheItemRequest, CachePath};
+use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath};
 use crate::cache::{CacheKey, CacheStatus};
 use crate::services::download::DownloadStatus;
 use crate::sources::SourceFileId;
@@ -126,10 +125,7 @@ impl CacheItemRequest for FetchFileDataRequest {
     ///
     /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
     /// returned.
-    fn compute(
-        &self,
-        path: &Path,
-    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
+    fn compute(&self, path: &Path) -> BoxedFuture<Result<CacheStatus, Self::Error>> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file data for {}", cache_key);
 

--- a/src/actors/objects/data_cache.rs
+++ b/src/actors/objects/data_cache.rs
@@ -10,11 +10,13 @@ use std::cmp;
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
+use std::pin::Pin;
 use std::process;
 use std::time::Duration;
 
-use futures::future::TryFutureExt;
-use futures01::Future;
+use futures::compat::Future01CompatExt;
+use futures::future::{Future, FutureExt, TryFutureExt};
+use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::{tempfile_in, NamedTempFile};
@@ -24,7 +26,7 @@ use crate::cache::{CacheKey, CacheStatus};
 use crate::services::download::DownloadStatus;
 use crate::sources::SourceFileId;
 use crate::types::{ObjectId, Scope};
-use crate::utils::sentry::{SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
 use super::meta_cache::FetchFileMetaRequest;
 use super::ObjectError;
@@ -124,7 +126,10 @@ impl CacheItemRequest for FetchFileDataRequest {
     ///
     /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
     /// returned.
-    fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
+    fn compute(
+        &self,
+        path: &Path,
+    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file data for {}", cache_key);
 
@@ -136,78 +141,80 @@ impl CacheItemRequest for FetchFileDataRequest {
             self.0.file_id.write_sentry_scope(scope);
         });
 
-        let download_file = tryf!(self.0.data_cache.tempfile());
+        let download_file = tryf03pin!(self.0.data_cache.tempfile());
         let download_dir =
-            tryf!(download_file.path().parent().ok_or(ObjectError::NoTempDir)).to_owned();
+            tryf03pin!(download_file.path().parent().ok_or(ObjectError::NoTempDir)).to_owned();
         let request = self
             .0
             .download_svc
             .download(self.0.file_id.clone(), download_file.path().to_owned())
-            .compat()
             .map_err(Into::into);
 
-        let result = request.and_then(move |status| -> Result<CacheStatus, ObjectError> {
-            match status {
-                DownloadStatus::Completed => {
-                    log::trace!("Finished download of {}", cache_key);
-                    let decompress_result =
-                        decompress_object_file(&download_file, tempfile_in(download_dir)?);
+        let result = request.and_then(move |status| {
+            async move {
+                match status {
+                    DownloadStatus::Completed => {
+                        log::trace!("Finished download of {}", cache_key);
+                        let decompress_result =
+                            decompress_object_file(&download_file, tempfile_in(download_dir)?);
 
-                    // Treat decompression errors as malformed files. It is more likely that
-                    // the error comes from a corrupt file than a local file system error.
-                    let mut decompressed = match decompress_result {
-                        Ok(decompressed) => decompressed,
-                        Err(_) => return Ok(CacheStatus::Malformed),
-                    };
-
-                    // Seek back to the start and parse this object so we can deal with it.
-                    // Since objects in Sentry (and potentially also other sources) might be
-                    // multi-arch files (e.g. FatMach), we parse as Archive and try to
-                    // extract the wanted file.
-                    decompressed.seek(SeekFrom::Start(0))?;
-                    let view = ByteView::map_file(decompressed)?;
-                    let archive = match Archive::parse(&view) {
-                        Ok(archive) => archive,
-                        Err(_) => {
-                            return Ok(CacheStatus::Malformed);
-                        }
-                    };
-                    let mut persist_file = fs::File::create(&path)?;
-                    if archive.is_multi() {
-                        let object_opt = archive
-                            .objects()
-                            .filter_map(Result::ok)
-                            .find(|object| object_id.match_object(object));
-
-                        let object = match object_opt {
-                            Some(object) => object,
-                            None => {
-                                if archive.objects().any(|r| r.is_err()) {
-                                    return Ok(CacheStatus::Malformed);
-                                } else {
-                                    return Ok(CacheStatus::Negative);
-                                }
-                            }
+                        // Treat decompression errors as malformed files. It is more likely that
+                        // the error comes from a corrupt file than a local file system error.
+                        let mut decompressed = match decompress_result {
+                            Ok(decompressed) => decompressed,
+                            Err(_) => return Ok(CacheStatus::Malformed),
                         };
 
-                        io::copy(&mut object.data(), &mut persist_file)?;
-                    } else {
-                        // Attempt to parse the object to capture errors. The result can be
-                        // discarded as the object's data is the entire ByteView.
-                        if archive.object_by_index(0).is_err() {
-                            return Ok(CacheStatus::Malformed);
+                        // Seek back to the start and parse this object so we can deal with it.
+                        // Since objects in Sentry (and potentially also other sources) might be
+                        // multi-arch files (e.g. FatMach), we parse as Archive and try to
+                        // extract the wanted file.
+                        decompressed.seek(SeekFrom::Start(0))?;
+                        let view = ByteView::map_file(decompressed)?;
+                        let archive = match Archive::parse(&view) {
+                            Ok(archive) => archive,
+                            Err(_) => {
+                                return Ok(CacheStatus::Malformed);
+                            }
+                        };
+                        let mut persist_file = fs::File::create(&path)?;
+                        if archive.is_multi() {
+                            let object_opt = archive
+                                .objects()
+                                .filter_map(Result::ok)
+                                .find(|object| object_id.match_object(object));
+
+                            let object = match object_opt {
+                                Some(object) => object,
+                                None => {
+                                    if archive.objects().any(|r| r.is_err()) {
+                                        return Ok(CacheStatus::Malformed);
+                                    } else {
+                                        return Ok(CacheStatus::Negative);
+                                    }
+                                }
+                            };
+
+                            io::copy(&mut object.data(), &mut persist_file)?;
+                        } else {
+                            // Attempt to parse the object to capture errors. The result can be
+                            // discarded as the object's data is the entire ByteView.
+                            if archive.object_by_index(0).is_err() {
+                                return Ok(CacheStatus::Malformed);
+                            }
+
+                            io::copy(&mut view.as_ref(), &mut persist_file)?;
                         }
 
-                        io::copy(&mut view.as_ref(), &mut persist_file)?;
+                        Ok(CacheStatus::Positive)
                     }
-
-                    Ok(CacheStatus::Positive)
-                }
-                DownloadStatus::NotFound => {
-                    log::debug!("No debug file found for {}", cache_key);
-                    Ok(CacheStatus::Negative)
+                    DownloadStatus::NotFound => {
+                        log::debug!("No debug file found for {}", cache_key);
+                        Ok(CacheStatus::Negative)
+                    }
                 }
             }
+            .boxed()
         });
 
         let result = result
@@ -215,16 +222,19 @@ impl CacheItemRequest for FetchFileDataRequest {
                 sentry::capture_error(&e);
                 e
             })
-            .sentry_hub_current();
+            .bind_hub(Hub::current());
 
         let type_name = self.0.file_id.source().type_name();
 
-        Box::new(future_metrics!(
-            "objects",
-            Some((Duration::from_secs(600), ObjectError::Timeout)),
-            result,
-            "source_type" => type_name,
-        ))
+        Box::pin(
+            future_metrics!(
+                "objects",
+                Some((Duration::from_secs(600), ObjectError::Timeout)),
+                result.compat(),
+                "source_type" => type_name,
+            )
+            .compat(),
+        )
     }
 
     fn load(

--- a/src/actors/objects/data_cache.rs
+++ b/src/actors/objects/data_cache.rs
@@ -20,11 +20,12 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::{tempfile_in, NamedTempFile};
 
-use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath};
+use crate::actors::common::cache::{CacheItemRequest, CachePath};
 use crate::cache::{CacheKey, CacheStatus};
 use crate::services::download::DownloadStatus;
 use crate::sources::SourceFileId;
 use crate::types::{ObjectId, Scope};
+use crate::utils::futures::BoxedFuture;
 use crate::utils::sentry::WriteSentryScope;
 
 use super::meta_cache::FetchFileMetaRequest;

--- a/src/actors/objects/meta_cache.rs
+++ b/src/actors/objects/meta_cache.rs
@@ -9,9 +9,10 @@
 
 use std::fs;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 
-use futures01::Future;
+use futures::Future;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::Object;
 
@@ -96,36 +97,43 @@ impl CacheItemRequest for FetchFileMetaRequest {
     /// This returns an error if the download failed.  If the data cache has a
     /// [`CacheStatus::Negative`] or [`CacheStatus::Malformed`] status the same status is
     /// returned.
-    fn compute(&self, path: &Path) -> Box<dyn Future<Item = CacheStatus, Error = Self::Error>> {
+    fn compute(
+        &self,
+        path: &Path,
+    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file meta for {}", cache_key);
 
         let path = path.to_owned();
-        let result = self
-            .data_cache
-            .compute_memoized(FetchFileDataRequest(self.clone()))
-            .map_err(ObjectError::Caching)
-            .and_then(move |object_handle: Arc<ObjectHandle>| {
-                if object_handle.status == CacheStatus::Positive {
-                    if let Ok(object) = Object::parse(&object_handle.data) {
-                        let mut new_cache = fs::File::create(path)?;
+        let data_cache = self.data_cache.clone();
+        let slf = self.clone();
+        let result = async move {
+            data_cache
+                .compute_memoized(FetchFileDataRequest(slf))
+                .await
+                .map_err(ObjectError::Caching)
+                .and_then(move |object_handle: Arc<ObjectHandle>| {
+                    if object_handle.status == CacheStatus::Positive {
+                        if let Ok(object) = Object::parse(&object_handle.data) {
+                            let mut new_cache = fs::File::create(path)?;
 
-                        let meta = ObjectFeatures {
-                            has_debug_info: object.has_debug_info(),
-                            has_unwind_info: object.has_unwind_info(),
-                            has_symbols: object.has_symbols(),
-                            has_sources: object.has_sources(),
-                        };
+                            let meta = ObjectFeatures {
+                                has_debug_info: object.has_debug_info(),
+                                has_unwind_info: object.has_unwind_info(),
+                                has_symbols: object.has_symbols(),
+                                has_sources: object.has_sources(),
+                            };
 
-                        log::trace!("Persisting object meta for {}: {:?}", cache_key, meta);
-                        serde_json::to_writer(&mut new_cache, &meta)?;
+                            log::trace!("Persisting object meta for {}: {:?}", cache_key, meta);
+                            serde_json::to_writer(&mut new_cache, &meta)?;
+                        }
                     }
-                }
 
-                Ok(object_handle.status)
-            });
+                    Ok(object_handle.status)
+                })
+        };
 
-        Box::new(result)
+        Box::pin(result)
     }
 
     fn should_load(&self, data: &[u8]) -> bool {

--- a/src/actors/objects/meta_cache.rs
+++ b/src/actors/objects/meta_cache.rs
@@ -9,15 +9,12 @@
 
 use std::fs;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::Future;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::Object;
 
-use crate::actors::common::cache::Cacher;
-use crate::actors::common::cache::{CacheItemRequest, CachePath};
+use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath, Cacher};
 use crate::cache::{CacheKey, CacheStatus};
 use crate::sources::{SourceFileId, SourceId, SourceLocation};
 use crate::types::{ObjectFeatures, ObjectId, Scope};
@@ -97,10 +94,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
     /// This returns an error if the download failed.  If the data cache has a
     /// [`CacheStatus::Negative`] or [`CacheStatus::Malformed`] status the same status is
     /// returned.
-    fn compute(
-        &self,
-        path: &Path,
-    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
+    fn compute(&self, path: &Path) -> BoxedFuture<Result<CacheStatus, Self::Error>> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file meta for {}", cache_key);
 

--- a/src/actors/objects/meta_cache.rs
+++ b/src/actors/objects/meta_cache.rs
@@ -14,11 +14,11 @@ use std::sync::Arc;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::Object;
 
-use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath, Cacher};
+use crate::actors::common::cache::{CacheItemRequest, CachePath, Cacher};
 use crate::cache::{CacheKey, CacheStatus};
 use crate::sources::{SourceFileId, SourceId, SourceLocation};
 use crate::types::{ObjectFeatures, ObjectId, Scope};
-use crate::utils::futures::ThreadPool;
+use crate::utils::futures::{BoxedFuture, ThreadPool};
 
 use super::{FetchFileDataRequest, ObjectError, ObjectHandle};
 

--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use ::sentry::Hub;
 use backtrace::Backtrace;
-use futures::compat::Future01CompatExt;
 use futures::future::{self, Future, TryFutureExt};
 use sentry::SentryFutureExt;
 use symbolic::debuginfo;
@@ -208,7 +207,6 @@ impl ObjectsActor {
     ) -> impl Future<Output = Result<Arc<ObjectHandle>, ObjectError>> {
         self.data_cache
             .compute_memoized(FetchFileDataRequest(shallow_file.request.clone()))
-            .compat()
             .map_err(ObjectError::Caching)
     }
 
@@ -325,7 +323,6 @@ impl ObjectsActor {
                 };
                 meta_cache
                     .compute_memoized(request)
-                    .compat()
                     .bind_hub(sentry::Hub::new_from_top(sentry::Hub::current()))
                     .await
                     .map_err(|error| CacheLookupError {

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,7 +11,7 @@ use symbolic::common::{Arch, ByteView};
 use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use thiserror::Error;
 
-use crate::actors::common::cache::{CacheItemRequest, CachePath, Cacher};
+use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath, Cacher};
 use crate::actors::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
     ObjectsActor,
@@ -126,10 +125,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
         self.object_meta.cache_key()
     }
 
-    fn compute(
-        &self,
-        path: &Path,
-    ) -> Pin<Box<dyn Future<Output = Result<CacheStatus, Self::Error>>>> {
+    fn compute(&self, path: &Path) -> BoxedFuture<Result<CacheStatus, Self::Error>> {
         let path = path.to_owned();
         let object = self
             .objects_actor

--- a/src/actors/symcaches.rs
+++ b/src/actors/symcaches.rs
@@ -11,7 +11,7 @@ use symbolic::common::{Arch, ByteView};
 use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use thiserror::Error;
 
-use crate::actors::common::cache::{BoxedFuture, CacheItemRequest, CachePath, Cacher};
+use crate::actors::common::cache::{CacheItemRequest, CachePath, Cacher};
 use crate::actors::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
     ObjectsActor,
@@ -21,7 +21,7 @@ use crate::sources::{FileType, SourceConfig};
 use crate::types::{
     AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
 };
-use crate::utils::futures::ThreadPool;
+use crate::utils::futures::{BoxedFuture, ThreadPool};
 use crate::utils::sentry::WriteSentryScope;
 
 /// Errors happening while generating a symcache.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,6 +14,37 @@ macro_rules! tryf {
     };
 }
 
+/// Same as [`tryf`] but a hack for futures 0.3.  These futures can be replaced with
+/// async/await code and then this hack goes away.
+#[macro_export]
+macro_rules! tryf03 {
+    ($e:expr) => {
+        match $e {
+            Ok(value) => value,
+            Err(e) => {
+                return Box::new(::futures::future::err(::std::convert::From::from(e)))
+                    as Box<dyn ::futures::future::Future<Output = _>>;
+            }
+        }
+    };
+}
+
+/// Same as [`tryf`] but a hack for futures 0.3.  These futures can be replaced with
+/// async/await code and then this hack goes away.
+#[macro_export]
+macro_rules! tryf03pin {
+    ($e:expr) => {
+        match $e {
+            Ok(value) => value,
+            Err(e) => {
+                use ::std::pin::Pin;
+                return Box::pin(::futures::future::err(::std::convert::From::from(e)))
+                    as Pin<Box<dyn ::futures::future::Future<Output = _>>>;
+            }
+        }
+    };
+}
+
 /// Declare a closure that clone specific values before moving them into their bodies. Mainly useful
 /// when using combinator functions such as [`Future::and_then`](futures01::Future::and_then) or
 /// [`Future::map`](futures01::Future::map).

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -126,7 +126,7 @@ macro_rules! future_metrics {
     // Collect generic metrics about a future
     ($task_name:expr, $timeout:expr, $future:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use std::time::Instant;
-        use futures01::future::{self, Either};
+        use futures01::future::{self, Either, Future};
         use tokio::prelude::FutureExt;
 
         let creation_time = Instant::now();

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -59,8 +59,11 @@ impl ThreadPool {
 
     /// Spawn a future on to the thread pool, return a future representing the produced value.
     ///
-    /// The [`SpawnHandle`] returned is a future that is a proxy for future itself. When future
-    /// completes on this thread pool then the SpawnHandle will itself be resolved.
+    /// The [`SpawnHandle`] returned is a future that is a proxy for future itself. When
+    /// future completes on this thread pool then the SpawnHandle will itself be resolved
+    /// and the outcome of the spawned future will be in the `Ok` variant.  If the spawned
+    /// future got cancelled the outcome of this proxy future will resolve into an `Err`
+    /// variant.
     pub fn spawn_handle<F>(&self, future: F) -> SpawnHandle<F::Output>
     where
         F: Future + Send + 'static,

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -12,6 +13,16 @@ use tokio::runtime::Runtime as TokioRuntime;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 
 static IS_TEST: AtomicBool = AtomicBool::new(false);
+
+/// A pinned, boxed future.
+///
+/// This is the type of future that [`futures::FutureExt::boxed`] would return.  This is
+/// pretty boring but clippy quickly complains about type complexity without this.
+///
+/// You would mainly use this if you are dealing with a trait methods which deals with
+/// futures.  Trait methods can not be async/await and using this type in their return value
+/// allows to integrate with async await code.
+pub type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
 /// Enables test mode of all thread pools and remote threads.
 ///


### PR DESCRIPTION
This refactors the cache actor to futures 0.3, as this involves a
trait this requires touching everything using this trait.  No attempt
at changing the code-style itself or moving to async/await has been
made, now that everything is on futures 0.3 this can be done in
smaller parts where more careful thought can be put into this.
Instead changes have been tried to keep to just the minimum required
for the futures conversion, only laying the groundwork for more
improvements later.

The trait itself has been changed to return Pin<Box<dyn Future ...>>,
since you can not do async/await in traits this matches the signature
that the async-trait crate generates.  This allows seamless
integration in future async/await code, without the Pin currently a
few Unpin requirements would already break.

#skip-changelog