### PR TITLE
Feat/dif info unwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Symbolication responses include download information about all DIF object files which were looked up on the available object sources. ([#309](https://github.com/getsentry/symbolicator/pull/309) [#316](https://github.com/getsentry/symbolicator/pull/316))
+- Symbolication responses include download, debug and unwind information about all DIF object files which were looked up on the available object sources. ([#309](https://github.com/getsentry/symbolicator/pull/309) [#316](https://github.com/getsentry/symbolicator/pull/316) [#324](https://github.com/getsentry/symbolicator/pull/324))
 
 ### Bug Fixes
 

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::compat::Future01CompatExt;
-use futures::future::{self, Either};
-use futures::{FutureExt, TryFutureExt};
+use futures::prelude::*;
 use sentry::{configure_scope, Hub, SentryFutureExt};
 use symbolic::{
     common::ByteView,
@@ -20,7 +19,9 @@ use crate::actors::objects::{
 };
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::sources::{FileType, SourceConfig};
-use crate::types::{ObjectFeatures, ObjectId, ObjectType, Scope};
+use crate::types::{
+    AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
+};
 use crate::utils::futures::{BoxedFuture, ThreadPool};
 use crate::utils::sentry::WriteSentryScope;
 
@@ -72,6 +73,7 @@ pub struct CfiCacheFile {
     features: ObjectFeatures,
     status: CacheStatus,
     path: CachePath,
+    candidates: AllObjectCandidates,
 }
 
 impl CfiCacheFile {
@@ -89,13 +91,19 @@ impl CfiCacheFile {
     pub fn path(&self) -> &Path {
         self.path.as_ref()
     }
+
+    /// Returns all the DIF object candidates.
+    pub fn candidates(&self) -> &AllObjectCandidates {
+        &self.candidates
+    }
 }
 
 #[derive(Clone, Debug)]
 struct FetchCfiCacheInternal {
     request: FetchCfiCache,
     objects_actor: ObjectsActor,
-    object_meta: Arc<ObjectMetaHandle>,
+    meta_handle: Arc<ObjectMetaHandle>,
+    candidates: AllObjectCandidates,
     threadpool: ThreadPool,
 }
 
@@ -104,7 +112,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     type Error = CfiCacheError;
 
     fn get_cache_key(&self) -> CacheKey {
-        self.object_meta.cache_key()
+        self.meta_handle.cache_key()
     }
 
     /// Extracts the Call Frame Information (CFI) from an object file.
@@ -112,38 +120,44 @@ impl CacheItemRequest for FetchCfiCacheInternal {
     /// The extracted CFI is written to `path` in symbolic's
     /// [`CfiCache`](symbolic::minidump::cfi::CfiCache) format.
     fn compute(&self, path: &Path) -> BoxedFuture<Result<CacheStatus, Self::Error>> {
-        let path = path.to_owned();
-        let object = self
-            .objects_actor
-            .fetch(self.object_meta.clone())
-            .map_err(CfiCacheError::Fetching);
-
+        let objects_actor = self.objects_actor.clone();
+        let meta_handle = self.meta_handle.clone();
         let threadpool = self.threadpool.clone();
-        let result = object.and_then(move |object| {
-            let future = future::lazy(move |_| {
-                if object.status() != CacheStatus::Positive {
-                    return Ok(object.status());
-                }
+        let path = path.to_owned();
 
-                let status = if let Err(e) = write_cficache(&path, &*object) {
-                    log::warn!("Could not write cficache: {}", e);
-                    sentry::capture_error(&e);
+        let result = async move {
+            let object_handle = objects_actor
+                .fetch(meta_handle.clone())
+                .await
+                .map_err(CfiCacheError::Fetching)?;
 
-                    CacheStatus::Malformed
-                } else {
-                    CacheStatus::Positive
+            let future = async move {
+                let status = match object_handle.status() {
+                    CacheStatus::Positive => match write_cficache(&path, &*object_handle) {
+                        Ok(()) => CacheStatus::Positive,
+                        Err(err) => {
+                            log::warn!("Could not write cficache: {}", err);
+                            sentry::capture_error(&err);
+                            CacheStatus::Malformed
+                        }
+                    },
+                    cache_status => cache_status,
                 };
-
                 Ok(status)
-            });
+            };
 
-            threadpool
+            match threadpool
                 .spawn_handle(future.bind_hub(Hub::current()))
-                .unwrap_or_else(|_| Err(CfiCacheError::Canceled))
-        });
+                .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(CfiCacheError::Canceled),
+            }
+        }
+        .boxed_local();
 
+        // TODO(flub): Implement future_metrics! in futures 0.3.
         let num_sources = self.request.sources.len();
-
         Box::pin(
             future_metrics!(
                 "cficaches",
@@ -168,14 +182,38 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         data: ByteView<'static>,
         path: CachePath,
     ) -> Self::Item {
+        let unwind = match status {
+            CacheStatus::Positive => ObjectUseInfo::Ok,
+            CacheStatus::Negative => {
+                if self.meta_handle.status() == CacheStatus::Positive {
+                    ObjectUseInfo::Error {
+                        details: String::from("Object file no longer available"),
+                    }
+                } else {
+                    // No need to pretend that we were going to use this cficache if the
+                    // original object file was already not there, that status is already
+                    // reported.
+                    ObjectUseInfo::None
+                }
+            }
+            CacheStatus::Malformed => ObjectUseInfo::Malformed,
+        };
+        let mut candidates = self.candidates.clone();
+        candidates.set_unwind(
+            self.meta_handle.source().clone(),
+            self.meta_handle.location(),
+            unwind,
+        );
+
         CfiCacheFile {
             object_type: self.request.object_type,
             identifier: self.request.identifier.clone(),
             scope,
             data,
-            features: self.object_meta.features(),
+            features: self.meta_handle.features(),
             status,
             path,
+            candidates,
         }
     }
 }
@@ -196,11 +234,11 @@ impl CfiCacheActor {
     /// debug filename (the basename).  To do this it looks in the existing cache with the
     /// given scope and if it does not yet exist in cached form will fetch the required DIFs
     /// and compute the required CFI cache file.
-    pub fn fetch(
+    pub async fn fetch(
         &self,
         request: FetchCfiCache,
-    ) -> BoxedFuture<Result<Arc<CfiCacheFile>, Arc<CfiCacheError>>> {
-        let object = self
+    ) -> Result<Arc<CfiCacheFile>, Arc<CfiCacheError>> {
+        let found_result = self
             .objects
             .clone()
             .find(FindObject {
@@ -210,41 +248,32 @@ impl CfiCacheActor {
                 scope: request.scope.clone(),
                 purpose: ObjectPurpose::Unwind,
             })
-            .map_err(|e| Arc::new(CfiCacheError::Fetching(e)));
+            .map_err(|e| Arc::new(CfiCacheError::Fetching(e)))
+            .await?;
 
-        let cficaches = self.cficaches.clone();
-        let threadpool = self.threadpool.clone();
-        let objects = self.objects.clone();
-
-        let object_type = request.object_type;
-        let identifier = request.identifier.clone();
-        let scope = request.scope.clone();
-
-        object
-            .and_then(move |object| {
-                object
-                    .meta
-                    .map(move |object_meta| {
-                        Either::Left(cficaches.compute_memoized(FetchCfiCacheInternal {
-                            request,
-                            objects_actor: objects,
-                            object_meta,
-                            threadpool,
-                        }))
+        match found_result.meta {
+            Some(meta_handle) => {
+                self.cficaches
+                    .compute_memoized(FetchCfiCacheInternal {
+                        request,
+                        objects_actor: self.objects.clone(),
+                        meta_handle,
+                        threadpool: self.threadpool.clone(),
+                        candidates: found_result.candidates,
                     })
-                    .unwrap_or_else(move || {
-                        Either::Right(future::ok(Arc::new(CfiCacheFile {
-                            object_type,
-                            identifier,
-                            scope,
-                            data: ByteView::from_slice(b""),
-                            features: ObjectFeatures::default(),
-                            status: CacheStatus::Negative,
-                            path: CachePath::new(),
-                        })))
-                    })
-            })
-            .boxed_local()
+                    .await
+            }
+            None => Ok(Arc::new(CfiCacheFile {
+                object_type: request.object_type,
+                identifier: request.identifier,
+                scope: request.scope,
+                data: ByteView::from_slice(b""),
+                features: ObjectFeatures::default(),
+                status: CacheStatus::Negative,
+                path: CachePath::new(),
+                candidates: found_result.candidates,
+            })),
+        }
     }
 }
 

--- a/src/actors/cficaches.rs
+++ b/src/actors/cficaches.rs
@@ -176,27 +176,11 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         data: ByteView<'static>,
         path: CachePath,
     ) -> Self::Item {
-        let unwind = match status {
-            CacheStatus::Positive => ObjectUseInfo::Ok,
-            CacheStatus::Negative => {
-                if self.meta_handle.status() == CacheStatus::Positive {
-                    ObjectUseInfo::Error {
-                        details: String::from("Object file no longer available"),
-                    }
-                } else {
-                    // No need to pretend that we were going to use this cficache if the
-                    // original object file was already not there, that status is already
-                    // reported.
-                    ObjectUseInfo::None
-                }
-            }
-            CacheStatus::Malformed => ObjectUseInfo::Malformed,
-        };
         let mut candidates = self.candidates.clone();
         candidates.set_unwind(
             self.meta_handle.source().clone(),
             self.meta_handle.location(),
-            unwind,
+            ObjectUseInfo::from_derived_status(status, self.meta_handle.status()),
         );
 
         CfiCacheFile {

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -16,7 +16,7 @@ use crate::types::Scope;
 use crate::utils::futures::{BoxedFuture, CallOnDrop};
 
 /// Result from [`Cacher::compute_memoized`].
-type CacheResult<T, E> = BoxedFuture<Result<Arc<T>, Arc<E>>>;
+type CacheResultFuture<T, E> = BoxedFuture<Result<Arc<T>, Arc<E>>>;
 
 // Inner result necessary because `futures::Shared` won't give us `Arc`s but its own custom
 // newtype around it.
@@ -311,7 +311,7 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// occurs the error result is returned, **however** in this case nothing is written
     /// into the cache and the next call to the same cache item will attempt to re-compute
     /// the cache.
-    pub fn compute_memoized(&self, request: T) -> CacheResult<T::Item, T::Error> {
+    pub fn compute_memoized(&self, request: T) -> CacheResultFuture<T::Item, T::Error> {
         let key = request.get_cache_key();
         let name = self.config.name();
 

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_windows.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_windows.snap
@@ -190,6 +190,8 @@ modules:
             has_unwind_info: true
             has_symbols: true
             has_sources: false
+        unwind:
+          status: ok
         debug:
           status: ok
       - source: local
@@ -256,6 +258,27 @@ modules:
     debug_file: dbgcore.pdb
     image_addr: 0x70b70000
     image_size: 151552
+    candidates:
+      - source: local
+        location: dbgcore.dll/57898DAB25000/dbgcore.dl_
+        download:
+          status: notfound
+      - source: local
+        location: dbgcore.dll/57898DAB25000/dbgcore.dll
+        download:
+          status: notfound
+      - source: local
+        location: dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.pd_
+        download:
+          status: notfound
+      - source: local
+        location: dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.pdb
+        download:
+          status: notfound
+      - source: local
+        location: dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.sym
+        download:
+          status: notfound
   - debug_status: unused
     unwind_status: unused
     features:
@@ -412,6 +435,27 @@ modules:
     debug_file: wrpcrt4.pdb
     image_addr: 0x75810000
     image_size: 790528
+    candidates:
+      - source: local
+        location: rpcrt4.dll/5A49BB75c1000/rpcrt4.dl_
+        download:
+          status: notfound
+      - source: local
+        location: rpcrt4.dll/5A49BB75c1000/rpcrt4.dll
+        download:
+          status: notfound
+      - source: local
+        location: wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.pd_
+        download:
+          status: notfound
+      - source: local
+        location: wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.pdb
+        download:
+          status: notfound
+      - source: local
+        location: wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.sym
+        download:
+          status: notfound
   - debug_status: unused
     unwind_status: unused
     features:

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1476,9 +1476,9 @@ impl SymbolicationActor {
         // cache files are added to the frame_info_map.
         for (code_module_id, result) in &cfi_results {
             let cache_file = match result {
-                Ok(x) => {
-                    dif_candidates.insert(*code_module_id, x.candidates().clone());
-                    x
+                Ok(cfi_cache_file) => {
+                    dif_candidates.insert(*code_module_id, cfi_cache_file.candidates().clone());
+                    cfi_cache_file
                 }
                 Err(e) => {
                     log::debug!("Error while fetching cficache: {}", LogError(e.as_ref()));

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -474,6 +474,14 @@ impl ObjectFeatures {
     }
 }
 
+/// Newtype around a collection of [`ObjectCandidate`] structs.
+///
+/// This abstracts away some common operations needed on this collection.
+///
+/// [`CacheItemRequest`]: ../actors/common/cache/trait.CacheItemRequest.html
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct AllObjectCandidates(Vec<ObjectCandidate>);
+
 /// Information about a Debug Information File in the [`CompleteObjectInfo`].
 ///
 /// All DIFs are backed by an [`ObjectHandle`](crate::actors::objects::ObjectHandle).  But we
@@ -578,14 +586,6 @@ pub enum ObjectUseInfo {
     /// This enum is not serialised into its parent object when it is set to this value.
     None,
 }
-
-/// Newtype around a collection of [`ObjectCandidate`] structs.
-///
-/// This abstracts away some common operations needed on this collection.
-///
-/// [`CacheItemRequest`]: ../actors/common/cache/trait.CacheItemRequest.html
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
-pub struct AllObjectCandidates(Vec<ObjectCandidate>);
 
 /// Normalized [`RawObjectInfo`] with status attached.
 ///

--- a/tests/integration/test_minidump.py
+++ b/tests/integration/test_minidump.py
@@ -491,6 +491,7 @@ MINIDUMP_SUCCESS = {
                 },
                 {
                     "debug": {"status": "ok"},
+                    "unwind": {"status": "ok"},
                     "download": {
                         "features": {
                             "has_debug_info": True,
@@ -657,6 +658,7 @@ MINIDUMP_SUCCESS = {
                 },
                 {
                     "debug": {"status": "ok"},
+                    "unwind": {"status": "ok"},
                     "download": {
                         "features": {
                             "has_debug_info": True,
@@ -743,6 +745,7 @@ MINIDUMP_SUCCESS = {
                         "status": "ok",
                     },
                     "debug": {"status": "ok"},
+                    "unwind": {"status": "ok"},
                 },
             ],
         },
@@ -875,6 +878,7 @@ MINIDUMP_SUCCESS = {
                         "status": "ok",
                     },
                     "debug": {"status": "ok"},
+                    "unwind": {"status": "ok"},
                 },
             ],
         },


### PR DESCRIPTION
This adds the unwind info to dif candidates.  For this the cficache actor
also exposes DIF info and the symbolication actor now correctly merges
the various DIF candidates info together.

sentry snapshots do not need updating