### PR TITLE
ref(downloader): Make the GCS downloader a stateful struct

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,7 @@ impl ServiceState {
         let io_threadpool = ThreadPool::new();
         let io_thread = RemoteThread::new();
 
-        let download_svc = Arc::new(DownloadService::new(io_thread, config.clone()));
+        let download_svc = DownloadService::new(io_thread, config.clone());
 
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -23,10 +23,18 @@ use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey, SourceFileId, Sour
 use crate::types::ObjectId;
 use crate::utils::futures::delay;
 
-lazy_static::lazy_static! {
-    static ref GCS_TOKENS: Mutex<lru::LruCache<Arc<GcsSourceKey>, Arc<GcsToken>>> =
-        Mutex::new(lru::LruCache::new(100));
-}
+/// An LRU cache for GCS OAuth tokens.
+type GcsTokenCache = lru::LruCache<Arc<GcsSourceKey>, Arc<GcsToken>>;
+
+/// Maximum number of cached GCS OAuth tokens.
+///
+/// This number defines the size of the internal cache for GCS authentication and should be higher
+/// than expected concurrency across GCS buckets. If this number is too low, the downloader will
+/// re-authenticate between every request.
+///
+/// This can be monitored with the `source.gcs.token.requests` and `source.gcs.token.cached` counter
+/// metrics.
+const GCS_TOKEN_CACHE_SIZE: usize = 100;
 
 #[derive(Serialize)]
 struct JwtClaims {
@@ -70,6 +78,9 @@ pub enum GcsError {
     Auth(#[from] failure::Compat<SendRequestError>),
 }
 
+/// Parses the given private key string into its binary representation.
+///
+/// Returns `Ok` on success. Returns `GcsError::Base64`, if the key cannot be parsed.
 fn key_from_string(mut s: &str) -> Result<Vec<u8>, GcsError> {
     if s.starts_with("-----BEGIN PRIVATE KEY-----") {
         s = s.splitn(5, "-----").nth(2).unwrap();
@@ -85,6 +96,7 @@ fn key_from_string(mut s: &str) -> Result<Vec<u8>, GcsError> {
     Ok(base64::decode(bytes)?)
 }
 
+/// Computes a JWT authentication assertion for the given GCS bucket.
 fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, GcsError> {
     let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
 
@@ -102,136 +114,162 @@ fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, Gc
     Ok(jsonwebtoken::encode(&header, &jwt_claims, pkcs8)?)
 }
 
-async fn request_new_token(source_key: &GcsSourceKey) -> Result<GcsToken, GcsError> {
-    let expires_at = Utc::now() + Duration::minutes(58);
-    let auth_jwt = get_auth_jwt(source_key, expires_at.timestamp() + 30)?;
-
-    let mut builder = client::post("https://www.googleapis.com/oauth2/v4/token");
-    // for some inexplicable reason we otherwise get gzipped data back that actix-web
-    // client has no idea what to do with.
-    builder.header("accept-encoding", "identity");
-    let response = builder
-        .form(&OAuth2Grant {
-            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".into(),
-            assertion: auth_jwt,
-        })
-        .unwrap()
-        .send();
-
-    let response = response.compat().await.map_err(|err| {
-        log::debug!("Failed to authenticate against gcs: {}", err);
-        err.compat()
-    })?;
-    let token = response
-        .json::<GcsTokenResponse>()
-        .compat()
-        .await
-        .map_err(Fail::compat)?;
-    Ok(GcsToken {
-        access_token: token.access_token,
-        expires_at,
-    })
+/// Downloader implementation that supports the [`GcsSourceConfig`] source.
+#[derive(Debug)]
+pub struct GcsDownloader {
+    token_cache: Mutex<GcsTokenCache>,
 }
 
-async fn get_token(source_key: &Arc<GcsSourceKey>) -> Result<Arc<GcsToken>, GcsError> {
-    if let Some(token) = GCS_TOKENS.lock().get(source_key) {
-        if token.expires_at >= Utc::now() {
-            metric!(counter("source.gcs.token.cached") += 1);
-            return Ok(token.clone());
-        }
+impl GcsDownloader {
+    pub fn new() -> Self {
+        let token_cache = Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE));
+        Self { token_cache }
     }
 
-    let source_key = source_key.clone();
-    let token = request_new_token(&source_key).await?;
-    metric!(counter("source.gcs.token.requests") += 1);
-    let token = Arc::new(token);
-    GCS_TOKENS.lock().put(source_key, token.clone());
-    Ok(token)
-}
+    /// Requests a new GCS OAuth token.
+    async fn request_new_token(&self, source_key: &GcsSourceKey) -> Result<GcsToken, GcsError> {
+        let expires_at = Utc::now() + Duration::minutes(58);
+        let auth_jwt = get_auth_jwt(source_key, expires_at.timestamp() + 30)?;
 
-async fn start_request(
-    url: &str,
-    token: &GcsToken,
-) -> Result<client::ClientResponse, client::SendRequestError> {
-    let mut builder = client::get(&url);
-    builder.header("authorization", format!("Bearer {}", token.access_token));
-    builder.finish().unwrap().send().compat().await
-}
+        let mut builder = client::post("https://www.googleapis.com/oauth2/v4/token");
+        // for some inexplicable reason we otherwise get gzipped data back that actix-web
+        // client has no idea what to do with.
+        builder.header("accept-encoding", "identity");
+        let response = builder
+            .form(&OAuth2Grant {
+                grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".into(),
+                assertion: auth_jwt,
+            })
+            .unwrap()
+            .send();
 
-pub async fn download_source(
-    source: Arc<GcsSourceConfig>,
-    download_path: SourceLocation,
-    destination: PathBuf,
-) -> Result<DownloadStatus, DownloadError> {
-    let key = source.get_key(&download_path);
-    log::debug!("Fetching from GCS: {} (from {})", &key, source.bucket);
-    let token = get_token(&source.source_key).await?;
-    log::debug!("Got valid GCS token: {:?}", &token);
+        let response = response.compat().await.map_err(|err| {
+            log::debug!("Failed to authenticate against gcs: {}", err);
+            err.compat()
+        })?;
 
-    let url = format!(
-        "https://www.googleapis.com/download/storage/v1/b/{}/o/{}?alt=media",
-        percent_encode(source.bucket.as_bytes(), PATH_SEGMENT_ENCODE_SET),
-        percent_encode(key.as_bytes(), PATH_SEGMENT_ENCODE_SET),
-    );
+        let token = response
+            .json::<GcsTokenResponse>()
+            .compat()
+            .await
+            .map_err(Fail::compat)?;
 
-    let mut backoff = ExponentialBackoff::from_millis(10).map(jitter).take(3);
-    let response = loop {
-        let result = start_request(&url, &token).await;
-        match backoff.next() {
-            Some(duration) if result.is_err() => delay(duration).await,
-            _ => break result,
+        Ok(GcsToken {
+            access_token: token.access_token,
+            expires_at,
+        })
+    }
+
+    /// Resolves a valid GCS OAuth token.
+    ///
+    /// If the cache contains a valid token, then this token is returned. Otherwise, a new token is
+    /// requested from GCS and stored in the cache.
+    async fn get_token(&self, source_key: &Arc<GcsSourceKey>) -> Result<Arc<GcsToken>, GcsError> {
+        if let Some(token) = self.token_cache.lock().get(source_key) {
+            if token.expires_at >= Utc::now() {
+                metric!(counter("source.gcs.token.cached") += 1);
+                return Ok(token.clone());
+            }
         }
-    };
 
-    match response {
-        Ok(response) => {
-            if response.status().is_success() {
-                log::trace!("Success hitting GCS {} (from {})", &key, source.bucket);
-                let stream = response
-                    .payload()
-                    .compat()
-                    .map(|i| i.map_err(DownloadError::stream));
-                super::download_stream(
-                    SourceFileId::Gcs(source, download_path),
-                    stream,
-                    destination,
-                )
-                .await
-            } else {
+        let source_key = source_key.clone();
+        let token = self.request_new_token(&source_key).await?;
+        metric!(counter("source.gcs.token.requests") += 1);
+        let token = Arc::new(token);
+        self.token_cache.lock().put(source_key, token.clone());
+        Ok(token)
+    }
+
+    /// Requests the given URL from GCS, returning the response.
+    ///
+    /// The response body has not been read.
+    async fn start_request(
+        &self,
+        url: &str,
+        token: &GcsToken,
+    ) -> Result<client::ClientResponse, client::SendRequestError> {
+        let mut builder = client::get(&url);
+        builder.header("authorization", format!("Bearer {}", token.access_token));
+        builder.finish().unwrap().send().compat().await
+    }
+
+    pub async fn download_source(
+        &self,
+        source: Arc<GcsSourceConfig>,
+        download_path: SourceLocation,
+        destination: PathBuf,
+    ) -> Result<DownloadStatus, DownloadError> {
+        let key = source.get_key(&download_path);
+        log::debug!("Fetching from GCS: {} (from {})", &key, source.bucket);
+        let token = self.get_token(&source.source_key).await?;
+        log::debug!("Got valid GCS token: {:?}", &token);
+
+        let url = format!(
+            "https://www.googleapis.com/download/storage/v1/b/{}/o/{}?alt=media",
+            percent_encode(source.bucket.as_bytes(), PATH_SEGMENT_ENCODE_SET),
+            percent_encode(key.as_bytes(), PATH_SEGMENT_ENCODE_SET),
+        );
+
+        let mut backoff = ExponentialBackoff::from_millis(10).map(jitter).take(3);
+        let response = loop {
+            let result = self.start_request(&url, &token).await;
+            match backoff.next() {
+                Some(duration) if result.is_err() => delay(duration).await,
+                _ => break result,
+            }
+        };
+
+        match response {
+            Ok(response) => {
+                if response.status().is_success() {
+                    log::trace!("Success hitting GCS {} (from {})", &key, source.bucket);
+                    let stream = response
+                        .payload()
+                        .compat()
+                        .map(|i| i.map_err(DownloadError::stream));
+                    super::download_stream(
+                        SourceFileId::Gcs(source, download_path),
+                        stream,
+                        destination,
+                    )
+                    .await
+                } else {
+                    log::trace!(
+                        "Unexpected status code from GCS {} (from {}): {}",
+                        &key,
+                        source.bucket,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
+                }
+            }
+            Err(e) => {
                 log::trace!(
-                    "Unexpected status code from GCS {} (from {}): {}",
+                    "Skipping response from GCS {} (from {}): {} ({:?})",
                     &key,
                     source.bucket,
-                    response.status()
+                    &e,
+                    &e
                 );
                 Ok(DownloadStatus::NotFound)
             }
         }
-        Err(e) => {
-            log::trace!(
-                "Skipping response from GCS {} (from {}): {} ({:?})",
-                &key,
-                source.bucket,
-                &e,
-                &e
-            );
-            Ok(DownloadStatus::NotFound)
-        }
     }
-}
 
-pub fn list_files(
-    source: Arc<GcsSourceConfig>,
-    filetypes: &'static [FileType],
-    object_id: ObjectId,
-) -> Vec<SourceFileId> {
-    super::SourceLocationIter {
-        filetypes: filetypes.iter(),
-        filters: &source.files.filters,
-        object_id: &object_id,
-        layout: source.files.layout,
-        next: Vec::new(),
+    pub fn list_files(
+        &self,
+        source: Arc<GcsSourceConfig>,
+        filetypes: &'static [FileType],
+        object_id: ObjectId,
+    ) -> Vec<SourceFileId> {
+        super::SourceLocationIter {
+            filetypes: filetypes.iter(),
+            filters: &source.files.filters,
+            object_id: &object_id,
+            layout: source.files.layout,
+            next: Vec::new(),
+        }
+        .map(|loc| SourceFileId::Gcs(source.clone(), loc))
+        .collect()
     }
-    .map(|loc| SourceFileId::Gcs(source.clone(), loc))
-    .collect()
 }


### PR DESCRIPTION
This is a work-in-progress proof of concept for creating stateful downloaders rather than storing caches in global static data structures. This will allow to unit-test the downloaders more easily.

As part of this, I noticed that we largely do not to return `impl Future` and can use `async fn` directly. This is possible even in the case of the `download` function, although it is made harder by the thread pool. Since the pool requires `'static` futures, we cannot spawn any async function that takes `&self`. This requires one of the following workarounds:

1. Get rid of the thread pool and move resource delegation up the call hierarchy. Probably the most desirable solution, but also exceeds the scope of this PR.
2. Use [`async-scoped`](https://docs.rs/async-scoped) to spawn a future with a bound life time. In our case, this would be perfectly safe, since the downloaders do not have constrained lifetime in the application. However, it just layers more complexity on top of an existing problem.
3. Clone `self` inside the function. This creates the requirement that all fields internally be cloneable (i.e. likely put inside an `Arc`). We use this pattern in several places, but it is not easily spottable when looking at usage sites. I would rather not introduce another instance of this now.
4. Finally, require the caller to `Arc` the downloader. In fact, we already require this for the downloader, and by changing `Downloader::new`, we codify this contract. It can be reverted easily once the thread pool is dropped, and until then provides a clear interface.


If desired, I can split this up into two PRs: One refactoring to `async fn` and another one to introduce the stateful GCS downloader.

#skip-changelog