### PR TITLE
ci(release): Pin action-prepare-release to 33507ed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: 'Release a new version'
     steps:
       - name: Prepare release
-        uses: getsentry/action-prepare-release@main
+        uses: getsentry/action-prepare-release@33507ed
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
This is to avoid any issues when getsentry/action-prepare-release#4 is merged.

#skip-changelog