### PR TITLE
ref(downloader): Upgrade downloaders to tokio 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Silently ignore unknown fields in minidump and apple crash report requests instead of responding with `400 Bad Request`. ([#321](https://github.com/getsentry/symbolicator/pull/321))
 - Update breakpad to allow processing MIPS minidumps and improve amd64 stack scanning by excluding some false-positive frames. ([#325](https://github.com/getsentry/symbolicator/pull/325))
 
+### Internal
+
+- Changed the internal HTTP transport layer. There is no expected difference in the way Symbolicator downloads files from symbol servers, although some internal timeouts and error messages may change. ([#335](https://github.com/getsentry/symbolicator/pull/335))
+
 ## 0.3.2
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.1.22",
+ "tokio 1.0.1",
  "tokio-retry",
  "url 1.7.2",
  "url_serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "log",
- "mio",
+ "mio 0.6.21",
  "native-tls",
  "net2",
  "num_cpus",
@@ -82,7 +82,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "mio",
+ "mio 0.6.21",
  "native-tls",
  "net2",
  "num_cpus",
@@ -96,7 +96,7 @@ dependencies = [
  "sha1",
  "slab",
  "smallvec 0.6.13",
- "time",
+ "time 0.1.44",
  "tokio 0.1.22",
  "tokio-current-thread",
  "tokio-io",
@@ -205,6 +205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,14 +254,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.9.3"
+name = "base-x"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -272,6 +279,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -311,22 +324,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-dependencies = [
- "arrayref",
- "byte-tools 0.2.0",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
- "byte-tools 0.3.1",
+ "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
 ]
@@ -346,7 +349,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
 ]
 
 [[package]]
@@ -354,12 +357,6 @@ name = "bumpalo"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -380,7 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
  "byteorder",
- "either",
  "iovec",
  "serde",
 ]
@@ -390,6 +386,12 @@ name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "bytes"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
 
 [[package]]
 name = "bzip2"
@@ -451,7 +453,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi 0.3.8",
 ]
 
@@ -551,6 +553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,7 +570,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fac5e7bdefb6160fb181ee0eaa6f96704b625c70e6d61c465cb35750a4ea12"
 dependencies = [
- "time",
+ "time 0.1.44",
  "url 1.7.2",
 ]
 
@@ -653,15 +661,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-dependencies = [
- "crossbeam-utils 0.6.6",
-]
-
-[[package]]
-name = "crossbeam-queue"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
@@ -693,12 +692,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.5.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "constant_time_eq",
- "generic-array 0.9.0",
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -708,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -743,15 +742,6 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.0",
-]
-
-[[package]]
-name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -769,15 +759,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "1.0.5"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dmsort"
@@ -790,12 +796,6 @@ name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-
-[[package]]
-name = "either"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encode_unicode"
@@ -914,9 +914,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
  "synstructure",
 ]
 
@@ -1084,9 +1084,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -1123,15 +1123,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -1146,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1254,18 +1245,18 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hmac"
-version = "0.5.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
- "digest 0.7.6",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1303,23 +1294,21 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "http 0.1.21",
- "tokio-buf",
-]
-
-[[package]]
-name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.4",
+ "http 0.2.1",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.0",
  "http 0.2.1",
 ]
 
@@ -1362,36 +1351,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "futures-cpupool",
- "h2 0.1.26",
- "http 0.1.21",
- "http-body 0.1.0",
- "httparse",
- "iovec",
- "itoa",
- "log",
- "net2",
- "rustc_version",
- "time",
- "tokio 0.1.22",
- "tokio-buf",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "want 0.2.0",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
@@ -1407,24 +1366,34 @@ dependencies = [
  "itoa",
  "log",
  "net2",
- "pin-project",
- "time",
+ "pin-project 0.4.8",
+ "time 0.1.44",
  "tokio 0.2.16",
  "tower-service 0.3.0",
- "want 0.3.0",
+ "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.3.2"
+name = "hyper"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "hyper 0.12.35",
- "native-tls",
- "tokio-io",
+ "bytes 1.0.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.1",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.3",
+ "socket2",
+ "tokio 1.0.1",
+ "tower-service 0.3.0",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -1438,6 +1407,19 @@ dependencies = [
  "native-tls",
  "tokio 0.2.16",
  "tokio-tls 0.3.0",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.0",
+ "hyper 0.14.2",
+ "native-tls",
+ "tokio 1.0.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1479,7 +1461,7 @@ dependencies = [
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1534,7 +1516,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "libc",
- "mio",
+ "mio 0.6.21",
  "rand 0.7.3",
  "serde",
  "tempfile",
@@ -1735,9 +1717,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md5"
-version = "0.3.8"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1819,14 +1801,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.6"
+name = "mio"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
+ "libc",
  "log",
- "mio",
- "miow 0.3.3",
+ "miow 0.3.6",
+ "ntapi",
  "winapi 0.3.8",
 ]
 
@@ -1838,7 +1821,7 @@ checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.21",
 ]
 
 [[package]]
@@ -1855,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
@@ -1908,6 +1891,15 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+dependencies = [
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2001,6 +1993,12 @@ name = "object"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+
+[[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -2205,9 +2203,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2227,7 +2225,16 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.8",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a83804639aad6ba65345661744708855f9fbcb71176ea8d28d05aeb11d975e7"
+dependencies = [
+ "pin-project-internal 1.0.3",
 ]
 
 [[package]]
@@ -2236,9 +2243,20 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bcc46b8f73443d15bc1c5fecbb315718491fa9187fa483f0e359323cde8b3a"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2246,6 +2264,12 @@ name = "pin-project-lite"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
 
 [[package]]
 name = "pin-utils"
@@ -2294,10 +2318,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
- "version_check 0.9.1",
+ "syn 1.0.58",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2306,11 +2330,11 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
  "syn-mid",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2336,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2379,7 +2403,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -2640,7 +2664,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "serde",
  "serde_json",
  "serde_urlencoded 0.6.1",
@@ -2679,63 +2703,83 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.40.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1a1069ba04874a485528d1602fab4569f2434a5547614428e2cc22b91bfb71"
+checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
 dependencies = [
- "base64 0.9.3",
- "bytes 0.4.12",
- "futures 0.1.29",
- "hex",
- "hmac",
- "http 0.1.21",
- "hyper 0.12.35",
- "hyper-tls 0.3.2",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes 1.0.0",
+ "crc32fast",
+ "futures 0.3.4",
+ "http 0.2.1",
+ "hyper 0.14.2",
+ "hyper-tls 0.5.0",
  "lazy_static",
  "log",
- "md5",
  "rusoto_credential",
+ "rusoto_signature",
  "rustc_version",
  "serde",
- "serde_derive",
  "serde_json",
- "sha2",
- "time",
- "tokio 0.1.22",
- "tokio-timer",
- "url 1.7.2",
+ "tokio 1.0.1",
  "xml-rs",
 ]
 
 [[package]]
 name = "rusoto_credential"
-version = "0.40.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d6cc3a602f01b9c5a04c8ed4ee281b789c5b2692d93202367c9b99ebc022ed"
+checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
 dependencies = [
+ "async-trait",
  "chrono",
- "dirs",
- "futures 0.1.29",
- "hyper 0.12.35",
- "regex",
+ "dirs-next",
+ "futures 0.3.4",
+ "hyper 0.14.2",
  "serde",
- "serde_derive",
  "serde_json",
  "shlex",
- "tokio-process",
- "tokio-timer",
+ "tokio 1.0.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "rusoto_s3"
-version = "0.40.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da6eac54781d2aac517a99f1d85d0d6a78674543f8d122d884628c1ff21b495"
+checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
 dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
+ "async-trait",
+ "bytes 1.0.0",
+ "futures 0.3.4",
  "rusoto_core",
  "xml-rs",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.0",
+ "futures 0.3.4",
+ "hex",
+ "hmac",
+ "http 0.2.1",
+ "hyper 0.14.2",
+ "log",
+ "md5",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.1",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2",
+ "time 0.2.23",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -2770,12 +2814,6 @@ name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
@@ -2814,9 +2852,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2987,9 +3025,9 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -3072,14 +3110,15 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.7.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
- "block-buffer 0.3.3",
- "byte-tools 0.2.0",
- "digest 0.7.6",
- "fake-simd",
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3131,13 +3170,12 @@ checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -3152,6 +3190,61 @@ name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
+name = "standback"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "serde",
+ "serde_derive",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string"
@@ -3187,10 +3280,16 @@ checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "symbolic"
@@ -3350,11 +3449,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -3365,9 +3464,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -3376,9 +3475,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
  "unicode-xid 0.2.0",
 ]
 
@@ -3448,9 +3547,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -3474,6 +3573,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "standback",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,7 +3618,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "mio",
+ "mio 0.6.21",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -3509,21 +3646,29 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.21",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "slab",
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.1"
+name = "tokio"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
 dependencies = [
- "bytes 0.4.12",
- "either",
- "futures 0.1.29",
+ "autocfg 1.0.0",
+ "bytes 1.0.0",
+ "libc",
+ "memchr",
+ "mio 0.7.7",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.1",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3580,22 +3725,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-process"
-version = "0.2.5"
+name = "tokio-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382d90f43fa31caebe5d3bc6cfd854963394fff3b8cb59d5146607aaae7e7e43"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
- "crossbeam-queue 0.1.2",
- "futures 0.1.29",
- "lazy_static",
- "libc",
- "log",
- "mio",
- "mio-named-pipes",
- "tokio-io",
- "tokio-reactor",
- "tokio-signal",
- "winapi 0.3.8",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -3608,7 +3755,7 @@ dependencies = [
  "futures 0.1.29",
  "lazy_static",
  "log",
- "mio",
+ "mio 0.6.21",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab",
@@ -3636,7 +3783,7 @@ checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
  "futures 0.1.29",
  "libc",
- "mio",
+ "mio 0.6.21",
  "mio-uds",
  "signal-hook-registry",
  "tokio-executor",
@@ -3664,7 +3811,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
- "mio",
+ "mio 0.6.21",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -3676,7 +3823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-queue 0.2.1",
+ "crossbeam-queue",
  "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
@@ -3728,7 +3875,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "log",
- "mio",
+ "mio 0.6.21",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -3745,7 +3892,7 @@ dependencies = [
  "iovec",
  "libc",
  "log",
- "mio",
+ "mio 0.6.21",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
@@ -3762,7 +3909,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "tokio 0.2.16",
 ]
 
@@ -3780,6 +3927,26 @@ name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.1",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "trust-dns-proto"
@@ -3881,7 +4048,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -4001,9 +4168,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ca2a14bc3fc5b64d188b087a7d3a927df87b152e941ccfbc66672e20c467ae"
 dependencies = [
  "nom",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -4036,9 +4203,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "walrus"
@@ -4061,20 +4228,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c2bb690b44cb1b0fdcc54d4998d21f8bdaf706b93775425e440b174f39ad16"
 dependencies = [
  "heck",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
-]
-
-[[package]]
-name = "want"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-dependencies = [
- "futures 0.1.29",
- "log",
- "try-lock",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -4120,9 +4276,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -4154,9 +4310,9 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2 1.0.24",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4268,12 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-dependencies = [
- "bitflags",
-]
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"
@@ -4285,6 +4438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+
+[[package]]
 name = "zip"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,7 +4453,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "podio",
- "time",
+ "time 0.1.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fragile"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,7 +1222,27 @@ dependencies = [
  "log",
  "slab",
  "tokio 0.2.16",
- "tokio-util",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+dependencies = [
+ "bytes 1.0.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.1",
+ "indexmap",
+ "slab",
+ "tokio 1.0.1",
+ "tokio-util 0.6.0",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1383,6 +1413,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.3.0",
  "http 0.2.1",
  "http-body 0.4.0",
  "httparse",
@@ -1568,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2670,7 +2701,42 @@ dependencies = [
  "serde_urlencoded 0.6.1",
  "tokio 0.2.16",
  "tokio-tls 0.3.0",
- "url 2.1.1",
+ "url 2.2.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http 0.2.1",
+ "http-body 0.4.0",
+ "hyper 0.14.2",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.1",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.0.1",
+ "tokio-native-tls",
+ "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2902,7 +2968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "933beb0343c84eefd69a368318e9291b179e09e51982d49c65d7b362b0e9466f"
 dependencies = [
  "httpdate",
- "reqwest",
+ "reqwest 0.10.8",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -3006,7 +3072,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "url 2.1.1",
+ "url 2.2.0",
  "uuid 0.8.1",
 ]
 
@@ -3062,7 +3128,19 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.1.1",
+ "url 2.2.0",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3416,6 +3494,7 @@ dependencies = [
  "pretty_env_logger",
  "procspawn",
  "regex",
+ "reqwest 0.11.0",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_s3",
@@ -3793,6 +3872,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.1",
+ "tokio 1.0.1",
+]
+
+[[package]]
 name = "tokio-sync"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,6 +4004,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
+dependencies = [
+ "bytes 1.0.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.1",
+ "tokio 1.0.1",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +4051,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.8",
+ "tracing",
 ]
 
 [[package]]
@@ -4113,10 +4228,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -4257,11 +4373,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4269,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4284,11 +4400,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4296,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote 1.0.3",
  "wasm-bindgen-macro-support",
@@ -4306,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.3",
@@ -4319,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,8 +2809,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+source = "git+https://github.com/jan-auer/reqwest?branch=hack/restricted-connector#c5c1cdac52659666f412983785b5d1bb808067d1"
 dependencies = [
  "async-compression",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.11.0"
-source = "git+https://github.com/jan-auer/reqwest?branch=hack/restricted-connector#c5c1cdac52659666f412983785b5d1bb808067d1"
+source = "git+https://github.com/jan-auer/reqwest?tag=v0.11.0#62edd49dd1eb0ab54b43d315c6c6ebb17ef15b99"
 dependencies = [
  "async-compression",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "tokio-tcp",
  "tokio-timer",
  "trust-dns-proto 0.5.0",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.10.3",
  "uuid 0.7.4",
 ]
 
@@ -53,7 +53,7 @@ dependencies = [
  "tokio-tcp",
  "tokio-timer",
  "tower-service 0.1.0",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.10.3",
 ]
 
 [[package]]
@@ -203,6 +203,19 @@ name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
+name = "async-compression"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72c1f1154e234325b50864a349b9c8e56939e266a4c307c0f159812df2f9537"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.1",
+ "tokio 1.0.1",
+]
 
 [[package]]
 name = "async-trait"
@@ -548,7 +561,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "proc-macro-hack",
 ]
 
@@ -709,6 +722,12 @@ dependencies = [
  "quote 1.0.3",
  "syn 1.0.58",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "debugid"
@@ -877,6 +896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.24",
+ "quote 1.0.3",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,9 +1062,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1046,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1056,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
 
 [[package]]
 name = "futures-cpupool"
@@ -1072,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1083,15 +1114,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -1101,21 +1132,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
 dependencies = [
  "futures 0.1.29",
  "futures-channel",
@@ -1125,6 +1159,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project-lite 0.2.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1159,6 +1194,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1562,9 +1608,21 @@ checksum = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
 dependencies = [
  "error-chain",
  "socket2",
- "widestring",
+ "widestring 0.2.2",
  "winapi 0.3.8",
  "winreg 0.5.1",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+dependencies = [
+ "socket2",
+ "widestring 0.4.3",
+ "winapi 0.3.8",
+ "winreg 0.6.2",
 ]
 
 [[package]]
@@ -2304,9 +2362,9 @@ checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2328,9 +2386,9 @@ checksum = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pretty_env_logger"
@@ -2370,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2488,11 +2546,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2516,6 +2586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,7 +2616,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -2555,6 +2644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2640,7 +2738,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -2714,6 +2812,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes 1.0.0",
  "encoding_rs",
@@ -2736,6 +2835,8 @@ dependencies = [
  "serde_urlencoded 0.7.0",
  "tokio 1.0.1",
  "tokio-native-tls",
+ "tokio-util 0.6.0",
+ "trust-dns-resolver 0.20.0",
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2748,6 +2849,16 @@ name = "resolv-conf"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+dependencies = [
+ "hostname",
+ "quick-error",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
@@ -2777,7 +2888,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes 1.0.0",
  "crc32fast",
- "futures 0.3.4",
+ "futures 0.3.9",
  "http 0.2.1",
  "hyper 0.14.2",
  "hyper-tls 0.5.0",
@@ -2801,7 +2912,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dirs-next",
- "futures 0.3.4",
+ "futures 0.3.9",
  "hyper 0.14.2",
  "serde",
  "serde_json",
@@ -2818,7 +2929,7 @@ checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
 dependencies = [
  "async-trait",
  "bytes 1.0.0",
- "futures 0.3.4",
+ "futures 0.3.9",
  "rusoto_core",
  "xml-rs",
 ]
@@ -2831,7 +2942,7 @@ checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.0",
- "futures 0.3.4",
+ "futures 0.3.9",
  "hex",
  "hmac",
  "http 0.2.1",
@@ -3480,7 +3591,7 @@ dependencies = [
  "flate2",
  "fragile",
  "futures 0.1.29",
- "futures 0.3.4",
+ "futures 0.3.9",
  "glob",
  "humantime-serde",
  "insta",
@@ -4113,6 +4224,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a0381b2864c2978db7f8e17c7b23cca5a3a5f99241076e13002261a8ecbabd"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.0",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand 0.8.1",
+ "smallvec 1.5.0",
+ "thiserror",
+ "tokio 1.0.1",
+ "url 2.2.0",
+]
+
+[[package]]
 name = "trust-dns-resolver"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,14 +4256,34 @@ dependencies = [
  "cfg-if 0.1.10",
  "failure",
  "futures 0.1.29",
- "ipconfig",
+ "ipconfig 0.1.9",
  "lazy_static",
  "log",
  "lru-cache",
- "resolv-conf",
+ "resolv-conf 0.6.3",
  "smallvec 0.6.13",
  "tokio 0.1.22",
  "trust-dns-proto 0.6.3",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3072d18c10bd621cb00507d59cfab5517862285c353160366e37fbf4c74856e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig 0.2.2",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot 0.11.1",
+ "resolv-conf 0.7.0",
+ "smallvec 1.5.0",
+ "thiserror",
+ "tokio 1.0.1",
+ "trust-dns-proto 0.20.0",
 ]
 
 [[package]]
@@ -4469,6 +4624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 
 [[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4516,6 +4677,15 @@ name = "winreg"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ structopt = "0.3.2"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.1.0"
 thiserror = "1.0.20"
+tokio = { version = "1.0.1", features = ["rt", "macros"] }
 tokio01 = { version = "0.1.22", package = "tokio" }
 tokio-retry = "0.2.0"
 url = "1.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,9 @@ parking_lot = "0.10.0"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.3.3"
-# rusoto >= 0.43 supports async/await natively, with tokio 0.2 under the hood
-# For now we will stick with an older version, until our downloader client / runtime is compatible with tokio 0.2
-rusoto_core = "0.40.0"
-rusoto_credential = "0.40.0"
-rusoto_s3 = "0.40.0"
+rusoto_core = "0.46.0"
+rusoto_credential = "0.46.0"
+rusoto_s3 = "0.46.0"
 sentry = { version = "0.21.0", features = ["debug-images", "failure", "log"] }
 serde = { version = "1.0.101", features = ["derive", "rc"] }
 serde_json = "1.0.45"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ parking_lot = "0.10.0"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.3.3"
-reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
+reqwest = { git = "https://github.com/jan-auer/reqwest", branch = "hack/restricted-connector", features = ["gzip", "json", "stream", "trust-dns"] }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ parking_lot = "0.10.0"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.3.3"
-reqwest = { git = "https://github.com/jan-auer/reqwest", branch = "hack/restricted-connector", features = ["gzip", "json", "stream", "trust-dns"] }
+reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ parking_lot = "0.10.0"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.3.3"
+reqwest = { version = "0.11.0", features = ["json", "stream"] }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ parking_lot = "0.10.0"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.3.3"
-reqwest = { version = "0.11.0", features = ["json", "stream"] }
+reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,6 @@ use crate::cache::Caches;
 use crate::config::Config;
 use crate::services::download::DownloadService;
 use crate::utils::futures::ThreadPool;
-use crate::utils::http;
 
 /// The shared state for the service.
 #[derive(Clone, Debug)]
@@ -34,10 +33,6 @@ pub struct ServiceState {
 impl ServiceState {
     pub fn create(config: Config) -> Result<Self> {
         let config = Arc::new(config);
-
-        if !config.connect_to_reserved_ips {
-            http::start_safe_connector();
-        }
 
         let cpu_threadpool = ThreadPool::new();
         let io_threadpool = ThreadPool::new();

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -131,10 +131,6 @@ impl GcsDownloader {
         let request = self
             .client
             .post("https://www.googleapis.com/oauth2/v4/token")
-            // TODO(ja): check if this still holds
-            // for some inexplicable reason we otherwise get gzipped data back that actix-web
-            // client has no idea what to do with.
-            .header("accept-encoding", "identity")
             .form(&OAuth2Grant {
                 grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".into(),
                 assertion: auth_jwt,

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -116,11 +116,9 @@ pub struct GcsDownloader {
 
 impl GcsDownloader {
     pub fn new() -> Self {
-        let token_cache = Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE));
-        let client = reqwest::Client::new();
         Self {
-            token_cache,
-            client,
+            token_cache: Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE)),
+            client: reqwest::Client::new(),
         }
     }
 

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Utc};
 use futures::prelude::*;
 use parking_lot::Mutex;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -115,10 +116,10 @@ pub struct GcsDownloader {
 }
 
 impl GcsDownloader {
-    pub fn new() -> Self {
+    pub fn new(client: Client) -> Self {
         Self {
             token_cache: Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE)),
-            client: reqwest::Client::new(),
+            client,
         }
     }
 
@@ -310,7 +311,7 @@ mod tests {
         test::setup();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new();
+        let downloader = GcsDownloader::new(Client::new());
 
         let object_id = ObjectId {
             code_id: Some("e514c9464eed3be5943a2c61d9241fad".parse().unwrap()),
@@ -334,7 +335,7 @@ mod tests {
         test::setup_logging();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new();
+        let downloader = GcsDownloader::new(Client::new());
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");
@@ -360,7 +361,7 @@ mod tests {
         test::setup_logging();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new();
+        let downloader = GcsDownloader::new(Client::new());
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");
@@ -386,7 +387,7 @@ mod tests {
         };
 
         let source = gcs_source(broken_credentials);
-        let downloader = GcsDownloader::new();
+        let downloader = GcsDownloader::new(Client::new());
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::prelude::*;
-use reqwest::header;
+use reqwest::{header, Client};
 use url::Url;
 
 use super::{DownloadError, DownloadStatus, USER_AGENT};
@@ -35,14 +35,12 @@ fn join_url_encoded(base: &Url, path: &SourceLocation) -> Result<Url, ()> {
 /// Downloader implementation that supports the [`HttpSourceConfig`] source.
 #[derive(Debug)]
 pub struct HttpDownloader {
-    client: reqwest::Client,
+    client: Client,
 }
 
 impl HttpDownloader {
-    pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-        }
+    pub fn new(client: Client) -> Self {
+        Self { client }
     }
 
     pub async fn download_source(
@@ -139,7 +137,7 @@ mod tests {
         };
         let loc = SourceLocation::new("hello.txt");
 
-        let downloader = HttpDownloader::new();
+        let downloader = HttpDownloader::new(Client::new());
         let download_status = downloader
             .download_source(http_source, loc, dest.clone())
             .await
@@ -165,7 +163,7 @@ mod tests {
         };
         let loc = SourceLocation::new("i-do-not-exist");
 
-        let downloader = HttpDownloader::new();
+        let downloader = HttpDownloader::new(Client::new());
         let download_status = downloader
             .download_source(http_source, loc, dest)
             .await

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use ::sentry::{Hub, SentryFutureExt};
 use actix_web::error::PayloadError;
-use bytes::Bytes;
 use failure::Fail;
 use futures::prelude::*;
 use thiserror::Error;
@@ -200,7 +199,7 @@ impl DownloadService {
 /// This is common functionality used by all many downloaders.
 async fn download_stream(
     source: SourceFileId,
-    stream: impl Stream<Item = Result<Bytes, DownloadError>>,
+    stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,
     destination: PathBuf,
 ) -> Result<DownloadStatus, DownloadError> {
     // All file I/O in this function is blocking!

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -63,10 +63,7 @@ pub enum DownloadStatus {
 }
 
 fn create_client(config: &Config, trusted: bool) -> reqwest::Client {
-    let builder = reqwest::ClientBuilder::new()
-        .gzip(true)
-        .trust_dns(true)
-        .tcp_keepalive(Duration::from_secs(15));
+    let builder = reqwest::ClientBuilder::new().gzip(true).trust_dns(true);
 
     if !(trusted || config.connect_to_reserved_ips) {
         // TODO(ja): Enforce IP restriction

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -62,16 +62,6 @@ pub enum DownloadStatus {
     NotFound,
 }
 
-fn create_client(config: &Config, trusted: bool) -> reqwest::Client {
-    let builder = reqwest::ClientBuilder::new().gzip(true).trust_dns(true);
-
-    if !(trusted || config.connect_to_reserved_ips) {
-        // TODO(ja): Enforce IP restriction
-    }
-
-    builder.build().unwrap()
-}
-
 /// A service which can download files from a [`SourceConfig`].
 ///
 /// The service is rather simple on the outside but will one day control
@@ -90,8 +80,8 @@ pub struct DownloadService {
 impl DownloadService {
     /// Creates a new downloader that runs all downloads in the given remote thread.
     pub fn new(worker: Arc<Runtime>, config: Arc<Config>) -> Arc<Self> {
-        let trusted_client = create_client(&config, true);
-        let restricted_client = create_client(&config, false);
+        let trusted_client = crate::utils::http::create_client(&config, true);
+        let restricted_client = crate::utils::http::create_client(&config, false);
 
         Arc::new(Self {
             worker,

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -39,6 +39,9 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 pub enum DownloadError {
     #[error("failed to download")]
     Io(#[source] std::io::Error),
+    // TODO(ja): Find a better error classification
+    #[error("failed to download")]
+    Reqwest(#[source] reqwest::Error),
     #[error("failed to download stream")]
     Stream(#[source] failure::Compat<PayloadError>),
     #[error("bad file destination")]

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -38,7 +38,6 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 pub enum DownloadError {
     #[error("failed to download")]
     Io(#[source] std::io::Error),
-    // TODO(ja): Find a better error classification
     #[error("failed to download")]
     Reqwest(#[source] reqwest::Error),
     #[error("bad file destination")]

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -10,8 +10,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ::sentry::{Hub, SentryFutureExt};
-use actix_web::error::PayloadError;
-use failure::Fail;
 use futures::prelude::*;
 use thiserror::Error;
 
@@ -42,8 +40,6 @@ pub enum DownloadError {
     // TODO(ja): Find a better error classification
     #[error("failed to download")]
     Reqwest(#[source] reqwest::Error),
-    #[error("failed to download stream")]
-    Stream(#[source] failure::Compat<PayloadError>),
     #[error("bad file destination")]
     BadDestination(#[source] std::io::Error),
     #[error("failed writing the downloaded file")]
@@ -54,12 +50,6 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
-}
-
-impl DownloadError {
-    pub fn stream(err: PayloadError) -> Self {
-        Self::Stream(err.compat())
-    }
 }
 
 /// Completion status of a successful download request.

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -192,8 +192,8 @@ mod tests {
         let head_result = s3_client
             .head_bucket(rusoto_s3::HeadBucketRequest {
                 bucket: S3_BUCKET.to_owned(),
+                ..Default::default()
             })
-            .compat()
             .await;
 
         match head_result {
@@ -212,7 +212,6 @@ mod tests {
                 bucket: S3_BUCKET.to_owned(),
                 ..Default::default()
             })
-            .compat()
             .await
             .unwrap();
     }
@@ -230,7 +229,6 @@ mod tests {
                 key: key.clone(),
                 ..Default::default()
             })
-            .compat()
             .await;
 
         match head_result {
@@ -248,7 +246,6 @@ mod tests {
                 key,
                 ..Default::default()
             })
-            .compat()
             .await
             .unwrap();
     }

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -61,10 +61,9 @@ impl fmt::Debug for SentryDownloader {
 }
 
 impl SentryDownloader {
-    pub fn new() -> Self {
+    pub fn new(client: reqwest::Client) -> Self {
         Self {
-            // TODO(ja): Bypass IP restriction
-            client: reqwest::Client::new(),
+            client,
             index_cache: Mutex::new(SentryIndexCache::new(100_000)),
         }
     }

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -8,15 +8,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use actix::{Actor, Addr};
-use actix_web::client::{ClientConnector, ClientResponse, SendRequestError};
-use actix_web::error::JsonPayloadError;
-use actix_web::http::StatusCode;
-use actix_web::{client, HttpMessage};
-use failure::Fail;
-use futures::compat::{Future01CompatExt, Stream01CompatExt};
 use futures::prelude::*;
 use parking_lot::Mutex;
+use reqwest::StatusCode;
 use thiserror::Error;
 use url::Url;
 
@@ -44,18 +38,16 @@ type SentryIndexCache = lru::LruCache<SearchQuery, (Instant, Vec<SearchResult>)>
 /// Errors happening while fetching data from Sentry.
 #[derive(Debug, Error)]
 pub enum SentryError {
-    #[error("failed parsing JSON response from Sentry")]
-    Parsing(#[from] failure::Compat<JsonPayloadError>),
-
+    // TODO(ja): Find better errors here
     #[error("failed sending request to Sentry")]
-    SendRequest(#[from] failure::Compat<SendRequestError>),
+    Reqwest(#[from] reqwest::Error),
 
     #[error("bad status code from Sentry: {0}")]
     BadStatusCode(StatusCode),
 }
 
 pub struct SentryDownloader {
-    connector: Addr<ClientConnector>,
+    client: reqwest::Client,
     index_cache: Mutex<SentryIndexCache>,
 }
 
@@ -71,30 +63,10 @@ impl fmt::Debug for SentryDownloader {
 impl SentryDownloader {
     pub fn new() -> Self {
         Self {
-            connector: ClientConnector::default().start(),
+            // TODO(ja): Bypass IP restriction
+            client: reqwest::Client::new(),
             index_cache: Mutex::new(SentryIndexCache::new(100_000)),
         }
-    }
-
-    async fn start_request(
-        &self,
-        source: &SentrySourceConfig,
-        url: &Url,
-    ) -> Result<ClientResponse, SendRequestError> {
-        // The timeout is for the entire HTTP download *including* the response stream itself,
-        // in contrast to what the Actix-Web docs say. We have tested this manually.
-        //
-        // The intent is to disable the timeout entirely, but there is no API for that.
-        client::get(url)
-            .with_connector(self.connector.clone())
-            .header("User-Agent", USER_AGENT)
-            .header("Authorization", format!("Bearer {}", &source.token))
-            .timeout(Duration::from_secs(9999))
-            .finish()
-            .unwrap()
-            .send()
-            .compat()
-            .await
     }
 
     /// Make a request to sentry, parse the result as a JSON SearchResult list.
@@ -102,25 +74,18 @@ impl SentryDownloader {
         &self,
         query: &SearchQuery,
     ) -> Result<Vec<SearchResult>, SentryError> {
-        let response = client::get(&query.index_url)
-            .with_connector(self.connector.clone())
+        let response = self
+            .client
+            .get(query.index_url.as_str())
             .header("Accept-Encoding", "identity")
             .header("User-Agent", USER_AGENT)
             .header("Authorization", format!("Bearer {}", &query.token))
-            .finish()
-            .unwrap()
             .send()
-            .compat()
-            .await
-            .map_err(Fail::compat)?;
+            .await?;
 
         if response.status().is_success() {
             log::trace!("Success fetching index from Sentry");
-            response
-                .json()
-                .compat()
-                .await
-                .map_err(|e| Fail::compat(e).into())
+            Ok(response.json().await?)
         } else {
             log::warn!("Sentry returned status code {}", response.status());
             Err(SentryError::BadStatusCode(response.status()))
@@ -218,16 +183,21 @@ impl SentryDownloader {
     ) -> Result<DownloadStatus, DownloadError> {
         let download_url = source.download_url(&file_id);
         log::debug!("Fetching debug file from {}", download_url);
-        let response = future_utils::retry(|| self.start_request(&source, &download_url)).await;
+        let result = future_utils::retry(|| {
+            self.client
+                .get(download_url.as_str())
+                .header("User-Agent", USER_AGENT)
+                .header("Authorization", format!("Bearer {}", &source.token))
+                .send()
+        })
+        .await;
 
-        match response {
+        match result {
             Ok(response) => {
                 if response.status().is_success() {
                     log::trace!("Success hitting {}", download_url);
-                    let stream = response
-                        .payload()
-                        .compat()
-                        .map(|i| i.map_err(DownloadError::stream));
+                    let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
+
                     super::download_stream(
                         SourceFileId::Sentry(source, file_id),
                         stream,

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -38,7 +38,6 @@ type SentryIndexCache = lru::LruCache<SearchQuery, (Instant, Vec<SearchResult>)>
 /// Errors happening while fetching data from Sentry.
 #[derive(Debug, Error)]
 pub enum SentryError {
-    // TODO(ja): Find better errors here
     #[error("failed sending request to Sentry")]
     Reqwest(#[from] reqwest::Error),
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -69,6 +69,18 @@ impl Drop for Inner {
     }
 }
 
+/// Initializes logging for tests.
+///
+/// The logger only captures logs from the `symbolicator` crate and mutes all other logs (such as
+/// actix or symbolic).
+pub(crate) fn setup_logging() {
+    env_logger::builder()
+        .filter(Some("symbolicator"), LevelFilter::Trace)
+        .is_test(true)
+        .try_init()
+        .ok();
+}
+
 /// Setup the test environment.
 ///
 ///  - Initializes logs: The logger only captures logs from the `symbolicator` crate and mutes all
@@ -77,11 +89,7 @@ impl Drop for Inner {
 ///    but instead return the futures that are spawned. This allows to capture console output logged
 ///    from spawned tasks.
 pub(crate) fn setup() {
-    env_logger::builder()
-        .filter(Some("symbolicator"), LevelFilter::Trace)
-        .is_test(true)
-        .try_init()
-        .ok();
+    setup_logging();
 
     // Force initialization of the actix system
     SYSTEM.with(|_sys| ());

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 
 use actix::{System, SystemRunner};
 use actix_web::fs::StaticFiles;
-use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future, IntoFuture};
 use log::LevelFilter;
 
@@ -128,34 +127,6 @@ where
         let mut inner = cell.borrow_mut();
         inner.set_current();
         inner.runner().block_on(future::lazy(f))
-    })
-}
-
-/// Runs the provided function, blocking the current thread until the result
-/// [`Future`](std::future::Future) completes.
-///
-/// This function can be used to synchronously block the current thread until the provided `Future`
-/// has resolved either successfully or with an error. The result of the future is then returned
-/// from this function call.
-///
-/// This is provided rather than a `block_on`-like interface to avoid accidentally calling a
-/// function which spawns before creating a future, which would attempt to spawn before actix is
-/// initialised.
-///
-/// Note that this function is intended to be used only for testing purpose. This function panics on
-/// nested call.
-pub fn block_fn<F, R, T>(f: F) -> T
-where
-    F: FnOnce() -> R,
-    R: std::future::Future<Output = T>,
-{
-    SYSTEM.with(|cell| {
-        let mut inner = cell.borrow_mut();
-        inner.set_current();
-        inner
-            .runner()
-            .block_on(async move { f().await }.unit_error().boxed_local().compat())
-            .unwrap()
     })
 }
 

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -6,8 +6,7 @@ use std::time::{Duration, Instant};
 
 use futures::channel::oneshot;
 use futures::compat::Future01CompatExt;
-use futures::{future, FutureExt, TryFutureExt};
-use futures01::future::Future as Future01;
+use futures::{FutureExt, TryFutureExt};
 use tokio01::prelude::FutureExt as TokioFutureExt;
 use tokio01::runtime::Runtime as TokioRuntime;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -41,8 +40,7 @@ pub use oneshot::Canceled as RemoteCanceled;
 ///
 /// This handle is a future representing the completion of a different future spawned on to the
 /// thread pool. Created through the [`ThreadPool::spawn_handle`] function this handle will resolve
-/// when the future provided resolves on the thread pool. If the remote thread restarts due to
-/// panics, [`SpawnError::Canceled`] is returned.
+/// when the future provided resolves on the thread pool.
 pub use oneshot::Receiver as SpawnHandle;
 
 /// Work-stealing based thread pool for executing futures.
@@ -95,168 +93,6 @@ impl ThreadPool {
         }
 
         receiver
-    }
-}
-
-/// A remote thread which can run non-sendable futures.
-///
-/// This can be used to implement any services which internally need to use
-/// non-`Send`able futures and are sufficient with running on single thread.
-///
-/// When the global `IS_TEST` is set by calling `enable_test_mode`, this will
-/// not create a new thread and instead spawn any executions in the current
-/// thread.  This is a workaround for the stdout and panic capturing not being
-/// exposed properly to the test framework users which stops us from enabling
-/// these things in spawned threads during tests.
-#[derive(Clone, Debug)]
-pub struct RemoteThread {
-    inner: Arc<InnerRemoteThread>,
-}
-
-/// Inner [`RemoteThread`] struct to get correct clone behaviour.
-///
-/// We only have an [`actix::Addr`] to the arbiter, which itself can be cloned. Dropping this
-/// does not terminate the arbiter, but we wan the [`RemoteThread`] to stop when dropped. So
-/// we need to implement [`Drop`], but only want to actually trigger this drop when all clones
-/// of our [`RemoteThread`] are dropped.  Hence the need to put the drop on an inner struct
-/// which is wrapped in an Arc.
-#[derive(Debug)]
-struct InnerRemoteThread {
-    arbiter: Option<actix::Addr<actix::Arbiter>>,
-}
-
-/// Spawning the future on the remote failed.
-///
-/// This is an error caused by the remote, not the result or output of the future itself.
-/// In the future this could include loadshedding errors and the like.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum SpawnError {
-    /// The future was cancelled, e.g. because the remote was dropped.
-    Canceled,
-    /// The future exceeded its timeout.
-    Timeout,
-}
-
-/// Dropping terminates the [`RemoteThread`], cancelling all futures.
-impl Drop for InnerRemoteThread {
-    fn drop(&mut self) {
-        // Without sending the StopArbiter message the arbiter thread keeps running even if
-        // you drop the arbiter.
-        if let Some(ref addr) = self.arbiter {
-            addr.do_send(actix::msgs::StopArbiter(0));
-        }
-    }
-}
-
-impl RemoteThread {
-    /// Create a new instance, spawning the thread.
-    pub fn new() -> Self {
-        let arbiter = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
-            None
-        } else {
-            Some(actix::Arbiter::new("RemoteThread"))
-        };
-        Self {
-            inner: Arc::new(InnerRemoteThread { arbiter }),
-        }
-    }
-
-    /// Create a new instance, even when running in test mode.
-    ///
-    /// Some tests actually need to test this stuff works, support that.
-    #[cfg(test)]
-    pub fn new_threaded() -> Self {
-        Self {
-            inner: Arc::new(InnerRemoteThread {
-                arbiter: Some(actix::Arbiter::new("RemoteThread")),
-            }),
-        }
-    }
-
-    /// Create a future in the remote thread and run it.
-    ///
-    /// The returned future resolves when the spawned future has completed execution.  The
-    /// output type of the spawned future is wrapped in a `Result`, normally the output is
-    /// returned in an `Ok`.
-    ///
-    /// When the future takes too long [`SpawnError::Timeout`] is returned, if the
-    /// `RemoteThread` it is running on is dropped [`SpawnError::Canceled`] is returned.
-    pub fn spawn<F, R, T>(
-        &self,
-        task_name: &'static str,
-        timeout: Duration,
-        factory: F,
-    ) -> impl Future<Output = Result<T, SpawnError>>
-    where
-        F: FnOnce() -> R + Send + 'static,
-        R: Future<Output = T> + 'static,
-        T: Send + 'static,
-    {
-        enum ChannelMsg<T> {
-            Output(T),
-            Timeout,
-        }
-        let (tx, rx) = oneshot::channel();
-        let creation_time = Instant::now();
-        let msg = actix::msgs::Execute::new(move || -> Result<(), ()> {
-            let fut01 = futures01::future::lazy(move || {
-                metric!(
-                    timer("futures.wait_time") = creation_time.elapsed(),
-                    "task_name" => task_name,
-                );
-                let start_time = Instant::now();
-                factory()
-                    .unit_error()
-                    .boxed_local()
-                    .compat()
-                    .timeout(timeout)
-                    .then(move |r: Result<T, tokio01::timer::timeout::Error<()>>| {
-                        metric!(
-                            timer("futures.done") = start_time.elapsed(),
-                            "task_name" => task_name,
-                            "status" => if r.is_ok() {"done"} else {"timeout"},
-                        );
-                        let msg = match r {
-                            Ok(o) => ChannelMsg::Output(o),
-                            Err(_) => {
-                                // Because we wrapped our T into Ok() above using
-                                // .unit_error() to make a TryFuture, we know the <Timeout
-                                // as Future>::Error will only occur if the error is
-                                // actually because of a timeout, so we do not need to check
-                                // with .is_timer() or .is_inner().
-                                ChannelMsg::Timeout
-                            }
-                        };
-                        tx.send(msg).unwrap_or_else(|_| {
-                            log::debug!(
-                                "Failed to send result of {} task, caller dropped",
-                                task_name
-                            )
-                        });
-                        futures01::future::ok(())
-                    })
-            });
-            actix::spawn(fut01);
-            Ok(())
-        });
-        match self.inner.arbiter {
-            Some(ref arbiter) => arbiter.do_send(msg),
-            None => {
-                let arbiter = actix::Arbiter::current();
-                arbiter.do_send(msg);
-            }
-        }
-        rx.then(move |oneshot_result| match oneshot_result {
-            Ok(ChannelMsg::Output(o)) => future::ready(Ok(o)),
-            Ok(ChannelMsg::Timeout) => future::ready(Err(SpawnError::Timeout)),
-            Err(oneshot::Canceled) => {
-                metric!(
-                    counter("futures.canceled") += 1,
-                    "task_name" => task_name,
-                );
-                future::ready(Err(SpawnError::Canceled))
-            }
-        })
     }
 }
 
@@ -426,7 +262,7 @@ pub mod m {
     ///
     ///  - `"ok"` if the future resolves to `Ok(_)`
     ///  - `"timeout"` if the future times out
-    pub fn timed<T, TE>(result: &Result<T, TE>) -> &'static str {
+    pub fn timed<T>(result: &Result<T, tokio::time::error::Elapsed>) -> &'static str {
         match result {
             Ok(_) => "ok",
             Err(_) => "timeout",
@@ -462,93 +298,5 @@ where
             Some(duration) if result.is_err() => delay(duration).await,
             _ => break result,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::test;
-
-    /// Elaborate executor-neutral way of sleeping in a future
-    async fn sleep(duration: Duration) {
-        let (tx, rx) = oneshot::channel();
-        std::thread::spawn(move || {
-            std::thread::sleep(duration);
-            tx.send(()).ok();
-        });
-        rx.await.ok();
-    }
-
-    /// Create a new RemoteThread for testing purposes.
-    fn setup_remote_thread() -> RemoteThread {
-        // Ensure actix is setup.
-        test::setup();
-
-        // test::setup() enables logging, but this test spawns a thread where
-        // logging is not captured.  For normal test runs we don't want to
-        // pollute the stdout so silence logs here.  When debugging this test
-        // you may want to temporarily remove this.
-        log::set_max_level(log::LevelFilter::Off);
-
-        RemoteThread::new_threaded()
-    }
-
-    #[test]
-    fn test_remote_thread() {
-        let remote = setup_remote_thread();
-        let fut = remote.spawn("task", Duration::from_secs(10), || future::ready(42));
-        let ret = test::block_fn(|| fut);
-        assert_eq!(ret, Ok(42));
-    }
-
-    #[test]
-    fn test_remote_thread_timeout() {
-        let remote = setup_remote_thread();
-        let fut = remote.spawn("task", Duration::from_nanos(1), || {
-            sleep(Duration::from_secs(1))
-        });
-        let ret = test::block_fn(|| fut);
-        assert_eq!(ret, Err(SpawnError::Timeout));
-    }
-
-    #[test]
-    fn test_remote_thread_canceled() {
-        let remote = setup_remote_thread();
-        let fut = remote.spawn("task", Duration::from_secs(2), || {
-            sleep(Duration::from_secs(1))
-        });
-        std::mem::drop(remote);
-        let ret = test::block_fn(|| fut);
-        assert_eq!(ret, Err(SpawnError::Canceled));
-    }
-
-    #[test]
-    fn test_remote_thread_clone_drop() {
-        // When dropping a clone of the RemoteThread the other one needs to keep working.
-        let remote0 = setup_remote_thread();
-        let remote1 = remote0.clone();
-        std::mem::drop(remote0);
-        let fut = remote1.spawn("task", Duration::from_secs(1), || future::ready(42));
-        let ret = test::block_fn(|| fut);
-        assert_eq!(ret, Ok(42));
-    }
-
-    #[test]
-    fn test_timeout_compat() {
-        test::block_fn(|| async {
-            let long_job = sleep(Duration::from_secs(1));
-            let result: Result<(), Elapsed> =
-                timeout_compat(Duration::from_millis(10), long_job).await;
-            assert_eq!(result, Err(Elapsed(())));
-        });
-
-        test::block_fn(|| async {
-            let long_job = sleep(Duration::from_millis(10));
-            let result: Result<(), Elapsed> =
-                timeout_compat(Duration::from_secs(1), long_job).await;
-            assert_eq!(result, Ok(()));
-        });
     }
 }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_untrusted_client() {
-        test::setup();
+        test::setup_logging();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));
@@ -75,8 +75,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_untrusted_client_loopback() {
+        test::setup_logging();
+
+        let server = test::TestServer::new(|app| {
+            app.resource("/", |resource| resource.f(|_| "OK"));
+        });
+
+        let config = Config {
+            connect_to_reserved_ips: false,
+            ..Config::default()
+        };
+
+        let result = create_client(&config, false) // untrusted
+            .get(&format!("http://127.0.0.1:{}/", server.addr().port()))
+            .send()
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn test_untrusted_client_allowed() {
-        test::setup();
+        test::setup_logging();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));
@@ -99,7 +120,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trusted() {
-        test::setup();
+        test::setup_logging();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));


### PR DESCRIPTION
Introduces Tokio 1 in the downloader module, migrates to reqwest, and updates to the latest version of rusoto for S3. Downloaders share the same HTTP client and run in a single-threaded runtime. At this point, the new runtime is only used by the downloaders.

Since reqwest does not allow to hook into the resolver, this uses a patched version: jan-auer/reqwest@62edd49 until reqwest adds the required APIs.