### PR TITLE
ref(downloader): Make HTTP and FS downloaders stateful structs

### DIFF
--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -39,91 +39,105 @@ fn join_url_encoded(base: &Url, path: &SourceLocation) -> Result<Url, ()> {
     Ok(joined)
 }
 
-/// Start a request to the web server.
-///
-/// This initiates the request, when the future resolves the headers will have been
-/// retrieved but not the entire payload.
-async fn start_request(
-    source: &HttpSourceConfig,
-    url: Url,
-) -> Result<client::ClientResponse, client::SendRequestError> {
-    http::follow_redirects(url, MAX_HTTP_REDIRECTS, move |url| {
-        let mut builder = client::get(url);
-        for (key, value) in source.headers.iter() {
-            if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {
-                builder.header(key, value.as_str());
+/// Downloader implementation that supports the [`HttpSourceConfig`] source.
+#[derive(Debug)]
+pub struct HttpDownloader {}
+
+impl HttpDownloader {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Start a request to the web server.
+    ///
+    /// This initiates the request, when the future resolves the headers will have been
+    /// retrieved but not the entire payload.
+    async fn start_request(
+        &self,
+        source: &HttpSourceConfig,
+        url: Url,
+    ) -> Result<client::ClientResponse, client::SendRequestError> {
+        http::follow_redirects(url, MAX_HTTP_REDIRECTS, move |url| {
+            let mut builder = client::get(url);
+            for (key, value) in source.headers.iter() {
+                if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {
+                    builder.header(key, value.as_str());
+                }
+            }
+            builder.header(header::USER_AGENT, USER_AGENT);
+            // This timeout is for the entire HTTP download *including* the response stream
+            // itself, in contrast to what the Actix-Web docs say. We have tested this
+            // manually.
+            //
+            // The intent is to disable the timeout entirely, but there is no API for that.
+            builder.timeout(Duration::from_secs(9999));
+            builder.finish()
+        })
+        .await
+    }
+
+    pub async fn download_source(
+        &self,
+        source: Arc<HttpSourceConfig>,
+        download_path: SourceLocation,
+        destination: PathBuf,
+    ) -> Result<DownloadStatus, DownloadError> {
+        // This can effectively never error since the URL is always validated to be a base URL.
+        // Though unfortunately this happens outside of this service, so ideally we'd fix this.
+        let download_url = match join_url_encoded(&source.url, &download_path) {
+            Ok(x) => x,
+            Err(_) => return Ok(DownloadStatus::NotFound),
+        };
+        log::debug!("Fetching debug file from {}", download_url);
+        let response =
+            future_utils::retry(|| self.start_request(&source, download_url.clone())).await;
+
+        match response {
+            Ok(response) => {
+                if response.status().is_success() {
+                    log::trace!("Success hitting {}", download_url);
+                    let stream = response
+                        .payload()
+                        .compat()
+                        .map(|i| i.map_err(DownloadError::stream));
+                    super::download_stream(
+                        SourceFileId::Http(source, download_path),
+                        stream,
+                        destination,
+                    )
+                    .await
+                } else {
+                    log::trace!(
+                        "Unexpected status code from {}: {}",
+                        download_url,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
+                }
+            }
+            Err(e) => {
+                log::trace!("Skipping response from {}: {}", download_url, e);
+                Ok(DownloadStatus::NotFound) // must be wrong type
             }
         }
-        builder.header(header::USER_AGENT, USER_AGENT);
-        // This timeout is for the entire HTTP download *including* the response stream
-        // itself, in contrast to what the Actix-Web docs say. We have tested this
-        // manually.
-        //
-        // The intent is to disable the timeout entirely, but there is no API for that.
-        builder.timeout(Duration::from_secs(9999));
-        builder.finish()
-    })
-    .await
-}
-
-pub async fn download_source(
-    source: Arc<HttpSourceConfig>,
-    download_path: SourceLocation,
-    destination: PathBuf,
-) -> Result<DownloadStatus, DownloadError> {
-    // This can effectively never error since the URL is always validated to be a base URL.
-    // Though unfortunately this happens outside of this service, so ideally we'd fix this.
-    let download_url = match join_url_encoded(&source.url, &download_path) {
-        Ok(x) => x,
-        Err(_) => return Ok(DownloadStatus::NotFound),
-    };
-    log::debug!("Fetching debug file from {}", download_url);
-    let response = future_utils::retry(|| start_request(&source, download_url.clone())).await;
-
-    match response {
-        Ok(response) => {
-            if response.status().is_success() {
-                log::trace!("Success hitting {}", download_url);
-                let stream = response
-                    .payload()
-                    .compat()
-                    .map(|i| i.map_err(DownloadError::stream));
-                super::download_stream(
-                    SourceFileId::Http(source, download_path),
-                    stream,
-                    destination,
-                )
-                .await
-            } else {
-                log::trace!(
-                    "Unexpected status code from {}: {}",
-                    download_url,
-                    response.status()
-                );
-                Ok(DownloadStatus::NotFound)
-            }
-        }
-        Err(e) => {
-            log::trace!("Skipping response from {}: {}", download_url, e);
-            Ok(DownloadStatus::NotFound) // must be wrong type
-        }
     }
-}
 
-pub fn list_files(
-    source: Arc<HttpSourceConfig>,
-    filetypes: &'static [FileType],
-    object_id: ObjectId,
-) -> Vec<SourceFileId> {
-    super::SourceLocationIter {
-        filetypes: filetypes.iter(),
-        filters: &source.files.filters,
-        object_id: &object_id,
-        layout: source.files.layout,
-        next: Vec::new(),
+    pub fn list_files(
+        &self,
+        source: Arc<HttpSourceConfig>,
+        filetypes: &'static [FileType],
+        object_id: ObjectId,
+    ) -> Vec<SourceFileId> {
+        super::SourceLocationIter {
+            filetypes: filetypes.iter(),
+            filters: &source.files.filters,
+            object_id: &object_id,
+            layout: source.files.layout,
+            next: Vec::new(),
+        }
+        .map(|loc| SourceFileId::Http(source.clone(), loc))
+        .collect()
     }
-    .map(|loc| SourceFileId::Http(source.clone(), loc))
-    .collect()
 }
 
 #[cfg(test)]
@@ -147,7 +161,8 @@ mod tests {
         };
         let loc = SourceLocation::new("hello.txt");
 
-        let ret = test::block_fn(|| download_source(http_source, loc, dest.clone()));
+        let downloader = HttpDownloader::new();
+        let ret = test::block_fn(|| downloader.download_source(http_source, loc, dest.clone()));
         assert_eq!(ret.unwrap(), DownloadStatus::Completed);
         let content = std::fs::read_to_string(dest).unwrap();
         assert_eq!(content, "hello world\n");
@@ -167,7 +182,8 @@ mod tests {
         };
         let loc = SourceLocation::new("i-do-not-exist");
 
-        let ret = test::block_fn(|| download_source(http_source, loc, dest.clone()));
+        let downloader = HttpDownloader::new();
+        let ret = test::block_fn(|| downloader.download_source(http_source, loc, dest.clone()));
         assert_eq!(ret.unwrap(), DownloadStatus::NotFound);
     }
 

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -80,6 +80,7 @@ pub struct DownloadService {
     http: http::HttpDownloader,
     s3: s3::S3Downloader,
     gcs: gcs::GcsDownloader,
+    fs: filesystem::FilesystemDownloader,
 }
 
 impl DownloadService {
@@ -91,6 +92,7 @@ impl DownloadService {
             http: http::HttpDownloader::new(),
             s3: s3::S3Downloader::new(),
             gcs: gcs::GcsDownloader::new(),
+            fs: filesystem::FilesystemDownloader::new(),
         })
     }
 
@@ -114,7 +116,7 @@ impl DownloadService {
                 self.gcs.download_source(source, loc, destination).await
             }
             SourceFileId::Filesystem(source, loc) => {
-                filesystem::download_source(source, loc, destination)
+                self.fs.download_source(source, loc, destination)
             }
         }
     }
@@ -180,7 +182,7 @@ impl DownloadService {
             SourceConfig::Http(cfg) => Ok(self.http.list_files(cfg, filetypes, object_id)),
             SourceConfig::S3(cfg) => Ok(self.s3.list_files(cfg, filetypes, object_id)),
             SourceConfig::Gcs(cfg) => Ok(self.gcs.list_files(cfg, filetypes, object_id)),
-            SourceConfig::Filesystem(cfg) => Ok(filesystem::list_files(cfg, filetypes, object_id)),
+            SourceConfig::Filesystem(cfg) => Ok(self.fs.list_files(cfg, filetypes, object_id)),
         }
     }
 }


### PR DESCRIPTION
Continues work from #330 for the HTTP download source. This is in preparation of moving to reqwest.

#skip-changelog