### PR TITLE
ref(futures): Use futures' BoxFuture instead of our own alias

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,9 +37,8 @@ macro_rules! tryf03pin {
         match $e {
             Ok(value) => value,
             Err(e) => {
-                use ::std::pin::Pin;
-                return Box::pin(::futures::future::err(::std::convert::From::from(e)))
-                    as Pin<Box<dyn ::futures::future::Future<Output = _>>>;
+                use ::futures::future::FutureExt;
+                return ::futures::future::err(::std::convert::From::from(e)).boxed_local();
             }
         }
     };

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -13,16 +12,6 @@ use tokio::runtime::Runtime as TokioRuntime;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 
 static IS_TEST: AtomicBool = AtomicBool::new(false);
-
-/// A pinned, boxed future.
-///
-/// This is the type of future that [`futures::FutureExt::boxed`] would return.  This is
-/// pretty boring but clippy quickly complains about type complexity without this.
-///
-/// You would mainly use this if you are dealing with a trait methods which deals with
-/// futures.  Trait methods can not be async/await and using this type in their return value
-/// allows to integrate with async await code.
-pub type BoxedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
 /// Enables test mode of all thread pools and remote threads.
 ///


### PR DESCRIPTION
Turns out futures already has this type alias which works well with
the future combinators provided by the FutureExt trait.  So switch
over to this.

This ends up being more strongly typed, we need to be explicit about
lifetime and Send instead of letting the compiler resolve this.

**Note:** I started this to use an already defined type, but the
lifetime and Send specific versions of this do make it more
complicated.  The previous version was also closer to what async-trait
does and to what plain async/await does.  So **I actually am -1 on
merging this PR**.  Still, it's interesting to discuss and some code
does get a little bit more readable as now we can use the .boxed()
.boxed_local() combinators.

#skip-changelog