### PR TITLE
build: Alias tokio as tokio01

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ structopt = "0.3.2"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.1.0"
 thiserror = "1.0.20"
-tokio = "0.1.22"
+tokio01 = { version = "0.1.22", package = "tokio" }
 tokio-retry = "0.2.0"
 url = "1.7.2"
 url_serde = "0.2.0"

--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -7,7 +7,7 @@ use failure::{Error, Fail};
 use futures::future::{FutureExt, TryFutureExt};
 use futures01::{future::Either, Future, IntoFuture, Stream};
 use sentry::Hub;
-use tokio::codec::{BytesCodec, FramedRead};
+use tokio01::codec::{BytesCodec, FramedRead};
 
 use crate::actors::objects::{FindObject, ObjectFileBytes, ObjectPurpose};
 use crate::app::{ServiceApp, ServiceState};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -127,7 +127,7 @@ macro_rules! future_metrics {
     ($task_name:expr, $timeout:expr, $future:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use std::time::Instant;
         use futures01::future::{self, Either, Future};
-        use tokio::prelude::FutureExt;
+        use tokio01::prelude::FutureExt;
 
         let creation_time = Instant::now();
 

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -12,7 +12,7 @@ use futures::compat::{Future01CompatExt, Stream01CompatExt};
 use futures01::Stream;
 use parking_lot::Mutex;
 use rusoto_s3::S3;
-use tokio::codec::{BytesCodec, FramedRead};
+use tokio01::codec::{BytesCodec, FramedRead};
 
 use super::{DownloadError, DownloadStatus};
 use crate::sources::{FileType, S3SourceConfig, S3SourceKey, SourceFileId, SourceLocation};

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -8,8 +8,8 @@ use futures::channel::oneshot;
 use futures::compat::Future01CompatExt;
 use futures::{future, FutureExt, TryFutureExt};
 use futures01::future::Future as Future01;
-use tokio::prelude::FutureExt as TokioFutureExt;
-use tokio::runtime::Runtime as TokioRuntime;
+use tokio01::prelude::FutureExt as TokioFutureExt;
+use tokio01::runtime::Runtime as TokioRuntime;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 
 static IS_TEST: AtomicBool = AtomicBool::new(false);
@@ -61,7 +61,7 @@ impl ThreadPool {
         let inner = if cfg!(test) && IS_TEST.load(Ordering::Relaxed) {
             None
         } else {
-            let runtime = tokio::runtime::Builder::new().build().unwrap();
+            let runtime = tokio01::runtime::Builder::new().build().unwrap();
             Some(Arc::new(runtime))
         };
 
@@ -210,7 +210,7 @@ impl RemoteThread {
                     .boxed_local()
                     .compat()
                     .timeout(timeout)
-                    .then(move |r: Result<T, tokio::timer::timeout::Error<()>>| {
+                    .then(move |r: Result<T, tokio01::timer::timeout::Error<()>>| {
                         metric!(
                             timer("futures.done") = start_time.elapsed(),
                             "task_name" => task_name,
@@ -287,7 +287,7 @@ impl Drop for CallOnDrop {
 
 /// Delay aka sleep for a given duration
 pub async fn delay(duration: Duration) {
-    tokio::timer::Delay::new(Instant::now() + duration)
+    tokio01::timer::Delay::new(Instant::now() + duration)
         .compat()
         .await
         .ok();

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -12,8 +12,8 @@ use actix_web::{http::header, HttpMessage};
 use futures::compat::Future01CompatExt;
 use futures01::{future::Either, Async, Future, IntoFuture, Poll};
 use ipnetwork::Ipv4Network;
-use tokio::net::{tcp::ConnectFuture, TcpStream};
-use tokio::timer::Delay;
+use tokio01::net::{tcp::ConnectFuture, TcpStream};
+use tokio01::timer::Delay;
 use url::Url;
 
 lazy_static::lazy_static! {


### PR DESCRIPTION
Since tokio 1.0 is out, we will slowly start to migrate over. See #335 for part
of this effort. In order to do this, we need to load both tokio versions
side-by-side, which requires aliasing the old version to `tokio01`.

#skip-changelog

