### PR TITLE
ref(symsorter): Implement multi-threading

### DIFF
--- a/symsorter/Cargo.lock
+++ b/symsorter/Cargo.lock
@@ -173,12 +173,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -321,15 +373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -573,6 +635,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -782,11 +869,9 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
  "console",
- "itertools 0.10.0",
  "lazy_static",
- "parking_lot",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -1042,6 +1127,6 @@ checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
 dependencies = [
  "cc",
  "glob",
- "itertools 0.9.0",
+ "itertools",
  "libc",
 ]

--- a/symsorter/Cargo.toml
+++ b/symsorter/Cargo.toml
@@ -5,18 +5,16 @@ authors = ["Sentry <hello@getsentry.com>"]
 edition = "2018"
 
 [dependencies]
-structopt = "0.3.21"
-clap = "2.33.3"
 anyhow = "1.0.37"
-walkdir = "2.3.1"
-symbolic = { version="8.0.2", features = ["debuginfo-serde"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
-zstd = "0.6.0"
-itertools = "0.10.0"
-zip = "0.5.9"
-parking_lot = "0.11.1"
+lazy_static = "1.4.0"
+rayon = "1.5.0"
+regex = "1.4.3"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"
-chrono = { version = "0.4.19", features = ["serde"] }
-regex = "1.4.3"
-lazy_static = "1.4.0"
+structopt = "0.3.21"
+symbolic = { version="8.0.2", features = ["debuginfo-serde"] }
+walkdir = "2.3.1"
+zip = "0.5.9"
+zstd = "0.6.0"

--- a/symsorter/src/app.rs
+++ b/symsorter/src/app.rs
@@ -214,8 +214,8 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     bv,
                     path.file_name().unwrap().to_string_lossy().to_string(),
                 )? {
-                    let mut source_candidates = source_candidates.lock().unwrap();
                     if sort_config.with_sources {
+                        let mut source_candidates = source_candidates.lock().unwrap();
                         if object_kind == ObjectKind::Sources {
                             source_candidates.insert(unified_id.clone(), None);
                         } else if object_kind == ObjectKind::Debug

--- a/symsorter/src/app.rs
+++ b/symsorter/src/app.rs
@@ -1,14 +1,15 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use console::style;
+use rayon::prelude::*;
 use serde::Serialize;
-use serde_json;
 use structopt::StructOpt;
 use symbolic::common::{Arch, ByteView};
 use symbolic::debuginfo::{Archive, FileFormat, ObjectKind};
@@ -169,28 +170,25 @@ fn process_file(
     Ok(rv)
 }
 
-fn sort_files<'a, I: Iterator<Item = &'a Path>>(
-    sort_config: &SortConfig,
-    paths: I,
-) -> Result<(usize, usize)> {
+fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, usize)> {
     let mut source_bundles_created = 0;
-    let mut source_candidates: HashMap<String, Option<PathBuf>> = HashMap::new();
-    let mut bundle_meta = BundleMeta {
-        name: sort_config.bundle_id.to_string(),
-        timestamp: Utc::now(),
-        debug_ids: vec![],
-    };
+    let source_candidates = Mutex::new(HashMap::<String, Option<PathBuf>>::new());
+    let debug_ids = Mutex::new(Vec::new());
 
-    for path in paths {
-        for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-            if !entry.metadata().ok().map_or(false, |x| x.is_file()) {
-                continue;
-            }
+    log!("{}", style("Sorting debug information files").bold());
 
+    paths
+        .into_iter()
+        .map(WalkDir::new)
+        .flatten()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.metadata().ok().map_or(false, |x| x.is_file()))
+        .par_bridge()
+        .map(|entry| {
             let path = entry.path();
             let bv = match ByteView::open(path) {
                 Ok(bv) => bv,
-                Err(_) => continue,
+                Err(_) => return Ok(()),
             };
 
             // zip archive
@@ -201,7 +199,7 @@ fn sort_files<'a, I: Iterator<Item = &'a Path>>(
                     let name = zip_file.name().rsplit('/').next().unwrap().to_string();
                     let bv = ByteView::read(zip_file)?;
                     if Archive::peek(&bv) != FileFormat::Unknown {
-                        bundle_meta.debug_ids.extend(
+                        debug_ids.lock().unwrap().extend(
                             process_file(&sort_config, bv, name)?
                                 .into_iter()
                                 .map(|x| x.0),
@@ -216,6 +214,7 @@ fn sort_files<'a, I: Iterator<Item = &'a Path>>(
                     bv,
                     path.file_name().unwrap().to_string_lossy().to_string(),
                 )? {
+                    let mut source_candidates = source_candidates.lock().unwrap();
                     if sort_config.with_sources {
                         if object_kind == ObjectKind::Sources {
                             source_candidates.insert(unified_id.clone(), None);
@@ -225,34 +224,51 @@ fn sort_files<'a, I: Iterator<Item = &'a Path>>(
                             source_candidates.insert(unified_id.clone(), Some(path.to_path_buf()));
                         }
                     }
-                    bundle_meta.debug_ids.push(unified_id);
+                    debug_ids.lock().unwrap().push(unified_id);
                 }
             }
-        }
-    }
 
-    // we have some sources we want to build
+            Ok(())
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     if sort_config.with_sources {
         log!("{}", style("Creating source bundles").bold());
-        for (unified_id, path) in source_candidates.into_iter() {
-            if let Some(path) = path {
-                if let Some(source_bundle) = create_source_bundle(&path, &unified_id)? {
-                    bundle_meta.debug_ids.extend(
-                        process_file(
-                            &sort_config,
-                            source_bundle,
-                            path.file_name().unwrap().to_string_lossy().to_string(),
-                        )?
-                        .into_iter()
-                        .map(|x| x.0),
-                    );
-                    source_bundles_created += 1;
-                }
-            }
-        }
+        source_bundles_created = source_candidates
+            .into_inner()
+            .unwrap()
+            .into_par_iter()
+            .filter_map(|(id, path)| Some((id, path?)))
+            .map(|(unified_id, path)| -> Result<usize> {
+                let source_bundle = match create_source_bundle(&path, &unified_id)? {
+                    Some(source_bundle) => source_bundle,
+                    None => return Ok(0),
+                };
+
+                let processed_objects = process_file(
+                    &sort_config,
+                    source_bundle,
+                    path.file_name().unwrap().to_string_lossy().to_string(),
+                )?;
+
+                debug_ids
+                    .lock()
+                    .unwrap()
+                    .extend(processed_objects.into_iter().map(|x| x.0));
+
+                Ok(1)
+            })
+            .reduce(|| Ok(0), |sum, res| Ok(sum? + res?))?
     }
 
-    // write bundle meta
+    log!("{}", style("Writing bundle meta data").bold());
+
+    let bundle_meta = BundleMeta {
+        name: sort_config.bundle_id.clone(),
+        timestamp: Utc::now(),
+        debug_ids: debug_ids.into_inner().unwrap(),
+    };
+
     let bundle_meta_filename = RunConfig::get()
         .output
         .join("bundles")
@@ -285,8 +301,6 @@ fn execute() -> Result<()> {
         log!();
     }
 
-    log!("{}", style("Sorting debug information files").bold());
-
     let mut debug_files = 0;
     let mut source_bundles = 0;
     let mut sort_config = SortConfig {
@@ -296,11 +310,11 @@ fn execute() -> Result<()> {
     };
 
     if cli.multiple_bundles {
-        for path in cli.input.iter() {
+        for path in cli.input.into_iter() {
             sort_config.bundle_id = make_bundle_id(&path.file_name().unwrap().to_string_lossy());
             log!("[bundle: {}]", style(&sort_config.bundle_id).dim());
             let (debug_files_sorted, source_bundles_created) =
-                sort_files(&sort_config, Some(path.as_path()).into_iter())?;
+                sort_files(&sort_config, vec![path])?;
             debug_files += debug_files_sorted;
             source_bundles *= source_bundles_created;
         }
@@ -308,8 +322,7 @@ fn execute() -> Result<()> {
         let bundle_id = cli.bundle_id.unwrap();
         anyhow::ensure!(is_bundle_id(&bundle_id), "Invalid bundle id");
         sort_config.bundle_id = bundle_id;
-        let (debug_files_sorted, source_bundles_created) =
-            sort_files(&sort_config, cli.input.iter().map(|x| x.as_path()))?;
+        let (debug_files_sorted, source_bundles_created) = sort_files(&sort_config, cli.input)?;
         debug_files += debug_files_sorted;
         source_bundles *= source_bundles_created;
     }


### PR DESCRIPTION
Uses `rayon` to move file handling and source bundle creation into a thread
pool. The main thread walks the given paths and continuously produces paths into
the thread pool. In the worker threads, the file is opened, inspected, and
potentially processed. The maximum number of concurrent files at any given time
therefore is `ncpu`.

Note that this is optimized for sorting directories with a high density object
files.

#skip-changelog
