### PR TITLE
ci(periodic): Rename workflow and job names

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,4 +1,4 @@
-name: Nightly CI
+name: Periodic CI
 
 on:
   schedule:
@@ -8,7 +8,7 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  test:
+  lint-and-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -27,6 +27,7 @@ jobs:
       - name: Run clippy ${{ matrix.rust }}
         uses: actions-rs/clippy-check@v1
         with:
+          name: clippy-${{ matrix.rust }}-periodic
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --workspace --tests --examples
 


### PR DESCRIPTION
The workflow rename is so that it makes a bit more sense.  The job
renames are another attempt at getting github to show the annotations
correctly.  If this still doesn't work perhaps just using the cargo
action is a better option.

#skip-changelog