### PR TITLE
ci(periodic): Allow manually triggering the workflow

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -3,7 +3,7 @@ name: Periodic CI
 on:
   schedule:
     - cron: '11 7 * * 1,4'
-  workflow_dispatch
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -3,6 +3,7 @@ name: Periodic CI
 on:
   schedule:
     - cron: '11 7 * * 1,4'
+  workflow_dispatch
 
 env:
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
It's useful to be able to run the periodic workflow instead of having
to wait until the next time it triggers.  Apparently this needs to be
explicitly enabled.

#skip-changelog