### PR TITLE
ci(periodic): Use cargo action for clippy

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -26,10 +26,9 @@ jobs:
           components: clippy
 
       - name: Run clippy ${{ matrix.rust }}
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
-          name: clippy-${{ matrix.rust }}-periodic
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-features --workspace --tests --examples
 
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Giving up on this.

Run clippy with the cargo action.  The annotations from the clippy
action end up in the wrong place and github can't figure this out.
Running the cargo action still annotates via stdout plus it doesn't
run the actualy command with json output so humans can read it anyway.

#skip-changelog