### PR TITLE
ci: Run clippy via the cargo action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Run clipppy
-        uses: actions-rs/clippy-check@v1
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-features --workspace --tests --examples
 
   unit-test:

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -22,7 +22,7 @@ use crate::types::Scope;
 /// The malformed state is useful for failed computations that are unlikely to succeed before the
 /// next deploy. For example, symcache writing may fail due to an object file symbolic can't parse
 /// yet.
-pub const MALFORMED_MARKER: &'static [u8] = b"malformed";
+pub const MALFORMED_MARKER: &[u8] = b"malformed";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CacheStatus {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -22,7 +22,7 @@ use crate::types::Scope;
 /// The malformed state is useful for failed computations that are unlikely to succeed before the
 /// next deploy. For example, symcache writing may fail due to an object file symbolic can't parse
 /// yet.
-pub const MALFORMED_MARKER: &[u8] = b"malformed";
+pub const MALFORMED_MARKER: &'static [u8] = b"malformed";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CacheStatus {


### PR DESCRIPTION
Switches to the standard cargo action for running clippy lints since it
emits sane CI output while still creating annotations in GitHub.

#skip-changelog