### PR TITLE
ref(downloader): Cleanup location utilities

### DIFF
--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -44,7 +44,7 @@ impl FilesystemObjectFileSource {
     /// not provide a hostname nor percent-encode.  Use this only for diagnostics and use
     /// [`FilesystemObjectFileSource::path`] if the actual file location is needed.
     pub fn uri(&self) -> ObjectFileSourceURI {
-        format!("file:///{path}", path = self.path().display()).into()
+        format!("file:///{}", self.path().display()).into()
     }
 }
 

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -10,7 +10,6 @@ use futures::prelude::*;
 use reqwest::{header, Client};
 use url::Url;
 
-use super::locations::join_url_encoded;
 use super::{
     DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI, SourceLocation,
     USER_AGENT,
@@ -46,7 +45,7 @@ impl HttpObjectFileSource {
 
     /// Returns the URL from which to download this object file.
     pub fn url(&self) -> Result<Url> {
-        join_url_encoded(&self.source.url, &self.location)
+        self.location.to_url(&self.source.url)
     }
 }
 


### PR DESCRIPTION
In preparation of upgrading the `url` crate, this PR applies a few
syntactic changes to location utilities and downloaders. There is no
change in behavior.

- Move constants to the top of the code file
- Make location utilities methods on `SourceLocation`
- For brevity, use shorter `format!` statements

#skip-changelog