### PR TITLE
feat: Update `url` to 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,8 +3622,7 @@ dependencies = [
  "tokio 0.1.22",
  "tokio 1.0.1",
  "tokio-retry",
- "url 1.7.2",
- "url_serde",
+ "url 2.2.0",
  "uuid 0.8.1",
  "zstd",
 ]
@@ -4394,16 +4393,6 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
  "serde",
-]
-
-[[package]]
-name = "url_serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
-dependencies = [
- "serde",
- "url 1.7.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,7 @@ thiserror = "1.0.20"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 tokio01 = { version = "0.1.22", package = "tokio" }
 tokio-retry = "0.2.0"
-url = "1.7.2"
-url_serde = "0.2.0"
+url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 zstd = "0.5.1"
 

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -44,7 +44,7 @@ impl FilesystemObjectFileSource {
     /// not provide a hostname nor percent-encode.  Use this only for diagnostics and use
     /// [`FilesystemObjectFileSource::path`] if the actual file location is needed.
     pub fn uri(&self) -> ObjectFileSourceURI {
-        format!("file:///{path}", path = self.path().display()).into()
+        format!("file:///{}", self.path().display()).into()
     }
 }
 

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -10,7 +10,6 @@ use futures::prelude::*;
 use reqwest::{header, Client};
 use url::Url;
 
-use super::locations::join_url_encoded;
 use super::{
     DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI, SourceLocation,
     USER_AGENT,
@@ -46,7 +45,7 @@ impl HttpObjectFileSource {
 
     /// Returns the URL from which to download this object file.
     pub fn url(&self) -> Result<Url> {
-        join_url_encoded(&self.source.url, &self.location)
+        self.location.to_url(&self.source.url)
     }
 }
 

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -72,7 +72,7 @@ impl HttpDownloader {
 
         log::debug!("Fetching debug file from {}", download_url);
         let response = future_utils::retry(|| {
-            let mut builder = self.client.get(download_url.as_str());
+            let mut builder = self.client.get(download_url.clone());
 
             for (key, value) in file_source.source.headers.iter() {
                 if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -115,7 +115,7 @@ impl SentryDownloader {
     ) -> Result<Vec<SearchResult>, SentryError> {
         let response = self
             .client
-            .get(query.index_url.as_str())
+            .get(query.index_url.clone())
             .header("Accept-Encoding", "identity")
             .header("User-Agent", USER_AGENT)
             .header("Authorization", format!("Bearer {}", &query.token))
@@ -223,7 +223,7 @@ impl SentryDownloader {
         log::debug!("Fetching debug file from {}", download_url);
         let result = future_utils::retry(|| {
             self.client
-                .get(download_url.as_str())
+                .get(download_url.clone())
                 .header("User-Agent", USER_AGENT)
                 .header(
                     "Authorization",

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -107,7 +107,6 @@ pub struct SentrySourceConfig {
     pub id: SourceId,
 
     /// Absolute URL of the endpoint.
-    #[serde(with = "url_serde")]
     pub url: Url,
 
     /// Bearer authorization token.
@@ -121,7 +120,6 @@ pub struct HttpSourceConfig {
     pub id: SourceId,
 
     /// Absolute URL of the symbol server.
-    #[serde(with = "url_serde")]
     pub url: Url,
 
     /// Additional headers to be sent to the symbol server with every request.


### PR DESCRIPTION
Updates the URL crate to 2.2.0. This allows us to pass the URL directly to the web client without going through a second parse stage.

With version 2, the `url::percent_encoding` module is no longer exposed. Instead, we have to use `Url::path_segments_mut` to construct a URL with encoded path segments.

#skip-changelog