### PR TITLE
build: Update insta and yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,15 +533,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "terminal_size",
- "termios",
  "winapi 0.3.8",
 ]
 
@@ -1552,11 +1551,11 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.3.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863bf97e7130bf788f29a99bc4073735af6b8ecc3da6a39c23b3a688d2d3109a"
+checksum = "bca6f2bcc5e2ce13f3652ecd05a643b986d035add3f0c38fbabd78f723b5f7e9"
 dependencies = [
- "console 0.12.0",
+ "console 0.14.0",
  "difference",
  "lazy_static",
  "pest",
@@ -1564,6 +1563,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -3190,18 +3190,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.3",
@@ -3210,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -3257,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
+checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -4718,9 +4718,9 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 zstd = "0.5.1"
 
 [dev-dependencies]
-insta = { version = "1.3.0", features = ["redactions"] }
+insta = { version = "1.5.2", features = ["redactions"] }
 procspawn = { version = "0.9.0", features = ["test-support"] }
 sha-1 = "0.9.2"
 

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__add_bucket-2.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__add_bucket-2.snap
@@ -7,10 +7,10 @@ stacktraces:
   - frames:
       - status: symbolicated
         original_index: 0
-        instruction_addr: 0x100000fa0
+        instruction_addr: "0x100000fa0"
         lang: c
         symbol: main
-        sym_addr: 0x100000fa0
+        sym_addr: "0x100000fa0"
         function: main
         filename: hello.c
         abs_path: /tmp/hello.c
@@ -26,7 +26,7 @@ modules:
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7
-    image_addr: 0x100000000
+    image_addr: "0x100000000"
     image_size: 4096
     candidates:
       - source: local

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__add_bucket.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__add_bucket.snap
@@ -7,7 +7,7 @@ stacktraces:
   - frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x100000fa0
+        instruction_addr: "0x100000fa0"
 modules:
   - debug_status: missing
     features:
@@ -19,5 +19,5 @@ modules:
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7
-    image_addr: 0x100000000
+    image_addr: "0x100000000"
     image_size: 4096

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__apple_crash_report.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__apple_crash_report.snap
@@ -19,96 +19,96 @@ stacktraces:
     frames:
       - status: unknown_image
         original_index: 0
-        instruction_addr: 0x7fff61bc6c2a
+        instruction_addr: "0x7fff61bc6c2a"
         package: libsystem_kernel.dylib
       - status: unknown_image
         original_index: 1
-        instruction_addr: 0x7fff349f505e
+        instruction_addr: "0x7fff349f505e"
         package: CoreFoundation
       - status: unknown_image
         original_index: 2
-        instruction_addr: 0x7fff349f45ad
+        instruction_addr: "0x7fff349f45ad"
         package: CoreFoundation
       - status: unknown_image
         original_index: 3
-        instruction_addr: 0x7fff349f3ce4
+        instruction_addr: "0x7fff349f3ce4"
         package: CoreFoundation
       - status: unknown_image
         original_index: 4
-        instruction_addr: 0x7fff33c8d895
+        instruction_addr: "0x7fff33c8d895"
         package: HIToolbox
       - status: unknown_image
         original_index: 5
-        instruction_addr: 0x7fff33c8d5cb
+        instruction_addr: "0x7fff33c8d5cb"
         package: HIToolbox
       - status: unknown_image
         original_index: 6
-        instruction_addr: 0x7fff33c8d348
+        instruction_addr: "0x7fff33c8d348"
         package: HIToolbox
       - status: unknown_image
         original_index: 7
-        instruction_addr: 0x7fff31f4a95b
+        instruction_addr: "0x7fff31f4a95b"
         package: AppKit
       - status: unknown_image
         original_index: 8
-        instruction_addr: 0x7fff31f496fa
+        instruction_addr: "0x7fff31f496fa"
         package: AppKit
       - status: unknown_image
         original_index: 9
-        instruction_addr: 0x7fff31f4375d
+        instruction_addr: "0x7fff31f4375d"
         package: AppKit
       - status: missing
         original_index: 10
-        instruction_addr: 0x108b7092b
+        instruction_addr: "0x108b7092b"
         package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
       - status: missing
         original_index: 11
-        instruction_addr: 0x108b702a6
+        instruction_addr: "0x108b702a6"
         package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
       - status: unknown_image
         original_index: 12
-        instruction_addr: 0x7fff61a8e085
+        instruction_addr: "0x7fff61a8e085"
         package: libdyld.dylib
       - status: unknown_image
         original_index: 13
-        instruction_addr: 0xea004
+        instruction_addr: "0xea004"
         package: YetanotherMac
   - thread_id: 1
     is_requesting: true
     registers:
-      cs: 0x2b
-      fs: 0x0
-      gs: 0x0
-      r10: 0x0
-      r11: 0xffffffff
-      r12: 0x8
-      r13: 0x11e800b00
-      r14: 0x1
-      r15: 0x0
-      r8: 0x3
-      r9: 0x10
-      rax: 0x20261bb4775b008f
-      rbp: 0x700015a616d0
-      rbx: 0x0
-      rcx: 0x1288266c0
-      rdi: 0x0
-      rdx: 0x1
-      rflags: 0x10206
-      rip: 0x1090a0132
-      rsi: 0x0
-      rsp: 0x700015a613f0
+      cs: "0x2b"
+      fs: "0x0"
+      gs: "0x0"
+      r10: "0x0"
+      r11: "0xffffffff"
+      r12: "0x8"
+      r13: "0x11e800b00"
+      r14: "0x1"
+      r15: "0x0"
+      r8: "0x3"
+      r9: "0x10"
+      rax: "0x20261bb4775b008f"
+      rbp: "0x700015a616d0"
+      rbx: "0x0"
+      rcx: "0x1288266c0"
+      rdi: "0x0"
+      rdx: "0x1"
+      rflags: "0x10206"
+      rip: "0x1090a0132"
+      rsi: "0x0"
+      rsp: "0x700015a613f0"
     frames:
       - status: unknown_image
         original_index: 0
-        instruction_addr: 0x7fff61bc85be
+        instruction_addr: "0x7fff61bc85be"
         package: libsystem_kernel.dylib
       - status: unknown_image
         original_index: 1
-        instruction_addr: 0x7fff61c7f415
+        instruction_addr: "0x7fff61c7f415"
         package: libsystem_pthread.dylib
       - status: unknown_image
         original_index: 2
-        instruction_addr: 0x54485244
+        instruction_addr: "0x54485244"
 modules:
   - debug_status: missing
     features:
@@ -122,7 +122,7 @@ modules:
     code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
     debug_id: 2d903291-397d-3d14-bfca-52c7fb8c5e00
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    image_addr: 0x10864e000
+    image_addr: "0x10864e000"
     image_size: 108797951
     candidates:
       - source: local
@@ -149,7 +149,7 @@ modules:
     code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3PROFILE.dylib
     debug_id: 6deccee4-a052-3ea4-bb67-957b06f53ad1
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3PROFILE.dylib
-    image_addr: 0x112bb2000
+    image_addr: "0x112bb2000"
     image_size: 2170879
   - debug_status: unused
     features:
@@ -163,7 +163,7 @@ modules:
     code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CookingPROFILE.dylib
     debug_id: 5e012a64-6cc5-36f1-9b4d-a0564049169b
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CookingPROFILE.dylib
-    image_addr: 0x112fc0000
+    image_addr: "0x112fc0000"
     image_size: 221183
   - debug_status: unused
     features:
@@ -177,7 +177,7 @@ modules:
     code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CommonPROFILE.dylib
     debug_id: 9c198544-7194-3de6-b67e-4cc27eed2eab
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPhysX3CommonPROFILE.dylib
-    image_addr: 0x113013000
+    image_addr: "0x113013000"
     image_size: 1474559
   - debug_status: unused
     features:
@@ -191,5 +191,5 @@ modules:
     code_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxFoundationPROFILE.dylib
     debug_id: 890f0997-f904-3544-9af7-cf011f09a06e
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxFoundationPROFILE.dylib
-    image_addr: 0x1131fa000
+    image_addr: "0x1131fa000"
     image_size: 28671

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_linux.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_linux.snap
@@ -17,97 +17,97 @@ stacktraces:
   - thread_id: 1304
     is_requesting: true
     registers:
-      r10: 0x131
-      r11: 0x7f5140aca4c0
-      r12: 0x401dc0
-      r13: 0x7fff5ae4ac90
-      r14: 0x7fff5ae4aab0
-      r15: 0x0
-      r8: 0x0
-      r9: 0x0
-      rax: 0xffffffffffffffff
-      rbp: 0x7fff5ae4abb0
-      rbx: 0x7fff5ae4aa20
-      rcx: 0x7f5140521b20
-      rdi: 0x7fff5ae4aab0
-      rdx: 0x7f5140efc000
-      rip: 0x401d72
-      rsi: 0x0
-      rsp: 0x7fff5ae4aa20
+      r10: "0x131"
+      r11: "0x7f5140aca4c0"
+      r12: "0x401dc0"
+      r13: "0x7fff5ae4ac90"
+      r14: "0x7fff5ae4aab0"
+      r15: "0x0"
+      r8: "0x0"
+      r9: "0x0"
+      rax: "0xffffffffffffffff"
+      rbp: "0x7fff5ae4abb0"
+      rbx: "0x7fff5ae4aa20"
+      rcx: "0x7f5140521b20"
+      rdi: "0x7fff5ae4aab0"
+      rdx: "0x7f5140efc000"
+      rip: "0x401d72"
+      rsi: "0x0"
+      rsp: "0x7fff5ae4aa20"
     frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x401d72
+        instruction_addr: "0x401d72"
         package: /work/linux/build/crash
         trust: context
       - status: missing
         original_index: 1
-        instruction_addr: 0x7f514025002e
+        instruction_addr: "0x7f514025002e"
         package: /lib/x86_64-linux-gnu/libc-2.23.so
         trust: scan
       - status: missing
         original_index: 2
-        instruction_addr: 0x7f51401e4800
+        instruction_addr: "0x7f51401e4800"
         package: /lib/x86_64-linux-gnu/libc-2.23.so
         trust: scan
       - status: missing
         original_index: 3
-        instruction_addr: 0x7f5140cebac6
+        instruction_addr: "0x7f5140cebac6"
         package: /lib/x86_64-linux-gnu/ld-2.23.so
         trust: scan
       - status: missing
         original_index: 4
-        instruction_addr: 0x401ec0
+        instruction_addr: "0x401ec0"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 5
-        instruction_addr: 0x414c30
+        instruction_addr: "0x414c30"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 6
-        instruction_addr: 0x7f514017d830
+        instruction_addr: "0x7f514017d830"
         package: /lib/x86_64-linux-gnu/libc-2.23.so
         trust: scan
       - status: missing
         original_index: 7
-        instruction_addr: 0x401c70
+        instruction_addr: "0x401c70"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 8
-        instruction_addr: 0x401dc0
+        instruction_addr: "0x401dc0"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 9
-        instruction_addr: 0x401c70
+        instruction_addr: "0x401c70"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 10
-        instruction_addr: 0x414ca0
+        instruction_addr: "0x414ca0"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 11
-        instruction_addr: 0x401dc0
+        instruction_addr: "0x401dc0"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 12
-        instruction_addr: 0x401de9
+        instruction_addr: "0x401de9"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 13
-        instruction_addr: 0x400040
+        instruction_addr: "0x400040"
         package: /work/linux/build/crash
         trust: scan
       - status: missing
         original_index: 14
-        instruction_addr: 0x401dc0
+        instruction_addr: "0x401dc0"
         package: /work/linux/build/crash
         trust: scan
 modules:
@@ -124,7 +124,7 @@ modules:
     code_file: /work/linux/build/crash
     debug_id: c0bcc3f1-9827-fe65-3058-404b2831d9e6
     debug_file: /work/linux/build/crash
-    image_addr: 0x400000
+    image_addr: "0x400000"
     image_size: 106496
     candidates:
       - source: local
@@ -152,7 +152,7 @@ modules:
     code_file: /lib/x86_64-linux-gnu/libm-2.23.so
     debug_id: e45db8df-af2d-09fd-640c-8fe377d572de
     debug_file: /lib/x86_64-linux-gnu/libm-2.23.so
-    image_addr: 0x7f513fe54000
+    image_addr: "0x7f513fe54000"
     image_size: 1081344
   - debug_status: missing
     unwind_status: missing
@@ -167,7 +167,7 @@ modules:
     code_file: /lib/x86_64-linux-gnu/libc-2.23.so
     debug_id: 451a38b5-0679-79d2-0738-22a5ceb24c4b
     debug_file: /lib/x86_64-linux-gnu/libc-2.23.so
-    image_addr: 0x7f514015d000
+    image_addr: "0x7f514015d000"
     image_size: 1835008
     candidates:
       - source: local
@@ -195,7 +195,7 @@ modules:
     code_file: /lib/x86_64-linux-gnu/libgcc_s.so.1
     debug_id: e20a2268-5dc6-c165-b6aa-a12fa6765a6e
     debug_file: /lib/x86_64-linux-gnu/libgcc_s.so.1
-    image_addr: 0x7f5140527000
+    image_addr: "0x7f5140527000"
     image_size: 90112
   - debug_status: unused
     unwind_status: unused
@@ -210,7 +210,7 @@ modules:
     code_file: /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
     debug_id: 81c893cb-9b92-3c52-01ac-ef171b52d526
     debug_file: /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
-    image_addr: 0x7f514073d000
+    image_addr: "0x7f514073d000"
     image_size: 1515520
   - debug_status: unused
     unwind_status: unused
@@ -225,7 +225,7 @@ modules:
     code_file: /lib/x86_64-linux-gnu/libpthread-2.23.so
     debug_id: 23e017ce-2254-fc65-11d9-bc8f534bb4f0
     debug_file: /lib/x86_64-linux-gnu/libpthread-2.23.so
-    image_addr: 0x7f5140abf000
+    image_addr: "0x7f5140abf000"
     image_size: 98304
   - debug_status: missing
     unwind_status: missing
@@ -240,7 +240,7 @@ modules:
     code_file: /lib/x86_64-linux-gnu/ld-2.23.so
     debug_id: 59627b5d-2255-a375-c17b-d4c3fd05f5a6
     debug_file: /lib/x86_64-linux-gnu/ld-2.23.so
-    image_addr: 0x7f5140cdc000
+    image_addr: "0x7f5140cdc000"
     image_size: 155648
     candidates:
       - source: local
@@ -268,5 +268,5 @@ modules:
     code_file: linux-gate.so
     debug_id: 75185f6c-04b9-b48f-b8df-d832e74ad31a
     debug_file: linux-gate.so
-    image_addr: 0x7fff5aef1000
+    image_addr: "0x7fff5aef1000"
     image_size: 8192

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_macos.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_macos.snap
@@ -17,42 +17,42 @@ stacktraces:
   - thread_id: 775
     is_requesting: true
     registers:
-      r10: 0x2e
-      r11: 0x7fffe8105171
-      r12: 0x0
-      r13: 0x0
-      r14: 0x0
-      r15: 0x0
-      r8: 0xc0008ff
-      r9: 0x0
-      rax: 0x1
-      rbp: 0x7fff56064258
-      rbx: 0x7fff56064120
-      rcx: 0x0
-      rdi: 0x7fff56064120
-      rdx: 0x0
-      rip: 0x109ba8c15
-      rsi: 0x7fff56064140
-      rsp: 0x7fff56064110
+      r10: "0x2e"
+      r11: "0x7fffe8105171"
+      r12: "0x0"
+      r13: "0x0"
+      r14: "0x0"
+      r15: "0x0"
+      r8: "0xc0008ff"
+      r9: "0x0"
+      rax: "0x1"
+      rbp: "0x7fff56064258"
+      rbx: "0x7fff56064120"
+      rcx: "0x0"
+      rdi: "0x7fff56064120"
+      rdx: "0x0"
+      rip: "0x109ba8c15"
+      rsi: "0x7fff56064140"
+      rsp: "0x7fff56064110"
     frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x109ba8c15
+        instruction_addr: "0x109ba8c15"
         package: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
         trust: context
       - status: missing
         original_index: 1
-        instruction_addr: 0x109ba8c70
+        instruction_addr: "0x109ba8c70"
         package: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
         trust: scan
       - status: missing
         original_index: 2
-        instruction_addr: 0x7fffe7eeb235
+        instruction_addr: "0x7fffe7eeb235"
         package: /usr/lib/system/libdyld.dylib
         trust: scan
       - status: missing
         original_index: 3
-        instruction_addr: 0x7fffe7eeb235
+        instruction_addr: "0x7fffe7eeb235"
         package: /usr/lib/system/libdyld.dylib
         trust: scan
 modules:
@@ -69,7 +69,7 @@ modules:
     code_file: /Users/travis/build/getsentry/breakpad-tools/macos/build/./crash
     debug_id: 67e9247c-814e-392b-a027-dbde6748fcbf
     debug_file: crash
-    image_addr: 0x109b9b000
+    image_addr: "0x109b9b000"
     image_size: 69632
     candidates:
       - source: local
@@ -97,7 +97,7 @@ modules:
     code_file: /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     debug_id: 36385a3a-60d3-32db-bf55-c6d8931a7aa6
     debug_file: CoreFoundation
-    image_addr: 0x7fffd229c000
+    image_addr: "0x7fffd229c000"
     image_size: 4800512
   - debug_status: unused
     unwind_status: unused
@@ -112,7 +112,7 @@ modules:
     code_file: /usr/lib/libDiagnosticMessagesClient.dylib
     debug_id: 84a04d24-0e60-3810-a8c0-90a65e2df61a
     debug_file: libDiagnosticMessagesClient.dylib
-    image_addr: 0x7fffe668e000
+    image_addr: "0x7fffe668e000"
     image_size: 8192
   - debug_status: unused
     unwind_status: unused
@@ -127,7 +127,7 @@ modules:
     code_file: /usr/lib/libSystem.B.dylib
     debug_id: f18ac1e7-c6f1-34b1-8069-be571b3231d4
     debug_file: libSystem.B.dylib
-    image_addr: 0x7fffe68cd000
+    image_addr: "0x7fffe68cd000"
     image_size: 8192
   - debug_status: unused
     unwind_status: unused
@@ -142,7 +142,7 @@ modules:
     code_file: /usr/lib/libc++.1.dylib
     debug_id: 0b43bb5d-e6eb-3464-8de9-b41ac8ed9d1c
     debug_file: libc++.1.dylib
-    image_addr: 0x7fffe6a80000
+    image_addr: "0x7fffe6a80000"
     image_size: 356352
   - debug_status: unused
     unwind_status: unused
@@ -157,7 +157,7 @@ modules:
     code_file: /usr/lib/libc++abi.dylib
     debug_id: bc271ad3-831b-362a-9da7-e8c51f285fe4
     debug_file: libc++abi.dylib
-    image_addr: 0x7fffe6ad7000
+    image_addr: "0x7fffe6ad7000"
     image_size: 172032
   - debug_status: unused
     unwind_status: unused
@@ -172,7 +172,7 @@ modules:
     code_file: /usr/lib/libicucore.A.dylib
     debug_id: ccd2ed24-3071-383b-925d-8d763bb12a6f
     debug_file: libicucore.A.dylib
-    image_addr: 0x7fffe7041000
+    image_addr: "0x7fffe7041000"
     image_size: 2252800
   - debug_status: unused
     unwind_status: unused
@@ -187,7 +187,7 @@ modules:
     code_file: /usr/lib/libobjc.A.dylib
     debug_id: 4df3c25c-52c2-3f01-a3ef-0d9d53a73c1c
     debug_file: libobjc.A.dylib
-    image_addr: 0x7fffe75f5000
+    image_addr: "0x7fffe75f5000"
     image_size: 4022272
   - debug_status: unused
     unwind_status: unused
@@ -202,7 +202,7 @@ modules:
     code_file: /usr/lib/libz.1.dylib
     debug_id: 46e3ffa2-4328-327a-8d34-a03e20bffb8e
     debug_file: libz.1.dylib
-    image_addr: 0x7fffe7def000
+    image_addr: "0x7fffe7def000"
     image_size: 73728
   - debug_status: unused
     unwind_status: unused
@@ -217,7 +217,7 @@ modules:
     code_file: /usr/lib/system/libcache.dylib
     debug_id: 093a4dab-8385-3d47-a350-e20cb7ccf7bf
     debug_file: libcache.dylib
-    image_addr: 0x7fffe7e0f000
+    image_addr: "0x7fffe7e0f000"
     image_size: 20480
   - debug_status: unused
     unwind_status: unused
@@ -232,7 +232,7 @@ modules:
     code_file: /usr/lib/system/libcommonCrypto.dylib
     debug_id: 8a64d1b0-c70e-385c-92f0-e669079fda90
     debug_file: libcommonCrypto.dylib
-    image_addr: 0x7fffe7e14000
+    image_addr: "0x7fffe7e14000"
     image_size: 45056
   - debug_status: unused
     unwind_status: unused
@@ -247,7 +247,7 @@ modules:
     code_file: /usr/lib/system/libcompiler_rt.dylib
     debug_id: 55d47421-772a-32ab-b529-1a46c2f43b4d
     debug_file: libcompiler_rt.dylib
-    image_addr: 0x7fffe7e1f000
+    image_addr: "0x7fffe7e1f000"
     image_size: 32768
   - debug_status: unused
     unwind_status: unused
@@ -262,7 +262,7 @@ modules:
     code_file: /usr/lib/system/libcopyfile.dylib
     debug_id: 819bea3c-df11-3e3d-a1a1-5a51c5bf1961
     debug_file: libcopyfile.dylib
-    image_addr: 0x7fffe7e27000
+    image_addr: "0x7fffe7e27000"
     image_size: 36864
   - debug_status: unused
     unwind_status: unused
@@ -277,7 +277,7 @@ modules:
     code_file: /usr/lib/system/libcorecrypto.dylib
     debug_id: 65d7165e-2e71-335d-a2d6-33f78e2df0c1
     debug_file: libcorecrypto.dylib
-    image_addr: 0x7fffe7e30000
+    image_addr: "0x7fffe7e30000"
     image_size: 540672
   - debug_status: unused
     unwind_status: unused
@@ -292,7 +292,7 @@ modules:
     code_file: /usr/lib/system/libdispatch.dylib
     debug_id: 6582bad6-ed27-3b30-b620-90b1c5a4ae3c
     debug_file: libdispatch.dylib
-    image_addr: 0x7fffe7eb4000
+    image_addr: "0x7fffe7eb4000"
     image_size: 204800
   - debug_status: missing
     unwind_status: missing
@@ -307,7 +307,7 @@ modules:
     code_file: /usr/lib/system/libdyld.dylib
     debug_id: 9b2ac56d-107c-3541-a127-9094a751f2c9
     debug_file: libdyld.dylib
-    image_addr: 0x7fffe7ee6000
+    image_addr: "0x7fffe7ee6000"
     image_size: 24576
     candidates:
       - source: local
@@ -335,7 +335,7 @@ modules:
     code_file: /usr/lib/system/libkeymgr.dylib
     debug_id: 7aa011a9-dc21-3488-bf73-3b5b14d1fdd6
     debug_file: libkeymgr.dylib
-    image_addr: 0x7fffe7eec000
+    image_addr: "0x7fffe7eec000"
     image_size: 4096
   - debug_status: unused
     unwind_status: unused
@@ -350,7 +350,7 @@ modules:
     code_file: /usr/lib/system/liblaunch.dylib
     debug_id: b856abd2-896e-3de0-b2c8-146a6af8e2a7
     debug_file: liblaunch.dylib
-    image_addr: 0x7fffe7efa000
+    image_addr: "0x7fffe7efa000"
     image_size: 4096
   - debug_status: unused
     unwind_status: unused
@@ -365,7 +365,7 @@ modules:
     code_file: /usr/lib/system/libmacho.dylib
     debug_id: 17d5d855-f6c3-3b04-b680-e9bf02ef8aed
     debug_file: libmacho.dylib
-    image_addr: 0x7fffe7efb000
+    image_addr: "0x7fffe7efb000"
     image_size: 24576
   - debug_status: unused
     unwind_status: unused
@@ -380,7 +380,7 @@ modules:
     code_file: /usr/lib/system/libquarantine.dylib
     debug_id: 12448cc2-378e-35f3-be33-9dc395a5b970
     debug_file: libquarantine.dylib
-    image_addr: 0x7fffe7f01000
+    image_addr: "0x7fffe7f01000"
     image_size: 12288
   - debug_status: unused
     unwind_status: unused
@@ -395,7 +395,7 @@ modules:
     code_file: /usr/lib/system/libremovefile.dylib
     debug_id: 38d4cb9c-10cd-30d3-8b7b-a515ec75fe85
     debug_file: libremovefile.dylib
-    image_addr: 0x7fffe7f04000
+    image_addr: "0x7fffe7f04000"
     image_size: 8192
   - debug_status: unused
     unwind_status: unused
@@ -410,7 +410,7 @@ modules:
     code_file: /usr/lib/system/libsystem_asl.dylib
     debug_id: 096e4228-3b7c-30a6-8b13-ec909a64499a
     debug_file: libsystem_asl.dylib
-    image_addr: 0x7fffe7f06000
+    image_addr: "0x7fffe7f06000"
     image_size: 102400
   - debug_status: unused
     unwind_status: unused
@@ -425,7 +425,7 @@ modules:
     code_file: /usr/lib/system/libsystem_blocks.dylib
     debug_id: 10dc5404-73ab-35b3-a277-a8afecb476eb
     debug_file: libsystem_blocks.dylib
-    image_addr: 0x7fffe7f1f000
+    image_addr: "0x7fffe7f1f000"
     image_size: 4096
   - debug_status: unused
     unwind_status: unused
@@ -440,7 +440,7 @@ modules:
     code_file: /usr/lib/system/libsystem_c.dylib
     debug_id: e5ae5244-7d0c-36ac-8bb6-c7ae7ea52a4b
     debug_file: libsystem_c.dylib
-    image_addr: 0x7fffe7f20000
+    image_addr: "0x7fffe7f20000"
     image_size: 581632
   - debug_status: unused
     unwind_status: unused
@@ -455,7 +455,7 @@ modules:
     code_file: /usr/lib/system/libsystem_configuration.dylib
     debug_id: becc01a2-ca8d-31e6-bcdf-d452965fa976
     debug_file: libsystem_configuration.dylib
-    image_addr: 0x7fffe7fae000
+    image_addr: "0x7fffe7fae000"
     image_size: 16384
   - debug_status: unused
     unwind_status: unused
@@ -470,7 +470,7 @@ modules:
     code_file: /usr/lib/system/libsystem_coreservices.dylib
     debug_id: 7d26de79-b424-3450-85e1-f7fab32714ab
     debug_file: libsystem_coreservices.dylib
-    image_addr: 0x7fffe7fb2000
+    image_addr: "0x7fffe7fb2000"
     image_size: 16384
   - debug_status: unused
     unwind_status: unused
@@ -485,7 +485,7 @@ modules:
     code_file: /usr/lib/system/libsystem_coretls.dylib
     debug_id: ec6fcf07-dcfb-3a03-9cc9-6dd3709974c6
     debug_file: libsystem_coretls.dylib
-    image_addr: 0x7fffe7fb6000
+    image_addr: "0x7fffe7fb6000"
     image_size: 102400
   - debug_status: unused
     unwind_status: unused
@@ -500,7 +500,7 @@ modules:
     code_file: /usr/lib/system/libsystem_dnssd.dylib
     debug_id: cc960215-0b1b-3822-a13a-3dde96fa796f
     debug_file: libsystem_dnssd.dylib
-    image_addr: 0x7fffe7fcf000
+    image_addr: "0x7fffe7fcf000"
     image_size: 28672
   - debug_status: unused
     unwind_status: unused
@@ -515,7 +515,7 @@ modules:
     code_file: /usr/lib/system/libsystem_info.dylib
     debug_id: 611db84c-bf70-3f92-8702-b9f28a900920
     debug_file: libsystem_info.dylib
-    image_addr: 0x7fffe7fd6000
+    image_addr: "0x7fffe7fd6000"
     image_size: 172032
   - debug_status: unused
     unwind_status: unused
@@ -530,7 +530,7 @@ modules:
     code_file: /usr/lib/system/libsystem_kernel.dylib
     debug_id: 34b1f16c-bc9c-3c5f-9045-0cae91cb5914
     debug_file: libsystem_kernel.dylib
-    image_addr: 0x7fffe8000000
+    image_addr: "0x7fffe8000000"
     image_size: 143360
   - debug_status: unused
     unwind_status: unused
@@ -545,7 +545,7 @@ modules:
     code_file: /usr/lib/system/libsystem_m.dylib
     debug_id: 86d499b5-bbdc-3d3b-8a4e-97ae8e6672a4
     debug_file: libsystem_m.dylib
-    image_addr: 0x7fffe8023000
+    image_addr: "0x7fffe8023000"
     image_size: 294912
   - debug_status: unused
     unwind_status: unused
@@ -560,7 +560,7 @@ modules:
     code_file: /usr/lib/system/libsystem_malloc.dylib
     debug_id: a3d15f17-99a6-3367-8c7e-4280e8619c95
     debug_file: libsystem_malloc.dylib
-    image_addr: 0x7fffe806b000
+    image_addr: "0x7fffe806b000"
     image_size: 126976
   - debug_status: unused
     unwind_status: unused
@@ -575,7 +575,7 @@ modules:
     code_file: /usr/lib/system/libsystem_network.dylib
     debug_id: 369d0221-56ca-3c3e-9ede-94b41cae77b7
     debug_file: libsystem_network.dylib
-    image_addr: 0x7fffe808a000
+    image_addr: "0x7fffe808a000"
     image_size: 368640
   - debug_status: unused
     unwind_status: unused
@@ -590,7 +590,7 @@ modules:
     code_file: /usr/lib/system/libsystem_networkextension.dylib
     debug_id: b021f2b3-8a75-3633-abb0-fc012b8e9b0c
     debug_file: libsystem_networkextension.dylib
-    image_addr: 0x7fffe80e4000
+    image_addr: "0x7fffe80e4000"
     image_size: 40960
   - debug_status: unused
     unwind_status: unused
@@ -605,7 +605,7 @@ modules:
     code_file: /usr/lib/system/libsystem_notify.dylib
     debug_id: b8160190-a069-3b3a-bdf6-2aa408221fae
     debug_file: libsystem_notify.dylib
-    image_addr: 0x7fffe80ee000
+    image_addr: "0x7fffe80ee000"
     image_size: 40960
   - debug_status: unused
     unwind_status: unused
@@ -620,7 +620,7 @@ modules:
     code_file: /usr/lib/system/libsystem_platform.dylib
     debug_id: 897462fd-b318-321b-a554-e61982630f7e
     debug_file: libsystem_platform.dylib
-    image_addr: 0x7fffe80f8000
+    image_addr: "0x7fffe80f8000"
     image_size: 36864
   - debug_status: unused
     unwind_status: unused
@@ -635,7 +635,7 @@ modules:
     code_file: /usr/lib/system/libsystem_pthread.dylib
     debug_id: b8fb5e20-3295-39e2-b5eb-b464d1d4b104
     debug_file: libsystem_pthread.dylib
-    image_addr: 0x7fffe8101000
+    image_addr: "0x7fffe8101000"
     image_size: 45056
   - debug_status: unused
     unwind_status: unused
@@ -650,7 +650,7 @@ modules:
     code_file: /usr/lib/system/libsystem_sandbox.dylib
     debug_id: 4b92ec49-acd0-36ae-b07a-a2b8152eaf9d
     debug_file: libsystem_sandbox.dylib
-    image_addr: 0x7fffe810c000
+    image_addr: "0x7fffe810c000"
     image_size: 16384
   - debug_status: unused
     unwind_status: unused
@@ -665,7 +665,7 @@ modules:
     code_file: /usr/lib/system/libsystem_secinit.dylib
     debug_id: f78b847b-3565-3e4b-98a6-f7ad40392e2d
     debug_file: libsystem_secinit.dylib
-    image_addr: 0x7fffe8110000
+    image_addr: "0x7fffe8110000"
     image_size: 8192
   - debug_status: unused
     unwind_status: unused
@@ -680,7 +680,7 @@ modules:
     code_file: /usr/lib/system/libsystem_symptoms.dylib
     debug_id: 3390e07c-c1ce-348f-adbd-2c5440b45eaa
     debug_file: libsystem_symptoms.dylib
-    image_addr: 0x7fffe8112000
+    image_addr: "0x7fffe8112000"
     image_size: 32768
   - debug_status: unused
     unwind_status: unused
@@ -695,7 +695,7 @@ modules:
     code_file: /usr/lib/system/libsystem_trace.dylib
     debug_id: ac63a7fe-50d9-3a30-96e6-f6b7ff16e465
     debug_file: libsystem_trace.dylib
-    image_addr: 0x7fffe811a000
+    image_addr: "0x7fffe811a000"
     image_size: 81920
   - debug_status: unused
     unwind_status: unused
@@ -710,7 +710,7 @@ modules:
     code_file: /usr/lib/system/libunwind.dylib
     debug_id: 3d50d8a8-c460-334d-a519-2da841102c6b
     debug_file: libunwind.dylib
-    image_addr: 0x7fffe812e000
+    image_addr: "0x7fffe812e000"
     image_size: 24576
   - debug_status: unused
     unwind_status: unused
@@ -725,5 +725,5 @@ modules:
     code_file: /usr/lib/system/libxpc.dylib
     debug_id: bf896df0-d8e9-31a8-a4b3-01120bfeee52
     debug_file: libxpc.dylib
-    image_addr: 0x7fffe8134000
+    image_addr: "0x7fffe8134000"
     image_size: 172032

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_windows.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__minidump_windows.snap
@@ -17,23 +17,23 @@ stacktraces:
   - thread_id: 1636
     is_requesting: true
     registers:
-      eax: 0x0
-      ebp: 0x10ff670
-      ebx: 0xfe5000
-      ecx: 0x10ff670
-      edi: 0x13bfd78
-      edx: 0x7
-      eflags: 0x10246
-      eip: 0x2a2a3d
-      esi: 0x759c6314
-      esp: 0x10ff644
+      eax: "0x0"
+      ebp: "0x10ff670"
+      ebx: "0xfe5000"
+      ecx: "0x10ff670"
+      edi: "0x13bfd78"
+      edx: "0x7"
+      eflags: "0x10246"
+      eip: "0x2a2a3d"
+      esi: "0x759c6314"
+      esp: "0x10ff644"
     frames:
       - status: symbolicated
         original_index: 0
-        instruction_addr: 0x2a2a3d
+        instruction_addr: "0x2a2a3d"
         package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         symbol: main
-        sym_addr: 0x2a2910
+        sym_addr: "0x2a2910"
         function: main
         filename: main.cpp
         abs_path: "c:\\projects\\breakpad-tools\\windows\\crash\\main.cpp"
@@ -41,10 +41,10 @@ stacktraces:
         trust: context
       - status: symbolicated
         original_index: 1
-        instruction_addr: 0x2a2d96
+        instruction_addr: "0x2a2d96"
         package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         symbol: __scrt_common_main_seh
-        sym_addr: 0x2a2c9e
+        sym_addr: "0x2a2c9e"
         function: __scrt_common_main_seh
         filename: exe_common.inl
         abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl"
@@ -52,104 +52,104 @@ stacktraces:
         trust: cfi
       - status: missing
         original_index: 2
-        instruction_addr: 0x750662c4
+        instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: cfi
       - status: missing
         original_index: 3
-        instruction_addr: 0x771d0f79
+        instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
       - status: missing
         original_index: 4
-        instruction_addr: 0x771d0f44
+        instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
   - thread_id: 3580
     is_requesting: false
     registers:
-      eax: 0x0
-      ebp: 0x159faa4
-      ebx: 0x13b0990
-      ecx: 0x0
-      edi: 0x13b4af0
-      edx: 0x0
-      eflags: 0x216
-      eip: 0x771e016c
-      esi: 0x13b4930
-      esp: 0x159f900
+      eax: "0x0"
+      ebp: "0x159faa4"
+      ebx: "0x13b0990"
+      ecx: "0x0"
+      edi: "0x13b4af0"
+      edx: "0x0"
+      eflags: "0x216"
+      eip: "0x771e016c"
+      esi: "0x13b4930"
+      esp: "0x159f900"
     frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x771e016c
+        instruction_addr: "0x771e016c"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
       - status: missing
         original_index: 1
-        instruction_addr: 0x750662c4
+        instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: fp
       - status: missing
         original_index: 2
-        instruction_addr: 0x771d0f79
+        instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
       - status: missing
         original_index: 3
-        instruction_addr: 0x771d0f44
+        instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
   - thread_id: 2600
     is_requesting: false
     registers:
-      eax: 0x0
-      ebp: 0x169fb98
-      ebx: 0x13b0990
-      ecx: 0x0
-      edi: 0x13b7c28
-      edx: 0x0
-      eflags: 0x202
-      eip: 0x771e016c
-      esi: 0x13b7a68
-      esp: 0x169f9f4
+      eax: "0x0"
+      ebp: "0x169fb98"
+      ebx: "0x13b0990"
+      ecx: "0x0"
+      edi: "0x13b7c28"
+      edx: "0x0"
+      eflags: "0x202"
+      eip: "0x771e016c"
+      esi: "0x13b7a68"
+      esp: "0x169f9f4"
     frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x771e016c
+        instruction_addr: "0x771e016c"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
       - status: missing
         original_index: 1
-        instruction_addr: 0x750662c4
+        instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: fp
       - status: missing
         original_index: 2
-        instruction_addr: 0x771d0f79
+        instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
       - status: missing
         original_index: 3
-        instruction_addr: 0x771d0f44
+        instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
   - thread_id: 2920
     is_requesting: false
     registers:
-      eax: 0x0
-      ebp: 0x179f2b8
-      ebx: 0x17b1aa0
-      ecx: 0x0
-      edi: 0x17b1a90
-      edx: 0x0
-      eflags: 0x206
-      eip: 0x771df3dc
-      esi: 0x2cc
-      esp: 0x179f2ac
+      eax: "0x0"
+      ebp: "0x179f2b8"
+      ebx: "0x17b1aa0"
+      ecx: "0x0"
+      edi: "0x17b1a90"
+      edx: "0x0"
+      eflags: "0x206"
+      eip: "0x771df3dc"
+      esi: "0x2cc"
+      esp: "0x179f2ac"
     frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x771df3dc
+        instruction_addr: "0x771df3dc"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
 modules:
@@ -166,7 +166,7 @@ modules:
     code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
     debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
     debug_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb"
-    image_addr: 0x2a0000
+    image_addr: "0x2a0000"
     image_size: 36864
     candidates:
       - source: local
@@ -211,7 +211,7 @@ modules:
     code_file: "C:\\Windows\\System32\\dbghelp.dll"
     debug_id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
     debug_file: dbghelp.pdb
-    image_addr: 0x70850000
+    image_addr: "0x70850000"
     image_size: 1331200
   - debug_status: unused
     unwind_status: unused
@@ -226,7 +226,7 @@ modules:
     code_file: "C:\\Windows\\System32\\msvcp140.dll"
     debug_id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
     debug_file: msvcp140.i386.pdb
-    image_addr: 0x709a0000
+    image_addr: "0x709a0000"
     image_size: 442368
   - debug_status: unused
     unwind_status: unused
@@ -241,7 +241,7 @@ modules:
     code_file: "C:\\Windows\\System32\\apphelp.dll"
     debug_id: 8daf7773-372f-460a-af38-944e193f7e33-1
     debug_file: apphelp.pdb
-    image_addr: 0x70a10000
+    image_addr: "0x70a10000"
     image_size: 598016
   - debug_status: unused
     unwind_status: unused
@@ -256,7 +256,7 @@ modules:
     code_file: "C:\\Windows\\System32\\dbgcore.dll"
     debug_id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
     debug_file: dbgcore.pdb
-    image_addr: 0x70b70000
+    image_addr: "0x70b70000"
     image_size: 151552
     candidates:
       - source: local
@@ -292,7 +292,7 @@ modules:
     code_file: "C:\\Windows\\System32\\VCRUNTIME140.dll"
     debug_id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
     debug_file: vcruntime140.i386.pdb
-    image_addr: 0x70c60000
+    image_addr: "0x70c60000"
     image_size: 81920
   - debug_status: unused
     unwind_status: unused
@@ -307,7 +307,7 @@ modules:
     code_file: "C:\\Windows\\System32\\CRYPTBASE.dll"
     debug_id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
     debug_file: cryptbase.pdb
-    image_addr: 0x73ba0000
+    image_addr: "0x73ba0000"
     image_size: 40960
   - debug_status: unused
     unwind_status: unused
@@ -322,7 +322,7 @@ modules:
     code_file: "C:\\Windows\\System32\\sspicli.dll"
     debug_id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
     debug_file: wsspicli.pdb
-    image_addr: 0x73bb0000
+    image_addr: "0x73bb0000"
     image_size: 126976
   - debug_status: unused
     unwind_status: unused
@@ -337,7 +337,7 @@ modules:
     code_file: "C:\\Windows\\System32\\advapi32.dll"
     debug_id: 0c799483-b549-417d-8433-4331852031fe-1
     debug_file: advapi32.pdb
-    image_addr: 0x73c70000
+    image_addr: "0x73c70000"
     image_size: 487424
   - debug_status: unused
     unwind_status: unused
@@ -352,7 +352,7 @@ modules:
     code_file: "C:\\Windows\\System32\\msvcrt.dll"
     debug_id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
     debug_file: msvcrt.pdb
-    image_addr: 0x73cf0000
+    image_addr: "0x73cf0000"
     image_size: 778240
   - debug_status: unused
     unwind_status: unused
@@ -367,7 +367,7 @@ modules:
     code_file: "C:\\Windows\\System32\\sechost.dll"
     debug_id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
     debug_file: sechost.pdb
-    image_addr: 0x74450000
+    image_addr: "0x74450000"
     image_size: 266240
   - debug_status: missing
     unwind_status: unused
@@ -382,7 +382,7 @@ modules:
     code_file: "C:\\Windows\\System32\\kernel32.dll"
     debug_id: d3474559-96f7-47d6-bf43-c176b2171e68-1
     debug_file: wkernel32.pdb
-    image_addr: 0x75050000
+    image_addr: "0x75050000"
     image_size: 917504
     candidates:
       - source: local
@@ -418,7 +418,7 @@ modules:
     code_file: "C:\\Windows\\System32\\bcryptPrimitives.dll"
     debug_id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
     debug_file: bcryptprimitives.pdb
-    image_addr: 0x75130000
+    image_addr: "0x75130000"
     image_size: 368640
   - debug_status: unused
     unwind_status: unused
@@ -433,7 +433,7 @@ modules:
     code_file: "C:\\Windows\\System32\\rpcrt4.dll"
     debug_id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
     debug_file: wrpcrt4.pdb
-    image_addr: 0x75810000
+    image_addr: "0x75810000"
     image_size: 790528
     candidates:
       - source: local
@@ -469,7 +469,7 @@ modules:
     code_file: "C:\\Windows\\System32\\ucrtbase.dll"
     debug_id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
     debug_file: ucrtbase.pdb
-    image_addr: 0x758f0000
+    image_addr: "0x758f0000"
     image_size: 917504
   - debug_status: unused
     unwind_status: unused
@@ -484,7 +484,7 @@ modules:
     code_file: "C:\\Windows\\System32\\KERNELBASE.dll"
     debug_id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
     debug_file: wkernelbase.pdb
-    image_addr: 0x76db0000
+    image_addr: "0x76db0000"
     image_size: 1708032
   - debug_status: missing
     unwind_status: unused
@@ -499,7 +499,7 @@ modules:
     code_file: "C:\\Windows\\System32\\ntdll.dll"
     debug_id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
     debug_file: wntdll.pdb
-    image_addr: 0x77170000
+    image_addr: "0x77170000"
     image_size: 1585152
     candidates:
       - source: local

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__remove_bucket-2.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__remove_bucket-2.snap
@@ -7,7 +7,7 @@ stacktraces:
   - frames:
       - status: missing
         original_index: 0
-        instruction_addr: 0x100000fa0
+        instruction_addr: "0x100000fa0"
 modules:
   - debug_status: missing
     features:
@@ -19,5 +19,5 @@ modules:
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7
-    image_addr: 0x100000000
+    image_addr: "0x100000000"
     image_size: 4096

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__remove_bucket.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__remove_bucket.snap
@@ -7,10 +7,10 @@ stacktraces:
   - frames:
       - status: symbolicated
         original_index: 0
-        instruction_addr: 0x100000fa0
+        instruction_addr: "0x100000fa0"
         lang: c
         symbol: main
-        sym_addr: 0x100000fa0
+        sym_addr: "0x100000fa0"
         function: main
         filename: hello.c
         abs_path: /tmp/hello.c
@@ -26,7 +26,7 @@ modules:
     type: macho
     code_id: 502fc0a51ec13e479998684fa139dca7
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7
-    image_addr: 0x100000000
+    image_addr: "0x100000000"
     image_size: 4096
     candidates:
       - source: local

--- a/src/actors/snapshots/symbolicator__actors__symbolication__tests__wasm_payload.snap
+++ b/src/actors/snapshots/symbolicator__actors__symbolication__tests__wasm_payload.snap
@@ -8,10 +8,10 @@ stacktraces:
       - status: symbolicated
         original_index: 0
         addr_mode: "rel:0"
-        instruction_addr: 0x8c
+        instruction_addr: "0x8c"
         lang: rust
         symbol: internal_func
-        sym_addr: 0x8b
+        sym_addr: "0x8b"
         function: internal_func
         filename: src/lib.rs
         abs_path: /Users/mitsuhiko/Development/wasm-example/simple/src/lib.rs
@@ -28,4 +28,4 @@ modules:
     code_id: bda18fd85d4a4eb893022d6bfad846b1
     debug_id: bda18fd8-5d4a-4eb8-9302-2d6bfad846b1
     debug_file: "file://foo.invalid/demo.wasm"
-    image_addr: 0x0
+    image_addr: "0x0"


### PR DESCRIPTION
Insta has updated its dependency on `serde_yaml`, which ships a change in string
rendering. For this reason, this forces an update to `serde_yaml` and updates
all snapshots.

#skip-changelog
