### PR TITLE
build(docker): Upgrade base image to buster-slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add NotFound status for sources which didn't provide any DIF object candidates. ([#327](https://github.com/getsentry/symbolicator/pull/327))
 - Symbolication responses include download, debug and unwind information about all DIF object files which were looked up on the available object sources. ([#309](https://github.com/getsentry/symbolicator/pull/309) [#316](https://github.com/getsentry/symbolicator/pull/316) [#324](https://github.com/getsentry/symbolicator/pull/324) [#344](https://github.com/getsentry/symbolicator/pull/344))
+- Updates the base image for the docker container to `buster-slim`. ([#356](https://github.com/getsentry/symbolicator/pull/356))
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.13.0+1.1.1i"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2083,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1598,27 @@ name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -3512,6 +3539,7 @@ dependencies = [
  "humantime-serde",
  "insta",
  "ipnetwork",
+ "jemallocator",
  "jsonwebtoken",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.6.0"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+jemallocator = "0.3.2"
+
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }
 procspawn = { version = "0.9.0", features = ["test-support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ parking_lot = "0.11.1"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.9.0", features = ["backtrace", "json"] }
 regex = "1.4.3"
-reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
+reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["gzip", "json", "native-tls-vendored", "stream", "trust-dns"] }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM rust:slim-buster AS symbolicator-build
+FROM rust:slim-stretch AS symbolicator-build
 
 WORKDIR /work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:slim-buster AS symbolicator-build
 WORKDIR /work
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libssl-dev pkg-config git zip \
+    && apt-get install -y --no-install-recommends build-essential git zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Build only dependencies to speed up subsequent builds
@@ -36,7 +36,7 @@ RUN sentry-cli --version \
 
 FROM debian:buster-slim
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssl ca-certificates gosu cabextract \
+    && apt-get install -y --no-install-recommends ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*
 
 ENV \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM rust:slim-stretch AS symbolicator-build
+FROM rust:slim-buster AS symbolicator-build
 
 WORKDIR /work
 
@@ -34,7 +34,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM rust:slim-stretch AS symbolicator-build
+FROM rust:slim-buster AS symbolicator-build
 
 WORKDIR /work
 
@@ -34,7 +34,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:buster-slim
+FROM debian:stretch-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM rust:slim-buster AS symbolicator-build
+FROM rust:slim-stretch AS symbolicator-build
 
 WORKDIR /work
 
@@ -34,7 +34,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:buster-slim
+FROM debian:stretch-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ mod utils;
 #[cfg(test)]
 mod test;
 
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn main() {
     match cli::execute() {
         Ok(()) => std::process::exit(0),


### PR DESCRIPTION
Last time we attempted this in #112, we caused a performance regression in the
downloader.
