### PR TITLE
ref(utils): Replace tokio_retry with constant-time backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,19 +2409,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -3539,7 +3526,6 @@ dependencies = [
  "thiserror",
  "tokio 0.1.22",
  "tokio 1.0.2",
- "tokio-retry",
  "url 2.2.0",
  "uuid 0.8.2",
  "zstd",
@@ -3851,17 +3837,6 @@ dependencies = [
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
-dependencies = [
- "futures 0.1.29",
- "rand 0.4.6",
- "tokio-timer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ tempfile = "3.2.0"
 thiserror = "1.0.23"
 tokio = { version = "1.0.2", features = ["rt", "macros"] }
 tokio01 = { version = "0.1.22", package = "tokio" }
-tokio-retry = "0.2.0"
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.6.0"

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -17,7 +17,7 @@ use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI};
 use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey};
 use crate::types::ObjectId;
-use crate::utils::futures::{delay, retry};
+use crate::utils::futures as future_utils;
 
 /// An LRU cache for GCS OAuth tokens.
 type GcsTokenCache = lru::LruCache<Arc<GcsSourceKey>, Arc<GcsToken>>;
@@ -226,7 +226,7 @@ impl GcsDownloader {
             .map_err(|_| GcsError::InvalidUrl)?
             .extend(&[&file_source.source.bucket, "o", &key]);
 
-        let response = retry(|| {
+        let response = future_utils::retry(|| {
             self.client
                 .get(url.clone())
                 .header("authorization", format!("Bearer {}", token.access_token))

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -81,10 +81,9 @@ impl HttpDownloader {
             }
 
             builder.header(header::USER_AGENT, USER_AGENT).send()
-        })
-        .await;
+        });
 
-        match response {
+        match response.await {
             Ok(response) => {
                 if response.status().is_success() {
                     log::trace!("Success hitting {}", download_url);

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -230,10 +230,9 @@ impl SentryDownloader {
                     format!("Bearer {}", &file_source.source.token),
                 )
                 .send()
-        })
-        .await;
+        });
 
-        match result {
+        match result.await {
             Ok(response) => {
                 if response.status().is_success() {
                     log::trace!("Success hitting {}", download_url);

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -286,9 +286,9 @@ pub mod m {
 }
 
 /// Retry a future 3 times with exponential backoff.
-pub async fn retry<G, F, T, E>(task_gen: G) -> Result<T, E>
+pub async fn retry<G, F, T, E>(mut task_gen: G) -> Result<T, E>
 where
-    G: Fn() -> F,
+    G: FnMut() -> F,
     F: Future<Output = Result<T, E>>,
 {
     let mut backoff = ExponentialBackoff::from_millis(10).map(jitter).take(3);


### PR DESCRIPTION
The `tokio-retry` crate has a dependency on an old version of the tokio runtime. We do not need any tokio-specific functionality, only the delay.

The exponential backoff was currently configured with a start delay of _10ms_ and limited to 3 retries in total. This does not result in significant variance, so we can get rid of the exponential part entirely. We can bring this back in a similar fashion with the `backoff` crate however, which even has bindings for futures.

#skip-changelog