### PR TITLE
ref: Remove all use of the actix crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,7 +3363,6 @@ dependencies = [
 name = "symbolicator"
 version = "0.3.2"
 dependencies = [
- "actix",
  "actix-web",
  "anyhow",
  "apple-crash-report-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ include = ["src/**/*", "Cargo.toml", "README.md"]
 readme = "README.md"
 
 [dependencies]
-actix = "0.7.9"
 actix-web = { version = "0.7.19", features = ["tls"], default-features = false }
 anyhow = "1.0.38"
 apple-crash-report-parser = "0.4.2"

--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -288,8 +288,8 @@ impl<T: CacheItemRequest> Cacher<T> {
         }
         .bind_hub(Hub::new_from_top(Hub::current()));
 
-        // TODO: This spawns into the arbiter of the caller. Consider more explicit resource
-        // allocation here to separate CPU intensive work from I/O work.
+        // TODO: This spawns into the current_thread runtime of the caller. Consider more explicit
+        // resource allocation here to separate CPU intensive work from I/O work.
         spawn_compat(channel);
 
         receiver.shared()

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -7,12 +7,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use actix::ResponseFuture;
 use apple_crash_report_parser::AppleCrashReport;
 use bytes::{Bytes, IntoBuf};
 use chrono::{DateTime, TimeZone, Utc};
 use futures::compat::Future01CompatExt;
-use futures::{future, FutureExt as _, TryFutureExt};
+use futures::future;
 use futures01::future::{Future as _, Shared};
 use futures01::sync::oneshot;
 use parking_lot::Mutex;
@@ -45,7 +44,9 @@ use crate::types::{
     RequestId, RequestOptions, Scope, Signal, SymbolicatedFrame, SymbolicationResponse, SystemInfo,
 };
 use crate::utils::addr::AddrMode;
-use crate::utils::futures::{m, measure, timeout_compat, CallOnDrop, ThreadPool};
+use crate::utils::futures::{
+    m, measure, spawn_compat, timeout_compat, CallOnDrop, ResponseFuture, ThreadPool,
+};
 use crate::utils::hex::HexValue;
 
 /// Options for demangling all symbols.
@@ -324,18 +325,16 @@ impl SymbolicationActor {
                 .compat()
                 .await
                 .ok();
+
             drop(token);
-            Ok(())
         }
-        .bind_hub(hub)
-        .boxed_local()
-        .compat();
+        .bind_hub(hub);
 
         // TODO: This spawns into the arbiter of the caller, which usually is the web handler. This
         // doesn't block the web request, but it congests the threads that should only do web I/O.
         // Instead, this should spawn into a dedicated resource (e.g. a threadpool) to keep web
         // requests flowing while symbolication tasks may backlog.
-        actix::spawn(request_future);
+        spawn_compat(request_future);
 
         request_id
     }

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -330,10 +330,10 @@ impl SymbolicationActor {
         }
         .bind_hub(hub);
 
-        // TODO: This spawns into the arbiter of the caller, which usually is the web handler. This
-        // doesn't block the web request, but it congests the threads that should only do web I/O.
-        // Instead, this should spawn into a dedicated resource (e.g. a threadpool) to keep web
-        // requests flowing while symbolication tasks may backlog.
+        // TODO: This spawns into the current_thread runtime of the caller, which usually is the web
+        // handler. This doesn't block the web request, but it congests the threads that should only
+        // do web I/O. Instead, this should spawn into a dedicated resource (e.g. a threadpool) to
+        // keep web requests flowing while symbolication tasks may backlog.
         spawn_compat(request_future);
 
         request_id

--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -1,4 +1,3 @@
-use actix::ResponseFuture;
 use actix_web::{
     dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
     State,
@@ -12,7 +11,7 @@ use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
 use crate::sources::SourceConfig;
 use crate::types::{RequestId, RequestOptions, Scope, SymbolicationResponse};
-use crate::utils::futures::ThreadPool;
+use crate::utils::futures::{ResponseFuture, ThreadPool};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -1,4 +1,3 @@
-use actix::ResponseFuture;
 use actix_web::{
     dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
     State,
@@ -12,7 +11,7 @@ use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
 use crate::sources::SourceConfig;
 use crate::types::{RequestId, RequestOptions, Scope, SymbolicationResponse};
-use crate::utils::futures::ThreadPool;
+use crate::utils::futures::{ResponseFuture, ThreadPool};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };

--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -1,6 +1,5 @@
 use std::io::Cursor;
 
-use actix::ResponseFuture;
 use actix_web::{http::Method, pred, HttpRequest, HttpResponse, Path, State};
 use bytes::BytesMut;
 use failure::{Error, Fail};
@@ -12,6 +11,7 @@ use tokio01::codec::{BytesCodec, FramedRead};
 use crate::actors::objects::{FindObject, ObjectFileBytes, ObjectPurpose};
 use crate::app::{ServiceApp, ServiceState};
 use crate::types::Scope;
+use crate::utils::futures::ResponseFuture;
 use crate::utils::paths::parse_symstore_path;
 use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt};
 

--- a/src/endpoints/requests.rs
+++ b/src/endpoints/requests.rs
@@ -1,4 +1,3 @@
-use actix::ResponseFuture;
 use actix_web::{http::Method, HttpResponse, Path, Query, State};
 use failure::Error;
 use futures01::Future;
@@ -6,6 +5,7 @@ use serde::Deserialize;
 
 use crate::app::{ServiceApp, ServiceState};
 use crate::types::RequestId;
+use crate::utils::futures::ResponseFuture;
 
 /// Path parameters of the symbolication poll request.
 #[derive(Deserialize)]

--- a/src/endpoints/symbolicate.rs
+++ b/src/endpoints/symbolicate.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use actix::ResponseFuture;
 use actix_web::{http::Method, HttpRequest, Json, Query, State};
 use failure::Error;
 use futures01::Future;
@@ -13,6 +12,7 @@ use crate::sources::SourceConfig;
 use crate::types::{
     RawObjectInfo, RawStacktrace, RequestOptions, Scope, Signal, SymbolicationResponse,
 };
+use crate::utils::futures::ResponseFuture;
 use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
 
 /// Query parameters of the symbolication request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,3 @@
-use actix::System;
 use actix_web::{server::HttpServer, App};
 use anyhow::{Context, Result};
 
@@ -20,8 +19,6 @@ pub fn create_app(state: ServiceState) -> ServiceApp {
 
 /// Starts all actors and HTTP server based on loaded config.
 pub fn run(config: Config) -> Result<()> {
-    let sys = System::new("symbolicator");
-
     // Log this metric before actually starting the server. This allows to see restarts even if
     // service creation fails. The HTTP server is bound before the actix system runs.
     metric!(counter("server.starting") += 1);
@@ -33,10 +30,7 @@ pub fn run(config: Config) -> Result<()> {
     HttpServer::new(move || create_app(service.clone()))
         .bind(&bind)
         .context("failed to bind to the port")?
-        .start();
-
-    log::info!("Starting system");
-    sys.run();
+        .run();
     log::info!("System shutdown complete");
 
     Ok(())

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -358,7 +358,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_complete() {
-        test::setup_logging();
+        test::setup();
 
         let source = gcs_source(gcs_source_key!());
         let downloader = GcsDownloader::new(Client::new());
@@ -385,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_missing() {
-        test::setup_logging();
+        test::setup();
 
         let source = gcs_source(gcs_source_key!());
         let downloader = GcsDownloader::new(Client::new());
@@ -407,7 +407,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_invalid_credentials() {
-        test::setup_logging();
+        test::setup();
 
         let broken_credentials = GcsSourceKey {
             private_key: "".to_owned(),

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -134,7 +134,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_source() {
-        test::setup_logging();
+        test::setup();
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let dest = tmpfile.path().to_owned();
@@ -161,7 +161,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_source_missing() {
-        test::setup_logging();
+        test::setup();
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
         let dest = tmpfile.path().to_owned();

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -266,7 +266,7 @@ mod tests {
         let rt_pool = Arc::new(Runtime::new().unwrap());
 
         rt_main.block_on(async {
-            test::setup_logging();
+            test::setup();
 
             // test::setup() enables logging, but this test spawns a thread where
             // logging is not captured.  For normal test runs we don't want to
@@ -307,7 +307,7 @@ mod tests {
         let rt_pool = Arc::new(Runtime::new().unwrap());
 
         rt_main.block_on(async {
-            test::setup_logging();
+            test::setup();
 
             // test::setup() enables logging, but this test spawns a thread where
             // logging is not captured.  For normal test runs we don't want to

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_list_files() {
-        test::setup_logging();
+        test::setup();
 
         let source = s3_source(s3_source_key!());
         let downloader = S3Downloader::new();
@@ -338,7 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_complete() {
-        test::setup_logging();
+        test::setup();
 
         let source_key = s3_source_key!();
         setup_bucket(source_key.clone()).await;
@@ -367,7 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_missing() {
-        test::setup_logging();
+        test::setup();
 
         let source_key = s3_source_key!();
         setup_bucket(source_key.clone()).await;
@@ -392,7 +392,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_download_invalid_credentials() {
-        test::setup_logging();
+        test::setup();
 
         let broken_key = S3SourceKey {
             region: rusoto_core::Region::UsEast1,

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_untrusted_client() {
-        test::setup_logging();
+        test::setup();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));
@@ -76,7 +76,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_untrusted_client_loopback() {
-        test::setup_logging();
+        test::setup();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));
@@ -97,7 +97,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_untrusted_client_allowed() {
-        test::setup_logging();
+        test::setup();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));
@@ -120,7 +120,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trusted() {
-        test::setup_logging();
+        test::setup();
 
         let server = test::TestServer::new(|app| {
             app.resource("/", |resource| resource.f(|_| "OK"));

--- a/src/utils/multipart.rs
+++ b/src/utils/multipart.rs
@@ -1,10 +1,11 @@
-use actix::ResponseFuture;
 use actix_web::{dev::Payload, error, multipart, Error};
 use bytes::{Bytes, BytesMut};
 use futures01::{Future, Stream};
 
 use crate::sources::SourceConfig;
 use crate::types::RequestOptions;
+
+use super::futures::ResponseFuture;
 
 const MAX_JSON_SIZE: usize = 1_000_000;
 


### PR DESCRIPTION
Removes all use of the actix crate, specifically the `actix::spawn` function.
Since we no longer use actix web client, we can run on bare `tokio` runtimes.
This allows us to use `tokio::spawn` directly.

Additionally, this PR removes the futures test mode. It used to spawn all
futures on the same thread rather than thread pools. In Rust 1.49, capturing
test output from threads was fixed, so this is no longer necessary.

Finally, this replaces all use of `actix::ResponseFuture` with our own typedef,
until the transition to new-style futures is complete.

#skip-changelog
