### PR TITLE
ref: Use a single tokio runtime and tokio::test

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,14 +36,8 @@ impl ServiceState {
 
         let cpu_threadpool = ThreadPool::new();
         let io_threadpool = ThreadPool::new();
-        let io_thread = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .thread_name("symbolicator-download")
-            .enable_all()
-            .build()
-            .unwrap();
 
-        let download_svc = DownloadService::new(Arc::new(io_thread), config.clone());
+        let download_svc = DownloadService::new(config.clone());
 
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,7 +23,17 @@ pub fn run(config: Config) -> Result<()> {
     // service creation fails. The HTTP server is bound before the actix system runs.
     metric!(counter("server.starting") += 1);
 
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("symbolicator")
+        .enable_all()
+        .build()
+        .unwrap();
+
     let bind = config.bind.clone();
+
+    // Enter the tokio runtime before creating the services.
+    let _guard = runtime.enter();
     let service = ServiceState::create(config).context("failed to create service state")?;
 
     log::info!("Starting http server: {}", bind);


### PR DESCRIPTION
#skip-changelog

