### PR TITLE
ref(proxy): remove unnecessary struct

### DIFF
--- a/src/actors/objects/mod.rs
+++ b/src/actors/objects/mod.rs
@@ -136,14 +136,6 @@ struct CacheLookupError {
     error: Arc<ObjectError>,
 }
 
-pub struct ObjectFileBytes(pub Arc<ObjectHandle>);
-
-impl AsRef<[u8]> for ObjectFileBytes {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.data
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct ObjectsActor {
     meta_cache: Arc<Cacher<FetchFileMetaRequest>>,

--- a/src/endpoints/proxy.rs
+++ b/src/endpoints/proxy.rs
@@ -8,7 +8,7 @@ use futures01::{future::Either, Future, IntoFuture, Stream};
 use sentry::Hub;
 use tokio01::codec::{BytesCodec, FramedRead};
 
-use crate::actors::objects::{FindObject, ObjectFileBytes, ObjectPurpose};
+use crate::actors::objects::{FindObject, ObjectPurpose};
 use crate::app::{ServiceApp, ServiceState};
 use crate::types::Scope;
 use crate::utils::futures::ResponseFuture;
@@ -86,7 +86,7 @@ fn proxy_symstore_request(
                     if is_head {
                         Ok(response.finish())
                     } else {
-                        let bytes = Cursor::new(ObjectFileBytes(object_file));
+                        let bytes = Cursor::new(object_file.data());
                         let async_bytes = FramedRead::new(bytes, BytesCodec::new())
                             .map(BytesMut::freeze)
                             .map_err(|e| Error::from(e.context("failed to write object")));


### PR DESCRIPTION
This was struct was only dereffing to the ByteView, which in turn
derefs to [u8].  Use the ByteView directly, which is an Arc clone
itself anyway.

#skip-changelog