### PR TITLE
ref(downloaders): Introduce a NoPerm status

### DIFF
--- a/src/actors/objects/data_cache.rs
+++ b/src/actors/objects/data_cache.rs
@@ -150,7 +150,7 @@ impl CacheItemRequest for FetchFileDataRequest {
                 .map_err(Self::Error::from)?;
 
             match status {
-                DownloadStatus::NotFound => {
+                DownloadStatus::NotFound | DownloadStatus::NoPerm(_) => {
                     log::debug!("No debug file found for {}", cache_key);
                     return Ok(CacheStatus::Negative);
                 }

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -70,6 +70,7 @@ impl FilesystemDownloader {
             Ok(_) => Ok(DownloadStatus::Completed),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),
+                io::ErrorKind::PermissionDenied => Ok(DownloadStatus::NoPerm(format!("{}", e))),
                 _ => Err(DownloadError::Io(e)),
             },
         }

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -55,6 +55,10 @@ pub enum DownloadError {
 pub enum DownloadStatus {
     /// The download completed successfully and the file at the path can be used.
     Completed,
+    /// Insufficient permissions.
+    ///
+    /// Details about the error will be carried in the associated string.
+    NoPerm(String),
     /// The requested file was not found, there is no useful data at the provided path.
     NotFound,
 }


### PR DESCRIPTION
This introduces a NoPerm status for the download service and adopts
the downloaders to emit it when required.  For now the users ignore
this new status and map it back to NotFound as before.

- Sentry: This is an internal source, it never emits NoPerm

- S3: This is messy, authentication failures do not happen neatly and
  there is some ambiguity to the interpretation of the errors.

- GCS: Handles both authentication-time failures and access failures
  via HTTP status codes.

- HTTP: status codes are used.

- Filesystem: straight forward mapping.