### PR TITLE
ref(downloaders): Use tokio's async filesystem operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ structopt = "0.3.21"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.23"
-tokio = { version = "1.0.2", features = ["rt", "macros"] }
+tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }
 tokio01 = { version = "0.1.22", package = "tokio" }
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -4,10 +4,11 @@
 //! sources to be present on the local filesystem, usually only used for
 //! testing.
 
-use std::fs;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+use tokio::fs;
 
 use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, ObjectFileSource};
@@ -58,7 +59,7 @@ impl FilesystemDownloader {
     }
 
     /// Download from a filesystem source.
-    pub fn download_source(
+    pub async fn download_source(
         &self,
         file_source: FilesystemObjectFileSource,
         dest: PathBuf,
@@ -66,7 +67,7 @@ impl FilesystemDownloader {
         // All file I/O in this function is blocking!
         let abspath = file_source.path();
         log::debug!("Fetching debug file from {:?}", abspath);
-        match fs::copy(abspath, dest) {
+        match fs::copy(abspath, dest).await {
             Ok(_) => Ok(DownloadStatus::Completed),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -196,7 +196,7 @@ impl DownloadService {
 /// This is common functionality used by many downloaders.
 async fn download_stream(
     source: impl Into<ObjectFileSource>,
-    mut stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>> + Unpin,
+    stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,
     destination: PathBuf,
 ) -> Result<DownloadStatus, DownloadError> {
     // All file I/O in this function is blocking!
@@ -204,6 +204,7 @@ async fn download_stream(
     let mut file = File::create(&destination)
         .await
         .map_err(DownloadError::BadDestination)?;
+    futures::pin_mut!(stream);
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;


### PR DESCRIPTION
Now that all the downloaders run on tokio 1.0 they can and should use
the async filesystem operations provided.  Finally releasing us from
potentially blocking operations.

#skip-changelog