### PR TITLE
ref(futures): Remove unused macros

### DIFF
--- a/src/actors/common/cache.rs
+++ b/src/actors/common/cache.rs
@@ -211,7 +211,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         // cache_path is None when caching is disabled.
         let cache_path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
         if let Some(ref path) = cache_path {
-            if let Some(item) = tryf03pin!(self.lookup_cache(&request, &key, &path)) {
+            if let Some(item) = tryf!(self.lookup_cache(&request, &key, &path)) {
                 return Box::pin(future::ok(item));
             }
         }
@@ -223,7 +223,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         // just got pruned.
         metric!(counter(&format!("caches.{}.file.miss", name)) += 1);
 
-        let temp_file = tryf03pin!(self.tempfile());
+        let temp_file = tryf!(self.tempfile());
 
         let future =
             request

--- a/src/actors/objects/data_cache.rs
+++ b/src/actors/objects/data_cache.rs
@@ -139,9 +139,9 @@ impl CacheItemRequest for FetchFileDataRequest {
 
         let file_id = self.0.file_source.clone();
         let downloader = self.0.download_svc.clone();
-        let download_file = tryf03pin!(self.0.data_cache.tempfile());
+        let download_file = tryf!(self.0.data_cache.tempfile());
         let download_dir =
-            tryf03pin!(download_file.path().parent().ok_or(ObjectError::NoTempDir)).to_owned();
+            tryf!(download_file.path().parent().ok_or(ObjectError::NoTempDir)).to_owned();
 
         let future = async move {
             let status = downloader

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,38 +1,8 @@
-/// Same as [`try!`] but to be used in functions that return `Box<dyn Future>` instead of `Result`.
+/// Same as [`try!`] but to be used in functions that return `Pin<Box<dyn Future>>`.
 ///
-/// Useful when calling synchronous (but cheap enough) functions in async code.
+/// When these futures can be replaced with async/await code and then this hack goes away.
 #[macro_export]
 macro_rules! tryf {
-    ($e:expr) => {
-        match $e {
-            Ok(value) => value,
-            Err(e) => {
-                return Box::new(::futures01::future::err(::std::convert::From::from(e)))
-                    as Box<dyn ::futures01::future::Future<Item = _, Error = _>>;
-            }
-        }
-    };
-}
-
-/// Same as [`tryf`] but a hack for futures 0.3.  These futures can be replaced with
-/// async/await code and then this hack goes away.
-#[macro_export]
-macro_rules! tryf03 {
-    ($e:expr) => {
-        match $e {
-            Ok(value) => value,
-            Err(e) => {
-                return Box::new(::futures::future::err(::std::convert::From::from(e)))
-                    as Box<dyn ::futures::future::Future<Output = _>>;
-            }
-        }
-    };
-}
-
-/// Same as [`tryf`] but a hack for futures 0.3.  These futures can be replaced with
-/// async/await code and then this hack goes away.
-#[macro_export]
-macro_rules! tryf03pin {
     ($e:expr) => {
         match $e {
             Ok(value) => value,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,6 +7,7 @@ macro_rules! tryf {
         match $e {
             Ok(value) => value,
             Err(e) => {
+                use ::std::boxed::Box;
                 use ::std::pin::Pin;
                 return Box::pin(::futures::future::err(::std::convert::From::from(e)))
                     as Pin<Box<dyn ::futures::future::Future<Output = _>>>;


### PR DESCRIPTION
We no longer have any code which needs the futures 0.1 version of
tryf!, this has entirely moved to async/await code.  Likewise the
tryf03! is entirely replaced by async/await code.

Only the tryf03pin! macro remains as we still have some async code in
traits.  This has now been renamed back to the simpler tryf! as there
should never be a need to bring the other variations back.

#skip-changelog