### PR TITLE
ref(endpoints): Remove redundant I/O pools from functions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,10 +16,6 @@ use crate::utils::futures::ThreadPool;
 /// The shared state for the service.
 #[derive(Clone, Debug)]
 pub struct ServiceState {
-    /// Thread pool instance reserved for CPU-intensive tasks.
-    cpu_threadpool: ThreadPool,
-    /// Thread pool instance reserved for IO-intensive tasks.
-    io_threadpool: ThreadPool,
     /// Actor for minidump and stacktrace processing
     symbolication: SymbolicationActor,
     /// Actor for downloading and caching objects (no symcaches or cficaches)
@@ -27,18 +23,19 @@ pub struct ServiceState {
     /// The config object.
     config: Arc<Config>,
     /// The download service.
-    download_svc: Arc<DownloadService>,
+    downloader: Arc<DownloadService>,
 }
 
 impl ServiceState {
     pub fn create(config: Config) -> Result<Self> {
         let config = Arc::new(config);
 
-        let cpu_threadpool = ThreadPool::new();
-        let io_threadpool = ThreadPool::new();
+        let cpu_pool = ThreadPool::new();
+        let io_pool = ThreadPool::new();
+        let spawnpool = procspawn::Pool::new(config.processing_pool_size)
+            .context("failed to create process pool")?;
 
-        let download_svc = DownloadService::new(config.clone());
-
+        let downloader = DownloadService::new(config.clone());
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches
             .clear_tmp(&config)
@@ -46,37 +43,27 @@ impl ServiceState {
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,
-            io_threadpool.clone(),
-            download_svc.clone(),
+            io_pool,
+            downloader.clone(),
         );
-        let symcaches =
-            SymCacheActor::new(caches.symcaches, objects.clone(), cpu_threadpool.clone());
-        let cficaches =
-            CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_threadpool.clone());
-        let spawnpool = procspawn::Pool::new(config.processing_pool_size)
-            .context("failed to create process pool")?;
+        let symcaches = SymCacheActor::new(caches.symcaches, objects.clone(), cpu_pool.clone());
+        let cficaches = CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_pool.clone());
 
         let symbolication = SymbolicationActor::new(
             objects.clone(),
             symcaches,
             cficaches,
             caches.diagnostics,
-            cpu_threadpool.clone(),
+            cpu_pool,
             spawnpool,
         );
 
         Ok(Self {
-            cpu_threadpool,
-            io_threadpool,
             symbolication,
             objects,
             config,
-            download_svc,
+            downloader,
         })
-    }
-
-    pub fn io_pool(&self) -> ThreadPool {
-        self.io_threadpool.clone()
     }
 
     pub fn symbolication(&self) -> SymbolicationActor {

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -12,7 +12,7 @@ use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
 use crate::sources::SourceConfig;
 use crate::types::{RequestId, RequestOptions, Scope, SymbolicationResponse};
-use crate::utils::futures::{ResponseFuture, ThreadPool};
+use crate::utils::futures::ResponseFuture;
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };
@@ -26,14 +26,13 @@ struct MinidumpRequest {
 }
 
 fn handle_multipart_item(
-    threadpool: ThreadPool,
     mut request: MinidumpRequest,
     item: multipart::MultipartItem<Payload>,
 ) -> ResponseFuture<MinidumpRequest, Error> {
     let field = match item {
         multipart::MultipartItem::Field(field) => field,
         multipart::MultipartItem::Nested(nested) => {
-            return handle_multipart_stream(threadpool, request, nested);
+            return handle_multipart_stream(request, nested);
         }
     };
 
@@ -71,14 +70,13 @@ fn handle_multipart_item(
 }
 
 fn handle_multipart_stream(
-    threadpool: ThreadPool,
     request: MinidumpRequest,
     stream: multipart::Multipart<Payload>,
 ) -> ResponseFuture<MinidumpRequest, Error> {
     let future = stream
         .map_err(Error::from)
         .fold(request, move |request, item| {
-            handle_multipart_item(threadpool.clone(), request, item)
+            handle_multipart_item(request, item)
         });
 
     Box::new(future)
@@ -123,11 +121,8 @@ fn handle_minidump_request(
             params.write_sentry_scope(scope);
         });
 
-        let request_future = handle_multipart_stream(
-            state.io_pool(),
-            MinidumpRequest::default(),
-            request.multipart(),
-        );
+        let request_future =
+            handle_multipart_stream(MinidumpRequest::default(), request.multipart());
 
         let SymbolicationRequestQueryParams { scope, timeout } = params;
         let symbolication = state.symbolication();


### PR DESCRIPTION
The minidump and apple crash report endpoints pass an I/O threadpool without actually using it. Removing this allows to clean up the service state and remove I/O pools entirely from the public interface.

#skip-changelog