### PR TITLE
ref(endpoints): Rewrite multipart in async/await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,7 +3446,6 @@ dependencies = [
  "cadence",
  "chrono",
  "console",
- "crc32fast",
  "env_logger",
  "failure",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ bytes = { version = "0.4.12", features = ["serde"] }
 cadence = "0.18.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
-crc32fast = "1.2.1"
 env_logger = "0.7.1"
 failure = "0.1.8"
 flate2 = "1.0.19"

--- a/src/actors/symbolication.rs
+++ b/src/actors/symbolication.rs
@@ -1686,12 +1686,10 @@ impl SymbolicationActor {
         self,
         scope: Scope,
         minidump: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<(SymbolicateStacktraces, MinidumpState), SymbolicationError> {
         let future = async move {
-            let sources: Arc<[SourceConfig]> = Arc::from(sources);
-
             let referenced_modules = self
                 .get_referenced_modules_from_minidump(minidump.clone())
                 .await?;
@@ -1716,7 +1714,7 @@ impl SymbolicationActor {
         self,
         scope: Scope,
         minidump: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
         let (request, state) = self
@@ -1734,7 +1732,7 @@ impl SymbolicationActor {
         &self,
         scope: Scope,
         minidump: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> RequestId {
         self.create_symbolication_request(
@@ -1796,7 +1794,7 @@ impl SymbolicationActor {
         &self,
         scope: Scope,
         minidump: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), SymbolicationError> {
         let parse_future = async {
@@ -1847,7 +1845,7 @@ impl SymbolicationActor {
             let request = SymbolicateStacktraces {
                 modules,
                 scope,
-                sources: Arc::from(sources),
+                sources,
                 signal: None,
                 stacktraces,
                 options,
@@ -1909,7 +1907,7 @@ impl SymbolicationActor {
         self,
         scope: Scope,
         report: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
         let (request, state) = self
@@ -1925,7 +1923,7 @@ impl SymbolicationActor {
         &self,
         scope: Scope,
         apple_crash_report: Bytes,
-        sources: Vec<SourceConfig>,
+        sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> RequestId {
         self.create_symbolication_request(self.clone().do_process_apple_crash_report(
@@ -2192,7 +2190,7 @@ mod tests {
             let request_id = symbolication.process_minidump(
                 Scope::Global,
                 minidump,
-                vec![source],
+                Arc::new([source]),
                 RequestOptions {
                     dif_candidates: true,
                 },
@@ -2238,7 +2236,7 @@ mod tests {
             let request_id = service.symbolication().process_apple_crash_report(
                 Scope::Global,
                 report_file,
-                vec![source],
+                Arc::new([source]),
                 RequestOptions {
                     dif_candidates: true,
                 },

--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -1,157 +1,64 @@
-use actix_web::{
-    dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
-    State,
-};
-use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
-use futures01::{future, Future, Stream};
-use sentry::{configure_scope, Hub};
+use std::sync::Arc;
 
-use crate::actors::symbolication::SymbolicationActor;
+use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
+use futures::{compat::Stream01CompatExt, StreamExt};
+
 use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::sources::SourceConfig;
-use crate::types::{RequestId, RequestOptions, Scope, SymbolicationResponse};
-use crate::utils::futures::ResponseFuture;
+use crate::types::{RequestOptions, SymbolicationResponse};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };
-use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
-#[derive(Debug, Default)]
-struct AppleCrashReportRequest {
-    sources: Option<Vec<SourceConfig>>,
-    apple_crash_report: Option<Bytes>,
-    options: RequestOptions,
-}
-
-fn handle_multipart_item(
-    mut request: AppleCrashReportRequest,
-    item: multipart::MultipartItem<Payload>,
-) -> ResponseFuture<AppleCrashReportRequest, Error> {
-    let field = match item {
-        multipart::MultipartItem::Field(field) => field,
-        multipart::MultipartItem::Nested(nested) => {
-            return handle_multipart_stream(request, nested);
-        }
-    };
-
-    match field
-        .content_disposition()
-        .as_ref()
-        .and_then(|d| d.get_name())
-    {
-        Some("sources") => {
-            let future = read_multipart_sources(field).map(move |sources| {
-                request.sources = Some(sources);
-                request
-            });
-            Box::new(future)
-        }
-        Some("apple_crash_report") => {
-            let future = read_multipart_file(field).map(move |apple_crash_report| {
-                request.apple_crash_report = Some(apple_crash_report);
-                request
-            });
-            Box::new(future)
-        }
-        Some("options") => {
-            let future = read_multipart_request_options(field).map(move |options| {
-                request.options = options;
-                request
-            });
-            Box::new(future)
-        }
-        _ => {
-            // Always ignore unknown fields.
-            Box::new(future::ok(request))
-        }
-    }
-}
-
-fn handle_multipart_stream(
-    request: AppleCrashReportRequest,
-    stream: multipart::Multipart<Payload>,
-) -> ResponseFuture<AppleCrashReportRequest, Error> {
-    let future = stream
-        .map_err(Error::from)
-        .fold(request, move |request, item| {
-            handle_multipart_item(request, item)
-        });
-
-    Box::new(future)
-}
-
-fn process_apple_crash_report(
-    symbolication: &SymbolicationActor,
-    request: AppleCrashReportRequest,
-    scope: Scope,
-) -> Result<RequestId, Error> {
-    let report = request
-        .apple_crash_report
-        .ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
-
-    let sources = request
-        .sources
-        .ok_or_else(|| error::ErrorBadRequest("missing sources"))?;
-
-    Ok(symbolication.process_apple_crash_report(scope, report, sources, request.options))
-}
-
-fn handle_apple_crash_report_request(
+async fn handle_apple_crash_report_request(
     state: State<ServiceState>,
     params: Query<SymbolicationRequestQueryParams>,
     request: HttpRequest<ServiceState>,
-) -> ResponseFuture<Json<SymbolicationResponse>, Error> {
-    let hub = Hub::from_request(&request);
-    hub.start_session();
+) -> Result<Json<SymbolicationResponse>, Error> {
+    sentry::start_session();
 
-    Hub::run(hub, || {
-        let default_sources = state.config().default_sources();
+    let params = params.into_inner();
+    sentry::configure_scope(|scope| params.write_sentry_scope(scope));
 
-        let params = params.into_inner();
-        configure_scope(|scope| {
-            params.write_sentry_scope(scope);
-        });
+    let mut report = None;
+    let mut sources = state.config().default_sources();
+    let mut options = RequestOptions::default();
 
-        let request_future =
-            handle_multipart_stream(AppleCrashReportRequest::default(), request.multipart());
+    let mut stream = request.multipart().compat();
+    while let Some(item) = stream.next().await {
+        let field = match item? {
+            multipart::MultipartItem::Field(field) => field,
+            _ => return Err(error::ErrorBadRequest("unsupported nested formdata")),
+        };
 
-        let SymbolicationRequestQueryParams { scope, timeout } = params;
-        let symbolication = state.symbolication();
+        let content_disposition = field.content_disposition();
+        match content_disposition.as_ref().and_then(|d| d.get_name()) {
+            Some("apple_crash_report") => report = Some(read_multipart_file(field).await?),
+            Some("sources") => sources = Arc::from(read_multipart_sources(field).await?),
+            Some("options") => options = read_multipart_request_options(field).await?,
+            _ => (), // Always ignore unknown fields.
+        }
+    }
 
-        let response_future = request_future
-            .and_then(clone!(symbolication, |mut request| {
-                if request.sources.is_none() {
-                    request.sources = Some(default_sources.to_vec());
-                }
+    let report = report.ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
 
-                process_apple_crash_report(&symbolication, request, scope)
-            }))
-            .and_then(move |request_id| {
-                symbolication
-                    .get_response(request_id, timeout)
-                    .never_error()
-                    .boxed_local()
-                    .compat()
-                    .then(|result| match result {
-                        Ok(Some(response)) => Ok(Json(response)),
-                        Ok(None) => Err(error::ErrorInternalServerError(
-                            "symbolication request did not start",
-                        )),
-                        Err(never) => match never {},
-                    })
-                    .map_err(Error::from)
-            });
+    let symbolication = state.symbolication();
+    let request_id =
+        symbolication.process_apple_crash_report(params.scope, report.into(), sources, options);
 
-        Box::new(response_future.sentry_hub_current())
-    })
+    match symbolication.get_response(request_id, params.timeout).await {
+        Some(response) => Ok(Json(response)),
+        None => Err(error::ErrorInternalServerError(
+            "symbolication request did not start",
+        )),
+    }
 }
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/applecrashreport", |r| {
-        r.method(Method::POST)
-            .with(handle_apple_crash_report_request);
+        let handler = compat_handler!(handle_apple_crash_report_request, s, p, r);
+        r.post().with_async(handler);
     })
 }
 

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -1,163 +1,64 @@
-use actix_web::{
-    dev::Payload, error, http::Method, multipart, Error, HttpMessage, HttpRequest, Json, Query,
-    State,
-};
-use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
-use futures01::{future, Future, Stream};
-use sentry::{configure_scope, Hub};
+use std::sync::Arc;
 
-use crate::actors::symbolication::SymbolicationActor;
+use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
+use futures::{compat::Stream01CompatExt, StreamExt};
+
 use crate::app::{ServiceApp, ServiceState};
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::sources::SourceConfig;
-use crate::types::{RequestId, RequestOptions, Scope, SymbolicationResponse};
-use crate::utils::futures::ResponseFuture;
+use crate::types::{RequestOptions, SymbolicationResponse};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };
-use crate::utils::sentry::{ActixWebHubExt, SentryFutureExt, WriteSentryScope};
+use crate::utils::sentry::WriteSentryScope;
 
-#[derive(Debug, Default)]
-struct MinidumpRequest {
-    sources: Option<Vec<SourceConfig>>,
-    minidump: Option<Bytes>,
-    options: RequestOptions,
-}
-
-fn handle_multipart_item(
-    mut request: MinidumpRequest,
-    item: multipart::MultipartItem<Payload>,
-) -> ResponseFuture<MinidumpRequest, Error> {
-    let field = match item {
-        multipart::MultipartItem::Field(field) => field,
-        multipart::MultipartItem::Nested(nested) => {
-            return handle_multipart_stream(request, nested);
-        }
-    };
-
-    match field
-        .content_disposition()
-        .as_ref()
-        .and_then(|d| d.get_name())
-    {
-        Some("sources") => {
-            let future = read_multipart_sources(field).map(move |sources| {
-                request.sources = Some(sources);
-                request
-            });
-            Box::new(future)
-        }
-        Some("upload_file_minidump") => {
-            let future = read_multipart_file(field).map(move |minidump| {
-                request.minidump = Some(minidump);
-                request
-            });
-            Box::new(future)
-        }
-        Some("options") => {
-            let future = read_multipart_request_options(field).map(move |options| {
-                request.options = options;
-                request
-            });
-            Box::new(future)
-        }
-        _ => {
-            // Always ignore unknown fields.
-            Box::new(future::ok(request))
-        }
-    }
-}
-
-fn handle_multipart_stream(
-    request: MinidumpRequest,
-    stream: multipart::Multipart<Payload>,
-) -> ResponseFuture<MinidumpRequest, Error> {
-    let future = stream
-        .map_err(Error::from)
-        .fold(request, move |request, item| {
-            handle_multipart_item(request, item)
-        });
-
-    Box::new(future)
-}
-
-fn process_minidump(
-    symbolication: &SymbolicationActor,
-    request: MinidumpRequest,
-    scope: Scope,
-) -> Result<RequestId, Error> {
-    let minidump = request
-        .minidump
-        .ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
-
-    sentry::configure_scope(|scope| {
-        let mut hasher = crc32fast::Hasher::new();
-        hasher.update(&minidump);
-        scope.set_extra("minidump_crc32", hasher.finalize().into());
-        scope.set_extra("minidump_len", minidump.len().into());
-    });
-
-    let sources = request
-        .sources
-        .ok_or_else(|| error::ErrorBadRequest("missing sources"))?;
-
-    Ok(symbolication.process_minidump(scope, minidump, sources, request.options))
-}
-
-fn handle_minidump_request(
+async fn handle_minidump_request(
     state: State<ServiceState>,
     params: Query<SymbolicationRequestQueryParams>,
     request: HttpRequest<ServiceState>,
-) -> ResponseFuture<Json<SymbolicationResponse>, Error> {
-    let hub = Hub::from_request(&request);
-    hub.start_session();
+) -> Result<Json<SymbolicationResponse>, Error> {
+    sentry::start_session();
 
-    Hub::run(hub, || {
-        let default_sources = state.config().default_sources();
+    let params = params.into_inner();
+    sentry::configure_scope(|scope| params.write_sentry_scope(scope));
 
-        let params = params.into_inner();
-        configure_scope(|scope| {
-            params.write_sentry_scope(scope);
-        });
+    let mut minidump = None;
+    let mut sources = state.config().default_sources();
+    let mut options = RequestOptions::default();
 
-        let request_future =
-            handle_multipart_stream(MinidumpRequest::default(), request.multipart());
+    let mut stream = request.multipart().compat();
+    while let Some(item) = stream.next().await {
+        let field = match item? {
+            multipart::MultipartItem::Field(field) => field,
+            _ => return Err(error::ErrorBadRequest("unsupported nested formdata")),
+        };
 
-        let SymbolicationRequestQueryParams { scope, timeout } = params;
-        let symbolication = state.symbolication();
+        let content_disposition = field.content_disposition();
+        match content_disposition.as_ref().and_then(|d| d.get_name()) {
+            Some("upload_file_minidump") => minidump = Some(read_multipart_file(field).await?),
+            Some("sources") => sources = Arc::from(read_multipart_sources(field).await?),
+            Some("options") => options = read_multipart_request_options(field).await?,
+            _ => (), // Always ignore unknown fields.
+        }
+    }
 
-        let response_future = request_future
-            .and_then(clone!(symbolication, |mut request| {
-                if request.sources.is_none() {
-                    request.sources = Some(default_sources.to_vec());
-                }
+    let minidump = minidump.ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
 
-                process_minidump(&symbolication, request, scope)
-            }))
-            .and_then(move |request_id| {
-                symbolication
-                    .get_response(request_id, timeout)
-                    .never_error()
-                    .boxed_local()
-                    .compat()
-                    .then(|result| match result {
-                        Ok(Some(response)) => Ok(Json(response)),
-                        Ok(None) => Err(error::ErrorInternalServerError(
-                            "symbolication request did not start",
-                        )),
-                        Err(never) => match never {},
-                    })
-                    .map_err(Error::from)
-            });
+    let symbolication = state.symbolication();
+    let request_id =
+        symbolication.process_minidump(params.scope, minidump.into(), sources, options);
 
-        Box::new(response_future.sentry_hub_current())
-    })
+    match symbolication.get_response(request_id, params.timeout).await {
+        Some(response) => Ok(Json(response)),
+        None => Err(error::ErrorInternalServerError(
+            "symbolication request did not start",
+        )),
+    }
 }
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/minidump", |r| {
-        r.method(Method::POST).with(handle_minidump_request);
+        let handler = compat_handler!(handle_minidump_request, s, p, r);
+        r.post().with_async(handler);
     })
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,3 +42,14 @@ macro_rules! clone {
         }
     );
 }
+
+macro_rules! compat_handler {
+    ($func:ident , $($param:ident),*) => {{
+        use ::futures::{FutureExt, TryFutureExt};
+        |__hub: crate::utils::sentry::ActixHub, $($param),*| {
+            ::sentry::SentryFutureExt::bind_hub( $func ( $($param),* ), __hub )
+                .boxed_local()
+                .compat()
+        }
+    }};
+}

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use actix_web::middleware::{Finished, Middleware, Response, Started};
-use actix_web::{Error, HttpRequest, HttpResponse};
+use actix_web::{Error, FromRequest, HttpRequest, HttpResponse};
 use failure::Fail;
 use futures01::future::Future;
 use futures01::Poll;
@@ -296,5 +296,23 @@ fn exception_from_single_fail<F: Fail + ?Sized>(
             .map(|bt| format!("{:#?}", bt))
             .and_then(|x| parse_stacktrace(&x)),
         ..Default::default()
+    }
+}
+
+#[derive(Debug)]
+pub struct ActixHub(Arc<Hub>);
+
+impl<S> FromRequest<S> for ActixHub {
+    type Config = ();
+    type Result = Self;
+
+    fn from_request(req: &HttpRequest<S>, _: &Self::Config) -> Self::Result {
+        Self(Hub::from_request(req))
+    }
+}
+
+impl From<ActixHub> for Arc<Hub> {
+    fn from(ah: ActixHub) -> Self {
+        ah.0
     }
 }


### PR DESCRIPTION
Adds a `compat_handler` macro that converts async handler functions into a
legacy future and binds the `sentry::Hub` from the actix request.

The only functional difference in this PR is that we no longer record the CRC32
of the minidump, since we have never and will not require this context.

#skip-changelog

