### PR TITLE
ref(endpoints): Port remaining endpoints to async/await

### DIFF
--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
 use futures::{compat::Stream01CompatExt, StreamExt};
 
@@ -35,7 +33,7 @@ async fn handle_apple_crash_report_request(
         let content_disposition = field.content_disposition();
         match content_disposition.as_ref().and_then(|d| d.get_name()) {
             Some("apple_crash_report") => report = Some(read_multipart_file(field).await?),
-            Some("sources") => sources = Arc::from(read_multipart_sources(field).await?),
+            Some("sources") => sources = read_multipart_sources(field).await?.into(),
             Some("options") => options = read_multipart_request_options(field).await?,
             _ => (), // Always ignore unknown fields.
         }

--- a/src/endpoints/healthcheck.rs
+++ b/src/endpoints/healthcheck.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::Method, HttpRequest};
+use actix_web::HttpRequest;
 
 use crate::app::{ServiceApp, ServiceState};
 
@@ -9,6 +9,6 @@ fn healthcheck(_req: HttpRequest<ServiceState>) -> &'static str {
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/healthcheck", |r| {
-        r.method(Method::GET).with(healthcheck);
+        r.get().with(healthcheck);
     })
 }

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_web::{error, multipart, Error, HttpMessage, HttpRequest, Json, Query, State};
 use futures::{compat::Stream01CompatExt, StreamExt};
 
@@ -35,7 +33,7 @@ async fn handle_minidump_request(
         let content_disposition = field.content_disposition();
         match content_disposition.as_ref().and_then(|d| d.get_name()) {
             Some("upload_file_minidump") => minidump = Some(read_multipart_file(field).await?),
-            Some("sources") => sources = Arc::from(read_multipart_sources(field).await?),
+            Some("sources") => sources = read_multipart_sources(field).await?.into(),
             Some("options") => options = read_multipart_request_options(field).await?,
             _ => (), // Always ignore unknown fields.
         }

--- a/src/endpoints/requests.rs
+++ b/src/endpoints/requests.rs
@@ -1,12 +1,8 @@
-use actix_web::{http::Method, HttpResponse, Path, Query, State};
-use failure::Error;
-use futures::{FutureExt, TryFutureExt};
-use futures01::Future;
+use actix_web::{Error, HttpResponse, Path, Query, State};
 use serde::Deserialize;
 
 use crate::app::{ServiceApp, ServiceState};
 use crate::types::RequestId;
-use crate::utils::futures::ResponseFuture;
 
 /// Path parameters of the symbolication poll request.
 #[derive(Deserialize)]
@@ -21,31 +17,28 @@ struct PollSymbolicationRequestQueryParams {
     pub timeout: Option<u64>,
 }
 
-fn poll_request(
+async fn poll_request(
     state: State<ServiceState>,
     path: Path<PollSymbolicationRequestPath>,
     query: Query<PollSymbolicationRequestQueryParams>,
-) -> ResponseFuture<HttpResponse, Error> {
+) -> Result<HttpResponse, Error> {
     let path = path.into_inner();
     let query = query.into_inner();
 
-    let future = state
+    let response_opt = state
         .symbolication()
         .get_response(path.request_id, query.timeout)
-        .never_error()
-        .boxed_local()
-        .compat()
-        .map(|response_opt| match response_opt {
-            Some(response) => HttpResponse::Ok().json(response),
-            None => HttpResponse::NotFound().finish(),
-        })
-        .map_err(|never| match never {});
+        .await;
 
-    Box::new(future)
+    Ok(match response_opt {
+        Some(response) => HttpResponse::Ok().json(response),
+        None => HttpResponse::NotFound().finish(),
+    })
 }
 
 pub fn configure(app: ServiceApp) -> ServiceApp {
     app.resource("/requests/{request_id}", |r| {
-        r.method(Method::GET).with(poll_request);
+        let handler = compat_handler!(poll_request, s, p, q);
+        r.get().with_async(handler);
     })
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,8 +46,11 @@ macro_rules! clone {
 macro_rules! compat_handler {
     ($func:ident , $($param:ident),*) => {{
         use ::futures::{FutureExt, TryFutureExt};
+        use ::sentry::SentryFutureExt;
+
         |__hub: crate::utils::sentry::ActixHub, $($param),*| {
-            ::sentry::SentryFutureExt::bind_hub( $func ( $($param),* ), __hub )
+            $func ( $($param),* )
+                .bind_hub(__hub)
                 .boxed_local()
                 .compat()
         }

--- a/src/utils/futures.rs
+++ b/src/utils/futures.rs
@@ -117,9 +117,6 @@ where
     tokio01::runtime::current_thread::spawn(future.map(|_| Ok(())).boxed_local().compat());
 }
 
-/// A compatibility type for asynchronous results based on `futures` 0.1.
-pub type ResponseFuture<I, E> = Box<dyn futures01::Future<Item = I, Error = E>>;
-
 /// Error returned by [`timeout_compat`].
 #[derive(Debug, PartialEq, thiserror::Error)]
 #[error("deadline has elapsed")]


### PR DESCRIPTION
Follow-up to #371.

#skip-changelog

