### PR TITLE
ref(utils): Improve the configure scope trait

### DIFF
--- a/src/endpoints/applecrashreport.rs
+++ b/src/endpoints/applecrashreport.rs
@@ -7,7 +7,7 @@ use crate::types::{RequestOptions, SymbolicationResponse};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };
-use crate::utils::sentry::WriteSentryScope;
+use crate::utils::sentry::ConfigureScope;
 
 async fn handle_apple_crash_report_request(
     state: State<ServiceState>,
@@ -17,7 +17,7 @@ async fn handle_apple_crash_report_request(
     sentry::start_session();
 
     let params = params.into_inner();
-    sentry::configure_scope(|scope| params.write_sentry_scope(scope));
+    params.configure_scope();
 
     let mut report = None;
     let mut sources = state.config().default_sources();

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -7,7 +7,7 @@ use crate::types::{RequestOptions, SymbolicationResponse};
 use crate::utils::multipart::{
     read_multipart_file, read_multipart_request_options, read_multipart_sources,
 };
-use crate::utils::sentry::WriteSentryScope;
+use crate::utils::sentry::ConfigureScope;
 
 async fn handle_minidump_request(
     state: State<ServiceState>,
@@ -17,7 +17,7 @@ async fn handle_minidump_request(
     sentry::start_session();
 
     let params = params.into_inner();
-    sentry::configure_scope(|scope| params.write_sentry_scope(scope));
+    params.configure_scope();
 
     let mut minidump = None;
     let mut sources = state.config().default_sources();

--- a/src/endpoints/symbolicate.rs
+++ b/src/endpoints/symbolicate.rs
@@ -7,7 +7,7 @@ use crate::sources::SourceConfig;
 use crate::types::{
     RawObjectInfo, RawStacktrace, RequestOptions, Scope, Signal, SymbolicationResponse,
 };
-use crate::utils::sentry::WriteSentryScope;
+use crate::utils::sentry::ConfigureScope;
 
 /// Query parameters of the symbolication request.
 #[derive(Deserialize)]
@@ -18,8 +18,8 @@ pub struct SymbolicationRequestQueryParams {
     pub scope: Scope,
 }
 
-impl WriteSentryScope for SymbolicationRequestQueryParams {
-    fn write_sentry_scope(&self, scope: &mut sentry::Scope) {
+impl ConfigureScope for SymbolicationRequestQueryParams {
+    fn to_scope(&self, scope: &mut sentry::Scope) {
         scope.set_tag("request.scope", &self.scope);
         if let Some(timeout) = self.timeout {
             scope.set_tag("request.timeout", timeout);
@@ -52,7 +52,7 @@ async fn symbolicate_frames(
     sentry::start_session();
 
     let params = params.into_inner();
-    sentry::configure_scope(|scope| params.write_sentry_scope(scope));
+    params.configure_scope();
 
     let body = body.into_inner();
     let sources = match body.sources {

--- a/src/services/download/locations.rs
+++ b/src/services/download/locations.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::sources::SourceId;
-use crate::utils::sentry::WriteSentryScope;
+use crate::utils::sentry::ConfigureScope;
 
 use super::filesystem::FilesystemObjectFileSource;
 use super::gcs::GcsObjectFileSource;
@@ -197,8 +197,8 @@ impl ObjectFileSource {
     }
 }
 
-impl WriteSentryScope for ObjectFileSource {
-    fn write_sentry_scope(&self, scope: &mut ::sentry::Scope) {
+impl ConfigureScope for ObjectFileSource {
+    fn to_scope(&self, scope: &mut ::sentry::Scope) {
         scope.set_tag("source.id", self.source_id());
         scope.set_tag("source.type", self.source_type_name());
         scope.set_tag("source.is_public", self.is_public());

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -11,7 +11,6 @@ use url::Url;
 
 use crate::types::{Glob, ObjectId, ObjectType};
 use crate::utils::paths;
-use crate::utils::sentry::WriteSentryScope;
 
 /// An identifier for DIF sources.
 ///
@@ -78,25 +77,6 @@ impl SourceConfig {
             SourceConfig::Http(..) => "http",
             SourceConfig::Filesystem(..) => "filesystem",
         }
-    }
-
-    /// Determines whether debug files from this bucket may be shared.
-    pub fn is_public(&self) -> bool {
-        match *self {
-            SourceConfig::Http(ref x) => x.files.is_public,
-            SourceConfig::S3(ref x) => x.files.is_public,
-            SourceConfig::Gcs(ref x) => x.files.is_public,
-            SourceConfig::Sentry(_) => false,
-            SourceConfig::Filesystem(ref x) => x.files.is_public,
-        }
-    }
-}
-
-impl WriteSentryScope for SourceConfig {
-    fn write_sentry_scope(&self, scope: &mut sentry::Scope) {
-        scope.set_tag("source.id", self.id());
-        scope.set_tag("source.type", self.type_name());
-        scope.set_tag("source.is_public", self.is_public());
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 use crate::utils::addr::AddrMode;
 use crate::utils::hex::HexValue;
-use crate::utils::sentry::WriteSentryScope;
+use crate::utils::sentry::ConfigureScope;
 
 mod objects;
 
@@ -735,8 +735,8 @@ impl ObjectId {
     }
 }
 
-impl WriteSentryScope for ObjectId {
-    fn write_sentry_scope(&self, scope: &mut sentry::Scope) {
+impl ConfigureScope for ObjectId {
+    fn to_scope(&self, scope: &mut sentry::Scope) {
         scope.set_tag(
             "object_id.code_id",
             self.code_id

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -71,10 +71,14 @@ pub trait SentryFutureExt: Sized {
 impl<F> SentryFutureExt for F where F: futures01::future::Future {}
 
 /// Write own data to [`sentry::Scope`], only the subset that is considered useful for debugging.
-// Right now, this could have been a simple method, but the idea is that one day we want a custom
-// derive for this.
-pub trait WriteSentryScope {
-    fn write_sentry_scope(&self, scope: &mut Scope);
+pub trait ConfigureScope {
+    /// Writes information to the given scope.
+    fn to_scope(&self, scope: &mut Scope);
+
+    /// Configures the current scope.
+    fn configure_scope(&self) {
+        sentry::configure_scope(|scope| self.to_scope(scope));
+    }
 }
 
 /// Reports certain failures to sentry.


### PR DESCRIPTION
Introduces a convenience method to run `configure_scope` directly on a type that
implements the trait. Since the purpose of this trait is not to write a scope,
and rather configure it, it is now renamed to `ConfigureScope`.

#skip-changelog

