### PR TITLE
ref(service): Remove unused I/O threadpool

### DIFF
--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -65,7 +65,6 @@ impl Service {
         let config = Arc::new(config);
 
         let cpu_pool = ThreadPool::new();
-        let io_pool = ThreadPool::new();
         let spawnpool = procspawn::Pool::new(config.processing_pool_size)
             .context("failed to create process pool")?;
 
@@ -74,12 +73,7 @@ impl Service {
         caches
             .clear_tmp(&config)
             .context("failed to clear tmp caches")?;
-        let objects = ObjectsActor::new(
-            caches.object_meta,
-            caches.objects,
-            io_pool,
-            downloader.clone(),
-        );
+        let objects = ObjectsActor::new(caches.object_meta, caches.objects, downloader.clone());
         let symcaches = SymCacheActor::new(caches.symcaches, objects.clone(), cpu_pool.clone());
         let cficaches = CfiCacheActor::new(caches.cficaches, objects.clone(), cpu_pool.clone());
 

--- a/src/services/objects/meta_cache.rs
+++ b/src/services/objects/meta_cache.rs
@@ -19,7 +19,7 @@ use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
 use crate::services::download::{ObjectFileSource, ObjectFileSourceURI};
 use crate::sources::SourceId;
 use crate::types::{ObjectFeatures, ObjectId, Scope};
-use crate::utils::futures::{BoxedFuture, ThreadPool};
+use crate::utils::futures::BoxedFuture;
 
 use super::{FetchFileDataRequest, ObjectError, ObjectHandle};
 
@@ -35,7 +35,6 @@ pub(super) struct FetchFileMetaRequest {
     // XXX: This kind of state is not request data. We should find a different way to get this into
     // `<FetchFileMetaRequest as CacheItemRequest>::compute`, e.g. make the Cacher hold arbitrary
     // state for computing.
-    pub(super) threadpool: ThreadPool,
     pub(super) data_cache: Arc<Cacher<FetchFileDataRequest>>,
     pub(super) download_svc: Arc<crate::services::download::DownloadService>,
 }

--- a/src/services/objects/mod.rs
+++ b/src/services/objects/mod.rs
@@ -18,7 +18,6 @@ use crate::services::download::{
 };
 use crate::sources::{FileType, SourceConfig, SourceId};
 use crate::types::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectId, Scope};
-use crate::utils::futures::ThreadPool;
 
 use data_cache::FetchFileDataRequest;
 use meta_cache::FetchFileMetaRequest;
@@ -140,21 +139,14 @@ struct CacheLookupError {
 pub struct ObjectsActor {
     meta_cache: Arc<Cacher<FetchFileMetaRequest>>,
     data_cache: Arc<Cacher<FetchFileDataRequest>>,
-    threadpool: ThreadPool,
     download_svc: Arc<DownloadService>,
 }
 
 impl ObjectsActor {
-    pub fn new(
-        meta_cache: Cache,
-        data_cache: Cache,
-        threadpool: ThreadPool,
-        download_svc: Arc<DownloadService>,
-    ) -> Self {
+    pub fn new(meta_cache: Cache, data_cache: Cache, download_svc: Arc<DownloadService>) -> Self {
         ObjectsActor {
             meta_cache: Arc::new(Cacher::new(meta_cache)),
             data_cache: Arc::new(Cacher::new(data_cache)),
-            threadpool,
             download_svc,
         }
     }
@@ -302,7 +294,6 @@ impl ObjectsActor {
         for file_source in file_sources {
             let object_id = identifier.clone();
             let scope = scope.clone();
-            let threadpool = self.threadpool.clone();
             let data_cache = self.data_cache.clone();
             let download_svc = self.download_svc.clone();
             let meta_cache = self.meta_cache.clone();
@@ -317,7 +308,6 @@ impl ObjectsActor {
                     scope,
                     file_source: file_source.clone(),
                     object_id,
-                    threadpool,
                     data_cache,
                     download_svc,
                 };


### PR DESCRIPTION
The service state used to create an I/O threadpool that was passed into the
objects and download services. The pool has been removed from the Download
service since, and is not used in the objects actor. Therefore, it is dead code
and can be removed.

#skip-changelog

