### PR TITLE
ref(clippy): Do not use capitalised acronyms

### DIFF
--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -12,7 +12,7 @@ use tokio::fs;
 
 use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, ObjectFileSource};
-use crate::services::download::ObjectFileSourceURI;
+use crate::services::download::ObjectFileSourceUri;
 use crate::sources::{FileType, FilesystemSourceConfig};
 use crate::types::ObjectId;
 
@@ -44,7 +44,7 @@ impl FilesystemObjectFileSource {
     /// This is a quick-and-dirty approximation, not fully RFC8089-compliant.  E.g. we do
     /// not provide a hostname nor percent-encode.  Use this only for diagnostics and use
     /// [`FilesystemObjectFileSource::path`] if the actual file location is needed.
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         format!("file:///{}", self.path().display()).into()
     }
 }

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use url::Url;
 
 use super::locations::SourceLocation;
-use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI};
+use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri};
 use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey};
 use crate::types::ObjectId;
 use crate::utils::futures as future_utils;
@@ -58,7 +58,7 @@ impl GcsObjectFileSource {
     }
 
     /// Returns the `gs://` URI from which to download this object file.
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         format!("gs://{}/{}", self.source.bucket, self.key()).into()
     }
 }

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -11,7 +11,7 @@ use reqwest::{header, Client};
 use url::Url;
 
 use super::{
-    DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI, SourceLocation,
+    DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri, SourceLocation,
     USER_AGENT,
 };
 use crate::sources::{FileType, HttpSourceConfig};
@@ -36,7 +36,7 @@ impl HttpObjectFileSource {
         Self { source, location }
     }
 
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         match self.url() {
             Ok(url) => url.as_ref().into(),
             Err(_) => "".into(),

--- a/src/services/download/locations.rs
+++ b/src/services/download/locations.rs
@@ -186,7 +186,7 @@ impl ObjectFileSource {
     /// very abstract.  In general the source should try and producde a URI which can be
     /// used directly into the source-specific tooling.  E.g. for an HTTP source this would
     /// be an `http://` or `https://` URL, for AWS S3 it would be an `s3://` url etc.
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         match self {
             ObjectFileSource::Sentry(ref file_source) => file_source.uri(),
             ObjectFileSource::Http(ref file_source) => file_source.uri(),
@@ -214,15 +214,15 @@ impl ConfigureScope for ObjectFileSource {
 ///
 /// [`ObjectFileSource`]: crate::services::download::ObjectFileSource
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct ObjectFileSourceURI(String);
+pub struct ObjectFileSourceUri(String);
 
-impl ObjectFileSourceURI {
+impl ObjectFileSourceUri {
     pub fn new(s: impl Into<String>) -> Self {
         Self(s.into())
     }
 }
 
-impl<T> From<T> for ObjectFileSourceURI
+impl<T> From<T> for ObjectFileSourceUri
 where
     T: Into<String>,
 {
@@ -231,7 +231,7 @@ where
     }
 }
 
-impl fmt::Display for ObjectFileSourceURI {
+impl fmt::Display for ObjectFileSourceUri {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -26,7 +26,7 @@ mod sentry;
 use crate::config::Config;
 pub use crate::sources::{DirectoryLayout, FileType, SourceConfig, SourceFilters};
 pub use crate::types::ObjectId;
-pub use locations::{ObjectFileSource, ObjectFileSourceURI, SourceLocation};
+pub use locations::{ObjectFileSource, ObjectFileSourceUri, SourceLocation};
 
 /// HTTP User-Agent string to use.
 const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -12,7 +12,7 @@ use parking_lot::Mutex;
 use rusoto_s3::S3;
 
 use super::locations::SourceLocation;
-use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI};
+use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri};
 use crate::sources::{FileType, S3SourceConfig, S3SourceKey};
 use crate::types::ObjectId;
 
@@ -60,7 +60,7 @@ impl S3ObjectFileSource {
     }
 
     /// Returns the `s3://` URI from which to download this object file.
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         format!("s3://{}/{}", self.source.bucket, self.key()).into()
     }
 }

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use thiserror::Error;
 use url::Url;
 
-use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceURI, USER_AGENT};
+use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri, USER_AGENT};
 use crate::config::Config;
 use crate::sources::{FileType, SentrySourceConfig};
 use crate::types::ObjectId;
@@ -39,7 +39,7 @@ impl SentryObjectFileSource {
         Self { source, file_id }
     }
 
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         format!("sentry://project_debug_file/{}", self.file_id).into()
     }
 
@@ -287,7 +287,7 @@ mod tests {
         let uri = file_source.uri();
         assert_eq!(
             uri,
-            ObjectFileSourceURI::new("sentry://project_debug_file/abc123")
+            ObjectFileSourceUri::new("sentry://project_debug_file/abc123")
         );
     }
 }

--- a/src/services/objects/meta_cache.rs
+++ b/src/services/objects/meta_cache.rs
@@ -16,7 +16,7 @@ use symbolic::debuginfo::Object;
 
 use crate::cache::{CacheKey, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
-use crate::services::download::{ObjectFileSource, ObjectFileSourceURI};
+use crate::services::download::{ObjectFileSource, ObjectFileSourceUri};
 use crate::sources::SourceId;
 use crate::types::{ObjectFeatures, ObjectId, Scope};
 use crate::utils::futures::BoxedFuture;
@@ -63,7 +63,7 @@ impl ObjectMetaHandle {
         self.request.file_source.source_id()
     }
 
-    pub fn uri(&self) -> ObjectFileSourceURI {
+    pub fn uri(&self) -> ObjectFileSourceUri {
         self.request.file_source.uri()
     }
 

--- a/src/services/objects/mod.rs
+++ b/src/services/objects/mod.rs
@@ -14,7 +14,7 @@ use crate::cache::{Cache, CacheStatus};
 use crate::logging::LogError;
 use crate::services::cacher::Cacher;
 use crate::services::download::{
-    DownloadError, DownloadService, ObjectFileSource, ObjectFileSourceURI,
+    DownloadError, DownloadService, ObjectFileSource, ObjectFileSourceUri,
 };
 use crate::sources::{FileType, SourceConfig, SourceId};
 use crate::types::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectId, Scope};
@@ -424,7 +424,7 @@ fn create_candidates(
     for source_id in source_ids {
         let info = ObjectCandidate {
             source: source_id,
-            location: ObjectFileSourceURI::new("No object files listed on this source"),
+            location: ObjectFileSourceUri::new("No object files listed on this source"),
             download: ObjectDownloadInfo::NotFound,
             unwind: Default::default(),
             debug: Default::default(),

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -313,7 +313,7 @@ pub enum DirectoryLayoutType {
     SymstoreIndex2,
     /// Uses Microsoft SSQP server conventions.
     #[serde(rename = "ssqp")]
-    SSQP,
+    Ssqp,
     /// Uses [debuginfod](https://www.mankier.com/8/debuginfod) conventions.
     #[serde(rename = "debuginfod")]
     Debuginfod,

--- a/src/types/objects.rs
+++ b/src/types/objects.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::cache::CacheStatus;
-use crate::services::download::ObjectFileSourceURI;
+use crate::services::download::ObjectFileSourceUri;
 use crate::sources::SourceId;
 
 use super::ObjectFeatures;
@@ -32,7 +32,7 @@ pub struct ObjectCandidate {
     ///
     /// This is generally a URI which makes sense for the source type, however no guarantees
     /// are given and it could be any string.
-    pub location: ObjectFileSourceURI,
+    pub location: ObjectFileSourceUri,
     /// Information about fetching or downloading this DIF object.
     ///
     /// This section is always present and will at least have a `status` field.
@@ -176,7 +176,7 @@ impl AllObjectCandidates {
     ///
     /// You can only request symcaches from a DIF object that was already in the metadata
     /// candidate list, therefore if the candidate is missing it is treated as an error.
-    pub fn set_debug(&mut self, source: SourceId, uri: &ObjectFileSourceURI, info: ObjectUseInfo) {
+    pub fn set_debug(&mut self, source: SourceId, uri: &ObjectFileSourceUri, info: ObjectUseInfo) {
         let found_pos = self.0.binary_search_by(|candidate| {
             candidate
                 .source
@@ -202,7 +202,7 @@ impl AllObjectCandidates {
     ///
     /// You can only request cficaches from a DIF object that was already in the metadata
     /// candidate list, therefore if the candidate is missing it is treated as an error.
-    pub fn set_unwind(&mut self, source: SourceId, uri: &ObjectFileSourceURI, info: ObjectUseInfo) {
+    pub fn set_unwind(&mut self, source: SourceId, uri: &ObjectFileSourceUri, info: ObjectUseInfo) {
         let found_pos = self.0.binary_search_by(|candidate| {
             candidate
                 .source
@@ -280,7 +280,7 @@ mod tests {
         // If a candidate didn't exist yet it should be inserted in order.
         let src_a = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceURI::new("a"),
+            location: ObjectFileSourceUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -289,7 +289,7 @@ mod tests {
         };
         let src_b = ObjectCandidate {
             source: SourceId::new("B"),
-            location: ObjectFileSourceURI::new("b"),
+            location: ObjectFileSourceUri::new("b"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -298,7 +298,7 @@ mod tests {
         };
         let src_c = ObjectCandidate {
             source: SourceId::new("C"),
-            location: ObjectFileSourceURI::new("c"),
+            location: ObjectFileSourceUri::new("c"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -318,7 +318,7 @@ mod tests {
     fn test_all_object_info_merge_overwrite() {
         let src0 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceURI::new("a"),
+            location: ObjectFileSourceUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -327,7 +327,7 @@ mod tests {
         };
         let src1 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceURI::new("a"),
+            location: ObjectFileSourceUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -349,7 +349,7 @@ mod tests {
     fn test_all_object_info_merge_no_overwrite() {
         let src0 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceURI::new("uri://dummy"),
+            location: ObjectFileSourceUri::new("uri://dummy"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -358,7 +358,7 @@ mod tests {
         };
         let src1 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceURI::new("uri://dummy"),
+            location: ObjectFileSourceUri::new("uri://dummy"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -383,7 +383,7 @@ pub fn get_directory_paths(
         DirectoryLayoutType::SymstoreIndex2 => get_symstore_index2_path(filetype, identifier)
             .into_iter()
             .collect(),
-        DirectoryLayoutType::SSQP => get_symstore_path(filetype, identifier, true)
+        DirectoryLayoutType::Ssqp => get_symstore_path(filetype, identifier, true)
             .into_iter()
             .collect(),
         DirectoryLayoutType::Debuginfod => get_debuginfod_path(filetype, identifier)


### PR DESCRIPTION
Nightly clippy starts warning about this.  As long as it stays
consistent that seems like a reasonable thing.

#skip-changelog