### PR TITLE
fix(test): Enforce HTTP/1.1 to support proxying to MSDL

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import traceback
 import pytest
 import requests
 from pytest_localserver.http import WSGIServer
+from werkzeug.serving import WSGIRequestHandler
 
 SYMBOLICATOR_BIN = [os.environ.get("SYMBOLICATOR_BIN") or "target/debug/symbolicator"]
 
@@ -151,6 +152,11 @@ class HitCounter:
         self.before_request = None
         self._lock = threading.Lock()
         self.errors = []
+
+        # Required for proxying HTTP/1.1 transfer-encoding "chunked" from the microsoft symbol server.
+        # See: https://github.com/hyperium/hyper/blob/48d4594930da4e227039cfa254411b85c98b63c5/src/proto/h1/role.rs#L209
+        WSGIRequestHandler.protocol_version = "HTTP/1.1"
+
         self._server = WSGIServer(application=self._app, threaded=True)
 
     def __enter__(self):


### PR DESCRIPTION
The Microsoft symbol server has started returning `transfer-encoding: chunked`
for its `404` responses. Our HitCounter proxy uses to return this header to the
caller, but at the same time responds with `HTTP/1.0`. This is invalid and
causes the HTTP client in Symbolicator to fail.

This problem does not occur in production code. The fix is to configure the WSGI
test server for `HTTP/1.1`.

#skip-changelog
