### PR TITLE
ref(paths): Avoid manual slicing

### DIFF
--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -106,15 +106,13 @@ fn get_breakpad_path(identifier: &ObjectId) -> Option<String> {
 
     let debug_file = identifier.debug_file_basename()?;
     let debug_id = identifier.debug_id.as_ref()?;
-
-    let new_debug_file = if debug_file.ends_with(".exe")
-        || debug_file.ends_with(".dll")
-        || debug_file.ends_with(".pdb")
-    {
-        &debug_file[..debug_file.len() - 4]
-    } else {
-        debug_file
-    };
+    let new_debug_file = debug_file
+        .strip_suffix(".exe")
+        .unwrap_or(debug_file)
+        .strip_suffix(".dll")
+        .unwrap_or(debug_file)
+        .strip_suffix(".pdb")
+        .unwrap_or(debug_file);
 
     Some(format!(
         "{}/{}/{}.sym",


### PR DESCRIPTION
While this code wasn't unsafe due to the checks it is always safer not
to manually slice strings.

An alternative here was to use .trim_end_matches() which allows
chaining the operations without the .unwrap_or() calls in between and
is thus a bit more readable.
However it is no longer strictly the same since it would remove this
patter from the end as many times as it occurs instead of only once.
In practice we're unlikely to notice the difference I guess, but still
this is more correct.

#skip-changelog