### PR TITLE
build: Bump symbolic to fix endless loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Bug Fixes
-- Bump symbolic to fix large public records. ([#385](https://github.com/getsentry/symbolicator/pull/385))
+- Bump symbolic to fix large public records. ([#385](https://github.com/getsentry/symbolicator/pull/385), [#387](https://github.com/getsentry/symbolicator/pull/387))
 
 ## 0.3.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 [[package]]
 name = "symbolic"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "debugid",
  "memmap",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "dmsort",
  "fallible-iterator",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "symbolic-minidump"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3425,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "8.0.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#46ef9f7e89e16633897dda8944edf33e217ce158"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a1831f5ae98474c94290b706f812069cfc9dafed"
 dependencies = [
  "dmsort",
  "fnv",


### PR DESCRIPTION
This incorporates the symbolic fix in https://github.com/getsentry/symbolic/commit/4f371639dde89b734d84d4731d265946fa526053 into symbolicator.