### PR TITLE
fix(cache): Update the mtime when it is 1h out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Bug Fixes
+- Update the mtime of a cache when it is 1h out of date. ([#390](https://github.com/getsentry/symbolicator/pull/390))
 - Bump symbolic to fix large public records. ([#385](https://github.com/getsentry/symbolicator/pull/385), [#387](https://github.com/getsentry/symbolicator/pull/387))
 
 ## 0.3.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.4",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,6 +3502,7 @@ dependencies = [
  "console",
  "env_logger",
  "failure",
+ "filetime",
  "flate2",
  "fragile",
  "futures 0.1.29",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
 env_logger = "0.7.1"
 failure = "0.1.8"
+filetime = "0.2.14"
 flate2 = "1.0.19"
 fragile = "1.0.0" # used for vendoring sentry-actix
 futures = { version = "0.3.12", features = ["compat"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -265,9 +265,9 @@ impl Cache {
             && mtime.map(|x| x > Duration::from_secs(3600)).unwrap_or(true))
     }
 
-    /// Validates cachefile against expiration config and open a byteview on it.
+    /// Validates `cachefile` against expiration config and open a [`ByteView`] on it.
     ///
-    /// Takes care of bumping mtime.
+    /// Takes care of bumping `mtime`.
     pub fn open_cachefile(&self, path: &Path) -> io::Result<Option<ByteView<'static>>> {
         // `io::ErrorKind::NotFound` can be returned from multiple locations in this function. All
         // of those can indicate a cache miss as cache cleanup can run inbetween. Only when we have

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,12 +2,13 @@
 ///
 /// TODO:
 /// * We want to try upgrading derived caches without pruning them. This will likely require the concept of a content checksum (which would just be the cache key of the object file that would be used to create the derived cache.
-use std::fs::{self, read_dir, remove_file, File, OpenOptions};
+use std::fs::{self, read_dir, remove_file, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Result};
+use filetime::FileTime;
 use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 
@@ -264,8 +265,9 @@ impl Cache {
             && mtime.map(|x| x > Duration::from_secs(3600)).unwrap_or(true))
     }
 
-    /// Validate cachefile against expiration config and open a byteview on it. Takes care of
-    /// bumping mtime.
+    /// Validates cachefile against expiration config and open a byteview on it.
+    ///
+    /// Takes care of bumping mtime.
     pub fn open_cachefile(&self, path: &Path) -> io::Result<Option<ByteView<'static>>> {
         // `io::ErrorKind::NotFound` can be returned from multiple locations in this function. All
         // of those can indicate a cache miss as cache cleanup can run inbetween. Only when we have
@@ -274,10 +276,7 @@ impl Cache {
             let should_touch = self.check_expiry(path)?;
 
             if should_touch {
-                OpenOptions::new()
-                    .append(true)
-                    .truncate(false)
-                    .open(&path)?;
+                filetime::set_file_mtime(path, FileTime::now())?;
             }
 
             ByteView::open(path)
@@ -423,6 +422,7 @@ pub fn cleanup(config: Config) -> Result<()> {
 mod tests {
     use super::*;
 
+    use std::convert::TryInto;
     use std::fs::{self, create_dir_all};
     use std::io::Write;
     use std::thread::sleep;
@@ -591,6 +591,39 @@ mod tests {
         basenames.sort();
 
         assert_eq!(basenames, vec!["keepthis", "keepthis2"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_cachefile() -> Result<()> {
+        // Assert that opening a cache touches the mtime but does not invalidate it.
+        let tempdir = tempdir()?;
+        let cache = Cache::from_config(
+            "test",
+            Some(tempdir.path().to_path_buf()),
+            None,
+            CacheConfig::Downloaded(Default::default()),
+        )?;
+
+        // Create a file in the cache, with mtime of 1h 15s ago since it only gets touched
+        // if more than an hour old.
+        let path = tempdir.path().join("hello");
+        File::create(&path)?.write_all(b"world")?;
+        let now_unix = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_secs();
+        let old_mtime_unix = (now_unix - 3600 - 15).try_into()?;
+        filetime::set_file_mtime(&path, FileTime::from_unix_time(old_mtime_unix, 0))?;
+
+        let old_mtime = fs::metadata(&path)?.modified()?;
+
+        // Open it with the cache, check contents and new mtime.
+        let view = cache.open_cachefile(&path)?.expect("No file found");
+        assert_eq!(view.as_slice(), b"world");
+
+        let new_mtime = fs::metadata(&path)?.modified()?;
+        assert!(old_mtime < new_mtime);
 
         Ok(())
     }

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -146,7 +146,7 @@ NO_SOURCES = _make_unsuccessful_result("missing", source=None)
 UNKNOWN_SOURCE = _make_unsuccessful_result("missing", source="unknown")
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["cachedir", "no_cachedir"])
 def cache_dir_param(tmpdir, request):
     if request.param:
         return tmpdir.mkdir("caches")
@@ -177,8 +177,7 @@ def test_basic_windows(symbolicator, cache_dir_param, is_public, hitcounter):
 
     # i = 0: Cache miss
     # i = 1: Cache hit
-    # i = 2: Assert that touching the file during cache hit did not destroy the cache
-    for i in range(3):
+    for i in range(2):
         service = symbolicator(cache_dir=cache_dir_param)
         service.wait_healthcheck()
 


### PR DESCRIPTION
The code used to update the mtime wasn't actually updating the mtime
as nothing was ever written to the file, it was only opened.  This
pulls in a new library which seems to do a better job at this.

There is now an explicit unit test for this, before this was tried to
be covered by an extra iteration in an integration test but this was
occasionlly flaky and did not take into account the mtime needed to be
out of date for more than an hour.