### PR TITLE
ref(clippy): Flatten iterator instead of if let

### DIFF
--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -509,11 +509,12 @@ pub fn matches_path_patterns(object_id: &ObjectId, patterns: &[Glob]) -> bool {
     }
 
     for pattern in patterns {
-        for path in &[&object_id.code_file, &object_id.debug_file] {
-            if let Some(ref path) = path {
-                if pattern.matches_with(&canonicalize_path(path), GLOB_OPTIONS) {
-                    return true;
-                }
+        for path in [object_id.code_file.as_ref(), object_id.debug_file.as_ref()]
+            .iter()
+            .flatten()
+        {
+            if pattern.matches_with(&canonicalize_path(path), GLOB_OPTIONS) {
+                return true;
             }
         }
     }


### PR DESCRIPTION
It seems nightly clippy prefers you to flatten the iterator instead of
using if let inside.  Must admit it looks a little cleaner.

#skip-changelog