### PR TITLE
ref(symcache): Rewrite as async-await code

### DIFF
--- a/src/services/cficaches.rs
+++ b/src/services/cficaches.rs
@@ -218,7 +218,6 @@ impl CfiCacheActor {
     ) -> Result<Arc<CfiCacheFile>, Arc<CfiCacheError>> {
         let found_result = self
             .objects
-            .clone()
             .find(FindObject {
                 filetypes: FileType::from_object_type(request.object_type),
                 identifier: request.identifier.clone(),

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -98,8 +98,8 @@ impl Service {
         self.symbolication.clone()
     }
 
-    pub fn objects(&self) -> ObjectsActor {
-        self.objects.clone()
+    pub fn objects(&self) -> &ObjectsActor {
+        &self.objects
     }
 
     pub fn config(&self) -> Arc<Config> {

--- a/src/services/objects/mod.rs
+++ b/src/services/objects/mod.rs
@@ -206,10 +206,7 @@ impl ObjectsActor {
     /// Asking for the objects metadata from the data cache also triggers a download of each
     /// object, which will then be cached in the data cache.  The metadata itself is cached
     /// in the metadata cache which usually lives longer.
-    ///
-    /// TODO(flub): Once all the callers are async/await this should take `&self` again
-    /// instead of requiring `self`.
-    pub async fn find(self, request: FindObject) -> Result<FoundObject, ObjectError> {
+    pub async fn find(&self, request: FindObject) -> Result<FoundObject, ObjectError> {
         let FindObject {
             filetypes,
             scope,

--- a/src/services/symbolication.rs
+++ b/src/services/symbolication.rs
@@ -631,7 +631,6 @@ impl SourceLookup {
                 }
 
                 let opt_object_file_meta = objects
-                    .clone()
                     .find(FindObject {
                         filetypes: FileType::sources(),
                         purpose: ObjectPurpose::Source,


### PR DESCRIPTION
This is simpler and reduces the need for some clones.  It also finally
frees the object cache's .find() to not needlessly consume self.

#skip-changelog