### PR TITLE
test: Move remaining tests to Rust

### DIFF
--- a/src/endpoints/snapshots/symbolicator__endpoints__symbolicate__tests__no_sources.snap
+++ b/src/endpoints/snapshots/symbolicator__endpoints__symbolicate__tests__no_sources.snap
@@ -1,0 +1,27 @@
+---
+source: src/endpoints/symbolicate.rs
+expression: response
+---
+status: completed
+stacktraces:
+  - registers:
+      eip: "0x1509530"
+    frames:
+      - status: missing
+        original_index: 0
+        instruction_addr: "0x749e8630"
+        package: "C:\\Windows\\System32\\kernel32.dll"
+modules:
+  - debug_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_file: "C:\\Windows\\System32\\kernel32.dll"
+    debug_id: ff9f9f78-41db-88f0-cded-a9e1e9bff3b5-1
+    debug_file: "C:\\Windows\\System32\\wkernel32.pdb"
+    image_addr: "0x749d0000"
+    image_size: 851968

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -605,38 +605,39 @@ pub enum SymbolicationResponse {
 pub struct CompletedSymbolicationResponse {
     /// When the crash occurred.
     #[serde(
+        default,
         skip_serializing_if = "Option::is_none",
         with = "chrono::serde::ts_seconds_option"
     )]
     pub timestamp: Option<DateTime<Utc>>,
 
     /// The signal that caused this crash.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signal: Option<Signal>,
 
     /// Information about the operating system.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_info: Option<SystemInfo>,
 
     /// True if the process crashed, false if the dump was produced outside of an exception
     /// handler. Only set for minidumps.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crashed: Option<bool>,
 
     /// If the process crashed, the type of crash.  OS- and possibly CPU- specific.  For
     /// example, "EXCEPTION_ACCESS_VIOLATION" (Windows), "EXC_BAD_ACCESS /
     /// KERN_INVALID_ADDRESS" (Mac OS X), "SIGSEGV" (other Unix).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crash_reason: Option<String>,
 
     /// A detailed explanation of the crash, potentially in human readable form. This may
     /// include a string representation of the crash reason or application-specific info.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crash_details: Option<String>,
 
     /// If there was an assertion that was hit, a textual representation of that assertion,
     /// possibly including the file and line at which it occurred.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assertion: Option<String>,
 
     /// The threads containing symbolicated stack frames.

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -220,36 +220,6 @@ def test_basic_windows(symbolicator, cache_dir_param, is_public, hitcounter):
         }
 
 
-def test_no_sources(symbolicator, cache_dir_param):
-    input = dict(**WINDOWS_DATA, sources=[])
-
-    service = symbolicator(cache_dir=cache_dir_param)
-    service.wait_healthcheck()
-
-    response = service.post("/symbolicate", json=input)
-    response.raise_for_status()
-
-    assert_symbolication(response.json(), NO_SOURCES)
-
-    if cache_dir_param:
-        assert not cache_dir_param.join("objects/global").exists()
-        assert not cache_dir_param.join("symcaches/global").exists()
-
-
-def test_unknown_field(symbolicator, cache_dir_param):
-    service = symbolicator(cache_dir=cache_dir_param)
-    service.wait_healthcheck()
-
-    request = dict(
-        **WINDOWS_DATA,
-        sources=[],  # Disable for faster test result. We don't care about symbolication
-        unknown="value",  # Should be ignored
-    )
-
-    response = service.post("/symbolicate", json=request)
-    assert response.status_code == 200
-
-
 @pytest.mark.parametrize("is_public", [True, False])
 def test_lookup_deduplication(symbolicator, hitcounter, is_public):
     input = dict(


### PR DESCRIPTION
Moves the remaining tests from `test_basic.py` to Rust.

- [ ] test_basic_windows
- [x] test_no_sources
- [x] test_unknown_field
- [ ] test_lookup_deduplication
- [ ] test_sources_filetypes
- [ ] test_unknown_source_config
- [ ] test_timeouts
- [ ] test_unreachable_bucket
- [ ] test_malformed_objects
- [ ] test_path_patterns
- [ ] test_redirects
- [ ] test_reserved_ip_addresses
- [ ] test_no_dif_candidates