### PR TITLE
feat(download): Use circuit-breaker in sentry source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Update the mtime of a cache when it is 1h out of date. ([#390](https://github.com/getsentry/symbolicator/pull/390))
 - Bump symbolic to fix large public records. ([#385](https://github.com/getsentry/symbolicator/pull/385), [#387](https://github.com/getsentry/symbolicator/pull/387))
 - Bump symbolic to support `debug_addr` indexes in DWARF functions. ([#389](https://github.com/getsentry/symbolicator/pull/389))
+- Fix retry of DIF downloads from sentry ([#397](https://github.com/getsentry/symbolicator/pull/397))
+
 ## 0.3.3
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "failsafe"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0710501d57ee0ff382c51841154e17bf62397c1517036de644225c8ad58e21eb"
+dependencies = [
+ "futures-core",
+ "parking_lot 0.11.1",
+ "pin-project 0.4.8",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3513,7 @@ dependencies = [
  "chrono",
  "console",
  "env_logger",
+ "failsafe",
  "failure",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cadence = "0.18.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
 env_logger = "0.7.1"
+failsafe = "1.0.0"
 failure = "0.1.8"
 filetime = "0.2.14"
 flate2 = "1.0.19"


### PR DESCRIPTION
Introduces a circuit breaker to avoid hammering on sentry if
it had problems during outages. It takes a shortcut by only having one
global circuit-breaker instead of keeping one per source, because we
know all the sentry-sources will be the same.

**Todo:**

- [ ] Add tests
- [ ] Add metrics
- [ ] Consider whether this should be done on the top-level for all downloaders, indexed on the source.