### PR TITLE
ref(clippy): weekly nightly clippy fixes

### DIFF
--- a/src/services/symbolication.rs
+++ b/src/services/symbolication.rs
@@ -1273,8 +1273,8 @@ impl SymbolicationActor {
 
             CompletedSymbolicationResponse {
                 signal,
-                modules,
                 stacktraces,
+                modules,
                 ..Default::default()
             }
         };

--- a/src/utils/hex.rs
+++ b/src/utils/hex.rs
@@ -30,7 +30,7 @@ impl FromStr for HexValue {
         if s.starts_with("0x") || s.starts_with("0X") {
             u64::from_str_radix(&s[2..], 16).map(HexValue)
         } else {
-            u64::from_str_radix(&s, 10).map(HexValue)
+            s.parse().map(HexValue)
         }
     }
 }

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -23,12 +23,9 @@ fn get_gdb_path(identifier: &ObjectId) -> Option<String> {
 }
 
 fn get_mach_uuid(identifier: &ObjectId) -> Option<Uuid> {
-    if let Some(ref code_id) = identifier.code_id {
-        code_id.as_str().parse().ok()
-    } else if let Some(ref debug_id) = identifier.debug_id {
-        Some(debug_id.uuid())
-    } else {
-        None
+    match identifier.code_id {
+        Some(ref code_id) => code_id.as_str().parse().ok(),
+        None => identifier.debug_id.as_ref().map(|debug_id| debug_id.uuid()),
     }
 }
 

--- a/src/utils/sentry.rs
+++ b/src/utils/sentry.rs
@@ -203,11 +203,9 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
 
     fn response(&self, req: &HttpRequest<S>, mut resp: HttpResponse) -> Result<Response, Error> {
         if self.capture_server_errors && resp.status().is_server_error() {
-            let event_id = if let Some(error) = resp.error() {
-                Some(Hub::from_request(req).capture_actix_error(error))
-            } else {
-                None
-            };
+            let event_id = resp
+                .error()
+                .map(|error| Hub::from_request(req).capture_actix_error(error));
             match event_id {
                 Some(event_id) if self.emit_header => {
                     resp.headers_mut().insert(


### PR DESCRIPTION
- Construct structs in same order as they are defined.
- Use str::parse() instead of manual radix parsing.
- Use Option::map() instead of manual equivalent.

#skip-changelog