### PR TITLE
fix(download): Retry entire sentry download on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Update the mtime of a cache when it is 1h out of date. ([#390](https://github.com/getsentry/symbolicator/pull/390))
 - Bump symbolic to fix large public records. ([#385](https://github.com/getsentry/symbolicator/pull/385), [#387](https://github.com/getsentry/symbolicator/pull/387))
 - Bump symbolic to support `debug_addr` indexes in DWARF functions. ([#389](https://github.com/getsentry/symbolicator/pull/389))
+- Fix retry of DIF downloads from sentry ([#397](https://github.com/getsentry/symbolicator/pull/397))
+
 ## 0.3.3
 
 ### Features


### PR DESCRIPTION
Currently we only retry failures during fetching of the headers
instead of also retrying after failures during streaming of the body.
This makes us not very resilient against sentry workers going down.

----

This is part of #395 but without adding the circuit breaker.