### PR TITLE
test: Run minidump e2e tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --locked -- test_integration_microsoft --nocapture
+          args: --workspace --all-features --locked
         env:
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
           command: test
           args: -- test_integration_microsoft --nocapture
         env:
-          RUST_LOG: trace
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - run: cat /etc/resolv.conf
+
       - name: Install rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,49 +12,49 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  lints:
-    name: Lints
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # lints:
+  #   name: Lints
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Install python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Install python dependencies
-        run: pip install --upgrade black flake8
+  #     - name: Install python dependencies
+  #       run: pip install --upgrade black flake8
 
-      - name: Run Black
-        run: black --check --diff tests
+  #     - name: Run Black
+  #       run: black --check --diff tests
 
-      - name: Run Flake8
-        run: flake8 tests
+  #     - name: Run Flake8
+  #       run: flake8 tests
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt, clippy
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         components: rustfmt, clippy
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  #     - name: Run cargo fmt
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: fmt
+  #         args: --all -- --check
 
-      - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --workspace --tests --examples
+  #     - name: Run clippy
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: clippy
+  #         args: --all-features --workspace --tests --examples
 
   unit-test:
     name: Unit Tests
@@ -62,8 +62,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - run: cat /etc/resolv.conf
 
       - name: Install rust stable toolchain
         uses: actions-rs/toolchain@v1
@@ -79,83 +77,83 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --locked
+          args: -- test_integration_microsoft --nocapture
         env:
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
 
-  integration-test:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # integration-test:
+  #   name: Integration Tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - name: Build rust
-        run: cargo build --locked
+  #     - name: Build rust
+  #       run: cargo build --locked
 
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Install python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Setup python environment
-        run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
+  #     - name: Setup python environment
+  #       run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
 
-      - name: Integration tests
-        run: pytest -n12 -vv tests/integration
+  #     - name: Integration tests
+  #       run: pytest -n12 -vv tests/integration
 
-  doc-comments:
-    name: Rust doc comments
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # doc-comments:
+  #   name: Rust doc comments
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     RUSTDOCFLAGS: -Dwarnings
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rust-docs
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         components: rust-docs
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --document-private-items --no-deps
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: doc
+  #         args: --workspace --all-features --document-private-items --no-deps
 
-  docs:
-    name: Build docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # docs:
+  #   name: Build docs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Setup python dependencies
-        run: pip install --upgrade mkdocs mkdocs-material pygments
+  #     - name: Setup python dependencies
+  #       run: pip install --upgrade mkdocs mkdocs-material pygments
 
-      - name: Build Docs
-        run: mkdocs build
+  #     - name: Build Docs
+  #       run: mkdocs build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,49 +12,49 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  # lints:
-  #   name: Lints
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v2
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-  #     - name: Install python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-  #     - name: Install python dependencies
-  #       run: pip install --upgrade black flake8
+      - name: Install python dependencies
+        run: pip install --upgrade black flake8
 
-  #     - name: Run Black
-  #       run: black --check --diff tests
+      - name: Run Black
+        run: black --check --diff tests
 
-  #     - name: Run Flake8
-  #       run: flake8 tests
+      - name: Run Flake8
+        run: flake8 tests
 
-  #     - name: Install rust stable toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         components: rustfmt, clippy
-  #         override: true
+      - name: Install rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+          override: true
 
-  #     - name: Cache rust cargo artifacts
-  #       uses: swatinem/rust-cache@v1
+      - name: Cache rust cargo artifacts
+        uses: swatinem/rust-cache@v1
 
-  #     - name: Run cargo fmt
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: fmt
-  #         args: --all -- --check
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
-  #     - name: Run clippy
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: clippy
-  #         args: --all-features --workspace --tests --examples
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --workspace --tests --examples
 
   unit-test:
     name: Unit Tests
@@ -84,76 +84,76 @@ jobs:
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
 
-  # integration-test:
-  #   name: Integration Tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v2
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-  #     - name: Install rust stable toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
+      - name: Install rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
-  #     - name: Cache rust cargo artifacts
-  #       uses: swatinem/rust-cache@v1
+      - name: Cache rust cargo artifacts
+        uses: swatinem/rust-cache@v1
 
-  #     - name: Build rust
-  #       run: cargo build --locked
+      - name: Build rust
+        run: cargo build --locked
 
-  #     - name: Install python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-  #     - name: Setup python environment
-  #       run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
+      - name: Setup python environment
+        run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
 
-  #     - name: Integration tests
-  #       run: pytest -n12 -vv tests/integration
+      - name: Integration tests
+        run: pytest -n12 -vv tests/integration
 
-  # doc-comments:
-  #   name: Rust doc comments
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     RUSTDOCFLAGS: -Dwarnings
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v2
+  doc-comments:
+    name: Rust doc comments
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-  #     - name: Install rust stable toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         components: rust-docs
-  #         override: true
+      - name: Install rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rust-docs
+          override: true
 
-  #     - name: Cache rust cargo artifacts
-  #       uses: swatinem/rust-cache@v1
+      - name: Cache rust cargo artifacts
+        uses: swatinem/rust-cache@v1
 
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: doc
-  #         args: --workspace --all-features --document-private-items --no-deps
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --all-features --document-private-items --no-deps
 
-  # docs:
-  #   name: Build docs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v2
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-  #     - name: Setup Python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-  #     - name: Setup python dependencies
-  #       run: pip install --upgrade mkdocs mkdocs-material pygments
+      - name: Setup python dependencies
+        run: pip install --upgrade mkdocs mkdocs-material pygments
 
-  #     - name: Build Docs
-  #       run: mkdocs build
+      - name: Build Docs
+        run: mkdocs build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- test_integration_microsoft --nocapture
+          args: --workspace --all-features --locked -- test_integration_microsoft --nocapture
         env:
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,49 +12,49 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  lints:
-    name: Lints
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # lints:
+  #   name: Lints
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Install python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Install python dependencies
-        run: pip install --upgrade black flake8
+  #     - name: Install python dependencies
+  #       run: pip install --upgrade black flake8
 
-      - name: Run Black
-        run: black --check --diff tests
+  #     - name: Run Black
+  #       run: black --check --diff tests
 
-      - name: Run Flake8
-        run: flake8 tests
+  #     - name: Run Flake8
+  #       run: flake8 tests
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt, clippy
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         components: rustfmt, clippy
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  #     - name: Run cargo fmt
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: fmt
+  #         args: --all -- --check
 
-      - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --workspace --tests --examples
+  #     - name: Run clippy
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: clippy
+  #         args: --all-features --workspace --tests --examples
 
   unit-test:
     name: Unit Tests
@@ -77,83 +77,83 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --locked
+          args: -- test_integration_microsoft --nocapture
         env:
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
           SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
 
-  integration-test:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # integration-test:
+  #   name: Integration Tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - name: Build rust
-        run: cargo build --locked
+  #     - name: Build rust
+  #       run: cargo build --locked
 
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Install python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Setup python environment
-        run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
+  #     - name: Setup python environment
+  #       run: pip install --upgrade pytest pytest-localserver requests pytest-xdist pytest-icdiff boto3
 
-      - name: Integration tests
-        run: pytest -n12 -vv tests/integration
+  #     - name: Integration tests
+  #       run: pytest -n12 -vv tests/integration
 
-  doc-comments:
-    name: Rust doc comments
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # doc-comments:
+  #   name: Rust doc comments
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     RUSTDOCFLAGS: -Dwarnings
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Install rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rust-docs
-          override: true
+  #     - name: Install rust stable toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         components: rust-docs
+  #         override: true
 
-      - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v1
+  #     - name: Cache rust cargo artifacts
+  #       uses: swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --document-private-items --no-deps
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: doc
+  #         args: --workspace --all-features --document-private-items --no-deps
 
-  docs:
-    name: Build docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+  # docs:
+  #   name: Build docs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
 
-      - name: Setup python dependencies
-        run: pip install --upgrade mkdocs mkdocs-material pygments
+  #     - name: Setup python dependencies
+  #       run: pip install --upgrade mkdocs mkdocs-material pygments
 
-      - name: Build Docs
-        run: mkdocs build
+  #     - name: Build Docs
+  #       run: mkdocs build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           command: test
           args: -- test_integration_microsoft --nocapture
         env:
+          RUST_LOG: trace
           SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
           SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
           SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,6 +3632,7 @@ dependencies = [
  "thiserror",
  "tokio 0.1.22",
  "tokio 1.0.2",
+ "tracing",
  "url 2.2.0",
  "uuid 0.8.2",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.6.0"
 
+tracing = { version = "0.1.22", default-features = false, features = ["log", "log-always"] }
+
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }
 procspawn = { version = "0.9.0", features = ["test-support"] }

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -100,8 +100,7 @@ mod tests {
     }
 
     // This test is disabled because it locks up on CI. We have not found a way to reproduce this.
-    #[allow(dead_code)]
-    // #[tokio::test]
+    #[tokio::test]
     async fn test_integration_microsoft() {
         // TODO: Move this test to E2E tests
         test::setup();

--- a/src/endpoints/minidump.rs
+++ b/src/endpoints/minidump.rs
@@ -99,7 +99,6 @@ mod tests {
         insta::assert_yaml_snapshot!(response);
     }
 
-    // This test is disabled because it locks up on CI. We have not found a way to reproduce this.
     #[tokio::test]
     async fn test_integration_microsoft() {
         // TODO: Move this test to E2E tests

--- a/src/endpoints/snapshots/symbolicator__endpoints__minidump__tests__integration_microsoft.snap
+++ b/src/endpoints/snapshots/symbolicator__endpoints__minidump__tests__integration_microsoft.snap
@@ -39,30 +39,12 @@ stacktraces:
         package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         trust: fp
       - status: symbolicated
-        original_index: 2
-        instruction_addr: "0x7584e9bf"
-        package: "C:\\Windows\\System32\\rpcrt4.dll"
-        symbol: "?FreeWrapper@@YGXPAX@Z"
-        sym_addr: "0x7584e960"
-        function: FreeWrapper(void *)
-        lineno: 0
-        trust: scan
-      - status: symbolicated
         original_index: 3
         instruction_addr: "0x70b7ae3f"
         package: "C:\\Windows\\System32\\dbgcore.dll"
         symbol: "?DetermineOutputProvider@@YGJPAVMiniDumpAllocationProvider@@PAXQAU_MINIDUMP_CALLBACK_INFORMATION@@PAPAVMiniDumpOutputProvider@@@Z"
         sym_addr: "0x70b7ad6b"
         function: "DetermineOutputProvider(class MiniDumpAllocationProvider *,void *,struct _MINIDUMP_CALLBACK_INFORMATION * const,class MiniDumpOutputProvider * *)"
-        lineno: 0
-        trust: scan
-      - status: symbolicated
-        original_index: 4
-        instruction_addr: "0x7584e9bf"
-        package: "C:\\Windows\\System32\\rpcrt4.dll"
-        symbol: "?FreeWrapper@@YGXPAX@Z"
-        sym_addr: "0x7584e960"
-        function: FreeWrapper(void *)
         lineno: 0
         trust: scan
       - status: missing
@@ -88,9 +70,9 @@ stacktraces:
         original_index: 8
         instruction_addr: "0x771d0f78"
         package: "C:\\Windows\\System32\\ntdll.dll"
-        symbol: __RtlUserThreadStart@8
+        symbol: __RtlUserThreadStart
         sym_addr: "0x771d0f4a"
-        function: __RtlUserThreadStart@8
+        function: __RtlUserThreadStart
         lineno: 0
         trust: cfi
       - status: symbolicated
@@ -129,9 +111,9 @@ stacktraces:
         original_index: 1
         instruction_addr: "0x771a6a10"
         package: "C:\\Windows\\System32\\ntdll.dll"
-        symbol: TppWorkerThread@4
+        symbol: TppWorkerThread
         sym_addr: "0x771a6770"
-        function: TppWorkerThread@4
+        function: TppWorkerThread
         lineno: 0
         trust: cfi
       - status: symbolicated
@@ -147,9 +129,9 @@ stacktraces:
         original_index: 3
         instruction_addr: "0x771d0f78"
         package: "C:\\Windows\\System32\\ntdll.dll"
-        symbol: __RtlUserThreadStart@8
+        symbol: __RtlUserThreadStart
         sym_addr: "0x771d0f4a"
-        function: __RtlUserThreadStart@8
+        function: __RtlUserThreadStart
         lineno: 0
         trust: cfi
       - status: symbolicated
@@ -188,9 +170,9 @@ stacktraces:
         original_index: 1
         instruction_addr: "0x771a6a10"
         package: "C:\\Windows\\System32\\ntdll.dll"
-        symbol: TppWorkerThread@4
+        symbol: TppWorkerThread
         sym_addr: "0x771a6770"
-        function: TppWorkerThread@4
+        function: TppWorkerThread
         lineno: 0
         trust: cfi
       - status: symbolicated
@@ -206,9 +188,9 @@ stacktraces:
         original_index: 3
         instruction_addr: "0x771d0f78"
         package: "C:\\Windows\\System32\\ntdll.dll"
-        symbol: __RtlUserThreadStart@8
+        symbol: __RtlUserThreadStart
         sym_addr: "0x771d0f4a"
-        function: __RtlUserThreadStart@8
+        function: __RtlUserThreadStart
         lineno: 0
         trust: cfi
       - status: symbolicated

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,6 +43,9 @@ const SYMBOLS_PATH: &str = "tests/fixtures/symbols";
 pub(crate) fn setup() {
     env_logger::builder()
         .filter(Some("symbolicator"), LevelFilter::Trace)
+        .filter(Some("tokio"), LevelFilter::Trace)
+        .filter(Some("hyper"), LevelFilter::Trace)
+        .filter(Some("reqwest"), LevelFilter::Trace)
         .is_test(true)
         .try_init()
         .ok();


### PR DESCRIPTION
Re-enables the minidump symbolication test that was previously locking up in CI. Also, updates the snapshots which have changed after updating symbolic.

#skip-changelog