### PR TITLE
ref(clippy): Use <dyn Fail> for trait

### DIFF
--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -52,7 +52,7 @@ impl ApiErrorResponse {
     pub fn from_fail(fail: &dyn Fail) -> ApiErrorResponse {
         let mut messages = vec![];
 
-        for cause in Fail::iter_chain(fail) {
+        for cause in <dyn Fail>::iter_chain(fail) {
             let msg = cause.to_string();
             if !messages.contains(&msg) {
                 messages.push(msg);


### PR DESCRIPTION
The bare trait usage syntax is deprecated.

#skip-changelog