### PR TITLE
build(lints): Warn for unused crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,6 @@ dependencies = [
  "serde_json",
  "structopt",
  "symbolic",
- "thiserror",
  "walkdir",
  "zip",
  "zstd",

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,12 @@
 //! Symbolicator can act as a proxy to symbol servers supporting multiple formats, such as
 //! Microsoft's symbol server or Breakpad symbol repositories.
 
-#![warn(missing_docs, missing_debug_implementations, clippy::all)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    unused_crate_dependencies,
+    clippy::all
+)]
 
 #[macro_use]
 mod macros;

--- a/symsorter/Cargo.toml
+++ b/symsorter/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["debuginfo-serde"] }
-thiserror = "1.0.24"
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.6.0"

--- a/symsorter/src/main.rs
+++ b/symsorter/src/main.rs
@@ -1,6 +1,11 @@
 //! Sorts debug symbols into the right structure for symbolicator.
 
-#![warn(missing_docs, missing_debug_implementations, clippy::all)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    unused_crate_dependencies,
+    clippy::all
+)]
 
 #[macro_use]
 mod utils;

--- a/wasm-split/src/main.rs
+++ b/wasm-split/src/main.rs
@@ -1,6 +1,11 @@
 //! Tool to split a WASM file into a binary and debug companion file.
 
-#![warn(missing_docs, missing_debug_implementations, clippy::all)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    unused_crate_dependencies,
+    clippy::all
+)]
 
 use std::fs::File;
 use std::io::{BufReader, BufWriter};


### PR DESCRIPTION
This is disabled by default, so enable it explicitly.

#skip-changelog