### PR TITLE
fix(symcache): Better error reporting for bcsymbolmap failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,23 +3149,12 @@ checksum = "f27c425b07c7186018e2ef9ac3a25b01dae78b05a7ef604d07f216b9f59b42b4"
 dependencies = [
  "httpdate",
  "reqwest 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
-]
-
-[[package]]
-name = "sentry-anyhow"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223213d65495cb9e66f6cece80a78930c1a482a2e8d7fd3d259725b1d6361de"
-dependencies = [
- "anyhow",
- "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"
-sentry = { version = "0.22.0", features = ["debug-images", "log", "anyhow"] }
+sentry = { version = "0.22.0", features = ["debug-images", "log"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"

--- a/src/services/download/filesystem.rs
+++ b/src/services/download/filesystem.rs
@@ -79,7 +79,7 @@ impl FilesystemDownloader {
     pub fn list_files(
         &self,
         source: Arc<FilesystemSourceConfig>,
-        filetypes: &'static [FileType],
+        filetypes: &[FileType],
         object_id: ObjectId,
     ) -> Vec<ObjectFileSource> {
         super::SourceLocationIter {

--- a/src/services/download/gcs.rs
+++ b/src/services/download/gcs.rs
@@ -263,7 +263,7 @@ impl GcsDownloader {
     pub fn list_files(
         &self,
         source: Arc<GcsSourceConfig>,
-        filetypes: &'static [FileType],
+        filetypes: &[FileType],
         object_id: ObjectId,
     ) -> Vec<ObjectFileSource> {
         super::SourceLocationIter {

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -109,7 +109,7 @@ impl HttpDownloader {
     pub fn list_files(
         &self,
         source: Arc<HttpSourceConfig>,
-        filetypes: &'static [FileType],
+        filetypes: &[FileType],
         object_id: ObjectId,
     ) -> Vec<ObjectFileSource> {
         super::SourceLocationIter {

--- a/src/services/download/mod.rs
+++ b/src/services/download/mod.rs
@@ -153,7 +153,7 @@ impl DownloadService {
     pub async fn list_files(
         self: Arc<Self>,
         source: SourceConfig,
-        filetypes: &'static [FileType],
+        filetypes: &[FileType],
         object_id: ObjectId,
         hub: Arc<Hub>,
     ) -> Result<Vec<ObjectFileSource>, DownloadError> {
@@ -166,7 +166,7 @@ impl DownloadService {
                 // goes out of scope, which ensures 'static lifetime for `spawn` below.
                 let job = async move {
                     slf.sentry
-                        .list_files(cfg, filetypes, object_id, config)
+                        .list_files(cfg, object_id, config)
                         .bind_hub(hub)
                         .await
                 };

--- a/src/services/download/s3.rs
+++ b/src/services/download/s3.rs
@@ -156,7 +156,7 @@ impl S3Downloader {
     pub fn list_files(
         &self,
         source: Arc<S3SourceConfig>,
-        filetypes: &'static [FileType],
+        filetypes: &[FileType],
         object_id: ObjectId,
     ) -> Vec<ObjectFileSource> {
         super::SourceLocationIter {

--- a/src/services/download/sentry.rs
+++ b/src/services/download/sentry.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use super::{DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri, USER_AGENT};
 use crate::config::Config;
-use crate::sources::{FileType, SentrySourceConfig};
+use crate::sources::SentrySourceConfig;
 use crate::types::ObjectId;
 use crate::utils::futures::{self as future_utils, m, measure};
 
@@ -174,7 +174,6 @@ impl SentryDownloader {
     pub async fn list_files(
         &self,
         source: Arc<SentrySourceConfig>,
-        _filetypes: &'static [FileType],
         object_id: ObjectId,
         config: Arc<Config>,
     ) -> Result<Vec<ObjectFileSource>, DownloadError> {


### PR DESCRIPTION
This logs a single sentry error for bcsymbolmap failures.  We lose the
log entry though.  But the error contains both the full error chain as
well as more context on what went wrong with it.

To make the functions more robust it changes the file_type arg to not
take a list, this way the error logging doesn't need to take care of
this and is also more type-strict.  It has some lifetime implications
in the downloader which gets cleaned up a little bit.

#skip-changelog