### PR TITLE
ref(naming): Rename ObjectFileSource to RemoteDif

### DIFF
--- a/src/services/bitcode.rs
+++ b/src/services/bitcode.rs
@@ -19,7 +19,7 @@ use tempfile::tempfile_in;
 
 use crate::cache::{Cache, CacheKey, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
-use crate::services::download::{DownloadService, DownloadStatus, ObjectFileSource};
+use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
 use crate::sources::{FileType, SourceConfig};
 use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
@@ -60,7 +60,7 @@ struct CacheHandle {
 #[derive(Debug, Clone)]
 struct FetchFileRequest {
     scope: Scope,
-    file_source: ObjectFileSource,
+    file_source: RemoteDif,
     uuid: DebugId,
     download_svc: Arc<DownloadService>,
     cache: Arc<Cacher<FetchFileRequest>>,

--- a/src/services/download/http.rs
+++ b/src/services/download/http.rs
@@ -10,33 +10,30 @@ use futures::prelude::*;
 use reqwest::{header, Client};
 use url::Url;
 
-use super::{
-    DownloadError, DownloadStatus, ObjectFileSource, ObjectFileSourceUri, SourceLocation,
-    USER_AGENT,
-};
+use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri, SourceLocation, USER_AGENT};
 use crate::sources::{FileType, HttpSourceConfig};
 use crate::types::ObjectId;
 use crate::utils::futures as future_utils;
 
-/// The HTTP-specific [`ObjectFileSource`].
+/// The HTTP-specific [`RemoteDif`].
 #[derive(Debug, Clone)]
-pub struct HttpObjectFileSource {
+pub struct HttpRemoteDif {
     pub source: Arc<HttpSourceConfig>,
     pub location: SourceLocation,
 }
 
-impl From<HttpObjectFileSource> for ObjectFileSource {
-    fn from(source: HttpObjectFileSource) -> Self {
+impl From<HttpRemoteDif> for RemoteDif {
+    fn from(source: HttpRemoteDif) -> Self {
         Self::Http(source)
     }
 }
 
-impl HttpObjectFileSource {
+impl HttpRemoteDif {
     pub fn new(source: Arc<HttpSourceConfig>, location: SourceLocation) -> Self {
         Self { source, location }
     }
 
-    pub fn uri(&self) -> ObjectFileSourceUri {
+    pub fn uri(&self) -> RemoteDifUri {
         match self.url() {
             Ok(url) => url.as_ref().into(),
             Err(_) => "".into(),
@@ -62,7 +59,7 @@ impl HttpDownloader {
 
     pub async fn download_source(
         &self,
-        file_source: HttpObjectFileSource,
+        file_source: HttpRemoteDif,
         destination: PathBuf,
     ) -> Result<DownloadStatus, DownloadError> {
         let download_url = match file_source.url() {
@@ -111,7 +108,7 @@ impl HttpDownloader {
         source: Arc<HttpSourceConfig>,
         filetypes: &[FileType],
         object_id: ObjectId,
-    ) -> Vec<ObjectFileSource> {
+    ) -> Vec<RemoteDif> {
         super::SourceLocationIter {
             filetypes: filetypes.iter(),
             filters: &source.files.filters,
@@ -119,7 +116,7 @@ impl HttpDownloader {
             layout: source.files.layout,
             next: Vec::new(),
         }
-        .map(|loc| HttpObjectFileSource::new(source.clone(), loc).into())
+        .map(|loc| HttpRemoteDif::new(source.clone(), loc).into())
         .collect()
     }
 }
@@ -145,7 +142,7 @@ mod tests {
             _ => panic!("unexpected source"),
         };
         let loc = SourceLocation::new("hello.txt");
-        let file_source = HttpObjectFileSource::new(http_source, loc);
+        let file_source = HttpRemoteDif::new(http_source, loc);
 
         let downloader = HttpDownloader::new(Client::new());
         let download_status = downloader
@@ -172,7 +169,7 @@ mod tests {
             _ => panic!("unexpected source"),
         };
         let loc = SourceLocation::new("i-do-not-exist");
-        let file_source = HttpObjectFileSource::new(http_source, loc);
+        let file_source = HttpRemoteDif::new(http_source, loc);
 
         let downloader = HttpDownloader::new(Client::new());
         let download_status = downloader.download_source(file_source, dest).await.unwrap();

--- a/src/services/objects/data_cache.rs
+++ b/src/services/objects/data_cache.rs
@@ -22,7 +22,7 @@ use tempfile::tempfile_in;
 
 use crate::cache::{CacheKey, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CachePath};
-use crate::services::download::{DownloadStatus, ObjectFileSource};
+use crate::services::download::{DownloadStatus, RemoteDif};
 use crate::types::{ObjectId, Scope};
 use crate::utils::compression::decompress_object_file;
 use crate::utils::futures::BoxedFuture;
@@ -45,7 +45,7 @@ pub struct ObjectHandle {
     pub(super) object_id: ObjectId,
     pub(super) scope: Scope,
 
-    pub(super) file_source: ObjectFileSource,
+    pub(super) file_source: RemoteDif,
     pub(super) cache_key: CacheKey,
 
     /// The mmapped object.

--- a/src/services/objects/meta_cache.rs
+++ b/src/services/objects/meta_cache.rs
@@ -16,7 +16,7 @@ use symbolic::debuginfo::Object;
 
 use crate::cache::{CacheKey, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
-use crate::services::download::{ObjectFileSource, ObjectFileSourceUri};
+use crate::services::download::{RemoteDif, RemoteDifUri};
 use crate::sources::SourceId;
 use crate::types::{ObjectFeatures, ObjectId, Scope};
 use crate::utils::futures::BoxedFuture;
@@ -29,7 +29,7 @@ pub(super) struct FetchFileMetaRequest {
     /// The scope that the file should be stored under.
     pub(super) scope: Scope,
     /// Source-type specific attributes.
-    pub(super) file_source: ObjectFileSource,
+    pub(super) file_source: RemoteDif,
     pub(super) object_id: ObjectId,
 
     // XXX: This kind of state is not request data. We should find a different way to get this into
@@ -48,7 +48,7 @@ pub(super) struct FetchFileMetaRequest {
 pub struct ObjectMetaHandle {
     pub(super) scope: Scope,
     pub(super) object_id: ObjectId,
-    pub(super) file_source: ObjectFileSource,
+    pub(super) file_source: RemoteDif,
     pub(super) features: ObjectFeatures,
     pub(super) status: CacheStatus,
 }
@@ -66,7 +66,7 @@ impl ObjectMetaHandle {
         self.file_source.source_id()
     }
 
-    pub fn uri(&self) -> ObjectFileSourceUri {
+    pub fn uri(&self) -> RemoteDifUri {
         self.file_source.uri()
     }
 

--- a/src/services/objects/mod.rs
+++ b/src/services/objects/mod.rs
@@ -13,9 +13,7 @@ use symbolic::debuginfo;
 use crate::cache::{Cache, CacheStatus};
 use crate::logging::LogError;
 use crate::services::cacher::Cacher;
-use crate::services::download::{
-    DownloadError, DownloadService, ObjectFileSource, ObjectFileSourceUri,
-};
+use crate::services::download::{DownloadError, DownloadService, RemoteDif, RemoteDifUri};
 use crate::sources::{FileType, SourceConfig, SourceId};
 use crate::types::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectId, Scope};
 
@@ -130,7 +128,7 @@ impl From<debuginfo::ObjectError> for ObjectError {
 #[derive(Debug)]
 struct CacheLookupError {
     /// The object file which was attempted to be fetched.
-    file_source: ObjectFileSource,
+    file_source: RemoteDif,
     /// The wrapped [`ObjectError`] which occurred while fetching the object file.
     error: Arc<ObjectError>,
 }
@@ -243,7 +241,7 @@ impl ObjectsActor {
         sources: &'a [SourceConfig],
         filetypes: &'static [FileType],
         identifier: &'a ObjectId,
-    ) -> Vec<ObjectFileSource> {
+    ) -> Vec<RemoteDif> {
         let mut queries = Vec::with_capacity(sources.len());
 
         for source in sources.iter() {
@@ -287,7 +285,7 @@ impl ObjectsActor {
     /// [`ObjectCandidate`] list.
     async fn fetch_file_metas(
         &self,
-        file_sources: Vec<ObjectFileSource>,
+        file_sources: Vec<RemoteDif>,
         identifier: &ObjectId,
         scope: Scope,
     ) -> Vec<Result<Arc<ObjectMetaHandle>, CacheLookupError>> {
@@ -426,7 +424,7 @@ fn create_candidates(
     for source_id in source_ids {
         let info = ObjectCandidate {
             source: source_id,
-            location: ObjectFileSourceUri::new("No object files listed on this source"),
+            location: RemoteDifUri::new("No object files listed on this source"),
             download: ObjectDownloadInfo::NotFound,
             unwind: Default::default(),
             debug: Default::default(),

--- a/src/types/objects.rs
+++ b/src/types/objects.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::cache::CacheStatus;
-use crate::services::download::ObjectFileSourceUri;
+use crate::services::download::RemoteDifUri;
 use crate::sources::SourceId;
 
 use super::ObjectFeatures;
@@ -32,7 +32,7 @@ pub struct ObjectCandidate {
     ///
     /// This is generally a URI which makes sense for the source type, however no guarantees
     /// are given and it could be any string.
-    pub location: ObjectFileSourceUri,
+    pub location: RemoteDifUri,
     /// Information about fetching or downloading this DIF object.
     ///
     /// This section is always present and will at least have a `status` field.
@@ -176,7 +176,7 @@ impl AllObjectCandidates {
     ///
     /// You can only request symcaches from a DIF object that was already in the metadata
     /// candidate list, therefore if the candidate is missing it is treated as an error.
-    pub fn set_debug(&mut self, source: SourceId, uri: &ObjectFileSourceUri, info: ObjectUseInfo) {
+    pub fn set_debug(&mut self, source: SourceId, uri: &RemoteDifUri, info: ObjectUseInfo) {
         let found_pos = self.0.binary_search_by(|candidate| {
             candidate
                 .source
@@ -202,7 +202,7 @@ impl AllObjectCandidates {
     ///
     /// You can only request cficaches from a DIF object that was already in the metadata
     /// candidate list, therefore if the candidate is missing it is treated as an error.
-    pub fn set_unwind(&mut self, source: SourceId, uri: &ObjectFileSourceUri, info: ObjectUseInfo) {
+    pub fn set_unwind(&mut self, source: SourceId, uri: &RemoteDifUri, info: ObjectUseInfo) {
         let found_pos = self.0.binary_search_by(|candidate| {
             candidate
                 .source
@@ -280,7 +280,7 @@ mod tests {
         // If a candidate didn't exist yet it should be inserted in order.
         let src_a = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceUri::new("a"),
+            location: RemoteDifUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -289,7 +289,7 @@ mod tests {
         };
         let src_b = ObjectCandidate {
             source: SourceId::new("B"),
-            location: ObjectFileSourceUri::new("b"),
+            location: RemoteDifUri::new("b"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -298,7 +298,7 @@ mod tests {
         };
         let src_c = ObjectCandidate {
             source: SourceId::new("C"),
-            location: ObjectFileSourceUri::new("c"),
+            location: RemoteDifUri::new("c"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -318,7 +318,7 @@ mod tests {
     fn test_all_object_info_merge_overwrite() {
         let src0 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceUri::new("a"),
+            location: RemoteDifUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -327,7 +327,7 @@ mod tests {
         };
         let src1 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceUri::new("a"),
+            location: RemoteDifUri::new("a"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -349,7 +349,7 @@ mod tests {
     fn test_all_object_info_merge_no_overwrite() {
         let src0 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceUri::new("uri://dummy"),
+            location: RemoteDifUri::new("uri://dummy"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },
@@ -358,7 +358,7 @@ mod tests {
         };
         let src1 = ObjectCandidate {
             source: SourceId::new("A"),
-            location: ObjectFileSourceUri::new("uri://dummy"),
+            location: RemoteDifUri::new("uri://dummy"),
             download: ObjectDownloadInfo::Ok {
                 features: Default::default(),
             },


### PR DESCRIPTION
This struct is now no longer only used to locate object files on
sources (symbol servers) but generally it can be any Debug Information
File.  Hence it makese sense to name things better.

This is purely a renaming commit, no other changes are made.

#skip-changelog