### PR TITLE
feat: Test old and new stackwalking implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +455,12 @@ checksum = "2c882aa326a43102fd13b20b2f1249e76122b1606e3017944943da8d088ade43"
 dependencies = [
  "crossbeam-channel 0.3.9",
 ]
+
+[[package]]
+name = "cascade"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18c6a921baae2d947e4cf96f6ef1b5774b3056ae8edbdf5c5cfce4f33260921"
 
 [[package]]
 name = "cc"
@@ -1107,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,18 +1587,18 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.5.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca6f2bcc5e2ce13f3652ecd05a643b986d035add3f0c38fbabd78f723b5f7e9"
+checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
 dependencies = [
  "console",
- "difference",
  "lazy_static",
  "pest",
  "pest_derive",
  "serde",
  "serde_json",
  "serde_yaml",
+ "similar",
  "uuid 0.8.2",
 ]
 
@@ -1673,6 +1703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "joinery"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5c968b1e8336a945da21fab473045df2d5f8c81535e762d52f6b2c49477b9"
+
+[[package]]
 name = "js-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1764,19 @@ name = "leb128"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1829,9 +1878,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap"
@@ -2033,6 +2082,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66133f5b2e11a538a276b8ef98fae7e75ac6a68ffa5a94a7eb85d4d767c335f"
+dependencies = [
+ "cascade",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom 6.1.2",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,7 +2122,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-bigint 0.3.1",
+ "num-bigint 0.3.2",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2068,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -2114,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.0",
- "num-bigint 0.3.1",
+ "num-bigint 0.3.2",
  "num-integer",
  "num-traits",
 ]
@@ -2543,6 +2618,12 @@ checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -3411,6 +3492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+
+[[package]]
 name = "simple_asn1"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3563,12 @@ name = "standback"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"
@@ -3587,13 +3680,34 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 [[package]]
 name = "symbolic"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
 dependencies = [
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
  "symbolic-demangle",
  "symbolic-minidump",
  "symbolic-symcache",
+]
+
+[[package]]
+name = "symbolic"
+version = "8.0.5"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
+dependencies = [
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
+ "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "8.0.5"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+dependencies = [
+ "debugid",
+ "memmap",
+ "serde",
+ "stable_deref_trait",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3606,6 +3720,34 @@ dependencies = [
  "serde",
  "stable_deref_trait",
  "uuid 0.8.2",
+]
+
+[[package]]
+name = "symbolic-debuginfo"
+version = "8.0.5"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+dependencies = [
+ "dmsort",
+ "elementtree",
+ "fallible-iterator",
+ "flate2",
+ "gimli",
+ "goblin",
+ "lazy_static",
+ "lazycell",
+ "nom 6.1.2",
+ "nom-supreme",
+ "parking_lot 0.11.1",
+ "pdb",
+ "regex",
+ "serde",
+ "serde_json",
+ "smallvec 1.5.0",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "thiserror",
+ "walrus",
+ "wasmparser",
+ "zip",
 ]
 
 [[package]]
@@ -3629,7 +3771,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 1.5.0",
- "symbolic-common",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
  "thiserror",
  "walrus",
  "wasmparser",
@@ -3639,40 +3781,51 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
 dependencies = [
  "cc",
  "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
- "symbolic-common",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
 ]
 
 [[package]]
 name = "symbolic-minidump"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
 dependencies = [
  "cc",
  "lazy_static",
  "regex",
  "serde",
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-symcache",
+ "symbolic-unwind",
  "thiserror",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
 dependencies = [
  "dmsort",
  "fnv",
  "num",
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
  "thiserror",
+]
+
+[[package]]
+name = "symbolic-unwind"
+version = "8.0.5"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+dependencies = [
+ "insta",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -3718,7 +3871,7 @@ dependencies = [
  "serde_yaml",
  "sha-1 0.9.2",
  "structopt",
- "symbolic",
+ "symbolic 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
  "tempfile",
  "thiserror",
  "tokio 0.1.22",
@@ -3742,7 +3895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "symbolic",
+ "symbolic 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
  "walkdir",
  "zip",
  "zstd",
@@ -3781,6 +3934,12 @@ dependencies = [
  "syn 1.0.58",
  "unicode-xid 0.2.0",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4525,7 +4684,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ca2a14bc3fc5b64d188b087a7d3a927df87b152e941ccfbc66672e20c467ae"
 dependencies = [
- "nom",
+ "nom 4.2.3",
  "proc-macro2 1.0.24",
  "quote 1.0.3",
  "syn 1.0.58",
@@ -4867,6 +5026,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,12 +796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "feat/cfi_unwind", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1605,6 +1605,11 @@ impl SymbolicationActor {
         future::join_all(futures).await
     }
 
+    /// Post-processes breakpad's stackwalking result to extract module list and stacktraces.
+    ///
+    /// The breakpad [`ProcessState`] contains the results of the breakpad stackwalking.  This
+    /// code extracts from this the module list as well as the stack traces in the format required
+    /// for the symbolication response on the API.
     fn post_process(
         process_state: ProcessState,
         cfi_caches: CfiCacheModules,

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1670,7 +1670,8 @@ impl SymbolicationActor {
 
     /// The actual stackwalking procedure.
     ///
-    /// This is a method, as opposed to a closure in `stackwalk_minidump_with_cfi`,
+    /// This is a method, as opposed to a closure in
+    /// [`stackwalk_minidump_with_cfi`](SymbolicationActor::stackwalk_minidump_with_cfi),
     /// to circumvent a problem with `rustfmt`.
     fn procspawn_inner_stackwalk(
         cfi_caches: Json<CfiCacheModules>,

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -60,6 +60,9 @@ lazy_static::lazy_static! {
     static ref OS_MACOS_REGEX: Regex = Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap();
 }
 
+/// Output of a successfull stack walk.
+///
+/// Contains a module list, a list of stacktraces, and a minidump state.
 type StackwalkingOutput = (Vec<CompleteObjectInfo>, Vec<RawStacktrace>, MinidumpState);
 
 /// Errors during symbolication.

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1670,7 +1670,7 @@ impl SymbolicationActor {
 
     /// The actual stackwalking procedure.
     ///
-    /// This is a method, as opposed to a closure in [`stackwalk_minidump_with_cfi`],
+    /// This is a method, as opposed to a closure in `stackwalk_minidump_with_cfi`,
     /// to circumvent a problem with `rustfmt`.
     fn procspawn_inner_stackwalk(
         cfi_caches: Json<CfiCacheModules>,

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1668,7 +1668,11 @@ impl SymbolicationActor {
         (module_builder.build(), stacktraces, minidump_state)
     }
 
-    fn stackwalk_name_subject_to_change(
+    /// The actual stackwalking procedure.
+    ///
+    /// This is a method, as opposed to a closure in [`stackwalk_minidump_with_cfi`],
+    /// to circumvent a problem with `rustfmt`.
+    fn procspawn_inner_stackwalk(
         cfi_caches: Json<CfiCacheModules>,
         minidump: Bytes,
         spawn_time: SystemTime,
@@ -1761,7 +1765,7 @@ impl SymbolicationActor {
                     options.compare_stackwalking_methods,
                 ),
                 |(cfi_caches, minidump, spawn_time, compare_stackwalking_methods)| {
-                    Self::stackwalk_name_subject_to_change(
+                    Self::procspawn_inner_stackwalk(
                         cfi_caches,
                         minidump,
                         spawn_time,

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -155,6 +155,9 @@ pub struct RequestOptions {
     /// [`ObjectCandidate`] struct for which extra information is returned for DIF objects.
     #[serde(default)]
     pub dif_candidates: bool,
+
+    #[serde(default)]
+    pub compare_stackwalking_methods: bool,
 }
 
 /// A map of register values.
@@ -165,7 +168,7 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 }
 
 /// An unsymbolicated frame from a symbolication request.
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize)]
 pub struct RawFrame {
     /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
     /// [`sym_addr`](Self::sym_addr).
@@ -233,7 +236,7 @@ pub struct RawFrame {
 }
 
 /// A stack trace containing unsymbolicated stack frames.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct RawStacktrace {
     /// The OS-dependent identifier of the thread.
     #[serde(default)]

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -156,6 +156,7 @@ pub struct RequestOptions {
     #[serde(default)]
     pub dif_candidates: bool,
 
+    /// Whether to run the new stackwalking method in addition to the old one and compare their results.
     #[serde(default)]
     pub compare_stackwalking_methods: bool,
 }


### PR DESCRIPTION
This adds a flag `compare_stackwalking_methods` to `RequestOptions` that causes `stackwalk_minidump_with_cfi` to run both the old and new implementations and report the respective runtimes if they output the same stacktrace. The intention is to enable this flag for a proportion of requests.

#skip-changelog