### PR TITLE
fix(bcsymbolmap): downloading BCSymbolMaps from sentry

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -66,7 +66,7 @@ impl Display for AuxDifKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AuxDifKind::BcSymbolMap => write!(f, "BCSymbolMap"),
-            AuxDifKind::UuidMap => write!(f, "PList"),
+            AuxDifKind::UuidMap => write!(f, "UuidMap"),
         }
     }
 }

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -3,6 +3,7 @@
 //! This service downloads and caches the `PList` and [`BcSymbolMap`] used to un-obfuscate
 //! debug symbols for obfuscated Apple bitcode builds.
 
+use std::fmt::{self, Display};
 use std::fs::File;
 use std::io::{self, Cursor, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -54,6 +55,22 @@ struct CacheHandle {
     data: ByteView<'static>,
 }
 
+/// The kinds of DIFs which are stored in the cache accessed from [`FetchFileRequest`].
+#[derive(Debug, Clone, Copy)]
+enum AuxDifKind {
+    BcSymbolMap,
+    PList,
+}
+
+impl Display for AuxDifKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuxDifKind::BcSymbolMap => write!(f, "BCSymbolMap"),
+            AuxDifKind::PList => write!(f, "PList"),
+        }
+    }
+}
+
 /// The interface to the [`Cacher`] service.
 ///
 /// The main work is done by the [`CacheItemRequest`] impl.
@@ -62,6 +79,7 @@ struct FetchFileRequest {
     scope: Scope,
     file_source: RemoteDif,
     uuid: DebugId,
+    kind: AuxDifKind,
     download_svc: Arc<DownloadService>,
     cache: Arc<Cacher<FetchFileRequest>>,
 }
@@ -101,14 +119,21 @@ impl FetchFileRequest {
                 decompressed.seek(SeekFrom::Start(0))?;
                 let view = ByteView::map_file(decompressed)?;
 
-                if BcSymbolMap::test(&view) {
-                    if let Err(err) = BcSymbolMap::parse(&view) {
-                        log::debug!("Failed to parse bcsymbolmap: {}", err);
-                        return Ok(CacheStatus::Malformed);
+                match self.kind {
+                    AuxDifKind::BcSymbolMap => {
+                        if let Err(err) = BcSymbolMap::parse(&view) {
+                            // TODO(flub): log metric?
+                            log::debug!("Failed to parse bcsymbolmap: {}", err);
+                            return Ok(CacheStatus::Malformed);
+                        }
                     }
-                } else if let Err(err) = UuidMapping::parse_plist(self.uuid, &view) {
-                    log::debug!("Failed to parse plist: {}", err);
-                    return Ok(CacheStatus::Malformed);
+                    AuxDifKind::PList => {
+                        if let Err(err) = UuidMapping::parse_plist(self.uuid, &view) {
+                            // TODO(flub): log metric?
+                            log::debug!("Failed to parse plist: {}", err);
+                            return Ok(CacheStatus::Malformed);
+                        }
+                    }
                 }
 
                 // The file is valid, lets save it.
@@ -189,7 +214,7 @@ impl BitcodeService {
     ) -> Result<Option<BcSymbolMapHandle>, Error> {
         // First find the PList.
         let find_plist = self
-            .fetch_file_from_all_sources(uuid, FileType::UuidMap, scope.clone(), sources.clone())
+            .fetch_file_from_all_sources(uuid, AuxDifKind::PList, scope.clone(), sources.clone())
             .await?;
         let plist_handle = match find_plist {
             Some(handle) => handle,
@@ -202,7 +227,7 @@ impl BitcodeService {
         let find_symbolmap = self
             .fetch_file_from_all_sources(
                 uuid_mapping.original_uuid(),
-                FileType::BcSymbolMap,
+                AuxDifKind::BcSymbolMap,
                 scope,
                 sources,
             )
@@ -221,17 +246,17 @@ impl BitcodeService {
     async fn fetch_file_from_all_sources(
         &self,
         uuid: DebugId,
-        file_type: FileType,
+        dif_kind: AuxDifKind,
         scope: Scope,
         sources: Arc<[SourceConfig]>,
     ) -> Result<Option<Arc<CacheHandle>>, Error> {
         sentry::configure_scope(|scope| {
             scope.set_tag("auxdif.debugid", uuid);
-            scope.set_extra("auxdif.file", file_type.as_ref().into());
+            scope.set_extra("auxdif.kind", dif_kind.to_string().into());
         });
         let mut jobs = Vec::with_capacity(sources.len());
         for source in sources.iter() {
-            let job = self.fetch_file_from_source(uuid, file_type, scope.clone(), source.clone());
+            let job = self.fetch_file_from_source(uuid, dif_kind, scope.clone(), source.clone());
             jobs.push(job);
         }
         let results = future::join_all(jobs).await;
@@ -253,7 +278,7 @@ impl BitcodeService {
     async fn fetch_file_from_source(
         &self,
         uuid: DebugId,
-        file_type: FileType,
+        dif_kind: AuxDifKind,
         scope: Scope,
         source: SourceConfig,
     ) -> Result<Option<Arc<CacheHandle>>, Error> {
@@ -261,10 +286,14 @@ impl BitcodeService {
             scope.set_extra("auxdif.source", source.type_name().into())
         });
         let hub = Arc::new(Hub::new_from_top(Hub::current()));
+        let file_type = match dif_kind {
+            AuxDifKind::BcSymbolMap => vec![FileType::BcSymbolMap],
+            AuxDifKind::PList => vec![FileType::PList],
+        };
         let file_sources = self
             .download_svc
             .clone()
-            .list_files(source, &[file_type], uuid.into(), hub)
+            .list_files(source, &file_type, uuid.into(), hub)
             .await?;
 
         let mut fetch_jobs = Vec::with_capacity(file_sources.len());
@@ -278,6 +307,7 @@ impl BitcodeService {
                 scope,
                 file_source,
                 uuid,
+                kind: dif_kind,
                 download_svc: self.download_svc.clone(),
                 cache: self.cache.clone(),
             };

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -146,6 +146,10 @@ impl DownloadService {
     ///
     /// If the source needs to be contacted to get matching objects this may fail and
     /// returns a [`DownloadError`].
+    ///
+    /// Note that the `filetypes` argument is not more then a hint, not all source types
+    /// will respect this and they may return all DIFs matching the `object_id`.  After
+    /// downloading you may still need to filter the files.
     pub async fn list_files(
         self: Arc<Self>,
         source: SourceConfig,
@@ -162,7 +166,7 @@ impl DownloadService {
                 // goes out of scope, which ensures 'static lifetime for `spawn` below.
                 let job = async move {
                     slf.sentry
-                        .list_files(cfg, object_id, config)
+                        .list_files(cfg, object_id, filetypes.clone(), config)
                         .bind_hub(hub)
                         .await
                 };

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -178,8 +178,8 @@ impl SentryDownloader {
         file_types: &[FileType],
         config: Arc<Config>,
     ) -> Result<Vec<RemoteDif>, DownloadError> {
-        // TODO(flub): LOL, we don't even handle pagination.  But sentry only starts to
-        // paginate at 20 results so i guess we get away with this for now.
+        // TODO(flub): These queries do not handle pagination.  But sentry only starts to
+        // paginate at 20 results so we get away with this for now.
 
         // There needs to be either a debug_id or a code_id filter in the query. Otherwise, this would
         // return a list of all debug files in the project.
@@ -195,7 +195,7 @@ impl SentryDownloader {
         }
         for file_type in file_types {
             match file_type {
-                FileType::PList => {
+                FileType::UuidMap => {
                     index_url
                         .query_pairs_mut()
                         .append_pair("file_formats", "plist");
@@ -205,8 +205,8 @@ impl SentryDownloader {
                         .query_pairs_mut()
                         .append_pair("file_formats", "bcsymbolmap");
                 }
-                // We do not currently attempt to filter objects
-                // TODO(flub): check object actor handles getting a plist correctly.
+                // We do not currently attempt to filter objects.  The object actor caches
+                // these as a "malformed" files and carries on.  But let's add them anyway.
                 _ => (),
             }
         }

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -199,7 +199,7 @@ impl SentryDownloader {
             file_types
                 .iter()
                 .map(|file_type| match file_type {
-                    FileType::UuidMap => "plist",
+                    FileType::UuidMap => "uuidmap",
                     FileType::BcSymbolMap => "bcsymbolmap",
                     FileType::Pe => "pe",
                     FileType::Pdb => "pdb",

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -197,7 +197,7 @@ impl SentryDownloader {
         // See <sentry-repo>/src/sentry/constants.py KNOWN_DIF_FORMATS for these query strings.
         index_url.query_pairs_mut().extend_pairs(
             file_types
-                .into_iter()
+                .iter()
                 .map(|file_type| match file_type {
                     FileType::UuidMap => "plist",
                     FileType::BcSymbolMap => "bcsymbolmap",

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -251,7 +251,7 @@ impl ObjectsActor {
                 let type_name = source.type_name();
                 self.download_svc
                     .clone()
-                    .list_files(source.clone(), filetypes, identifier.clone(), hub)
+                    .list_files(source.clone(), filetypes.to_vec(), identifier.clone(), hub)
                     .await
                     .unwrap_or_else(|err| {
                         // This basically only happens for the Sentry source type, when doing

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -312,6 +312,7 @@ impl ModuleListBuilder {
         for thread in minidump_process_state.threads() {
             for frame_pair in thread.frames().windows(2) {
                 if let [prev_frame, next_frame] = frame_pair {
+                    // TODO(flub): This never marks the first frame!
                     if let Some(code_id) = prev_frame.module().and_then(|m| m.id()) {
                         match next_frame.trust() {
                             FrameTrust::Scan => {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -312,7 +312,6 @@ impl ModuleListBuilder {
         for thread in minidump_process_state.threads() {
             for frame_pair in thread.frames().windows(2) {
                 if let [prev_frame, next_frame] = frame_pair {
-                    // TODO(flub): This never marks the first frame!
                     if let Some(code_id) = prev_frame.module().and_then(|m| m.id()) {
                         match next_frame.trust() {
                             FrameTrust::Scan => {


### PR DESCRIPTION
These are fixes to improve the downloading of BCSymbolMap and
associated PList files from the sentry source.  The sentry source did
not filter files by type, assuing they are all object files.  This is
no longer the case with BCSymbolMap and PList files introduced.

Related PRs:
https://github.com/getsentry/sentry/pull/25712
https://github.com/getsentry/sentry-cli/pull/952
https://github.com/getsentry/symbolic/pull/373

#skip-changelog