### PR TITLE
Add support for AWS credentials supplied by an ECS task's IAM role fo…

### DIFF
--- a/src/sources.rs
+++ b/src/sources.rs
@@ -145,9 +145,11 @@ pub struct S3SourceKey {
     pub region: rusoto_core::Region,
 
     /// S3 authorization key.
+    #[serde(default)]
     pub access_key: String,
 
     /// S3 secret key.
+    #[serde(default)]
     pub secret_key: String,
 }
 
@@ -216,6 +218,10 @@ pub struct S3SourceConfig {
     /// Authorization information for this bucket. Needs read access.
     #[serde(flatten)]
     pub source_key: Arc<S3SourceKey>,
+
+    /// Use ContainerProvider, ignore source_key
+    #[serde(default)]
+    pub use_container_credentials: bool,
 
     #[serde(flatten)]
     pub files: CommonSourceConfig,


### PR DESCRIPTION
…r downloading S3 sources

This commit adds support for an optional use_container_credentials flag,
defaulting to false. If set to true, both access_key and secret_key
should NOT be specified, or left blank.
It sidesteps more complex handling of YAML
configuration data by simply detecting invalid configurations and
panic!'ing.

For details on the AWS side, see
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html.