### PR TITLE
ref(wasm-split): Use structopt instead of argh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,35 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
-name = "argh"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91792f088f87cdc7a2cfb1d617fa5ea18d7f1dc22ef0e1b5f82f3157cdc522be"
-dependencies = [
- "argh_derive",
- "argh_shared",
-]
-
-[[package]]
-name = "argh_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4eb0c0c120ad477412dc95a4ce31e38f2113e46bd13511253f79196ca68b067"
-dependencies = [
- "argh_shared",
- "heck",
- "proc-macro2 1.0.24",
- "quote 1.0.3",
- "syn 1.0.58",
-]
-
-[[package]]
-name = "argh_shared"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4756,8 +4727,8 @@ name = "wasm-split"
 version = "0.3.3"
 dependencies = [
  "anyhow",
- "argh",
  "hex",
+ "structopt",
  "uuid 0.8.2",
  "wasmbin",
 ]

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-argh = "0.1.4"
+structopt = "0.3.21"
 hex = "0.4.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 wasmbin = "0.2.2"


### PR DESCRIPTION
This is purely to streamline with other workspace members.

Old help:

```
Usage: wasm-split <input> [-o <out>] [-d <debug-out>] [--strip] [--strip-names] [-q] [--build-id <build-id>]

Adds build IDs to wasm files. This tool can both add missing build IDs and split a WASM file into two: a main binary and a debug companion file.  The debug companion file will contain all sections of the original file. This is necessary as DWARF processing requires knowing the location of all sections (specially the code section) to calculate offsets. This prints the embedded build_id in hexadecimal format to stdout.

Options:
  -o, --out         path to the output wasm file. If not provided the same file
                    is modified in place.
  -d, --debug-out   path to the output debug wasm file. If not provided the
                    debug data stays in the input file.
  --strip           strip the file of debug info.
  --strip-names     strip the file of symbol names.
  -q, --quiet       do not print the build id.
  --build-id        explicit build id to provide
  --help            display usage information
```

New help:

```
wasm-split 0.3.3
Adds build IDs to wasm files.

This tool can both add missing build IDs and split a WASM file into two: a main binary and a debug companion file.  The
debug companion file will contain all sections of the original file. This is necessary as DWARF processing requires
knowing the location of all sections (specially the code section) to calculate offsets.

This prints the embedded build_id in hexadecimal format to stdout.

USAGE:
    wasm-split [FLAGS] [OPTIONS] <input>

FLAGS:
    -h, --help           Prints help information
    -q, --quiet          do not print the build id
        --strip          strip the file of debug info
        --strip-names    strip the file of symbol names
    -V, --version        Prints version information

OPTIONS:
        --build-id <build-id>      explicit build id to provide
    -d, --debug-out <debug-out>    path to the output debug wasm file
    -o, --out <out>                path to the output wasm file

ARGS:
    <input>    path to the wasm file
```

#skip-changelog

