### PR TITLE
build: Publish symsorter and wasm_split

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -43,3 +43,5 @@ requireNames:
   - /^gh-pages.zip$/
   - /^symbolicator-Linux-x86_64$/
   - /^symbolicator-Linux-x86_64-debug.zip$/
+  - /^symsorter-Linux-x86_64$/
+  - /^wasm_split-Linux-x86_64$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -44,4 +44,4 @@ requireNames:
   - /^symbolicator-Linux-x86_64$/
   - /^symbolicator-Linux-x86_64-debug.zip$/
   - /^symsorter-Linux-x86_64$/
-  - /^wasm_split-Linux-x86_64$/
+  - /^wasm-split-Linux-x86_64$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,20 +25,27 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked
+          args: --all --release --locked
 
       - name: Split and archive debug info
         run: |
+          mkdir -p build
+
+          # Split only symbolicator's debug information
           objcopy --only-keep-debug target/release/symbolicator{,.debug}
           objcopy --strip-debug --strip-unneeded target/release/symbolicator
           objcopy --add-gnu-debuglink target/release/symbolicator{.debug,}
-          zip -j symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
-          mv target/release/symbolicator symbolicator-Linux-x86_64
+          zip -j build/symbolicator-Linux-x86_64-debug.zip target/release/symbolicator.debug
+
+          # Move all binaries
+          mv target/release/symbolicator build/symbolicator-Linux-x86_64
+          mv target/release/wasm_split build/wasm_split-Linux-x86_64
+          mv target/release/symsorter build/symsorter-Linux-x86_64
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
-          path: symbolicator-Linux-*
+          path: build/*
 
   docs:
     name: Build Docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
           # Move all binaries
           mv target/release/symbolicator build/symbolicator-Linux-x86_64
-          mv target/release/wasm_split build/wasm_split-Linux-x86_64
+          mv target/release/wasm-split build/wasm-split-Linux-x86_64
           mv target/release/symsorter build/symsorter-Linux-x86_64
 
       - uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Tools
 
 - `wasm-split` can remove names with `--strip-names`. ([#412](https://github.com/getsentry/symbolicator/pull/412))
+- Linux x64 builds of `symsorter` and `wasm-split` can be downloaded from [GitHub releases](https://github.com/getsentry/symbolicator/releases/latest) now. ([#422](https://github.com/getsentry/symbolicator/pull/422))
 
 ## 0.3.3
 


### PR DESCRIPTION
Performs a full workspace build and adds `symsorter` and `wasm-split` to the list of published binaries. They are not stripped for so that backtraces can be enabled when needed.