### PR TITLE
Fix the generated filename to be correct _unified_ format.  Fixes #415

### DIFF
--- a/crates/symsorter/src/difs.rs
+++ b/crates/symsorter/src/difs.rs
@@ -56,7 +56,7 @@ impl DifType {
     ///
     /// This is a relative pathname to the root of the unified symbol server layout.
     pub fn unified_path_for(&self, unified_id: &DebugId) -> PathBuf {
-        let repr = format!("{:x}", unified_id.uuid());
+        let repr = unified_id.to_string().replace("-", "");
         let path = format!("{}/{}/{}", &repr[..2], &repr[2..], self.suffix());
         PathBuf::from(path)
     }


### PR DESCRIPTION
Previous version left in the hyphens and didn't add the "appendix".  Now generates filenames which fit what sentry looks for on symbol servers