### PR TITLE
feat(symsorter): Add support for AUX files

### DIFF
--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -1,26 +1,26 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io;
+use std::io::{self, Cursor};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use chrono::{DateTime, Utc};
 use console::style;
 use rayon::prelude::*;
 use serde::Serialize;
 use structopt::StructOpt;
-use symbolic::common::{Arch, ByteView};
+use symbolic::common::{Arch, ByteView, DebugId};
+use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use symbolic::debuginfo::{Archive, FileFormat, ObjectKind};
 use walkdir::WalkDir;
 use zip::ZipArchive;
 use zstd::stream::copy_encode;
 
 use crate::config::{RunConfig, SortConfig};
-use crate::utils::{
-    create_source_bundle, get_target_filename, get_unified_id, is_bundle_id, make_bundle_id,
-};
+use crate::difs::{get_dsym_aux_path, get_object_path, DSymAuxType};
+use crate::utils::{create_source_bundle, get_unified_id, is_bundle_id, make_bundle_id};
 
 /// Sorts debug symbols into the right structure for symbolicator.
 #[derive(PartialEq, Eq, PartialOrd, Ord, StructOpt, Debug)]
@@ -87,7 +87,18 @@ pub struct BundleMeta {
     pub debug_ids: Vec<String>,
 }
 
-fn process_file(
+fn print_error(err: Error, filename: &str) {
+    if RunConfig::get().ignore_errors {
+        eprintln!(
+            "{}: ignored error {:#} ({})",
+            style("error").red().bold(),
+            err,
+            style(filename).cyan(),
+        );
+    }
+}
+
+fn process_archive(
     sort_config: &SortConfig,
     bv: ByteView<'static>,
     filename: String,
@@ -100,12 +111,7 @@ fn process_file(
                 Ok(value) => value,
                 Err(err) => {
                     if RunConfig::get().ignore_errors {
-                        eprintln!(
-                            "{}: ignored error {} ({})",
-                            style("error").red().bold(),
-                            err,
-                            style(filename).cyan(),
-                        );
+                        print_error(err, &filename);
                         return Ok(rv);
                     } else {
                         return Err(err).context(format!("failed to process file {}", filename));
@@ -125,12 +131,13 @@ fn process_file(
     let archive = maybe_ignore_error!(
         Archive::parse(&bv).map_err(|e| anyhow!("failed to parse archive {}", e))
     );
+
     let root = &RunConfig::get().output;
 
     for obj in archive.objects() {
         let obj = maybe_ignore_error!(obj.map_err(|e| anyhow!(e)));
         let new_filename = root.join(maybe_ignore_error!(
-            get_target_filename(&obj).ok_or_else(|| anyhow!("unsupported file"))
+            get_object_path(&obj).ok_or_else(|| anyhow!("unsupported file"))
         ));
 
         fs::create_dir_all(new_filename.parent().unwrap())?;
@@ -170,6 +177,73 @@ fn process_file(
     Ok(rv)
 }
 
+fn process_aux_dif(
+    sort_config: &SortConfig,
+    bv: ByteView<'static>,
+    filename: &str,
+    ty: DSymAuxType,
+) -> Result<()> {
+    let stem = match filename.strip_suffix(&format!(".{}", ty)) {
+        Some(stem) => stem,
+        None => {
+            // Gracefully skip bad filenames, the test just accepts any old XML file so we
+            // might just have some bogus XML file.
+            return Ok(());
+        }
+    };
+    let id: DebugId = match stem.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            // Gracefully skip bad filenames, the test just accepts any old XML file so we
+            // might just have some bogus XML file.
+            return Ok(());
+        }
+    };
+
+    // Validate the file contents.
+    match ty {
+        DSymAuxType::PList => {
+            UuidMapping::parse_plist(id, &bv).context("Failed to parse PList")?;
+        }
+        DSymAuxType::BcSymbolMap => {
+            BcSymbolMap::parse(&bv).context("Failed to parse BCSymbolMap")?;
+        }
+    }
+
+    let root = &RunConfig::get().output;
+    let new_path = root.join(get_dsym_aux_path(ty, id));
+    fs::create_dir_all(
+        new_path
+            .parent()
+            .ok_or_else(|| Error::msg(format!("File has no parent: {}", filename)))?,
+    )
+    .with_context(|| format!("Failed to create destination directory for {}", filename))?;
+
+    log!(
+        "{} ({}, {}) -> {}",
+        style(&filename).dim(),
+        style("aux").yellow(),
+        style("-").yellow(),
+        style(new_path.display()).cyan(),
+    );
+    let mut reader = Cursor::new(bv);
+    let mut writer = fs::File::create(&new_path)?;
+    let compression_level = match sort_config.compression_level {
+        0 => 0,
+        1 => 3,
+        2 => 10,
+        3 => 19,
+        _ => 22,
+    };
+    if compression_level > 0 {
+        copy_encode(&mut reader, &mut writer, compression_level)?;
+    } else {
+        io::copy(&mut reader, &mut writer)?;
+    }
+
+    Ok(())
+}
+
 fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, usize)> {
     let mut source_bundles_created = 0;
     let source_candidates = Mutex::new(HashMap::<String, Option<PathBuf>>::new());
@@ -186,6 +260,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
         .par_bridge()
         .map(|entry| {
             let path = entry.path();
+            let filename = path.file_name().unwrap().to_string_lossy().to_string();
             let bv = match ByteView::open(path) {
                 Ok(bv) => bv,
                 Err(_) => return Ok(()),
@@ -200,7 +275,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     let bv = ByteView::read(zip_file)?;
                     if Archive::peek(&bv) != FileFormat::Unknown {
                         debug_ids.lock().unwrap().extend(
-                            process_file(&sort_config, bv, name)?
+                            process_archive(&sort_config, bv, name)?
                                 .into_iter()
                                 .map(|x| x.0),
                         );
@@ -209,11 +284,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
 
             // object file directly
             } else if Archive::peek(&bv) != FileFormat::Unknown {
-                for (unified_id, object_kind) in process_file(
-                    &sort_config,
-                    bv,
-                    path.file_name().unwrap().to_string_lossy().to_string(),
-                )? {
+                for (unified_id, object_kind) in process_archive(&sort_config, bv, filename)? {
                     if sort_config.with_sources {
                         let mut source_candidates = source_candidates.lock().unwrap();
                         if object_kind == ObjectKind::Sources {
@@ -226,8 +297,29 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     }
                     debug_ids.lock().unwrap().push(unified_id);
                 }
+            } else if BcSymbolMap::test(&bv) {
+                process_aux_dif(&sort_config, bv, &filename, DSymAuxType::BcSymbolMap)
+                    .context("Failed to process BCSymbolMap")
+                    .or_else(|err| {
+                        if RunConfig::get().ignore_errors {
+                            print_error(err, &filename);
+                            Ok(())
+                        } else {
+                            Err(err)
+                        }
+                    })?;
+            } else if bv.as_ref().starts_with(b"<?xml") {
+                process_aux_dif(&sort_config, bv, &filename, DSymAuxType::PList)
+                    .context("Failed to process PList")
+                    .or_else(|err| {
+                        if RunConfig::get().ignore_errors {
+                            print_error(err, &filename);
+                            Ok(())
+                        } else {
+                            Err(err)
+                        }
+                    })?;
             }
-
             Ok(())
         })
         .collect::<Result<Vec<_>>>()?;
@@ -245,7 +337,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     None => return Ok(0),
                 };
 
-                let processed_objects = process_file(
+                let processed_objects = process_archive(
                     &sort_config,
                     source_bundle,
                     path.file_name().unwrap().to_string_lossy().to_string(),

--- a/crates/symsorter/src/difs.rs
+++ b/crates/symsorter/src/difs.rs
@@ -1,0 +1,65 @@
+//! Generic handling of Debug Information Files.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use symbolic::common::DebugId;
+use symbolic::debuginfo::{FileFormat, Object, ObjectKind};
+
+/// Gets the unified ID from an object.
+pub fn get_unified_id(obj: &Object) -> String {
+    if obj.file_format() == FileFormat::Pe || obj.code_id().is_none() {
+        obj.debug_id().breakpad().to_string().to_lowercase()
+    } else {
+        // TODO: This is wrong for Windows source bundles
+        obj.code_id().as_ref().unwrap().as_str().to_string()
+    }
+}
+
+fn get_object_suffix(obj: &Object) -> Option<&'static str> {
+    match obj.kind() {
+        ObjectKind::Debug => Some("debuginfo"),
+        ObjectKind::Sources if obj.file_format() == FileFormat::SourceBundle => {
+            Some("sourcebundle")
+        }
+        ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => {
+            Some("executable")
+        }
+        _ => None,
+    }
+}
+
+fn join_unified_path(id: &str, suffix: impl fmt::Display) -> PathBuf {
+    format!("{}/{}/{}", &id[..2], &id[2..], suffix).into()
+}
+
+/// Returns the unified pathname for an object.
+///
+/// This is a relative pathname to the root of the unified symbol server layout.
+pub fn get_object_path(obj: &Object) -> Option<PathBuf> {
+    let id = get_unified_id(obj);
+    let suffix = get_object_suffix(obj)?;
+    Some(join_unified_path(&id, suffix))
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum DSymAuxType {
+    PList,
+    BcSymbolMap,
+}
+
+impl fmt::Display for DSymAuxType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DSymAuxType::PList => write!(f, "plist"),
+            DSymAuxType::BcSymbolMap => write!(f, "bcsymbolmap"),
+        }
+    }
+}
+
+/// Returns the unified pathname for an auxiliary file to a dSYM.
+///
+/// This is a relative pathname to the root of the unified symbol server layout.
+pub fn get_dsym_aux_path(ty: DSymAuxType, id: DebugId) -> PathBuf {
+    join_unified_path(&id.to_string(), ty)
+}

--- a/crates/symsorter/src/main.rs
+++ b/crates/symsorter/src/main.rs
@@ -12,6 +12,7 @@ mod utils;
 
 mod app;
 mod config;
+mod difs;
 
 fn main() {
     app::main();

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -1,12 +1,12 @@
 use std::io::Cursor;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
-use symbolic::debuginfo::{Archive, FileFormat, Object, ObjectKind};
+use symbolic::debuginfo::{Archive, FileFormat, Object};
 
 lazy_static! {
     static ref BAD_CHARS_RE: Regex = Regex::new(r"[^a-zA-Z0-9.,-]+").unwrap();
@@ -32,25 +32,6 @@ pub fn get_unified_id(obj: &Object) -> String {
     } else {
         obj.code_id().as_ref().unwrap().as_str().to_string()
     }
-}
-
-/// Returns the intended target filename for an object.
-pub fn get_target_filename(obj: &Object) -> Option<PathBuf> {
-    let id = get_unified_id(obj);
-    // match the unified format here.
-    let suffix = match obj.kind() {
-        ObjectKind::Debug => "debuginfo",
-        ObjectKind::Sources => {
-            if obj.file_format() == FileFormat::SourceBundle {
-                "sourcebundle"
-            } else {
-                return None;
-            }
-        }
-        ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
-        _ => return None,
-    };
-    Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
 }
 
 /// Creates a source bundle from a path.

--- a/crates/symsorter/tests/fixtures/2d10c42f-591d-3265-b147-78ba0868073f.plist
+++ b/crates/symsorter/tests/fixtures/2d10c42f-591d-3265-b147-78ba0868073f.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>DBGOriginalUUID</key>
+   <string>C8374B6D-6E96-34D8-AE38-EFAA5FEC424F</string>
+</dict>
+</plist>


### PR DESCRIPTION
Re-issues the symsorter-portion of #403 with a different approach to creating the actual paths. I'm not yet happy with this implementation at all, so please view this merely as a starting point.

The correct path needs more information, actually. We need:

1. The actual file type
2. The file type of the associated object file. This is exhaustively:
   - For source bundles, this is the file type of the creating file
   - For aux files, this is the file type of the corresponding object
   - For objects other than source bundles, this is the same as (1)

Next, based on (2) pick the right ID. This is exhaustively:
- ELF: `code_id`
- MachO: `code_id` or `debug_id`, they are equivalent
- PDB, PE: `debug_id`
- WASM: `code_id` if present, otherwise `debug_id`
- _note how SourceBundle, Breakpad, and AUX cannot occur here_

Finally, the suffix is based on the actual file type. This is exhaustively:
- `executable` for files containing executable code
- `debuginfo` for debug companions
- `breakpad` for .sym files
- `sourcebundle`, `plist`, `bcsymbolmap` for the respective files

The implementation in this PR does not handle Breakpad nor SourceBundles correctly yet. Note that symbolicator does in `get_unified_path`.