### PR TITLE
ref: Make symsorter more suited for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 # Local testing
 /local.yml
 /cache/
+/symbols/
 
 # mkdocs
 site

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -317,7 +317,7 @@ pub enum DirectoryLayoutType {
     /// Uses [debuginfod](https://www.mankier.com/8/debuginfod) conventions.
     #[serde(rename = "debuginfod")]
     Debuginfod,
-    /// Unified sentry propriertary bucket format.
+    /// Unified sentry proprietary bucket format.
     #[serde(rename = "unified")]
     Unified,
 }
@@ -362,8 +362,10 @@ pub enum FileType {
     #[serde(rename = "sourcebundle")]
     SourceBundle,
     /// PropertyList, mapping a dSYM UUID to a BCSymbolMap UUID for MachO.
+    #[serde(rename = "plist")]
     PList,
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
+    #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
 }
 

--- a/crates/symsorter/src/config.rs
+++ b/crates/symsorter/src/config.rs
@@ -37,7 +37,7 @@ impl RunConfig {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct SortConfig {
     /// The bundle ID of this task.
-    pub bundle_id: String,
+    pub bundle_id: Option<String>,
 
     /// If enable the system will attempt to create source bundles
     pub with_sources: bool,

--- a/local.example.yml
+++ b/local.example.yml
@@ -1,0 +1,19 @@
+# Symbolicator listens on port `3021` by default.
+cache_dir: cache
+sources:
+  # You can use symsorter to correctly sort symbols into the local filesystem source:
+  # `cargo run --release --package symsorter -- --output symbols $source_dir`
+  - id: local
+    type: filesystem
+    path: ./symbols
+    layout: { type: "unified" }
+    is_public: true
+
+  # More public symbol servers be found here:
+  # https://github.com/getsentry/sentry/blob/06265eed51c7f884b571bf55fe05312591ea146b/src/sentry/conf/server.py#L1894
+  - id: sentry:microsoft
+    type: http
+    url: https://msdl.microsoft.com/download/symbols/
+    layout: { type: "symstore" }
+    filters: { filetypes: ["pdb", "pe"] }
+    is_public: true


### PR DESCRIPTION
- Creates an example symbolicator config that includes a local source and the public microsoft server, with a link to more publicly available sources.
- Makes symsorter more suited to sort into a local filesystem source by removing the need to specify a bundle id, and removing a delay related to compression.

#skip-changelog