### PR TITLE
Revert "feat: Test old and new stackwalking implementations"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,18 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,12 +443,6 @@ checksum = "2c882aa326a43102fd13b20b2f1249e76122b1606e3017944943da8d088ade43"
 dependencies = [
  "crossbeam-channel 0.3.9",
 ]
-
-[[package]]
-name = "cascade"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18c6a921baae2d947e4cf96f6ef1b5774b3056ae8edbdf5c5cfce4f33260921"
 
 [[package]]
 name = "cc"
@@ -796,6 +778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,12 +1105,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1556,12 +1538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,18 +1557,18 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.7.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+checksum = "bca6f2bcc5e2ce13f3652ecd05a643b986d035add3f0c38fbabd78f723b5f7e9"
 dependencies = [
  "console",
+ "difference",
  "lazy_static",
  "pest",
  "pest_derive",
  "serde",
  "serde_json",
  "serde_yaml",
- "similar",
  "uuid 0.8.2",
 ]
 
@@ -1697,12 +1673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "joinery"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5c968b1e8336a945da21fab473045df2d5f8c81535e762d52f6b2c49477b9"
-
-[[package]]
 name = "js-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,19 +1728,6 @@ name = "leb128"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -1872,9 +1829,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -2076,32 +2033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
- "memchr",
- "version_check 0.9.2",
-]
-
-[[package]]
-name = "nom-supreme"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66133f5b2e11a538a276b8ef98fae7e75ac6a68ffa5a94a7eb85d4d767c335f"
-dependencies = [
- "cascade",
- "indent_write",
- "joinery",
- "memchr",
- "nom 6.1.2",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,7 +2047,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-bigint 0.3.2",
+ "num-bigint 0.3.1",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2137,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -2183,7 +2114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.0",
- "num-bigint 0.3.2",
+ "num-bigint 0.3.1",
  "num-integer",
  "num-traits",
 ]
@@ -2612,12 +2543,6 @@ checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -3486,12 +3411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "similar"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
-
-[[package]]
 name = "simple_asn1"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,12 +3476,6 @@ name = "standback"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"
@@ -3674,37 +3587,16 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 [[package]]
 name = "symbolic"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
 dependencies = [
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
- "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-common",
+ "symbolic-debuginfo",
  "symbolic-demangle",
  "symbolic-minidump",
  "symbolic-symcache",
 ]
 
 [[package]]
-name = "symbolic"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
-dependencies = [
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
- "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
-]
-
-[[package]]
-name = "symbolic-common"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
-dependencies = [
- "debugid",
- "memmap",
- "serde",
- "stable_deref_trait",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "symbolic-common"
 version = "8.0.5"
 source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
@@ -3714,34 +3606,6 @@ dependencies = [
  "serde",
  "stable_deref_trait",
  "uuid 0.8.2",
-]
-
-[[package]]
-name = "symbolic-debuginfo"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
-dependencies = [
- "dmsort",
- "elementtree",
- "fallible-iterator",
- "flate2",
- "gimli",
- "goblin",
- "lazy_static",
- "lazycell",
- "nom 6.1.2",
- "nom-supreme",
- "parking_lot 0.11.1",
- "pdb",
- "regex",
- "serde",
- "serde_json",
- "smallvec 1.5.0",
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
- "thiserror",
- "walrus",
- "wasmparser",
- "zip",
 ]
 
 [[package]]
@@ -3765,7 +3629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 1.5.0",
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
+ "symbolic-common",
  "thiserror",
  "walrus",
  "wasmparser",
@@ -3775,51 +3639,40 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
 dependencies = [
  "cc",
  "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-common",
 ]
 
 [[package]]
 name = "symbolic-minidump"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
 dependencies = [
  "cc",
  "lazy_static",
  "regex",
  "serde",
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
- "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
- "symbolic-symcache",
- "symbolic-unwind",
+ "symbolic-common",
+ "symbolic-debuginfo",
  "thiserror",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#3f796347dcb0f48a79550ffaff75d08e0dd2a1ff"
 dependencies = [
  "dmsort",
  "fnv",
  "num",
- "symbolic-common 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
- "symbolic-debuginfo 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic-common",
+ "symbolic-debuginfo",
  "thiserror",
-]
-
-[[package]]
-name = "symbolic-unwind"
-version = "8.0.5"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#41e6eaaf434f6ddf8688eecfac2dec2e0359ee78"
-dependencies = [
- "insta",
- "nom 6.1.2",
 ]
 
 [[package]]
@@ -3865,7 +3718,7 @@ dependencies = [
  "serde_yaml",
  "sha-1 0.9.2",
  "structopt",
- "symbolic 8.0.5 (git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind)",
+ "symbolic",
  "tempfile",
  "thiserror",
  "tokio 0.1.22",
@@ -3889,7 +3742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "symbolic 8.0.5 (git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes)",
+ "symbolic",
  "walkdir",
  "zip",
  "zstd",
@@ -3928,12 +3781,6 @@ dependencies = [
  "syn 1.0.58",
  "unicode-xid 0.2.0",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4678,7 +4525,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ca2a14bc3fc5b64d188b087a7d3a927df87b152e941ccfbc66672e20c467ae"
 dependencies = [
- "nom 4.2.3",
+ "nom",
  "proc-macro2 1.0.24",
  "quote 1.0.3",
  "syn 1.0.58",
@@ -5020,12 +4867,6 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "feat/cfi_unwind", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -5,7 +5,7 @@ use std::io::{Cursor, Write};
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use apple_crash_report_parser::AppleCrashReport;
@@ -13,7 +13,6 @@ use bytes::Bytes;
 use chrono::{DateTime, TimeZone, Utc};
 use futures::{channel::oneshot, future, FutureExt as _};
 use parking_lot::Mutex;
-use procspawn::serde::Json;
 use regex::Regex;
 use sentry::protocol::SessionStatus;
 use sentry::{Hub, SentryFutureExt};
@@ -59,11 +58,6 @@ lazy_static::lazy_static! {
     /// Format sent by Unreal Engine on macOS
     static ref OS_MACOS_REGEX: Regex = Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap();
 }
-
-/// Output of a successfull stack walk.
-///
-/// Contains a module list, a list of stacktraces, and a minidump state.
-type StackwalkingOutput = (Vec<CompleteObjectInfo>, Vec<RawStacktrace>, MinidumpState);
 
 /// Errors during symbolication.
 #[derive(Debug, Error)]
@@ -145,7 +139,7 @@ impl<'a> SymCacheLookupResult<'a> {
 /// provided by it.  This can later be used to compile the required modules information
 /// needed for the final response on the JSON API.  See the [`ModuleListBuilder`] struct for
 /// this.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct CfiCacheModules {
     inner: BTreeMap<CodeModuleId, CfiModule>,
 }
@@ -277,7 +271,7 @@ impl CfiCacheModules {
 }
 
 /// A module which was referenced in a minidump and processing information for it.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 struct CfiModule {
     /// Combined features provided by all the DIFs we found for this module.
     features: ObjectFeatures,
@@ -1367,7 +1361,7 @@ type CfiCacheResult = (CodeModuleId, Result<Arc<CfiCacheFile>, Arc<CfiCacheError
 /// subprocess and merged into the final symbolication result.
 ///
 /// A few more convenience methods exist to help with building the symbolication results.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
 struct MinidumpState {
     timestamp: DateTime<Utc>,
     system_info: SystemInfo,
@@ -1611,121 +1605,6 @@ impl SymbolicationActor {
         future::join_all(futures).await
     }
 
-    /// Post-processes breakpad's stackwalking result to extract module list and stacktraces.
-    ///
-    /// The breakpad [`ProcessState`] contains the results of the breakpad stackwalking.  This
-    /// code extracts from this the module list as well as the stack traces in the format required
-    /// for the symbolication response on the API.
-    fn post_process(
-        process_state: ProcessState,
-        cfi_caches: CfiCacheModules,
-    ) -> StackwalkingOutput {
-        let minidump_state = MinidumpState::new(&process_state);
-
-        // Start building the module list for the symbolication response.
-        let mut module_builder =
-            ModuleListBuilder::new(cfi_caches, &process_state, minidump_state.object_type());
-
-        // Finally iterate through the threads and build the stacktraces to
-        // return, marking modules as used when they are referenced by a frame.
-        let requesting_thread_index: Option<usize> =
-            process_state.requesting_thread().try_into().ok();
-        let threads = process_state.threads();
-        let mut stacktraces = Vec::with_capacity(threads.len());
-        for (index, thread) in threads.iter().enumerate() {
-            let registers = match thread.frames().get(0) {
-                Some(frame) => {
-                    map_symbolic_registers(frame.registers(minidump_state.system_info.cpu_arch))
-                }
-                None => Registers::new(),
-            };
-
-            // Trim infinite recursions explicitly because those do not
-            // correlate to minidump size. Every other kind of bloated
-            // input data we know is already trimmed/rejected by raw
-            // byte size alone.
-            let frame_count = thread.frames().len().min(20000);
-            let mut frames = Vec::with_capacity(frame_count);
-            for frame in thread.frames().iter().take(frame_count) {
-                let return_address = frame.return_address(minidump_state.system_info.cpu_arch);
-                module_builder.mark_referenced(return_address);
-
-                frames.push(RawFrame {
-                    instruction_addr: HexValue(return_address),
-                    package: frame.module().map(CodeModule::code_file),
-                    trust: frame.trust(),
-                    ..RawFrame::default()
-                });
-            }
-            stacktraces.push(RawStacktrace {
-                is_requesting: requesting_thread_index.map(|r| r == index),
-                thread_id: Some(thread.thread_id().into()),
-                registers,
-                frames,
-            });
-        }
-
-        (module_builder.build(), stacktraces, minidump_state)
-    }
-
-    /// The actual stackwalking procedure.
-    ///
-    /// This is a method, as opposed to a closure in
-    /// [`stackwalk_minidump_with_cfi`](SymbolicationActor::stackwalk_minidump_with_cfi),
-    /// to circumvent a problem with `rustfmt`.
-    fn procspawn_inner_stackwalk(
-        cfi_caches: Json<CfiCacheModules>,
-        minidump: Bytes,
-        spawn_time: SystemTime,
-        compare_stackwalking_methods: bool,
-    ) -> Result<Json<StackwalkingOutput>, ProcessMinidumpError> {
-        let procspawn::serde::Json(mut cfi_caches) = cfi_caches;
-        if let Ok(duration) = spawn_time.elapsed() {
-            metric!(timer("minidump.stackwalk.spawn.duration") = duration);
-        }
-        let cfi_caches_cloned = cfi_caches.clone();
-
-        // Stackwalk the minidump.
-        let cfi = cfi_caches.load_cfi();
-        let minidump = ByteView::from_slice(&minidump);
-        let timer_old = Instant::now();
-        let process_state = ProcessState::from_minidump_breakpad(&minidump, Some(&cfi))?;
-        let timer_old = timer_old.elapsed();
-        let (module_list, stacktraces, minidump_state) =
-            Self::post_process(process_state, cfi_caches_cloned);
-
-        // Run and time the new stackwalking method if compare_stackwalking_methods was passed
-        if compare_stackwalking_methods {
-            let timer_new = Instant::now();
-            match ProcessState::from_minidump(&minidump, Some(&cfi)) {
-                Ok(process_state_new) => {
-                    let timer_new = timer_new.elapsed();
-                    let (module_list_new, stacktraces_new, minidump_state_new) =
-                        Self::post_process(process_state_new, cfi_caches);
-
-                    // Report whether the stackwalking results are different or identical.
-                    if stacktraces == stacktraces_new
-                        && module_list == module_list_new
-                        && minidump_state == minidump_state_new
-                    {
-                        metric!(counter("minidump.stackwalk.identical") += 1);
-                    } else {
-                        metric!(counter("minidump.stackwalk.different") += 1);
-                    }
-
-                    metric!(timer("minidump.stackwalk.duration") = timer_old, "method" => "old");
-                    metric!(timer("minidump.stackwalk.duration") = timer_new, "method" => "new");
-                }
-
-                Err(e) => {
-                    // If the old method succeeded and the new one failed, report this fact
-                    sentry::capture_error(&e);
-                }
-            }
-        }
-        Ok(Json((module_list, stacktraces, minidump_state)))
-    }
-
     /// Unwind the stack from a minidump.
     ///
     /// This processes the minidump to stackwalk all the threads found in the minidump.
@@ -1763,15 +1642,73 @@ impl SymbolicationActor {
                     procspawn::serde::Json(cfi_caches),
                     minidump.clone(),
                     spawn_time,
-                    options.compare_stackwalking_methods,
                 ),
-                |(cfi_caches, minidump, spawn_time, compare_stackwalking_methods)| {
-                    Self::procspawn_inner_stackwalk(
+                |(cfi_caches, minidump, spawn_time)| -> Result<_, ProcessMinidumpError> {
+                    let procspawn::serde::Json(mut cfi_caches) = cfi_caches;
+
+                    if let Ok(duration) = spawn_time.elapsed() {
+                        metric!(timer("minidump.stackwalk.spawn.duration") = duration);
+                    }
+
+                    // Stackwalk the minidump.
+                    let cfi = cfi_caches.load_cfi();
+                    let minidump = ByteView::from_slice(&minidump);
+                    let process_state = ProcessState::from_minidump(&minidump, Some(&cfi))?;
+                    let minidump_state = MinidumpState::new(&process_state);
+
+                    // Start building the module list for the symbolication response.
+                    let mut module_builder = ModuleListBuilder::new(
                         cfi_caches,
-                        minidump,
-                        spawn_time,
-                        compare_stackwalking_methods,
-                    )
+                        &process_state,
+                        minidump_state.object_type(),
+                    );
+
+                    // Finally iterate through the threads and build the stacktraces to
+                    // return, marking modules as used when they are referenced by a frame.
+                    let requesting_thread_index: Option<usize> =
+                        process_state.requesting_thread().try_into().ok();
+                    let threads = process_state.threads();
+                    let mut stacktraces = Vec::with_capacity(threads.len());
+                    for (index, thread) in threads.iter().enumerate() {
+                        let registers = match thread.frames().get(0) {
+                            Some(frame) => map_symbolic_registers(
+                                frame.registers(minidump_state.system_info.cpu_arch),
+                            ),
+                            None => Registers::new(),
+                        };
+
+                        // Trim infinite recursions explicitly because those do not
+                        // correlate to minidump size. Every other kind of bloated
+                        // input data we know is already trimmed/rejected by raw
+                        // byte size alone.
+                        let frame_count = thread.frames().len().min(20000);
+                        let mut frames = Vec::with_capacity(frame_count);
+                        for frame in thread.frames().iter().take(frame_count) {
+                            let return_address =
+                                frame.return_address(minidump_state.system_info.cpu_arch);
+                            module_builder.mark_referenced(return_address);
+
+                            frames.push(RawFrame {
+                                instruction_addr: HexValue(return_address),
+                                package: frame.module().map(CodeModule::code_file),
+                                trust: frame.trust(),
+                                ..RawFrame::default()
+                            });
+                        }
+
+                        stacktraces.push(RawStacktrace {
+                            is_requesting: requesting_thread_index.map(|r| r == index),
+                            thread_id: Some(thread.thread_id().into()),
+                            registers,
+                            frames,
+                        });
+                    }
+
+                    Ok(procspawn::serde::Json((
+                        module_builder.build(),
+                        stacktraces,
+                        minidump_state,
+                    )))
                 },
             );
 
@@ -2174,7 +2111,6 @@ mod tests {
             })],
             options: RequestOptions {
                 dif_candidates: true,
-                ..Default::default()
             },
         }
     }
@@ -2321,7 +2257,6 @@ mod tests {
                 Arc::new([source]),
                 RequestOptions {
                     dif_candidates: true,
-                    ..Default::default()
                 },
             );
             symbolication.get_response(request_id, None).await
@@ -2368,7 +2303,6 @@ mod tests {
                 Arc::new([source]),
                 RequestOptions {
                     dif_candidates: true,
-                    ..Default::default()
                 },
             );
 

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -155,10 +155,6 @@ pub struct RequestOptions {
     /// [`ObjectCandidate`] struct for which extra information is returned for DIF objects.
     #[serde(default)]
     pub dif_candidates: bool,
-
-    /// Whether to run the new stackwalking method in addition to the old one and compare their results.
-    #[serde(default)]
-    pub compare_stackwalking_methods: bool,
 }
 
 /// A map of register values.
@@ -169,7 +165,7 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 }
 
 /// An unsymbolicated frame from a symbolication request.
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct RawFrame {
     /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
     /// [`sym_addr`](Self::sym_addr).
@@ -237,7 +233,7 @@ pub struct RawFrame {
 }
 
 /// A stack trace containing unsymbolicated stack frames.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct RawStacktrace {
     /// The OS-dependent identifier of the thread.
     #[serde(default)]


### PR DESCRIPTION
Reverts getsentry/symbolicator#413

The `get_referenced_modules_from_minidump` function is calling the wrong stackwalker currently which makes all symbolications fail hard because every subprocess panics.

#skip-changelog