### PR TITLE
fix: Switch demangling fixes back on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,8 +568,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "cpp_demangle"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
+source = "git+https://github.com/Swatinem/cpp_demangle?branch=sentry-patches#3850dfbe03a3f8621be88ab50429a00374a8470a"
 dependencies = [
  "cfg-if 1.0.0",
  "glob",
@@ -1965,8 +1964,7 @@ dependencies = [
 [[package]]
 name = "msvc-demangler"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6584cf122f02fc0396420a116cd395a9a776ec4347dffe1c5119c3fcc917c060"
+source = "git+https://github.com/Swatinem/msvc-demangler-rust?branch=sentry-patches#075432259fe0eaac2f3fc225550a4db479bf3c81"
 dependencies = [
  "bitflags",
 ]
@@ -3589,8 +3587,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 [[package]]
 name = "symbolic"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b052742c32348e5217c9bf28ba2a1a9d4169609ef1055eaea5333ccf7a7614"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3602,8 +3599,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7dfa630954f18297ceae1ff2890cb7f5008a0b2d2106b0468dafc45b0b6b12"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "debugid",
  "memmap",
@@ -3615,8 +3611,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fec6e5e3c9575f509bafa63e82e98f178d50f886a23c385f27fdcbbc5f29bbf"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "dmsort",
  "elementtree",
@@ -3644,8 +3639,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4ba42bd1221803e965054767b1899f2db9a12c89969965c6cb3a02af7014eb"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3657,8 +3651,7 @@ dependencies = [
 [[package]]
 name = "symbolic-minidump"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7cc4b27a557b1667873c1c15c1abd51afb8946a18ec488b101360038aec56c3"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3672,8 +3665,7 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d61abb3626bedf91e433e02821696cbdb9e7dd003ea13d46fe393a0dd41c7"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#d0fb80979f6bcc3ebe6442db9a1b15ab16d4f443"
 dependencies = [
  "dmsort",
  "fnv",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { version = "8.1.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.1.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { version = "8.1.0", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.1.0", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.6.0"


### PR DESCRIPTION
We saw a 4x regression in the number of demangling failures going with the officially released versions. Not sure we want to take that for now.

#skip-changelog