### PR TITLE
ref(api): Rename the PList filetype

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -253,7 +253,8 @@ impl BitcodeService {
 
     /// Fetches a file and returns the [`CacheHandle`] if found.
     ///
-    /// This should only be used to fetch [`FileType::PList`] and [`FileType::BcSymbolMap`].
+    /// This should only be used to fetch [`FileType::BcSymbolMapUuidMap`] and
+    /// [`FileType::BcSymbolMap`].
     async fn fetch_file_from_source(
         &self,
         uuid: DebugId,

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -189,12 +189,7 @@ impl BitcodeService {
     ) -> Result<Option<BcSymbolMapHandle>, Error> {
         // First find the PList.
         let find_plist = self
-            .fetch_file_from_all_sources(
-                uuid,
-                FileType::BcSymbolMapUuidMap,
-                scope.clone(),
-                sources.clone(),
-            )
+            .fetch_file_from_all_sources(uuid, FileType::UuidMap, scope.clone(), sources.clone())
             .await?;
         let plist_handle = match find_plist {
             Some(handle) => handle,
@@ -253,7 +248,7 @@ impl BitcodeService {
 
     /// Fetches a file and returns the [`CacheHandle`] if found.
     ///
-    /// This should only be used to fetch [`FileType::BcSymbolMapUuidMap`] and
+    /// This should only be used to fetch [`FileType::UuidMap`] and
     /// [`FileType::BcSymbolMap`].
     async fn fetch_file_from_source(
         &self,

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -189,7 +189,12 @@ impl BitcodeService {
     ) -> Result<Option<BcSymbolMapHandle>, Error> {
         // First find the PList.
         let find_plist = self
-            .fetch_file_from_all_sources(uuid, FileType::PList, scope.clone(), sources.clone())
+            .fetch_file_from_all_sources(
+                uuid,
+                FileType::BcSymbolMapUuidMap,
+                scope.clone(),
+                sources.clone(),
+            )
             .await?;
         let plist_handle = match find_plist {
             Some(handle) => handle,

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -384,11 +384,12 @@ pub enum FileType {
     /// Source bundle
     #[serde(rename = "sourcebundle")]
     SourceBundle,
-    /// PropertyList, mapping a dSYM UUID to a BCSymbolMap UUID for MachO.
-    #[serde(rename = "plist")]
-    PList,
+    /// A file mapping a dSYM UUID to a BCSymbolMap UUID for MachO.
+    ///
+    /// At the time of writing this only supports the XML PropertyList format, but this does
+    /// not need to remain so.
+    BcSymbolMapUuidMap,
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
-    #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
 }
 
@@ -408,7 +409,7 @@ impl FileType {
             WasmDebug,
             Breakpad,
             SourceBundle,
-            PList,
+            BcSymbolMapUuidMap,
             BcSymbolMap,
         ]
     }
@@ -445,7 +446,7 @@ impl AsRef<str> for FileType {
             FileType::WasmCode => "wasm_code",
             FileType::Breakpad => "breakpad",
             FileType::SourceBundle => "sourcebundle",
-            FileType::PList => "plist",
+            FileType::BcSymbolMapUuidMap => "bcsymbolmap_uuidmap",
             FileType::BcSymbolMap => "bcsymbolmap",
         }
     }

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -388,8 +388,10 @@ pub enum FileType {
     ///
     /// At the time of writing this only supports the XML PropertyList format, but this does
     /// not need to remain so.
+    #[serde(rename = "bcsymbolmap_uuidmap")]
     BcSymbolMapUuidMap,
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
+    #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
 }
 

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -384,12 +384,22 @@ pub enum FileType {
     /// Source bundle
     #[serde(rename = "sourcebundle")]
     SourceBundle,
-    /// A file mapping a dSYM UUID to a BCSymbolMap UUID for MachO.
+    /// A file mapping a MachO [`DebugId`] to an originating [`DebugId`].
     ///
-    /// At the time of writing this only supports the XML PropertyList format, but this does
-    /// not need to remain so.
-    #[serde(rename = "bcsymbolmap_uuidmap")]
-    BcSymbolMapUuidMap,
+    /// For the MachO format a [`DebugId`] is always a UUID.
+    ///
+    /// This is used when compilation introduces intermediate outputs, like Apple BitCode.
+    /// In this case some Debug Information Files will have the [`DebugId`] of the
+    /// intermediate compilation rather than of the final executable code.  Thus these maps
+    /// point to which other [`DebugId`]s provide DIFs.
+    ///
+    /// At the time of writing this is only used to map a dSYM UUID to a BCSymbolMap UUID
+    /// for MachO.  The only format supported for this is currently the XML PropertyList
+    /// format.  In the future other formats could be added to this.
+    ///
+    /// [`DebugId`]: symbolic::common::DebugId
+    #[serde(rename = "uuidmap")]
+    UuidMap,
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
     #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
@@ -411,7 +421,7 @@ impl FileType {
             WasmDebug,
             Breakpad,
             SourceBundle,
-            BcSymbolMapUuidMap,
+            UuidMap,
             BcSymbolMap,
         ]
     }
@@ -448,7 +458,7 @@ impl AsRef<str> for FileType {
             FileType::WasmCode => "wasm_code",
             FileType::Breakpad => "breakpad",
             FileType::SourceBundle => "sourcebundle",
-            FileType::BcSymbolMapUuidMap => "bcsymbolmap_uuidmap",
+            FileType::UuidMap => "uuidmap",
             FileType::BcSymbolMap => "bcsymbolmap",
         }
     }

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -196,7 +196,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
             rv.push(primary_path);
             rv
         }
-        FileType::PList => Vec::new(),
+        FileType::BcSymbolMapUuidMap => Vec::new(),
         FileType::BcSymbolMap => Vec::new(),
     }
 }
@@ -278,7 +278,7 @@ fn get_symstore_path(
         }
 
         // Microsoft SymbolServer does not specify PropertyList.
-        FileType::PList => None,
+        FileType::BcSymbolMapUuidMap => None,
 
         // Microsoft SymbolServer does not speicfy BCSymbolMap.
         FileType::BcSymbolMap => None,
@@ -325,7 +325,7 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
 
         // not available
         FileType::SourceBundle => None,
-        FileType::PList => None,
+        FileType::BcSymbolMapUuidMap => None,
         FileType::BcSymbolMap => None,
     }
 }
@@ -339,9 +339,10 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
 fn get_search_target_object_type(filetype: FileType, identifier: &ObjectId) -> ObjectType {
     match filetype {
         FileType::Pe | FileType::Pdb => ObjectType::Pe,
-        FileType::MachCode | FileType::MachDebug | FileType::PList | FileType::BcSymbolMap => {
-            ObjectType::Macho
-        }
+        FileType::MachCode
+        | FileType::MachDebug
+        | FileType::BcSymbolMapUuidMap
+        | FileType::BcSymbolMap => ObjectType::Macho,
         FileType::ElfCode | FileType::ElfDebug => ObjectType::Elf,
         FileType::WasmDebug | FileType::WasmCode => ObjectType::Wasm,
         FileType::SourceBundle | FileType::Breakpad => identifier.object_type,
@@ -357,7 +358,7 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
         }
         FileType::Breakpad => "breakpad",
         FileType::SourceBundle => "sourcebundle",
-        FileType::PList => "plist",
+        FileType::BcSymbolMapUuidMap => "plist",
         FileType::BcSymbolMap => "bcsymbolmap",
     };
 

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -196,7 +196,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
             rv.push(primary_path);
             rv
         }
-        FileType::BcSymbolMapUuidMap => Vec::new(),
+        FileType::UuidMap => Vec::new(),
         FileType::BcSymbolMap => Vec::new(),
     }
 }
@@ -278,7 +278,7 @@ fn get_symstore_path(
         }
 
         // Microsoft SymbolServer does not specify PropertyList.
-        FileType::BcSymbolMapUuidMap => None,
+        FileType::UuidMap => None,
 
         // Microsoft SymbolServer does not speicfy BCSymbolMap.
         FileType::BcSymbolMap => None,
@@ -325,7 +325,7 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
 
         // not available
         FileType::SourceBundle => None,
-        FileType::BcSymbolMapUuidMap => None,
+        FileType::UuidMap => None,
         FileType::BcSymbolMap => None,
     }
 }
@@ -339,10 +339,9 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
 fn get_search_target_object_type(filetype: FileType, identifier: &ObjectId) -> ObjectType {
     match filetype {
         FileType::Pe | FileType::Pdb => ObjectType::Pe,
-        FileType::MachCode
-        | FileType::MachDebug
-        | FileType::BcSymbolMapUuidMap
-        | FileType::BcSymbolMap => ObjectType::Macho,
+        FileType::MachCode | FileType::MachDebug | FileType::UuidMap | FileType::BcSymbolMap => {
+            ObjectType::Macho
+        }
         FileType::ElfCode | FileType::ElfDebug => ObjectType::Elf,
         FileType::WasmDebug | FileType::WasmCode => ObjectType::Wasm,
         FileType::SourceBundle | FileType::Breakpad => identifier.object_type,
@@ -358,7 +357,7 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
         }
         FileType::Breakpad => "breakpad",
         FileType::SourceBundle => "sourcebundle",
-        FileType::BcSymbolMapUuidMap => "plist",
+        FileType::UuidMap => "uuidmap",
         FileType::BcSymbolMap => "bcsymbolmap",
     };
 


### PR DESCRIPTION
This FileType is actually part of the public API as it can be used in
the configuration of a source to only use a source for certain
filetypes.  So we should have some meaningful name which won't be
wrong and confuse in the future without being too restrictive.
Calling it "PList" is just too generic, so that's a bad choice.

Since all other filetype use the snake_case convention there's no need
to diverge as it would only create confusion (the sourcebundle boat
has sadly sailed).

These changes are fine currently since none of this has been released
yet.

#skip-changelog