### PR TITLE
ref(clippy): Prefer std::mem::take()

### DIFF
--- a/crates/process-event/src/main.rs
+++ b/crates/process-event/src/main.rs
@@ -102,7 +102,7 @@ mod event {
         }
 
         for stacktrace in &mut stacktraces {
-            let frames = std::mem::replace(&mut stacktrace.frames, vec![]);
+            let frames = std::mem::take(&mut stacktrace.frames);
             stacktrace.frames = frames
                 .into_iter()
                 .rev()


### PR DESCRIPTION
Nightly clippy points out that as the std::mem::replace() is with
Default::default we can as well use std::mem::take().

#skip-changelog