### PR TITLE
fix(symbolication): Isolate new stackwalking procedure

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2017,7 +2017,7 @@ impl SymbolicationActor {
                     ),
                     |(cfi_caches, minidump, spawn_time)| {
                         if let Ok(duration) = spawn_time.elapsed() {
-                            metric!(timer("minidump.stackwalk_new.spawn.duration") = duration);
+                            metric!(timer("minidump.stackwalk.spawn.duration") = duration);
                         }
                         let procspawn::serde::Json(cfi_caches) = cfi_caches;
                         Self::procspawn_inner_stackwalk(


### PR DESCRIPTION
This refactors `stackwalk_minidump_with_cfi` so that the original stackwalking procedure is run in an external process and then, if `compare_stackwalking_methods` is enabled, the new one is run in another external process.

Questions:

- Is it right to put everything into one future?
- Is this sufficient to prevent failures in the new method from interfering with production?
- Where/how should error reporting to sentry take place?

Local tests indicate that it works correctly, but I could be missing something.

#skip-changelog