### PR TITLE
ref: Report different stackwalking results as sentry errors

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -68,7 +68,7 @@ enum StackwalkingMethod {
 }
 
 /// The output of a successful stack walk.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 struct StackwalkingOutput {
     module_list: Vec<CompleteObjectInfo>,
     stacktraces: Vec<RawStacktrace>,
@@ -2036,13 +2036,7 @@ impl SymbolicationActor {
                     &diagnostics_cache,
                 ) {
                     Ok(stackwalking_result_new) => {
-                        if stackwalking_result_new.module_list
-                            == stackwalking_result_old.module_list
-                            && stackwalking_result_new.stacktraces
-                                == stackwalking_result_old.stacktraces
-                            && stackwalking_result_new.minidump_state
-                                == stackwalking_result_old.minidump_state
-                        {
+                        if stackwalking_result_new == stackwalking_result_old {
                             metric!(counter("minidump.stackwalk.results") += 1, "equality" => "equal")
                         } else {
                             metric!(counter("minidump.stackwalk.results") += 1, "equality" => "not equal")

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1744,7 +1744,7 @@ impl SymbolicationActor {
                 Duration::from_secs(20),
                 "minidump.modules.spawn.error",
                 &minidump,
-                diagnostics_cache,
+                &diagnostics_cache,
             )
         };
 
@@ -1764,7 +1764,7 @@ impl SymbolicationActor {
         timeout: Duration,
         metric: &str,
         minidump: &[u8],
-        minidump_cache: crate::cache::Cache,
+        minidump_cache: &crate::cache::Cache,
     ) -> Result<T, anyhow::Error>
     where
         T: Serialize + DeserializeOwned,
@@ -1811,7 +1811,7 @@ impl SymbolicationActor {
     /// Save a minidump to temporary location.
     fn save_minidump(
         minidump: &[u8],
-        failed_cache: crate::cache::Cache,
+        failed_cache: &crate::cache::Cache,
     ) -> anyhow::Result<Option<PathBuf>> {
         if let Some(dir) = failed_cache.cache_dir() {
             std::fs::create_dir_all(dir)?;
@@ -2004,7 +2004,7 @@ impl SymbolicationActor {
                 Duration::from_secs(60),
                 "minidump.stackwalk.spawn.error",
                 &minidump,
-                diagnostics_cache.clone(),
+                &diagnostics_cache,
             )?;
 
             if options.compare_stackwalking_methods {
@@ -2033,7 +2033,7 @@ impl SymbolicationActor {
                     Duration::from_secs(60),
                     "minidump.stackwalk_new.spawn.error",
                     &minidump,
-                    diagnostics_cache,
+                    &diagnostics_cache,
                 ) {
                     Ok(stackwalking_result_new) => {
                         if stackwalking_result_new.module_list


### PR DESCRIPTION
This reports an error to sentry and saves the minidump if the new method returns a different stackwalking result than the old one.

This also contains two other minor changes (in separate commits):
1. `StackwalkingOutput` implements `PartialEq`, simplifying the comparison
2. `save_minidump` and `join_procspawn` take the `cache` argument by reference instead of by value. This saves some cloning.

#skip-changelog