### PR TITLE
fix: Convert stackwalking/cfi loading into a fixpoint iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for BCSymbolMap auxiliary files which when present on the symbol server will automatically resolve obfuscated symbol names ([#403](https://github.com/getsentry/symbolicator/pull/403))
 - S3 sources: add support for using AWS container credentials provided by IAM task roles. ([#417](https://github.com/getsentry/symbolicator/pull/417))
 - Implement new Symbolication Quality Metrics. ([#426](https://github.com/getsentry/symbolicator/pull/426))
+- Convert stackwalking/cfi loading into a fixpoint iteration. ([#450](https://github.com/getsentry/symbolicator/pull/450))
 
 ### Bug Fixes
 

--- a/crates/symbolicator/src/endpoints/snapshots/symbolicator__endpoints__minidump__tests__basic.snap
+++ b/crates/symbolicator/src/endpoints/snapshots/symbolicator__endpoints__minidump__tests__basic.snap
@@ -1,5 +1,5 @@
 ---
-source: src/endpoints/minidump.rs
+source: crates/symbolicator/src/endpoints/minidump.rs
 expression: response
 ---
 status: completed
@@ -332,7 +332,7 @@ modules:
     image_addr: "0x74450000"
     image_size: 266240
   - debug_status: missing
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false
@@ -407,7 +407,7 @@ modules:
     image_addr: "0x76db0000"
     image_size: 1708032
   - debug_status: missing
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -1,5 +1,5 @@
 ---
-source: src/services/symbolication.rs
+source: crates/symbolicator/src/services/symbolication.rs
 expression: response.await.unwrap()
 ---
 status: completed
@@ -244,7 +244,7 @@ modules:
     image_addr: "0x70a10000"
     image_size: 598016
   - debug_status: unused
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false
@@ -370,7 +370,7 @@ modules:
     image_addr: "0x74450000"
     image_size: 266240
   - debug_status: missing
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false
@@ -421,7 +421,7 @@ modules:
     image_addr: "0x75130000"
     image_size: 368640
   - debug_status: unused
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false
@@ -487,7 +487,7 @@ modules:
     image_addr: "0x76db0000"
     image_size: 1708032
   - debug_status: missing
-    unwind_status: unused
+    unwind_status: missing
     features:
       has_debug_info: false
       has_unwind_info: false

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -244,7 +244,7 @@ modules:
     image_addr: "0x70a10000"
     image_size: 598016
   - debug_status: unused
-    unwind_status: missing
+    unwind_status: unused
     features:
       has_debug_info: false
       has_unwind_info: false
@@ -421,7 +421,7 @@ modules:
     image_addr: "0x75130000"
     image_size: 368640
   - debug_status: unused
-    unwind_status: missing
+    unwind_status: unused
     features:
       has_debug_info: false
       has_unwind_info: false

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1794,8 +1794,7 @@ impl SymbolicationActor {
     ///
     /// This processes the minidump to stackwalk all the threads found in the minidump.
     ///
-    /// The `cfi_results` must contain all modules found in the minidump (extracted using
-    /// [`SymbolicationActor::get_referenced_modules_from_minidump`]) and the result of trying
+    /// The `cfi_results` will contain all modules found in the minidump and the result of trying
     /// to fetch the Call Frame Information (CFI) for them from the [`CfiCacheActor`].
     ///
     /// This function will load the CFI files and ask breakpad to stackwalk the minidump.

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -344,13 +344,13 @@ impl ModuleListBuilder {
     fn process_stacktraces(&mut self, stacktraces: &[RawStacktrace]) {
         for trace in stacktraces {
             if let Some(first_frame) = trace.frames.first() {
-                let return_address = first_frame.instruction_addr.0;
-                self.mark_referenced(return_address);
+                let addr = first_frame.instruction_addr.0;
+                self.mark_referenced(addr);
             }
             for frame_pair in trace.frames.windows(2) {
                 if let [prev_frame, next_frame] = frame_pair {
-                    let return_address = next_frame.instruction_addr.0;
-                    self.mark_referenced(return_address);
+                    let addr = next_frame.instruction_addr.0;
+                    self.mark_referenced(addr);
 
                     if let Some(info_index) = self.find_module_index(prev_frame.instruction_addr.0)
                     {
@@ -2607,7 +2607,7 @@ mod tests {
     }
 
     fn create_object_info(has_id: bool, addr: u64, size: Option<u64>) -> CompleteObjectInfo {
-        RawObjectInfo {
+        let mut info: CompleteObjectInfo = RawObjectInfo {
             ty: ObjectType::Elf,
             code_id: None,
             code_file: None,
@@ -2616,7 +2616,9 @@ mod tests {
             image_addr: HexValue(addr),
             image_size: size,
         }
-        .into()
+        .into();
+        info.unwind_status = Some(ObjectFileStatus::Unused);
+        info
     }
 
     #[test]


### PR DESCRIPTION
Instead of two times, it will now do up to 5 stack walks, trying to load increasing CFI on each iteration.