### PR TITLE
ref(clippy): Avoid unused references

### DIFF
--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -101,8 +101,8 @@ impl std::ops::Deref for CachePath {
     #[inline]
     fn deref(&self) -> &Self::Target {
         match *self {
-            Self::Temp(ref temp) => &temp,
-            Self::Cached(ref buf) => &buf,
+            Self::Temp(ref temp) => temp,
+            Self::Cached(ref buf) => buf,
         }
     }
 }
@@ -111,8 +111,8 @@ impl AsRef<Path> for CachePath {
     #[inline]
     fn as_ref(&self) -> &Path {
         match *self {
-            Self::Temp(ref temp) => &temp,
-            Self::Cached(ref buf) => &buf,
+            Self::Temp(ref temp) => temp,
+            Self::Cached(ref buf) => buf,
         }
     }
 }
@@ -211,7 +211,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         // cache_path is None when caching is disabled.
         let cache_path = get_scope_path(self.config.cache_dir(), &key.scope, &key.cache_key);
         if let Some(ref path) = cache_path {
-            if let Some(item) = tryf!(self.lookup_cache(&request, &key, &path)) {
+            if let Some(item) = tryf!(self.lookup_cache(&request, &key, path)) {
                 return Box::pin(future::ok(item));
             }
         }

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -42,7 +42,7 @@ impl SourceLocation {
 
     /// Returns this location as a local (relative) Path.
     pub fn path(&self) -> &Path {
-        &Path::new(&self.0)
+        Path::new(&self.0)
     }
 
     /// Returns this location relative to the given base.

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -142,7 +142,7 @@ impl S3Downloader {
 
         let source_key = &file_source.source.source_key;
         let result = self
-            .get_s3_client(&source_key)
+            .get_s3_client(source_key)
             .get_object(rusoto_s3::GetObjectRequest {
                 key: key.clone(),
                 bucket: bucket.clone(),

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -105,7 +105,7 @@ impl AsRef<str> for Scope {
     fn as_ref(&self) -> &str {
         match *self {
             Scope::Global => "global",
-            Scope::Scoped(ref s) => &s,
+            Scope::Scoped(ref s) => s,
         }
     }
 }
@@ -120,7 +120,7 @@ impl fmt::Display for Scope {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Scope::Global => f.write_str("global"),
-            Scope::Scoped(ref scope) => f.write_str(&scope),
+            Scope::Scoped(ref scope) => f.write_str(scope),
         }
     }
 }

--- a/crates/symbolicator/src/utils/sentry.rs
+++ b/crates/symbolicator/src/utils/sentry.rs
@@ -169,7 +169,7 @@ impl<S: 'static> Middleware<S> for SentryMiddleware {
                     let with_pii = client
                         .as_ref()
                         .map_or(false, |x| x.options().send_default_pii);
-                    *cached_data = Some(extract_request(&req.get(), with_pii));
+                    *cached_data = Some(extract_request(req.get(), with_pii));
                 }
 
                 if let Some((ref transaction, ref req)) = *cached_data {

--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -196,7 +196,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     let bv = ByteView::read(zip_file)?;
                     if Archive::peek(&bv) != FileFormat::Unknown {
                         debug_ids.lock().unwrap().extend(
-                            process_file(&sort_config, bv, name)?
+                            process_file(sort_config, bv, name)?
                                 .into_iter()
                                 .map(|x| x.0),
                         );
@@ -206,7 +206,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
             // object file directly
             } else if Archive::peek(&bv) != FileFormat::Unknown {
                 for (unified_id, object_kind) in process_file(
-                    &sort_config,
+                    sort_config,
                     bv,
                     path.file_name().unwrap().to_string_lossy().to_string(),
                 )? {
@@ -242,7 +242,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                 };
 
                 let processed_objects = process_file(
-                    &sort_config,
+                    sort_config,
                     source_bundle,
                     path.file_name().unwrap().to_string_lossy().to_string(),
                 )?;


### PR DESCRIPTION
Weekly clippy release!  This weeks edition is how to make your
compiler lenient in what it accepts so you can make your linting do
some work.

The compiler was dereferencing these immediately to match the actual
types needed.

#skip-changelog