### PR TITLE
build: Update symbolic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
- "gimli",
+ "gimli 0.23.0",
 ]
 
 [[package]]
@@ -586,7 +586,8 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "cpp_demangle"
 version = "0.3.2"
-source = "git+https://github.com/Swatinem/cpp_demangle?branch=sentry-patches#3850dfbe03a3f8621be88ab50429a00374a8470a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
 dependencies = [
  "cfg-if 1.0.0",
  "glob",
@@ -1282,6 +1283,12 @@ name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "gimli"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -1295,9 +1302,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669cdc3826f69a51d3f8fc3f86de81c2378110254f678b8407977736122057a4"
+checksum = "ee05c709047abe5eb0571880d2887ac77299c5f0835f8e6b7f4d5404f8962921"
 dependencies = [
  "log",
  "plain",
@@ -2006,8 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "msvc-demangler"
-version = "0.8.0"
-source = "git+https://github.com/Swatinem/msvc-demangler-rust?branch=sentry-patches#075432259fe0eaac2f3fc225550a4db479bf3c81"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
 dependencies = [
  "bitflags",
 ]
@@ -3629,7 +3637,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 [[package]]
 name = "symbolic"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3641,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "debugid",
  "memmap",
@@ -3653,13 +3661,13 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "dmsort",
  "elementtree",
  "fallible-iterator",
  "flate2",
- "gimli",
+ "gimli 0.24.0",
  "goblin",
  "lazy_static",
  "lazycell",
@@ -3682,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3694,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "symbolic-minidump"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3710,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3722,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "symbolic-unwind"
 version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#db2c1902dd14e11fdf818485a0c25f36cbf6d114"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#f56947a51469c115c3a6c566bc81074bdd12125a"
 dependencies = [
  "insta",
  "nom 6.1.2",
@@ -4638,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d470d0583e65f4cab21a1ff3c1ba3dd23ae49e68f516f0afceaeb001b32af39"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4652,9 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "walrus-macro"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c2bb690b44cb1b0fdcc54d4998d21f8bdaf706b93775425e440b174f39ad16"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
 dependencies = [
  "heck",
  "proc-macro2 1.0.24",
@@ -4822,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.59.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "web-sys"


### PR DESCRIPTION
This pulls the `NestedRangeMap` changes in symbolic into symbolicator.

#skip-changelog