### PR TITLE
fix(clippy): remove borrowing of reference

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1764,7 +1764,7 @@ impl SymbolicationActor {
                     .cficaches
                     .fetch(FetchCfiCache {
                         object_type: object_info.ty,
-                        identifier: object_id_from_object_info(&object_info),
+                        identifier: object_id_from_object_info(object_info),
                         sources,
                         scope,
                     })


### PR DESCRIPTION
This is immediately auto-derefed by the compiler already.  Thanks
clippy.

#skip-changelog