### PR TITLE
fix(ci): Update snapshot directory for Danger checks

### DIFF
--- a/crates/symbolicator/src/services/snapshots/CAUTION.md
+++ b/crates/symbolicator/src/services/snapshots/CAUTION.md
@@ -1,0 +1,1 @@
+When moving this directory, update `/dangerfile.js` with the new location.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -72,6 +72,18 @@ Follow these steps to update snapshots in Sentry:
 
 async function checkSnapshots() {
   const SNAPSHOT_LOCATION = "src/actors/snapshots/";
+
+  // Sanity check that the snapshot directory exists
+  let contents = await danger.github.utils.fileContents(
+    SNAPSHOT_LOCATION + "CAUTION.md"
+  );
+  if (!contents) {
+    fail(
+      "The snapshot directory has moved to a new location. Please update SNAPSHOT_LOCATION in /dangerfile.js."
+    );
+    return;
+  }
+
   const changesSnapshots = danger.git.modified_files.some((f) =>
     f.startsWith(SNAPSHOT_LOCATION)
   );

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -71,7 +71,7 @@ Follow these steps to update snapshots in Sentry:
 }
 
 async function checkSnapshots() {
-  const SNAPSHOT_LOCATION = "src/actors/snapshots/";
+  const SNAPSHOT_LOCATION = "crates/symbolicator/src/services/snapshots/";
 
   // Sanity check that the snapshot directory exists
   let contents = await danger.github.utils.fileContents(


### PR DESCRIPTION
Fixes the snapshot directory used by Danger bot. Also adds a sanity check to ensure Danger is checking the correct directory for snapshot changes.

If the directory does not exist, Danger fails the build with:

![Screen Shot 2021-06-11 at 12 21 45](https://user-images.githubusercontent.com/1433023/121672811-876c2b00-cab0-11eb-8ae8-a42728c3c6e8.png)

If snapshots have changed, Danger warns with:

![Screen Shot 2021-06-11 at 12 24 40](https://user-images.githubusercontent.com/1433023/121672835-8e933900-cab0-11eb-92f3-4577407a73c0.png)

#skip-changelog