### PR TITLE
feat(symsorter): Support for the dyld shared cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ __pycache__
 /local.yml
 /cache/
 /symbols/
+/symbols*/
+
+# Generated symbols
+executable
+meta
+
+# log files
+*.log
 
 # mkdocs
 site

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.4.3",
- "object",
+ "object 0.22.0",
  "rustc-demangle",
  "serde",
 ]
@@ -1835,9 +1835,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memmap"
@@ -2093,6 +2093,16 @@ name = "object"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+
+[[package]]
+name = "object"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "flate2",
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -3699,6 +3709,7 @@ dependencies = [
  "chrono",
  "console",
  "lazy_static",
+ "object 0.25.3",
  "rayon",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +455,12 @@ checksum = "2c882aa326a43102fd13b20b2f1249e76122b1606e3017944943da8d088ade43"
 dependencies = [
  "crossbeam-channel 0.3.9",
 ]
+
+[[package]]
+name = "cascade"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18c6a921baae2d947e4cf96f6ef1b5774b3056ae8edbdf5c5cfce4f33260921"
 
 [[package]]
 name = "cc"
@@ -1107,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1304,15 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "goblin"
+version = "0.4.1"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "goblin"
@@ -1544,6 +1577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
+
+[[package]]
 name = "js-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1779,19 @@ name = "leb128"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -2040,6 +2098,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "nom-supreme"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133b9264602f2a75dcc5e3e39f3f7f98c6cee76f2cc749b9d8e751ffe12a712f"
+dependencies = [
+ "cascade",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom 6.1.2",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,8 +2181,6 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 [[package]]
 name = "object"
 version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -2516,6 +2598,12 @@ checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.24",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -3452,6 +3540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,17 +3657,36 @@ name = "symbolic"
 version = "8.1.0"
 source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#bed8c79797c21c5b24e0b4cd8c113eec0fd6539b"
 dependencies = [
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.1.0",
+ "symbolic-debuginfo 8.1.0",
  "symbolic-demangle",
  "symbolic-minidump",
  "symbolic-symcache",
 ]
 
 [[package]]
+name = "symbolic"
+version = "8.2.1"
+dependencies = [
+ "symbolic-common 8.2.1",
+ "symbolic-debuginfo 8.2.1",
+]
+
+[[package]]
 name = "symbolic-common"
 version = "8.1.0"
 source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#bed8c79797c21c5b24e0b4cd8c113eec0fd6539b"
+dependencies = [
+ "debugid",
+ "memmap",
+ "serde",
+ "stable_deref_trait",
+ "uuid 0.8.2",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "8.2.1"
 dependencies = [
  "debugid",
  "memmap",
@@ -3592,7 +3705,7 @@ dependencies = [
  "fallible-iterator",
  "flate2",
  "gimli 0.24.0",
- "goblin",
+ "goblin 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "lazycell",
  "parking_lot 0.11.1",
@@ -3604,7 +3717,35 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 1.5.0",
- "symbolic-common",
+ "symbolic-common 8.1.0",
+ "thiserror",
+ "walrus",
+ "wasmparser",
+ "zip",
+]
+
+[[package]]
+name = "symbolic-debuginfo"
+version = "8.2.1"
+dependencies = [
+ "dmsort",
+ "elementtree",
+ "fallible-iterator",
+ "flate2",
+ "gimli 0.24.0",
+ "goblin 0.4.1",
+ "lazy_static",
+ "lazycell",
+ "nom 6.1.2",
+ "nom-supreme",
+ "parking_lot 0.11.1",
+ "pdb",
+ "regex",
+ "scroll",
+ "serde",
+ "serde_json",
+ "smallvec 1.5.0",
+ "symbolic-common 8.2.1",
  "thiserror",
  "walrus",
  "wasmparser",
@@ -3620,7 +3761,7 @@ dependencies = [
  "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
- "symbolic-common",
+ "symbolic-common 8.1.0",
 ]
 
 [[package]]
@@ -3632,8 +3773,8 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.1.0",
+ "symbolic-debuginfo 8.1.0",
  "thiserror",
 ]
 
@@ -3644,8 +3785,8 @@ source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#be
 dependencies = [
  "dmsort",
  "fnv",
- "symbolic-common",
- "symbolic-debuginfo",
+ "symbolic-common 8.1.0",
+ "symbolic-debuginfo 8.1.0",
  "thiserror",
 ]
 
@@ -3692,7 +3833,7 @@ dependencies = [
  "serde_yaml",
  "sha-1 0.9.2",
  "structopt",
- "symbolic",
+ "symbolic 8.1.0",
  "tempfile",
  "thiserror",
  "tokio 0.1.22",
@@ -3717,7 +3858,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "symbolic",
+ "symbolic 8.2.1",
  "walkdir",
  "zip",
  "zstd",
@@ -3756,6 +3897,12 @@ dependencies = [
  "syn 1.0.58",
  "unicode-xid 0.2.0",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4500,7 +4647,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ca2a14bc3fc5b64d188b087a7d3a927df87b152e941ccfbc66672e20c467ae"
 dependencies = [
- "nom",
+ "nom 4.2.3",
  "proc-macro2 1.0.24",
  "quote 1.0.3",
  "syn 1.0.58",
@@ -4842,6 +4989,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,9 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
+ "crc32fast",
  "flate2",
+ "indexmap",
  "memchr",
 ]
 

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -9,13 +9,14 @@ anyhow = "1.0.38"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
 lazy_static = "1.4.0"
-object = { version = "0.25.3", features = ["write_core"] }
+object = { path = "../../../object", features = ["write_core"] }
 rayon = "1.5.0"
 regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.1.0", features = ["debuginfo-serde"] }
+# This is locally checked out to fix/demangle-fixes to match what's being used on `master`
+symbolic = { path = "../../../symbolic/symbolic", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.6.0"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0.38"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
 lazy_static = "1.4.0"
-object = "0.25.3"
+object = { version = "0.25.3", features = ["write_core"] }
 rayon = "1.5.0"
 regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0.38"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"
 lazy_static = "1.4.0"
+object = "0.25.3"
 rayon = "1.5.0"
 regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }

--- a/crates/symsorter/README.md
+++ b/crates/symsorter/README.md
@@ -1,8 +1,8 @@
 # SymSorter
 
 A small utility that takes a folder structure of debug information files
-(currently mostly useful for apple and linux) and writes them into a folder
 structure that symbolicator can work with as a symbol source.  The structure
+(currently mostly useful for Apple and Linux) and writes them into a folder
 used is the `unified` format that the symbolicator also supports.
 
 ## Compiling

--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -7,10 +7,7 @@ use std::sync::Mutex;
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use console::style;
-// use object::macho::DyldInfoCommand;
-use object::macho::{DyldCacheHeader, MachHeader32, MachHeader64};
-// use object::pod::Bytes;
-use object::read::macho::MachHeader;
+use object::read::macho::DyldCache;
 use object::Endianness;
 use rayon::prelude::*;
 use serde::Serialize;
@@ -22,6 +19,7 @@ use zip::ZipArchive;
 use zstd::stream::copy_encode;
 
 use crate::config::{RunConfig, SortConfig};
+use crate::dyldcache;
 use crate::utils::{
     create_source_bundle, get_target_filename, get_unified_id, is_bundle_id, make_bundle_id,
 };
@@ -171,128 +169,6 @@ fn process_file(
     Ok(rv)
 }
 
-// fn process_dyld_image(
-//     sort_config: &SortConfig,
-//     // data: &ByteView,
-//     image: DyldCacheImage,
-// ) -> Result<Vec<(String, ObjectKind)>> {
-//     let mut rv = vec![];
-//     let filename = image.path()?.rsplit('/').next().unwrap().to_string();
-
-//     macro_rules! maybe_ignore_error {
-//         ($expr:expr) => {
-//             match $expr {
-//                 Ok(value) => value,
-//                 Err(err) => {
-//                     if RunConfig::get().ignore_errors {
-//                         eprintln!(
-//                             "{}: ignored error {} ({})",
-//                             style("error").red().bold(),
-//                             err,
-//                             style(filename).cyan(),
-//                         );
-
-//                         for cause in err.chain().skip(1) {
-//                             eprintln!("{}", style(format!("  caused by {}", cause)).dim());
-//                         }
-//                         return Ok(rv);
-//                     } else {
-//                         return Err(err).context(format!("failed to process file {}", filename));
-//                     }
-//                 }
-//             }
-//         };
-//     }
-
-//     let compression_level = match sort_config.compression_level {
-//         0 => 0,
-//         1 => 3,
-//         2 => 10,
-//         3 => 19,
-//         _ => 22,
-//     };
-
-//     let in_object = maybe_ignore_error!(image
-//         .parse_object()
-//         .map_err(|e| anyhow!("failed to parse archive {}", e)));
-
-//     let writable_data = clone_dyld_image(&in_object);
-
-//     let raw_kind = if in_object.is_64() {
-//         MachHeader64::parse(writable_data.as_slice(), 0)?.filetype(in_object.endianness())
-//     } else {
-//         MachHeader32::parse(writable_data.as_slice(), 0)?.filetype(in_object.endianness())
-//     };
-//     let kind = match raw_kind {
-//         object::macho::MH_OBJECT => ObjectKind::Relocatable,
-//         object::macho::MH_EXECUTE => ObjectKind::Executable,
-//         object::macho::MH_FVMLIB => ObjectKind::Library,
-//         object::macho::MH_CORE => ObjectKind::Dump,
-//         object::macho::MH_PRELOAD => ObjectKind::Executable,
-//         object::macho::MH_DYLIB => ObjectKind::Library,
-//         object::macho::MH_DYLINKER => ObjectKind::Executable,
-//         object::macho::MH_BUNDLE => ObjectKind::Library,
-//         object::macho::MH_DSYM => ObjectKind::Debug,
-//         object::macho::MH_KEXT_BUNDLE => ObjectKind::Library,
-//         _ => ObjectKind::Other,
-//     };
-
-//     let root = &RunConfig::get().output;
-//     let new_filename = root.join(maybe_ignore_error!(get_dyld_image_filename(
-//         &in_object, &kind
-//     )
-//     .ok_or_else(|| anyhow!("unsupported file"))));
-
-//     fs::create_dir_all(new_filename.parent().unwrap())?;
-
-//     if let Some(bundle_id) = &sort_config.bundle_id {
-//         let refs_path = new_filename.parent().unwrap().join("refs");
-//         fs::create_dir_all(&refs_path)?;
-//         fs::write(&refs_path.join(bundle_id), b"")?;
-//     }
-
-//     // all of the types recognized by DyldCacheHeader
-//     let arch = match in_object.architecture() {
-//         object::Architecture::I386 => Arch::X86,
-//         object::Architecture::PowerPc => Arch::Ppc,
-//         // we lose a bit of precision in the below variants because object combines all x86_64, arm,
-//         // and arm64 variants into one common enum member
-//         object::Architecture::X86_64 => Arch::Amd64,
-//         object::Architecture::Arm => Arch::Arm,
-//         object::Architecture::Aarch64 => Arch::Arm64_32,
-//         _ => Arch::Unknown,
-//     };
-
-//     let meta = DebugIdMeta {
-//         name: Some(filename.clone()),
-//         arch: Some(arch),
-//         file_format: Some(FileFormat::MachO),
-//     };
-
-//     fs::write(
-//         &new_filename.parent().unwrap().join("meta"),
-//         &serde_json::to_vec(&meta)?,
-//     )?;
-
-//     log!(
-//         "{} ({}, {}) -> {}",
-//         style(&filename).dim(),
-//         style(kind).yellow(),
-//         style(arch).yellow(),
-//         style(new_filename.display()).cyan(),
-//     );
-//     let mut out = fs::File::create(&new_filename)?;
-
-//     if compression_level > 0 {
-//         copy_encode(writable_data.as_slice(), &mut out, compression_level)?;
-//     } else {
-//         io::copy(&mut writable_data.as_slice(), &mut out)?;
-//     }
-//     rv.push((get_dyld_image_unified_id(&in_object), kind));
-
-//     Ok(rv)
-// }
-
 fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, usize)> {
     let mut source_bundles_created = 0;
     let source_candidates = Mutex::new(HashMap::<String, Option<PathBuf>>::new());
@@ -330,173 +206,38 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
                     }
                 }
             // dyld shared cache
-            // } else if let Ok(cache) = DyldCache::<Endianness>::parse(bv.as_slice()) {
-            } else if let Ok(header) = DyldCacheHeader::<Endianness>::parse(bv.as_slice()) {
-                let data = bv.as_slice();
-                let (_, endian) = header.parse_magic()?;
-                let mappings = header.mappings(endian, data)?;
-                let images = header.images(endian, data)?;
+            } else if let Ok(cache) = DyldCache::<Endianness>::parse(bv.as_slice()) {
+                for image in cache.images() {
+                    let path = image.path().unwrap_or_default();
 
-                for image in images.iter().take(2) {
-                    let mut image_data = Vec::<u8>::new();
-                    let image_path = match image.path(endian, data).map(|p| std::str::from_utf8(p))
-                    {
-                        Ok(Ok(path)) => path,
-                        Ok(Err(_)) | Err(_) => {
-                            log!("unable to grab pathname for image");
-                            continue;
-                        }
-                    };
-                    let image_offset = match image.file_offset(endian, mappings) {
-                        Ok(offset) => offset,
+                    let single_image = match dyldcache::extract_image(image) {
+                        Ok(object) => object,
                         Err(_) => {
-                            log!("unable to obtain offset for {:?}", image_path);
-                            continue;
-                        }
-                    };
-                    let kind = match object::FileKind::parse_at(data, image_offset) {
-                        Ok(file) => file,
-                        Err(err) => {
-                            log!("unable to parse file {:?}: {}", image_path, err);
-                            continue;
-                        }
-                    };
-                    log!("image: {}", image_path);
-                    match kind {
-                        object::FileKind::MachO32 => {
-                            let header = MachHeader32::<Endianness>::parse(data, image_offset)?;
-                            // 28 bytes for 32bit
-                            let start_header = image_offset as usize;
-                            let end_header =
-                                start_header + std::mem::size_of::<MachHeader32<Endianness>>();
-                            // TODO: remove in-cache bit from flags, flags &= 0x7FFFFFFF
-                            image_data.extend_from_slice(&data[start_header..end_header]);
-
-                            // #SEGMENT getting size based on values in header
-                            let start_commands = end_header;
-                            let end_commands = end_header + (header.sizeofcmds(endian) as usize);
-                            image_data.extend_from_slice(&data[start_commands..end_commands]);
-
-                            // header.load_commands(endian, data, image_offset)
-                        }
-                        object::FileKind::MachO64 => {
-                            let header = MachHeader64::<Endianness>::parse(data, image_offset)?;
-                            // 32 bytes for 64bit
-                            let start_header = image_offset as usize;
-                            let end_header =
-                                start_header + std::mem::size_of::<MachHeader64<Endianness>>();
-                            image_data.extend_from_slice(&data[start_header..end_header]);
-
-                            // #SEGMENT getting size based on values in header
-                            let start_commands = end_header;
-                            let end_commands = end_header + (header.sizeofcmds(endian) as usize);
-                            image_data.extend_from_slice(&data[start_commands..end_commands]);
-
-                            // header.load_commands(endian, data, image_offset)
-
-                            let mut commands =
-                                match header.load_commands(endian, data, image_offset) {
-                                    Ok(cmds) => cmds,
-                                    Err(_) => {
-                                        log!("could not load commands for {}", image_path);
-                                        continue;
-                                    }
-                                };
-
-                            let mut index = 0;
-                            while let Ok(Some(command)) = commands.next() {
-                                log!("cmdsize: {}", command.cmdsize());
-                                if let Ok(variant) = command.variant() {
-                                    match variant {
-                                        object::read::macho::LoadCommandVariant::Segment32(
-                                            _,
-                                            _,
-                                        ) => log!("ok"),
-                                        object::read::macho::LoadCommandVariant::Segment64(
-                                            _,
-                                            _,
-                                        ) => log!("ok"),
-                                        object::read::macho::LoadCommandVariant::DyldInfo(
-                                            dyld_info,
-                                        ) => {
-                                            log!("index: {}", index);
-                                            log!("dyldinfo: {:?}", dyld_info);
-                                            log!("cmd rep: {:?}", command);
-
-                                            // whoops, sizeofcmds is the size for ALL cmds, not per cmd
-                                            // let start = start_commands
-                                            //     + (index * header.sizeofcmds(endian)) as usize;
-                                            // let end = start + header.sizeofcmds(endian) as usize;
-
-                                            // let mut podbytes = Bytes(&data[start..end]);
-
-                                            // let wow: &DyldInfoCommand<Endianness> =
-                                            //     match podbytes.read() {
-                                            //         Ok(command) => command,
-                                            //         Err(_) => {
-                                            //             log!("oh no");
-                                            //             index += 1;
-                                            //             continue;
-                                            //         }
-                                            //     };
-                                        }
-                                        // specifically LC_DYLD_EXPORTS_TRI, LC_FUNCTION_STARTS, LC_DATA_IN_CODE
-                                        // REMOVE LC_SEGMENT_SPLIT_INFO
-                                        object::read::macho::LoadCommandVariant::LinkeditData(
-                                            _,
-                                        ) => {
-                                            log!("ok");
-                                        }
-                                        object::read::macho::LoadCommandVariant::Symtab(_) => {
-                                            log!("ok");
-                                        }
-                                        object::read::macho::LoadCommandVariant::Dysymtab(_) => {
-                                            log!("ok");
-                                        }
-                                        // LC_LOAD_DYLIB, etc
-                                        object::read::macho::LoadCommandVariant::Dylib(_) => {
-                                            log!("ok");
-                                        }
-                                        _ => {
-                                            // on second thought, just copy everything else over that doesn't
-                                            // need adjusting but maybe emit something if it isn't expected?
-                                            log!("unexpected load command: {:?}", command);
-                                            index += 1;
-                                            continue;
-                                        }
-                                    }
-                                }
-                                index += 1;
-                            }
-                        }
-                        other => {
-                            log!(
-                                "found unexpected file type in dyld shared cache: {:?}, {}",
-                                other,
-                                image_path
-                            );
+                            log!("unable to extract image");
                             continue;
                         }
                     };
 
-                    let root = &RunConfig::get().output;
-                    let filename = root.join(image_path.rsplit('/').next().unwrap().to_string());
-                    fs::create_dir_all(filename.parent().unwrap())?;
-                    let mut out = fs::File::create(&filename)?;
-                    io::copy(&mut image_data.as_slice(), &mut out)?;
+                    let raw_image = single_image
+                        .write()
+                        .map_err(|e| anyhow!("my image is unwritable {}", e))?;
+                    let rare_image = ByteView::from_vec(raw_image);
+
+                    dyldcache::check_against_dsc(path, rare_image.as_slice())?;
+
+                    let filename = path.rsplit('/').next().unwrap().to_string();
+                    if Archive::peek(&rare_image) != FileFormat::Unknown {
+                        debug_ids.lock().unwrap().extend(
+                            process_file(sort_config, rare_image, filename)?
+                                .into_iter()
+                                .map(|x| x.0),
+                        );
+                    }
                 }
-
-                // for image in cache.images() {
-                //     println!("path: {}", image.path().unwrap_or_default());
-
-                //     debug_ids.lock().unwrap().extend(
-                //         process_dyld_image(sort_config, image)?
-                //             .into_iter()
-                //             .map(|x| x.0),
-                //     );
-                // }
-                // object file directly
+            // object file directly
             } else if Archive::peek(&bv) != FileFormat::Unknown {
+                log!("Detected single object file");
+
                 for (unified_id, object_kind) in process_file(
                     sort_config,
                     bv,

--- a/crates/symsorter/src/config.rs
+++ b/crates/symsorter/src/config.rs
@@ -39,10 +39,10 @@ pub struct SortConfig {
     /// The bundle ID of this task.
     pub bundle_id: Option<String>,
 
-    /// If enable the system will attempt to create source bundles
+    /// If enabled, the system will attempt to create source bundles
     pub with_sources: bool,
 
-    /// If enabled debug symbols will be zstd compressed
+    /// If enabled, debug symbols will be zstd compressed
     /// (repeat to increase compression)
     pub compression_level: usize,
 }

--- a/crates/symsorter/src/dyldcache.rs
+++ b/crates/symsorter/src/dyldcache.rs
@@ -1,0 +1,310 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use object::read::macho::DyldCacheImage;
+use object::write;
+use object::{
+    Object, ObjectSection, ObjectSegment, ObjectSymbol, RelocationTarget, SymbolFlags, SymbolKind,
+    SymbolSection,
+};
+use symbolic::common::ByteView;
+use symbolic::debuginfo::{Archive, Symbol};
+
+use crate::config::RunConfig;
+
+// note: apple's dyld extractor zeroes out all dyld info (LC_DYLD_INFO_ONLY).
+// maybe if we decide to preserve its contents when we're manually extracting
+// these images we could get a little bit more extra info?
+pub(crate) fn extract_image(image: DyldCacheImage) -> Result<write::Object> {
+    let in_obj = image.parse_object()?;
+
+    let mut out_obj =
+        write::Object::new(in_obj.format(), in_obj.architecture(), in_obj.endianness());
+    out_obj.mangling = write::Mangling::None;
+    out_obj.flags = in_obj.flags();
+
+    match in_obj.mach_uuid() {
+        Ok(Some(uuid)) => out_obj.set_uuid(uuid),
+        Ok(None) => anyhow::bail!("image is missing a UUID"),
+        Err(e) => anyhow::bail!("unable to find a UUID for image {}", e),
+    }?;
+
+    let mut trimmed_sections = HashSet::new();
+    let mut out_sections = HashMap::new();
+    let mut first_symbol_offset = None;
+    for in_section in in_obj.sections() {
+        let segment_name = match in_section.segment_name() {
+            Ok(Some(name)) => name,
+            Ok(None) | Err(_) => {
+                log!(
+                    "a section at index {:?} is missing a segment name, skipping",
+                    in_section.index(),
+                );
+                trimmed_sections.insert(in_section.index());
+                continue;
+            }
+        };
+        if segment_name != "__TEXT" {
+            trimmed_sections.insert(in_section.index());
+            continue;
+        }
+        // If the name itself is empty, let Sentry figure out what to do with it
+        let section_name = match in_section.name() {
+            Ok(name) => name,
+            Err(_) => {
+                log!(
+                    "a section at index {:?} in segment {} is missing a section name, skipping",
+                    in_section.index(),
+                    segment_name,
+                );
+                trimmed_sections.insert(in_section.index());
+                continue;
+            }
+        };
+        if first_symbol_offset.is_none() {
+            let sec_address = in_section.address();
+            let seg_address = in_obj
+                .segments()
+                .find(|s| matches!(s.name(), Ok(Some(name)) if name == segment_name))
+                .map(|s| s.address());
+
+            match seg_address {
+                Some(seg_addr) => {
+                    first_symbol_offset = Some(sec_address - seg_addr);
+                }
+                None => {
+                    log!(
+                        "section {} (index: {:?}) in segment {} is missing an address, skipping",
+                        section_name,
+                        in_section.index(),
+                        segment_name,
+                    );
+                    trimmed_sections.insert(in_section.index());
+                    continue;
+                }
+            }
+        }
+        let section_id = out_obj.add_section(
+            segment_name.as_bytes().to_vec(),
+            section_name.as_bytes().to_vec(),
+            in_section.kind(),
+        );
+        let out_section = out_obj.section_mut(section_id);
+        // No need to check if this is a zerofill section because those are exclusive to __DATA
+        // segments
+        out_section.set_data(in_section.data().unwrap().into(), in_section.align());
+        out_section.flags = in_section.flags();
+        // TODO: Do we need to realign the section indices?
+        // If so, we're going to need a mapping of old indices to new indices for symbol
+        // mapping
+        out_sections.insert(in_section.index(), section_id);
+    }
+
+    if let Some(offset) = first_symbol_offset {
+        out_obj.set_symbol_start_vmaddr(offset)?;
+    }
+
+    // dyld_shared_cache_util does some merging of symbols from LINKEDIN into symtab which we're
+    // not doing here. I haven't found any evidence that we've lost any symbols from not doing the
+    // same.
+    let mut out_symbols = HashMap::new();
+    for in_symbol in in_obj.symbols() {
+        match in_symbol.kind() {
+            SymbolKind::Unknown => continue,
+            // Null and Label are unsupported according to object::macho_write()
+            SymbolKind::Null => continue,
+            SymbolKind::Label => continue,
+            _ => (),
+        }
+        let (section, value) = match in_symbol.section() {
+            SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
+            SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
+            SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
+            SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),
+            SymbolSection::Section(index) => {
+                if let Some(out_section) = out_sections.get(&index) {
+                    (
+                        write::SymbolSection::Section(*out_section),
+                        in_symbol.address() - in_obj.section_by_index(index).unwrap().address(),
+                    )
+                } else {
+                    // Ignore symbols for sections that we're not interested in, i.e. ones that
+                    // don't belong to __TEXT.
+                    if trimmed_sections.contains(&index) {
+                        continue;
+                    }
+
+                    // Ignore symbols for sections that we have skipped.
+                    assert_eq!(in_symbol.kind(), SymbolKind::Section);
+                    continue;
+                }
+            }
+            _ => anyhow::bail!("unknown symbol section for {:?}", in_symbol),
+        };
+        let flags = match in_symbol.flags() {
+            SymbolFlags::None => SymbolFlags::None,
+            SymbolFlags::MachO { n_desc } => SymbolFlags::MachO { n_desc },
+            SymbolFlags::Elf { .. } => {
+                anyhow::bail!(
+                    "encountered elf symbol flags for {:?} in a dyld cache image",
+                    in_symbol
+                )
+            }
+            SymbolFlags::CoffSection { .. } => {
+                anyhow::bail!(
+                    "encountered coff symbol flags for {:?} in a dyld cache image",
+                    in_symbol
+                )
+            }
+            _ => anyhow::bail!("unknown symbol flags for {:?}", in_symbol),
+        };
+        let out_symbol = write::Symbol {
+            name: in_symbol
+                .name()
+                .unwrap_or("nameless symbol")
+                .as_bytes()
+                .to_vec(),
+            value,
+            size: in_symbol.size(),
+            kind: in_symbol.kind(),
+            scope: in_symbol.scope(),
+            weak: in_symbol.is_weak(),
+            section,
+            flags,
+        };
+        let symbol_id = out_obj.add_symbol(out_symbol);
+        // TODO: Do we need to realign the symbol indices?
+        out_symbols.insert(in_symbol.index(), symbol_id);
+    }
+
+    for in_section in in_obj.sections() {
+        let segment_name = match in_section.segment_name() {
+            Ok(Some(name)) => name,
+            Ok(None) | Err(_) => {
+                log!(
+                    "unable to find or generate a valid segment name for section \"{}\"",
+                    in_section.name().unwrap_or("nameless section"),
+                );
+                continue;
+            }
+        };
+        if segment_name != "__TEXT" || in_section.name().is_err() {
+            continue;
+        }
+        let out_section = match out_sections.get(&in_section.index()) {
+            Some(section) => section,
+            None => {
+                log!(
+                    "searched for a __TEXT section that was filtered out; skipping. Name: {:?} Index: {:?}",
+                    in_section.name(),
+                    in_section.index()
+                );
+                continue;
+            }
+        };
+        for (offset, in_relocation) in in_section.relocations() {
+            let symbol = match in_relocation.target() {
+                RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
+                RelocationTarget::Section(section) => {
+                    out_obj.section_symbol(*out_sections.get(&section).unwrap())
+                }
+                _ => {
+                    log!("unknown relocation target for {:?}", in_relocation);
+                    continue;
+                }
+            };
+            let out_relocation = write::Relocation {
+                offset,
+                size: in_relocation.size(),
+                kind: in_relocation.kind(),
+                encoding: in_relocation.encoding(),
+                symbol,
+                addend: in_relocation.addend(),
+            };
+            out_obj
+                .add_relocation(*out_section, out_relocation)
+                .unwrap();
+        }
+    }
+
+    Ok(out_obj)
+}
+
+pub(crate) fn check_against_dsc(path: &str, rare_image: &[u8]) -> Result<()> {
+    let emitted_obj = Archive::parse(&rare_image)
+        .map_err(|e| anyhow!("failed to parse archive {}", e))?
+        .objects()
+        .next()
+        .unwrap()
+        .map_err(|e| anyhow!("couldn't grab object from archive {}", e))?;
+    let emitted_symbols = emitted_obj.symbol_map();
+
+    let mut applegen_path: PathBuf = PathBuf::from("/Users/betty/shared-cache-libraries/x86_64");
+    let (_, nonabspath) = path.split_once('/').unwrap();
+    applegen_path.push(nonabspath);
+    let raw_apple = ByteView::open(&applegen_path)
+        .map_err(|e| anyhow!("couldn't open file at {:?} {}", &applegen_path, e))?;
+    let applegen_obj = Archive::parse(&raw_apple)?
+        .objects()
+        .next()
+        .unwrap()
+        .map_err(|e| anyhow!("couldn't grab object from archive {}", e))?;
+    let applegen_symbols = applegen_obj.symbol_map();
+
+    match (emitted_symbols.len(), applegen_symbols.len()) {
+        (0, 0) => {}
+        (0, _) => {
+            log!("all symbols missing from emitted");
+            return Ok(());
+        }
+        (_, 0) => {
+            log!("applegen has no symbols but emitted does?");
+            return Ok(());
+        }
+        (_, _) => {}
+    }
+
+    let mut missing: Vec<(String, &Symbol, Option<&Symbol>)> = Vec::new();
+    for search in applegen_symbols.iter() {
+        if let Some(found) = emitted_symbols.lookup(search.address) {
+            // look, ma! fizzbuzz!
+            let mismatch = match (found.name() != search.name(), found.size != search.size) {
+                (true, true) => "name, size",
+                (true, false) => "name",
+                (false, true) => "size",
+                (false, false) => "",
+            }
+            .to_string();
+            if !mismatch.is_empty() {
+                missing.push((format!("applegen ({})", mismatch), search, Some(found)));
+            }
+        } else {
+            missing.push(("applegen".to_string(), search, None))
+        }
+    }
+
+    for search in emitted_symbols.iter() {
+        if let Some(found) = applegen_symbols.lookup(search.address) {
+            let mismatch = match (found.name() != search.name(), found.size != search.size) {
+                (true, true) => "name, size",
+                (true, false) => "name",
+                (false, true) => "size",
+                (false, false) => "",
+            }
+            .to_string();
+            if !mismatch.is_empty() {
+                missing.push((format!("emitted ({})", mismatch), search, Some(found)));
+            }
+        } else {
+            missing.push(("emitted".to_string(), search, None))
+        }
+    }
+
+    if missing.is_empty() {
+        log!("all symbols accounted for in {}", path);
+    } else {
+        log!("missing/mismatched symbols: {:#?}", missing);
+    }
+    Ok(())
+}

--- a/crates/symsorter/src/main.rs
+++ b/crates/symsorter/src/main.rs
@@ -12,6 +12,7 @@ mod utils;
 
 mod app;
 mod config;
+mod dyldcache;
 
 fn main() {
     app::main();

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -1,16 +1,10 @@
-// use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
-// use object::{
-//     write, Object as GimliObject, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget,
-//     SectionKind, SymbolFlags, SymbolKind, SymbolSection,
-// };
 use regex::Regex;
 use symbolic::common::ByteView;
-// use symbolic::common::{ByteView, CodeId, Uuid};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 use symbolic::debuginfo::{Archive, FileFormat, Object, ObjectKind};
 
@@ -59,26 +53,6 @@ pub fn get_target_filename(obj: &Object) -> Option<PathBuf> {
     Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
 }
 
-// pub fn get_dyld_image_unified_id(obj: &object::File) -> String {
-//     let uuid = &obj
-//         .mach_uuid()
-//         .unwrap_or_default()
-//         .and_then(|slice| Uuid::from_slice(slice.as_ref()).ok())
-//         .unwrap_or_default();
-//     CodeId::from_binary(&uuid.as_bytes()[..]).to_string()
-// }
-
-// pub fn get_dyld_image_filename(obj: &object::File, kind: &ObjectKind) -> Option<PathBuf> {
-//     let id = get_dyld_image_unified_id(obj);
-//     let suffix = match kind {
-//         ObjectKind::Debug => "debuginfo",
-//         ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
-//         _ => return None,
-//     };
-
-//     Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
-// }
-
 /// Creates a source bundle from a path.
 pub fn create_source_bundle(path: &Path, unified_id: &str) -> Result<Option<ByteView<'static>>> {
     let bv = ByteView::open(path)?;
@@ -109,139 +83,3 @@ macro_rules! log {
         }
     }
 }
-
-// pub fn clone_dyld_image(in_object: &object::File) -> Vec<u8> {
-//     println!("format: {:?}", in_object.format());
-//     let mut out_object = write::Object::new(
-//         in_object.format(),
-//         in_object.architecture(),
-//         in_object.endianness(),
-//     );
-//     out_object.mangling = write::Mangling::None;
-//     out_object.flags = in_object.flags();
-
-//     let mut out_sections = HashMap::new();
-//     for in_section in in_object.sections() {
-//         if in_section.kind() == SectionKind::Metadata {
-//             continue;
-//         }
-//         let section_id = out_object.add_section(
-//             in_section
-//                 .segment_name()
-//                 .unwrap()
-//                 .unwrap_or("")
-//                 .as_bytes()
-//                 .to_vec(),
-//             in_section.name().unwrap().as_bytes().to_vec(),
-//             in_section.kind(),
-//         );
-//         let out_section = out_object.section_mut(section_id);
-//         if out_section.is_bss() {
-//             out_section.append_bss(in_section.size(), in_section.align());
-//         } else {
-//             out_section.set_data(in_section.data().unwrap().into(), in_section.align());
-//         }
-//         out_section.flags = in_section.flags();
-//         out_sections.insert(in_section.index(), section_id);
-//     }
-
-//     let mut out_symbols = HashMap::new();
-//     for in_symbol in in_object.symbols() {
-//         match in_symbol.kind() {
-//             SymbolKind::Unknown => continue,
-//             // null and label are unsupported according to macho_write()
-//             SymbolKind::Null => continue,
-//             SymbolKind::Label => continue,
-//             _ => (),
-//         }
-//         let (section, value) = match in_symbol.section() {
-//             SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
-//             SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
-//             SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
-//             SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),
-//             SymbolSection::Section(index) => {
-//                 if let Some(out_section) = out_sections.get(&index) {
-//                     (
-//                         write::SymbolSection::Section(*out_section),
-//                         in_symbol.address() - in_object.section_by_index(index).unwrap().address(),
-//                     )
-//                 } else {
-//                     // Ignore symbols for sections that we have skipped.
-//                     assert_eq!(in_symbol.kind(), SymbolKind::Section);
-//                     continue;
-//                 }
-//             }
-//             _ => panic!("unknown symbol section for {:?}", in_symbol),
-//         };
-//         let flags = match in_symbol.flags() {
-//             SymbolFlags::None => SymbolFlags::None,
-//             SymbolFlags::Elf { st_info, st_other } => SymbolFlags::Elf { st_info, st_other },
-//             SymbolFlags::MachO { n_desc } => SymbolFlags::MachO { n_desc },
-//             SymbolFlags::CoffSection {
-//                 selection,
-//                 associative_section,
-//             } => {
-//                 let associative_section =
-//                     associative_section.map(|index| *out_sections.get(&index).unwrap());
-//                 SymbolFlags::CoffSection {
-//                     selection,
-//                     associative_section,
-//                 }
-//             }
-//             _ => panic!("unknown symbol flags for {:?}", in_symbol),
-//         };
-//         let out_symbol = write::Symbol {
-//             name: in_symbol.name().unwrap_or("").as_bytes().to_vec(),
-//             value,
-//             size: in_symbol.size(),
-//             kind: in_symbol.kind(),
-//             scope: in_symbol.scope(),
-//             weak: in_symbol.is_weak(),
-//             section,
-//             flags,
-//         };
-//         let symbol_id = out_object.add_symbol(out_symbol);
-//         out_symbols.insert(in_symbol.index(), symbol_id);
-//     }
-
-//     for in_section in in_object.sections() {
-//         if in_section.kind() == SectionKind::Metadata {
-//             continue;
-//         }
-//         let out_section = *out_sections.get(&in_section.index()).unwrap();
-//         for (offset, in_relocation) in in_section.relocations() {
-//             let symbol = match in_relocation.target() {
-//                 RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
-//                 RelocationTarget::Section(section) => {
-//                     out_object.section_symbol(*out_sections.get(&section).unwrap())
-//                 }
-//                 _ => panic!("unknown relocation target for {:?}", in_relocation),
-//             };
-//             let out_relocation = write::Relocation {
-//                 offset,
-//                 size: in_relocation.size(),
-//                 kind: in_relocation.kind(),
-//                 encoding: in_relocation.encoding(),
-//                 symbol,
-//                 addend: in_relocation.addend(),
-//             };
-//             out_object
-//                 .add_relocation(out_section, out_relocation)
-//                 .unwrap();
-//         }
-//     }
-
-//     for in_comdat in in_object.comdats() {
-//         let mut sections = Vec::new();
-//         for in_section in in_comdat.sections() {
-//             sections.push(*out_sections.get(&in_section).unwrap());
-//         }
-//         out_object.add_comdat(write::Comdat {
-//             kind: in_comdat.kind(),
-//             symbol: *out_symbols.get(&in_comdat.symbol()).unwrap(),
-//             sections,
-//         });
-//     }
-
-//     out_object.write().unwrap()
-// }

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -1,15 +1,16 @@
-use std::collections::HashMap;
+// use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
-use object::{
-    write, Object as GimliObject, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget,
-    SectionKind, SymbolFlags, SymbolKind, SymbolSection,
-};
+// use object::{
+//     write, Object as GimliObject, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget,
+//     SectionKind, SymbolFlags, SymbolKind, SymbolSection,
+// };
 use regex::Regex;
-use symbolic::common::{ByteView, CodeId, Uuid};
+use symbolic::common::ByteView;
+// use symbolic::common::{ByteView, CodeId, Uuid};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 use symbolic::debuginfo::{Archive, FileFormat, Object, ObjectKind};
 
@@ -58,25 +59,25 @@ pub fn get_target_filename(obj: &Object) -> Option<PathBuf> {
     Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
 }
 
-pub fn get_dyld_image_unified_id(obj: &object::File) -> String {
-    let uuid = &obj
-        .mach_uuid()
-        .unwrap_or_default()
-        .and_then(|slice| Uuid::from_slice(slice.as_ref()).ok())
-        .unwrap_or_default();
-    CodeId::from_binary(&uuid.as_bytes()[..]).to_string()
-}
+// pub fn get_dyld_image_unified_id(obj: &object::File) -> String {
+//     let uuid = &obj
+//         .mach_uuid()
+//         .unwrap_or_default()
+//         .and_then(|slice| Uuid::from_slice(slice.as_ref()).ok())
+//         .unwrap_or_default();
+//     CodeId::from_binary(&uuid.as_bytes()[..]).to_string()
+// }
 
-pub fn get_dyld_image_filename(obj: &object::File, kind: &ObjectKind) -> Option<PathBuf> {
-    let id = get_dyld_image_unified_id(obj);
-    let suffix = match kind {
-        ObjectKind::Debug => "debuginfo",
-        ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
-        _ => return None,
-    };
+// pub fn get_dyld_image_filename(obj: &object::File, kind: &ObjectKind) -> Option<PathBuf> {
+//     let id = get_dyld_image_unified_id(obj);
+//     let suffix = match kind {
+//         ObjectKind::Debug => "debuginfo",
+//         ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
+//         _ => return None,
+//     };
 
-    Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
-}
+//     Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
+// }
 
 /// Creates a source bundle from a path.
 pub fn create_source_bundle(path: &Path, unified_id: &str) -> Result<Option<ByteView<'static>>> {
@@ -109,137 +110,138 @@ macro_rules! log {
     }
 }
 
-pub fn clone_dyld_image(in_object: &object::File) -> Vec<u8> {
-    let mut out_object = write::Object::new(
-        in_object.format(),
-        in_object.architecture(),
-        in_object.endianness(),
-    );
-    out_object.mangling = write::Mangling::None;
-    out_object.flags = in_object.flags();
+// pub fn clone_dyld_image(in_object: &object::File) -> Vec<u8> {
+//     println!("format: {:?}", in_object.format());
+//     let mut out_object = write::Object::new(
+//         in_object.format(),
+//         in_object.architecture(),
+//         in_object.endianness(),
+//     );
+//     out_object.mangling = write::Mangling::None;
+//     out_object.flags = in_object.flags();
 
-    let mut out_sections = HashMap::new();
-    for in_section in in_object.sections() {
-        if in_section.kind() == SectionKind::Metadata {
-            continue;
-        }
-        let section_id = out_object.add_section(
-            in_section
-                .segment_name()
-                .unwrap()
-                .unwrap_or("")
-                .as_bytes()
-                .to_vec(),
-            in_section.name().unwrap().as_bytes().to_vec(),
-            in_section.kind(),
-        );
-        let out_section = out_object.section_mut(section_id);
-        if out_section.is_bss() {
-            out_section.append_bss(in_section.size(), in_section.align());
-        } else {
-            out_section.set_data(in_section.data().unwrap().into(), in_section.align());
-        }
-        out_section.flags = in_section.flags();
-        out_sections.insert(in_section.index(), section_id);
-    }
+//     let mut out_sections = HashMap::new();
+//     for in_section in in_object.sections() {
+//         if in_section.kind() == SectionKind::Metadata {
+//             continue;
+//         }
+//         let section_id = out_object.add_section(
+//             in_section
+//                 .segment_name()
+//                 .unwrap()
+//                 .unwrap_or("")
+//                 .as_bytes()
+//                 .to_vec(),
+//             in_section.name().unwrap().as_bytes().to_vec(),
+//             in_section.kind(),
+//         );
+//         let out_section = out_object.section_mut(section_id);
+//         if out_section.is_bss() {
+//             out_section.append_bss(in_section.size(), in_section.align());
+//         } else {
+//             out_section.set_data(in_section.data().unwrap().into(), in_section.align());
+//         }
+//         out_section.flags = in_section.flags();
+//         out_sections.insert(in_section.index(), section_id);
+//     }
 
-    let mut out_symbols = HashMap::new();
-    for in_symbol in in_object.symbols() {
-        match in_symbol.kind() {
-            SymbolKind::Unknown => continue,
-            // null and label are unsupported according to macho_write()
-            SymbolKind::Null => continue,
-            SymbolKind::Label => continue,
-            _ => (),
-        }
-        let (section, value) = match in_symbol.section() {
-            SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
-            SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
-            SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
-            SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),
-            SymbolSection::Section(index) => {
-                if let Some(out_section) = out_sections.get(&index) {
-                    (
-                        write::SymbolSection::Section(*out_section),
-                        in_symbol.address() - in_object.section_by_index(index).unwrap().address(),
-                    )
-                } else {
-                    // Ignore symbols for sections that we have skipped.
-                    assert_eq!(in_symbol.kind(), SymbolKind::Section);
-                    continue;
-                }
-            }
-            _ => panic!("unknown symbol section for {:?}", in_symbol),
-        };
-        let flags = match in_symbol.flags() {
-            SymbolFlags::None => SymbolFlags::None,
-            SymbolFlags::Elf { st_info, st_other } => SymbolFlags::Elf { st_info, st_other },
-            SymbolFlags::MachO { n_desc } => SymbolFlags::MachO { n_desc },
-            SymbolFlags::CoffSection {
-                selection,
-                associative_section,
-            } => {
-                let associative_section =
-                    associative_section.map(|index| *out_sections.get(&index).unwrap());
-                SymbolFlags::CoffSection {
-                    selection,
-                    associative_section,
-                }
-            }
-            _ => panic!("unknown symbol flags for {:?}", in_symbol),
-        };
-        let out_symbol = write::Symbol {
-            name: in_symbol.name().unwrap_or("").as_bytes().to_vec(),
-            value,
-            size: in_symbol.size(),
-            kind: in_symbol.kind(),
-            scope: in_symbol.scope(),
-            weak: in_symbol.is_weak(),
-            section,
-            flags,
-        };
-        let symbol_id = out_object.add_symbol(out_symbol);
-        out_symbols.insert(in_symbol.index(), symbol_id);
-    }
+//     let mut out_symbols = HashMap::new();
+//     for in_symbol in in_object.symbols() {
+//         match in_symbol.kind() {
+//             SymbolKind::Unknown => continue,
+//             // null and label are unsupported according to macho_write()
+//             SymbolKind::Null => continue,
+//             SymbolKind::Label => continue,
+//             _ => (),
+//         }
+//         let (section, value) = match in_symbol.section() {
+//             SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
+//             SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
+//             SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
+//             SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),
+//             SymbolSection::Section(index) => {
+//                 if let Some(out_section) = out_sections.get(&index) {
+//                     (
+//                         write::SymbolSection::Section(*out_section),
+//                         in_symbol.address() - in_object.section_by_index(index).unwrap().address(),
+//                     )
+//                 } else {
+//                     // Ignore symbols for sections that we have skipped.
+//                     assert_eq!(in_symbol.kind(), SymbolKind::Section);
+//                     continue;
+//                 }
+//             }
+//             _ => panic!("unknown symbol section for {:?}", in_symbol),
+//         };
+//         let flags = match in_symbol.flags() {
+//             SymbolFlags::None => SymbolFlags::None,
+//             SymbolFlags::Elf { st_info, st_other } => SymbolFlags::Elf { st_info, st_other },
+//             SymbolFlags::MachO { n_desc } => SymbolFlags::MachO { n_desc },
+//             SymbolFlags::CoffSection {
+//                 selection,
+//                 associative_section,
+//             } => {
+//                 let associative_section =
+//                     associative_section.map(|index| *out_sections.get(&index).unwrap());
+//                 SymbolFlags::CoffSection {
+//                     selection,
+//                     associative_section,
+//                 }
+//             }
+//             _ => panic!("unknown symbol flags for {:?}", in_symbol),
+//         };
+//         let out_symbol = write::Symbol {
+//             name: in_symbol.name().unwrap_or("").as_bytes().to_vec(),
+//             value,
+//             size: in_symbol.size(),
+//             kind: in_symbol.kind(),
+//             scope: in_symbol.scope(),
+//             weak: in_symbol.is_weak(),
+//             section,
+//             flags,
+//         };
+//         let symbol_id = out_object.add_symbol(out_symbol);
+//         out_symbols.insert(in_symbol.index(), symbol_id);
+//     }
 
-    for in_section in in_object.sections() {
-        if in_section.kind() == SectionKind::Metadata {
-            continue;
-        }
-        let out_section = *out_sections.get(&in_section.index()).unwrap();
-        for (offset, in_relocation) in in_section.relocations() {
-            let symbol = match in_relocation.target() {
-                RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
-                RelocationTarget::Section(section) => {
-                    out_object.section_symbol(*out_sections.get(&section).unwrap())
-                }
-                _ => panic!("unknown relocation target for {:?}", in_relocation),
-            };
-            let out_relocation = write::Relocation {
-                offset,
-                size: in_relocation.size(),
-                kind: in_relocation.kind(),
-                encoding: in_relocation.encoding(),
-                symbol,
-                addend: in_relocation.addend(),
-            };
-            out_object
-                .add_relocation(out_section, out_relocation)
-                .unwrap();
-        }
-    }
+//     for in_section in in_object.sections() {
+//         if in_section.kind() == SectionKind::Metadata {
+//             continue;
+//         }
+//         let out_section = *out_sections.get(&in_section.index()).unwrap();
+//         for (offset, in_relocation) in in_section.relocations() {
+//             let symbol = match in_relocation.target() {
+//                 RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
+//                 RelocationTarget::Section(section) => {
+//                     out_object.section_symbol(*out_sections.get(&section).unwrap())
+//                 }
+//                 _ => panic!("unknown relocation target for {:?}", in_relocation),
+//             };
+//             let out_relocation = write::Relocation {
+//                 offset,
+//                 size: in_relocation.size(),
+//                 kind: in_relocation.kind(),
+//                 encoding: in_relocation.encoding(),
+//                 symbol,
+//                 addend: in_relocation.addend(),
+//             };
+//             out_object
+//                 .add_relocation(out_section, out_relocation)
+//                 .unwrap();
+//         }
+//     }
 
-    for in_comdat in in_object.comdats() {
-        let mut sections = Vec::new();
-        for in_section in in_comdat.sections() {
-            sections.push(*out_sections.get(&in_section).unwrap());
-        }
-        out_object.add_comdat(write::Comdat {
-            kind: in_comdat.kind(),
-            symbol: *out_symbols.get(&in_comdat.symbol()).unwrap(),
-            sections,
-        });
-    }
+//     for in_comdat in in_object.comdats() {
+//         let mut sections = Vec::new();
+//         for in_section in in_comdat.sections() {
+//             sections.push(*out_sections.get(&in_section).unwrap());
+//         }
+//         out_object.add_comdat(write::Comdat {
+//             kind: in_comdat.kind(),
+//             symbol: *out_symbols.get(&in_comdat.symbol()).unwrap(),
+//             sections,
+//         });
+//     }
 
-    out_object.write().unwrap()
-}
+//     out_object.write().unwrap()
+// }

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -1,10 +1,15 @@
+use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
+use object::{
+    write, Object as GimliObject, ObjectComdat, ObjectSection, ObjectSymbol, RelocationTarget,
+    SectionKind, SymbolFlags, SymbolKind, SymbolSection,
+};
 use regex::Regex;
-use symbolic::common::ByteView;
+use symbolic::common::{ByteView, CodeId, Uuid};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 use symbolic::debuginfo::{Archive, FileFormat, Object, ObjectKind};
 
@@ -53,6 +58,26 @@ pub fn get_target_filename(obj: &Object) -> Option<PathBuf> {
     Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
 }
 
+pub fn get_dyld_image_unified_id(obj: &object::File) -> String {
+    let uuid = &obj
+        .mach_uuid()
+        .unwrap_or_default()
+        .and_then(|slice| Uuid::from_slice(slice.as_ref()).ok())
+        .unwrap_or_default();
+    CodeId::from_binary(&uuid.as_bytes()[..]).to_string()
+}
+
+pub fn get_dyld_image_filename(obj: &object::File, kind: &ObjectKind) -> Option<PathBuf> {
+    let id = get_dyld_image_unified_id(obj);
+    let suffix = match kind {
+        ObjectKind::Debug => "debuginfo",
+        ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
+        _ => return None,
+    };
+
+    Some(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())
+}
+
 /// Creates a source bundle from a path.
 pub fn create_source_bundle(path: &Path, unified_id: &str) -> Result<Option<ByteView<'static>>> {
     let bv = ByteView::open(path)?;
@@ -82,4 +107,139 @@ macro_rules! log {
             }
         }
     }
+}
+
+pub fn clone_dyld_image(in_object: &object::File) -> Vec<u8> {
+    let mut out_object = write::Object::new(
+        in_object.format(),
+        in_object.architecture(),
+        in_object.endianness(),
+    );
+    out_object.mangling = write::Mangling::None;
+    out_object.flags = in_object.flags();
+
+    let mut out_sections = HashMap::new();
+    for in_section in in_object.sections() {
+        if in_section.kind() == SectionKind::Metadata {
+            continue;
+        }
+        let section_id = out_object.add_section(
+            in_section
+                .segment_name()
+                .unwrap()
+                .unwrap_or("")
+                .as_bytes()
+                .to_vec(),
+            in_section.name().unwrap().as_bytes().to_vec(),
+            in_section.kind(),
+        );
+        let out_section = out_object.section_mut(section_id);
+        if out_section.is_bss() {
+            out_section.append_bss(in_section.size(), in_section.align());
+        } else {
+            out_section.set_data(in_section.data().unwrap().into(), in_section.align());
+        }
+        out_section.flags = in_section.flags();
+        out_sections.insert(in_section.index(), section_id);
+    }
+
+    let mut out_symbols = HashMap::new();
+    for in_symbol in in_object.symbols() {
+        match in_symbol.kind() {
+            SymbolKind::Unknown => continue,
+            // null and label are unsupported according to macho_write()
+            SymbolKind::Null => continue,
+            SymbolKind::Label => continue,
+            _ => (),
+        }
+        let (section, value) = match in_symbol.section() {
+            SymbolSection::None => (write::SymbolSection::None, in_symbol.address()),
+            SymbolSection::Undefined => (write::SymbolSection::Undefined, in_symbol.address()),
+            SymbolSection::Absolute => (write::SymbolSection::Absolute, in_symbol.address()),
+            SymbolSection::Common => (write::SymbolSection::Common, in_symbol.address()),
+            SymbolSection::Section(index) => {
+                if let Some(out_section) = out_sections.get(&index) {
+                    (
+                        write::SymbolSection::Section(*out_section),
+                        in_symbol.address() - in_object.section_by_index(index).unwrap().address(),
+                    )
+                } else {
+                    // Ignore symbols for sections that we have skipped.
+                    assert_eq!(in_symbol.kind(), SymbolKind::Section);
+                    continue;
+                }
+            }
+            _ => panic!("unknown symbol section for {:?}", in_symbol),
+        };
+        let flags = match in_symbol.flags() {
+            SymbolFlags::None => SymbolFlags::None,
+            SymbolFlags::Elf { st_info, st_other } => SymbolFlags::Elf { st_info, st_other },
+            SymbolFlags::MachO { n_desc } => SymbolFlags::MachO { n_desc },
+            SymbolFlags::CoffSection {
+                selection,
+                associative_section,
+            } => {
+                let associative_section =
+                    associative_section.map(|index| *out_sections.get(&index).unwrap());
+                SymbolFlags::CoffSection {
+                    selection,
+                    associative_section,
+                }
+            }
+            _ => panic!("unknown symbol flags for {:?}", in_symbol),
+        };
+        let out_symbol = write::Symbol {
+            name: in_symbol.name().unwrap_or("").as_bytes().to_vec(),
+            value,
+            size: in_symbol.size(),
+            kind: in_symbol.kind(),
+            scope: in_symbol.scope(),
+            weak: in_symbol.is_weak(),
+            section,
+            flags,
+        };
+        let symbol_id = out_object.add_symbol(out_symbol);
+        out_symbols.insert(in_symbol.index(), symbol_id);
+    }
+
+    for in_section in in_object.sections() {
+        if in_section.kind() == SectionKind::Metadata {
+            continue;
+        }
+        let out_section = *out_sections.get(&in_section.index()).unwrap();
+        for (offset, in_relocation) in in_section.relocations() {
+            let symbol = match in_relocation.target() {
+                RelocationTarget::Symbol(symbol) => *out_symbols.get(&symbol).unwrap(),
+                RelocationTarget::Section(section) => {
+                    out_object.section_symbol(*out_sections.get(&section).unwrap())
+                }
+                _ => panic!("unknown relocation target for {:?}", in_relocation),
+            };
+            let out_relocation = write::Relocation {
+                offset,
+                size: in_relocation.size(),
+                kind: in_relocation.kind(),
+                encoding: in_relocation.encoding(),
+                symbol,
+                addend: in_relocation.addend(),
+            };
+            out_object
+                .add_relocation(out_section, out_relocation)
+                .unwrap();
+        }
+    }
+
+    for in_comdat in in_object.comdats() {
+        let mut sections = Vec::new();
+        for in_section in in_comdat.sections() {
+            sections.push(*out_sections.get(&in_section).unwrap());
+        }
+        out_object.add_comdat(write::Comdat {
+            kind: in_comdat.kind(),
+            symbol: *out_symbols.get(&in_comdat.symbol()).unwrap(),
+            sections,
+        });
+    }
+
+    out_object.write().unwrap()
 }

--- a/docs/advanced/symbol-server-compatibility.md
+++ b/docs/advanced/symbol-server-compatibility.md
@@ -30,7 +30,7 @@ also has support for source bundles for all file types.
 
 ### `unified`
 
-This is the symbolicator proprietary but preferred source (Unified Symbol
+This is the proprietary, but preferred symbolicator source (Unified Symbol
 Server Layout) which adds a consistent lookup format for all architectures.
 It's used at Sentry for the internal symbol lookups (like Apple or Android
 symbols). Like The `native` format this supports source bundles.
@@ -39,8 +39,8 @@ symbols). Like The `native` format this supports source bundles.
 
 ### Identifiers
 
-There are two fundamentally different identifiers. Their semantics fundamentally
-depend on the symbol type, but follow certain rules:
+There are two different identifiers. Their semantics fundamentally depend on the
+symbol type, but follow certain rules:
 
 - **Code Identifier:** Identifies the actual executable or library file (e.g.
   EXE or DLL)


### PR DESCRIPTION
Starter implementation to add in support for macOS/iOS's dyld shared cache, so stack tracing is more useful when system libraries are involved in those platforms.

This adds in gimli's object as a dependency to make use of their logic to recognize dyld cache files. Support for this file type is isolated to `symsorter` for now instead of extending `symbolic` just to get the ball rolling - It may be good to revisit this decision in the future and consider whether it is worth adding this type in as a variant on `FileFormat`.

Unlike the existing logic that handles zip archives, failures to parse specific images from the dyld cache will not immediately exit symsorter; Instead, the goal is to collect all of the failed images and provide a sensible amount of info to diagnose why parsing failed for those files given the current scope of this PR.

The diff also contains trivial fixes to phrasing in documentation (removing redundancy, capitalization, etc) that I figured should be fine to bundle into this PR, but I'm open to pulling those out into their own dedicated PR if needed.