### PR TITLE
build: Update symbolic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,8 +3636,8 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "symbolic"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3648,8 +3648,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "debugid",
  "memmap",
@@ -3660,8 +3660,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "dmsort",
  "elementtree",
@@ -3689,8 +3689,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3701,8 +3701,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-minidump"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3717,8 +3717,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3729,8 +3729,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-unwind"
-version = "8.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#11c35ff079d6a7950aacea54dfdee555fb7aac65"
+version = "8.2.0"
+source = "git+https://github.com/getsentry/symbolic?branch=feat/cfi_unwind#c355107dbd7c8416384a115cd64073cbf3b948d0"
 dependencies = [
  "insta",
  "nom 6.1.2",


### PR DESCRIPTION
This advances the `symbolic` dependency from https://github.com/getsentry/symbolic/commit/11c35ff079d6a7950aacea54dfdee555fb7aac65 to https://github.com/getsentry/symbolic/commit/c355107dbd7c8416384a115cd64073cbf3b948d0. The main changes are performance fixes in https://github.com/getsentry/symbolic/commit/f60d47e07582ae5e4c5c5214789453b51ef7ec3e and https://github.com/getsentry/symbolic/commit/02a9b1a38831c2e0f2faf3756e3ebe975fea04b2.

#skip-changelog