### PR TITLE
feat: Log a unified diff of old and new stackwalking results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,6 +3679,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha-1 0.9.6",
+ "similar",
  "structopt",
  "symbolic",
  "tempfile",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -42,6 +42,7 @@ sentry = { version = "0.22.0", features = ["debug-images", "log"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
+similar = "1.3.0"
 structopt = "0.3.21"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "feat/cfi_unwind", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use apple_crash_report_parser::AppleCrashReport;
 use bytes::Bytes;
 use chrono::{DateTime, TimeZone, Utc};
@@ -2107,7 +2107,7 @@ impl SymbolicationActor {
                             }
                         })
                         .ok();
-                    sentry::capture_error(&*anyhow!("Different stackwalking results"));
+                    sentry::capture_message("Different stackwalking results", sentry::Level::Error);
                 }
 
                 if duration_new >= Duration::from_secs(5) {
@@ -2126,7 +2126,7 @@ impl SymbolicationActor {
                             }
                         })
                         .ok();
-                    sentry::capture_error(&*anyhow!("Slow stackwalking run"));
+                    sentry::capture_message("Slow stackwalking run", sentry::Level::Error);
                 }
             }
 


### PR DESCRIPTION
This uses `similar` to compute a unified diff of the old and new stackwalking results (if they compare unequal) and attaches it to the sentry error. I hope the parameters (algorithm, radius, unified diff) are chosen sensibly.