### PR TITLE
fix(symsorter): Don't emit files with empty debug identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump symbolic to support versioning of CFI Caches. ([#467](https://github.com/getsentry/symbolicator/pull/467))
 
+### Tools
+
+- `symsorter` no longer emits files with empty debug identifiers. ([#469](https://github.com/getsentry/symbolicator/pull/469))
+
 ## 0.3.4
 
 ### Features

--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -123,9 +123,7 @@ fn process_file(
 
     for obj in archive.objects() {
         let obj = maybe_ignore_error!(obj.map_err(|e| anyhow!(e)));
-        let new_filename = root.join(maybe_ignore_error!(
-            get_target_filename(&obj).ok_or_else(|| anyhow!("unsupported file"))
-        ));
+        let new_filename = root.join(maybe_ignore_error!(get_target_filename(&obj)));
 
         fs::create_dir_all(new_filename.parent().unwrap())?;
 
@@ -160,7 +158,8 @@ fn process_file(
         } else {
             io::copy(&mut obj.data(), &mut out)?;
         }
-        rv.push((get_unified_id(&obj), obj.kind()));
+        let unified_id = maybe_ignore_error!(get_unified_id(&obj));
+        rv.push((unified_id, obj.kind()));
     }
 
     Ok(rv)


### PR DESCRIPTION
Files that symsorter was unable to generate a valid, nonempty debug identifier (i.e. 000...000) for were being written to disk as if they were successfully parsed and sorted. Chances are if the debug identifier is empty, then the debug info is unusable. Not emitting these saves some manual cleanup work on the user's end since they don't have to prune these directories.

Related: #465 