### PR TITLE
ref: Update symbolic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Bump symbolic to support versioning of CFI Caches. ([#467](https://github.com/getsentry/symbolicator/pull/467))
+- Update symbolic to write versioned CFI Caches, and fix SymCache conversion related to inline-parent offset. ([#470](https://github.com/getsentry/symbolicator/pull/470))
 
 ## 0.3.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,8 +3535,8 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "symbolic"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3547,8 +3547,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "debugid",
  "memmap",
@@ -3559,8 +3559,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "dmsort",
  "elementtree",
@@ -3588,8 +3588,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3600,8 +3600,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-minidump"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3614,8 +3614,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.2.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#898bc7081b074f72dae201c4ea686d56db28f60b"
+version = "8.2.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#0086db6f6ac460821fafbd1da72e9292479d0c96"
 dependencies = [
  "dmsort",
  "fnv",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.1", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.0", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.1", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.9.0"


### PR DESCRIPTION
Updates symbolic to https://github.com/getsentry/symbolic/pull/262/commits/0086db6f6ac460821fafbd1da72e9292479d0c96

Includes the following changes:
- Actually *write* new versioned cfi cache files.
- Skip duplicated functions in SymCache, preventing inline parent offset errors.