### PR TITLE
fix: Avoid rustdoc complaining about bare url

### DIFF
--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -140,7 +140,7 @@ where
 /// The types of Amazon IAM credentials providers we support.
 ///
 /// For details on the AWS side, see:
-/// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html.
+/// <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AwsCredentialsProvider {


### PR DESCRIPTION
#skip-changelog