### PR TITLE
ref(sentry): Remove source tags from object sentry scope

### DIFF
--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -94,10 +94,7 @@ impl ObjectHandle {
 impl ConfigureScope for ObjectHandle {
     fn to_scope(&self, scope: &mut ::sentry::Scope) {
         self.object_id.to_scope(scope);
-        self.file_source.to_scope(scope);
-
         scope.set_tag("object_file.scope", self.scope());
-
         scope.set_extra(
             "object_file.first_16_bytes",
             format!("{:x?}", &self.data[..cmp::min(self.data.len(), 16)]).into(),


### PR DESCRIPTION
The source tags are relevant to the download part, but having them
also part of the object scope means they end up in errros about the
processing like CFI errors and write errors.  Yet they have nothing to
do with them.  This means that when you search for the source tags you
currently get these unrelated errors.  So remove this.

The source tags for downloads are added in
`<FetchFileDataRequest as CacheItemRequest>::compute()` and are
unchanged here.

#skip-changelog