### PR TITLE
fix: Reduce download timeout to 60 seconds

### DIFF
--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -129,7 +129,7 @@ impl DownloadService {
         // See: https://docs.rs/tokio/1.0.1/tokio/runtime/struct.Runtime.html#method.enter
         let _guard = self.worker.enter();
         let job = slf.dispatch_download(source, destination).bind_hub(hub);
-        let job = tokio::time::timeout(Duration::from_secs(300), job);
+        let job = tokio::time::timeout(Duration::from_secs(60), job);
         let job = measure("service.download", m::timed_result, job);
 
         // Map all SpawnError variants into DownloadError::Canceled.


### PR DESCRIPTION
Temporary measure because of recent issues with some of symbol servers.

#skip-changelog