### PR TITLE
ref: Error when the new stackwalking method takes 1.5x as long as the old one

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2147,7 +2147,7 @@ impl SymbolicationActor {
                     sentry::capture_message("Different stackwalking results", sentry::Level::Error);
                 }
 
-                if duration_new >= 1.5 * duration_old {
+                if 2 * duration_new >= 3 * duration_old {
                     Self::save_minidump(&minidump, &self.diagnostics_cache)
                         .map_err(|e| log::error!("Failed to save minidump {:?}", &e))
                         .map(|r| {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2147,7 +2147,7 @@ impl SymbolicationActor {
                     sentry::capture_message("Different stackwalking results", sentry::Level::Error);
                 }
 
-                if duration_new >= Duration::from_secs(5) {
+                if duration_new >= 1.5 * duration_old {
                     Self::save_minidump(&minidump, &self.diagnostics_cache)
                         .map_err(|e| log::error!("Failed to save minidump {:?}", &e))
                         .map(|r| {


### PR DESCRIPTION
As specified in https://getsentry.atlassian.net/browse/NATV-30?atlOrigin=eyJpIjoiOTI4ZjUyZDM3Y2I3NDg3ZThmYjJhZGI1OTViNTBkNjEiLCJwIjoiaiJ9, the new stackwalking method is allowed to take at most 1.5× as long as the old one to be considered ready for production.

#skip-changelog