### PR TITLE
build(rustc): bump compiler to 1.53

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 # We should really depend on the rust:slim-buster images again as this
 # will automatically upgrade our Rust toolchains when a new one is
 # released.  But while we can't: bump versions manually.
-ENV RUST_TOOLCHAIN=1.52.1
+ENV RUST_TOOLCHAIN=1.53
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_TOOLCHAIN
 


### PR DESCRIPTION
We need to do this manually these days, because of how our Docker
setup is.

#skip-changelog