### PR TITLE
feat(download): Measure how long it takes to download sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - `symsorter` no longer emits files with empty debug identifiers. ([#469](https://github.com/getsentry/symbolicator/pull/469))
 
+### Internal
+
+- Measure how long it takes to download sources from external servers. ([#483](https://github.com/getsentry/symbolicator/pull/483))
+
 ## 0.3.4
 
 ### Features

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -101,17 +101,6 @@ macro_rules! metric {
                 .send();
         })
     }};
-    (timer($id:expr), $block:block $(, $k:expr => $v:expr)* $(,)?) => {{
-        use $crate::metrics::_pred::*;
-        let now = Instant::now();
-        let rv = {$block};
-        $crate::metrics::with_client(|client| {
-            client.time_duration_with_tags($id, now.elapsed())
-                $(.with_tag($k, $v))*
-                .send();
-        });
-        rv
-    }};
 
     // we use statsd timers to send things such as filesizes as well.
     (time_raw($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
@@ -122,7 +111,6 @@ macro_rules! metric {
                 .send();
         })
     }};
-
 }
 
 macro_rules! future_metrics {

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -111,6 +111,16 @@ macro_rules! metric {
                 .send();
         })
     }};
+
+    // histograms
+    (histogram($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
+        use $crate::metrics::_pred::*;
+        $crate::metrics::with_client(|client| {
+            client.histogram_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        })
+    }};
 }
 
 macro_rules! future_metrics {

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -18,7 +18,7 @@ use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey};
 use crate::types::ObjectId;
-use crate::utils::futures::{self as future_utils, m};
+use crate::utils::futures as future_utils;
 
 /// An LRU cache for GCS OAuth tokens.
 type GcsTokenCache = lru::LruCache<Arc<GcsSourceKey>, Arc<GcsToken>>;
@@ -223,12 +223,7 @@ impl GcsDownloader {
                 .get(url.clone())
                 .header("authorization", format!("Bearer {}", token.access_token))
                 .send();
-            future_utils::measure_source_download(
-                "service.download.download_source",
-                source.source_metric_key(),
-                m::result,
-                request,
-            )
+            future_utils::measure_source_download(source.source_metric_key(), request)
         });
 
         match request.await {

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -223,7 +223,7 @@ impl GcsDownloader {
                 .get(url.clone())
                 .header("authorization", format!("Bearer {}", token.access_token))
                 .send();
-            future_utils::measure_source_download(source.source_metric_key(), request)
+            super::measure_download_time(source.source_metric_key(), request)
         });
 
         match request.await {

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -111,7 +111,7 @@ impl HttpDownloader {
         }
         let source = RemoteDif::from(file_source);
         let request = builder.header(header::USER_AGENT, USER_AGENT).send();
-        let request = future_utils::measure_source_download(source.source_metric_key(), request);
+        let request = super::measure_download_time(source.source_metric_key(), request);
 
         match request.await {
             Ok(request) => {

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -13,7 +13,7 @@ use url::Url;
 use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri, SourceLocation, USER_AGENT};
 use crate::sources::{FileType, HttpSourceConfig};
 use crate::types::ObjectId;
-use crate::utils::futures::{self as future_utils, m};
+use crate::utils::futures as future_utils;
 
 /// The HTTP-specific [`RemoteDif`].
 #[derive(Debug, Clone)]
@@ -111,12 +111,7 @@ impl HttpDownloader {
         }
         let source = RemoteDif::from(file_source);
         let request = builder.header(header::USER_AGENT, USER_AGENT).send();
-        let request = future_utils::measure_source_download(
-            "service.download.download_source",
-            source.source_metric_key(),
-            m::result,
-            request,
-        );
+        let request = future_utils::measure_source_download(source.source_metric_key(), request);
 
         match request.await {
             Ok(request) => {

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -62,56 +62,25 @@ impl HttpDownloader {
         file_source: HttpRemoteDif,
         destination: PathBuf,
     ) -> Result<DownloadStatus, DownloadError> {
-        let retries = future_utils::retry(|| {
-            self.download_source_once(file_source.clone(), destination.clone())
-        });
-
-        let download_url = file_source.url().ok();
-        match retries.await {
-            Ok(DownloadStatus::NotFound) => {
-                log::debug!(
-                    "Did not fetch debug file from {:?}: {:?}",
-                    download_url,
-                    DownloadStatus::NotFound
-                );
-                Ok(DownloadStatus::NotFound)
-            }
-            Ok(status) => {
-                log::debug!("Fetched debug file from {:?}: {:?}", download_url, status);
-                Ok(status)
-            }
-            Err(err) => {
-                log::debug!(
-                    "Failed to fetch debug file from {:?}: {}",
-                    download_url,
-                    err
-                );
-                Err(err)
-            }
-        }
-    }
-
-    async fn download_source_once(
-        &self,
-        file_source: HttpRemoteDif,
-        destination: PathBuf,
-    ) -> Result<DownloadStatus, DownloadError> {
         let download_url = match file_source.url() {
             Ok(x) => x,
             Err(_) => return Ok(DownloadStatus::NotFound),
         };
+        let headers = file_source.source.headers.clone();
+        let source = RemoteDif::from(file_source);
 
         log::debug!("Fetching debug file from {}", download_url);
-        let mut builder = self.client.get(download_url.clone());
+        let request = future_utils::retry(|| {
+            let mut builder = self.client.get(download_url.clone());
 
-        for (key, value) in file_source.source.headers.iter() {
-            if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {
-                builder = builder.header(key, value.as_str());
+            for (key, value) in headers.iter() {
+                if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {
+                    builder = builder.header(key, value.as_str());
+                }
             }
-        }
-        let source = RemoteDif::from(file_source);
-        let request = builder.header(header::USER_AGENT, USER_AGENT).send();
-        let request = super::measure_download_time(source.source_metric_key(), request);
+            let request = builder.header(header::USER_AGENT, USER_AGENT).send();
+            super::measure_download_time(source.source_metric_key(), request)
+        });
 
         match request.await {
             Ok(request) => {

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -184,6 +184,23 @@ impl RemoteDif {
         }
     }
 
+    /// Returns a key that uniquely identifies the source for metrics.
+    ///
+    /// If this is a built-in source the source_id is returned, otherwise this falls
+    /// back to the source type name.
+    pub fn source_metric_key(&self) -> &str {
+        let id = self.source_id().as_str();
+        // The IDs of built-in sources (see: SENTRY_BUILTIN_SOURCES in sentry) always start with
+        // "sentry:" (e.g. "sentry:electron") and are safe to use as a key. If this is a custom
+        // source, then the source_id is a random string which inflates the cardinality of this
+        // metric as the tag values will greatly vary.
+        if id.starts_with("sentry:") {
+            id
+        } else {
+            self.source_type_name()
+        }
+    }
+
     /// Returns a URI for the location of the object file.
     ///
     /// There is no guarantee about any format of this URI, for some sources it could be

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -3,9 +3,10 @@
 //! The sources are described on
 //! <https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/>
 
+use std::convert::TryInto;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ::sentry::{Hub, SentryFutureExt};
 use futures::prelude::*;
@@ -13,7 +14,7 @@ use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
-use crate::utils::futures::{m, measure, MeasureSourceDownload};
+use crate::utils::futures::{m, measure};
 use crate::utils::paths::get_directory_paths;
 
 mod filesystem;
@@ -208,7 +209,7 @@ async fn download_stream(
         .map_err(DownloadError::BadDestination)?;
     futures::pin_mut!(stream);
 
-    let mut measuring_stick = MeasureSourceDownload::new(
+    let mut measuring_stick = MeasureSourceDownloadGuard::new(
         "service.download.download_source_stream",
         source.source_metric_key(),
     );
@@ -227,6 +228,112 @@ async fn download_stream(
 
     file.flush().await.map_err(DownloadError::Write)?;
     Ok(DownloadStatus::Completed)
+}
+
+/// State of the [`MeasureSourceDownloadGuard`].
+#[derive(Clone, Copy, Debug)]
+enum MeasureState {
+    /// The future is not ready.
+    Pending,
+    /// The future has terminated with a status.
+    Done(&'static str),
+}
+
+/// A guard to [`measure`] the amount of time it takes to download a source. This guard is also
+/// capable of calculating and reporting the throughput of the connection. Two metrics are
+/// emitted if `bytes_transferred` is set:
+///
+/// 1. Amount of time taken to complete the measurement
+/// 2. Connection thoroughput (bytes transferred / time taken to complete)
+///
+/// If `bytes_transferred` is not set, then only the first metric (amount of time taken) is
+/// recorded.
+struct MeasureSourceDownloadGuard<'a> {
+    state: MeasureState,
+    task_name: &'a str,
+    source_name: &'a str,
+    creation_time: Instant,
+    bytes_transferred: Option<u64>,
+}
+
+impl<'a> MeasureSourceDownloadGuard<'a> {
+    /// Creates a new measure guard for downloading a source.
+    pub fn new(task_name: &'a str, source_name: &'a str) -> Self {
+        Self {
+            state: MeasureState::Pending,
+            task_name,
+            source_name,
+            bytes_transferred: None,
+            creation_time: Instant::now(),
+        }
+    }
+
+    /// A checked add to the amount of bytes transferred during the download.
+    ///
+    /// This value will be emitted when the download's future is completed or cancelled.
+    pub fn add_bytes_transferred(&mut self, additional_bytes: u64) {
+        let bytes = self.bytes_transferred.get_or_insert(Default::default());
+        *bytes = bytes.saturating_add(additional_bytes);
+    }
+
+    /// Marks the download as terminated.
+    pub fn done<T, E>(mut self, reason: &Result<T, E>) {
+        self.state = MeasureState::Done(m::result(reason));
+    }
+}
+
+impl Drop for MeasureSourceDownloadGuard<'_> {
+    fn drop(&mut self) {
+        let status = match self.state {
+            MeasureState::Pending => "canceled",
+            MeasureState::Done(status) => status,
+        };
+
+        let duration = self.creation_time.elapsed();
+        metric!(
+            timer(self.task_name) = duration,
+            "status" => status,
+            "source" => self.source_name,
+        );
+
+        if let Some(bytes_transferred) = self.bytes_transferred {
+            // Times are recorded in milliseconds, so match that unit when calculating throughput,
+            // recording a byte / ms value.
+            // This falls back to the throughput being equivalent to the amount of bytes transferred
+            // if the duration is zero, or there are any conversion errors.
+            let throughput = (bytes_transferred as u128)
+                .checked_div(duration.as_millis())
+                .and_then(|t| t.try_into().ok())
+                .unwrap_or(bytes_transferred);
+            metric!(
+                histogram(format!("{}.throughput", self.task_name).as_str()) = throughput,
+                "status" => status,
+                "source" => self.source_name,
+            );
+        }
+    }
+}
+
+/// Measures the timing of a download-related future and reports metrics as a histogram.
+///
+/// This function reports a single metric corresponding to the task name. This metric is reported
+/// regardless of the future's return value.
+///
+/// A tag with the source name is also added to the metric, in addition to a tag recording the
+/// status of the future.
+fn measure_download_time<'a, F, T, G>(
+    source_name: &'a str,
+    f: F,
+) -> impl Future<Output = F::Output> + 'a
+where
+    F: 'a + Future<Output = Result<T, G>>,
+{
+    let guard = MeasureSourceDownloadGuard::new("service.download.download_source", source_name);
+    async move {
+        let output = f.await;
+        guard.done(&output);
+        output
+    }
 }
 
 /// Iterator to generate a list of [`SourceLocation`]s to attempt downloading.

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -270,7 +270,7 @@ impl<'a> MeasureSourceDownloadGuard<'a> {
     ///
     /// This value will be emitted when the download's future is completed or cancelled.
     pub fn add_bytes_transferred(&mut self, additional_bytes: u64) {
-        let bytes = self.bytes_transferred.get_or_insert(Default::default());
+        let bytes = self.bytes_transferred.get_or_insert(0);
         *bytes = bytes.saturating_add(additional_bytes);
     }
 
@@ -328,7 +328,7 @@ fn measure_download_time<'a, F, T, E>(
 where
     F: 'a + Future<Output = Result<T, E>>,
 {
-    let guard = MeasureSourceDownloadGuard::new("source.download", source_name);
+    let guard = MeasureSourceDownloadGuard::new("source.connect", source_name);
     async move {
         let output = f.await;
         guard.done(&output);

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -222,7 +222,7 @@ async fn download_stream(
         Ok(())
     }
     .await;
-    measuring_stick.done(m::result(&result));
+    measuring_stick.done(&result);
     result?;
 
     file.flush().await.map_err(DownloadError::Write)?;

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -210,7 +210,7 @@ async fn download_stream(
     futures::pin_mut!(stream);
 
     let mut throughput_recorder =
-        MeasureSourceDownloadGuard::new("source.stream", source.source_metric_key());
+        MeasureSourceDownloadGuard::new("source.download.stream", source.source_metric_key());
     let result: Result<_, DownloadError> = async {
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
@@ -328,7 +328,7 @@ fn measure_download_time<'a, F, T, E>(
 where
     F: 'a + Future<Output = Result<T, E>>,
 {
-    let guard = MeasureSourceDownloadGuard::new("source.connect", source_name);
+    let guard = MeasureSourceDownloadGuard::new("source.download.connect", source_name);
     async move {
         let output = f.await;
         guard.done(&output);

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -210,7 +210,7 @@ async fn download_stream(
     futures::pin_mut!(stream);
 
     let mut throughput_recorder =
-        MeasureSourceDownloadGuard::new("source.download", source.source_metric_key());
+        MeasureSourceDownloadGuard::new("source.stream", source.source_metric_key());
     let result: Result<_, DownloadError> = async {
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -18,7 +18,7 @@ use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{AwsCredentialsProvider, FileType, S3SourceConfig, S3SourceKey};
 use crate::types::ObjectId;
-use crate::utils::futures::{self as future_utils, m};
+use crate::utils::futures as future_utils;
 
 type ClientCache = lru::LruCache<Arc<S3SourceKey>, Arc<rusoto_s3::S3Client>>;
 
@@ -150,12 +150,7 @@ impl S3Downloader {
         });
 
         let source = RemoteDif::from(file_source);
-        let request = future_utils::measure_source_download(
-            "service.download.download_source",
-            source.source_metric_key(),
-            m::result,
-            request,
-        );
+        let request = future_utils::measure_source_download(source.source_metric_key(), request);
 
         let response = match request.await {
             Ok(response) => response,

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -18,7 +18,6 @@ use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{AwsCredentialsProvider, FileType, S3SourceConfig, S3SourceKey};
 use crate::types::ObjectId;
-use crate::utils::futures as future_utils;
 
 type ClientCache = lru::LruCache<Arc<S3SourceKey>, Arc<rusoto_s3::S3Client>>;
 
@@ -150,7 +149,7 @@ impl S3Downloader {
         });
 
         let source = RemoteDif::from(file_source);
-        let request = future_utils::measure_source_download(source.source_metric_key(), request);
+        let request = super::measure_download_time(source.source_metric_key(), request);
 
         let response = match request.await {
             Ok(response) => response,

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::prelude::*;
+use futures::TryStreamExt;
 use parking_lot::Mutex;
 use reqwest::StatusCode;
 use serde::Deserialize;
@@ -283,7 +283,7 @@ impl SentryDownloader {
 
         let download_url = file_source.url();
         let source = RemoteDif::from(file_source);
-        let request = future_utils::measure_source_download(source.source_metric_key(), request);
+        let request = super::measure_download_time(source.source_metric_key(), request);
 
         match request.await {
             Ok(response) => {

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -283,12 +283,7 @@ impl SentryDownloader {
 
         let download_url = file_source.url();
         let source = RemoteDif::from(file_source);
-        let request = future_utils::measure_source_download(
-            "service.download.download_source",
-            source.source_metric_key(),
-            m::result,
-            request,
-        );
+        let request = future_utils::measure_source_download(source.source_metric_key(), request);
 
         match request.await {
             Ok(response) => {

--- a/crates/symbolicator/src/utils/futures.rs
+++ b/crates/symbolicator/src/utils/futures.rs
@@ -268,10 +268,8 @@ impl<'a> MeasureSourceDownload<'a> {
     ///
     /// This value will be emitted when the download's future is completed or cancelled.
     pub fn add_bytes_transferred(&mut self, additional_bytes: u64) {
-        self.bytes_transferred = self
-            .bytes_transferred
-            .and_then(|old_count| old_count.checked_add(additional_bytes).or(Some(old_count)))
-            .or(Some(additional_bytes));
+        let bytes = self.bytes_transferred.get_or_insert(Default::default());
+        *bytes = bytes.saturating_add(additional_bytes);
     }
 
     /// Marks the download as terminated.

--- a/crates/symbolicator/src/utils/futures.rs
+++ b/crates/symbolicator/src/utils/futures.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -232,104 +231,6 @@ where
         guard.start();
         let output = f.await;
         guard.done(get_status(&output));
-        output
-    }
-}
-
-/// A guard to [`measure`] the amount of time it takes to download a source. This guard is also
-/// capable of calculating and reporting the throughput of the connection. Two metrics are
-/// emitted if `bytes_transferred` is set:
-///
-/// 1. Amount of time taken to complete the measurement
-/// 2. Connection thoroughput (bytes transferred / time taken to complete)
-///
-/// If `bytes_transferred` is not set, then only 1 is recorded.
-pub struct MeasureSourceDownload<'a> {
-    state: MeasureState,
-    task_name: &'a str,
-    source_name: &'a str,
-    creation_time: Instant,
-    bytes_transferred: Option<u64>,
-}
-
-impl<'a> MeasureSourceDownload<'a> {
-    /// Creates a new measure guard for downloading a source.
-    pub fn new(task_name: &'a str, source_name: &'a str) -> Self {
-        Self {
-            state: MeasureState::Pending,
-            task_name,
-            source_name,
-            bytes_transferred: None,
-            creation_time: Instant::now(),
-        }
-    }
-
-    /// A checked add to the amount of bytes transferred during the download.
-    ///
-    /// This value will be emitted when the download's future is completed or cancelled.
-    pub fn add_bytes_transferred(&mut self, additional_bytes: u64) {
-        let bytes = self.bytes_transferred.get_or_insert(Default::default());
-        *bytes = bytes.saturating_add(additional_bytes);
-    }
-
-    /// Marks the download as terminated.
-    pub fn done<T, E>(mut self, reason: &Result<T, E>) {
-        self.state = MeasureState::Done(m::result(reason));
-    }
-}
-
-impl Drop for MeasureSourceDownload<'_> {
-    fn drop(&mut self) {
-        let status = match self.state {
-            MeasureState::Pending => "canceled",
-            MeasureState::Done(status) => status,
-        };
-
-        let duration = self.creation_time.elapsed();
-        metric!(
-            timer(self.task_name) = duration,
-            "status" => status,
-            "source" => self.source_name,
-        );
-
-        if let Some(bytes_transferred) = self.bytes_transferred {
-            // Times are recorded in milliseconds, so match that unit when calculating throughput,
-            // recording a byte / ms value.
-            // This falls back to the throughput being equivalent to the amount of bytes transferred
-            // if the duration is zero, or there are any conversion errors.
-            let throughput = (bytes_transferred as u128)
-                .checked_div(duration.as_millis())
-                .and_then(|t| t.try_into().ok())
-                .unwrap_or(bytes_transferred);
-            metric!(
-                histogram(format!("{}.throughput", self.task_name).as_str()) = throughput,
-                "status" => status,
-                "source" => self.source_name,
-            );
-        }
-    }
-}
-
-/// Measures the timing of a download-related future and reports metrics as a histogram.
-///
-/// This function reports a single metric corresponding to the task name. This metric is reported
-/// regardless of the future's return value.
-///
-/// The metric is tagged with a status derived with the `get_status` function. See the [`m`] module
-/// for status helpers.
-///
-/// An additional tag for the source name is also added to the metric.
-pub fn measure_source_download<'a, F, T, G>(
-    source_name: &'a str,
-    f: F,
-) -> impl Future<Output = F::Output> + 'a
-where
-    F: 'a + Future<Output = Result<T, G>>,
-{
-    let guard = MeasureSourceDownload::new("service.download.download_source", source_name);
-    async move {
-        let output = f.await;
-        guard.done(&output);
         output
     }
 }

--- a/crates/symbolicator/src/utils/futures.rs
+++ b/crates/symbolicator/src/utils/futures.rs
@@ -298,7 +298,7 @@ impl Drop for MeasureSourceDownload<'_> {
             metric!(
                 histogram(format!("{}.throughput", self.task_name).as_str()) = throughput,
                 "status" => status,
-                "source_name" => self.source_name,
+                "source" => self.source_name,
             );
         }
     }


### PR DESCRIPTION
This begins measuring requests and download throughput related to source-fetching in order to determine what a good set of default timeouts for such requests should be.

The changes can be broken down into three major parts:

1. The addition of `MeasureSourceDownload`, which is a modified version of `MeasureGuard` focused on source downloads
2. Logging stream throughput and duration in `download_stream` via `MeasureSourceDownload`
3. Logging the initial GET request's duration in every type of download source

Source downloads from the local filesystem have been skipped as it is unlikely that any meaningful or useful information will come from logging information about those.

Open questions and notes will be left directly on the diff.