### PR TITLE
feat: Cache download failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update symbolic to allow processing PDB files with broken inlinee records. ([#477](https://github.com/getsentry/symbolicator/pull/477))
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Make the timeout for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482))
+- Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484))
 
 ### Tools
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -31,8 +31,8 @@ pub enum CacheStatus {
     /// A cache item that represents the presence of something. E.g. we succeeded in downloading an
     /// object file and cached that file.
     Positive,
-    /// A cache item that represents the absence of something. E.g. we encountered a 404 while
-    /// trying to download a file, and cached that fact. Represented by an empty file.
+    /// A cache item that represents the absence of something. E.g. we encountered a 404 or an error
+    /// while trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache. See
     /// docs for [`MALFORMED_MARKER`].

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -206,6 +206,7 @@ impl ConfigureScope for RemoteDif {
         scope.set_tag("source.id", self.source_id());
         scope.set_tag("source.type", self.source_type_name());
         scope.set_tag("source.is_public", self.is_public());
+        scope.set_tag("source.uri", self.uri());
     }
 }
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -275,7 +275,6 @@ impl CacheItemRequest for FetchFileDataRequest {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
@@ -283,121 +282,13 @@ mod tests {
     use crate::cache::Cache;
     use crate::config::{CacheConfig, CacheConfigs, Config};
     use crate::services::download::DownloadService;
-    use crate::services::objects::data_cache::{CacheStatus, Scope};
+    use crate::services::objects::data_cache::Scope;
     use crate::services::objects::{FindObject, ObjectPurpose, ObjectsActor};
-    use crate::sources::{FileType, HttpSourceConfig, SourceConfig, SourceId};
-    use crate::test::{self, fixture, Server};
+    use crate::sources::FileType;
+    use crate::test;
 
     use symbolic::common::DebugId;
 
-    use warp::filters::fs::File;
-    use warp::reject::{Reject, Rejection};
-    use warp::Filter;
-
-    #[derive(Debug, Clone, Copy)]
-    struct GoAway;
-
-    impl Reject for GoAway {}
-
-    struct FailingSymbolServer {
-        server: Server,
-        times_accessed: Arc<AtomicUsize>,
-        accept_source: SourceConfig,
-        reject_source: SourceConfig,
-        pending_source: SourceConfig,
-        not_found_source: SourceConfig,
-    }
-    impl FailingSymbolServer {
-        fn new() -> Self {
-            let times_accessed = Arc::new(AtomicUsize::new(0));
-
-            let times = times_accessed.clone();
-            let reject = warp::path("reject")
-                .and(warp::fs::dir(fixture("symbols")))
-                .and_then(move |_| {
-                    let times = Arc::clone(&times);
-                    async move {
-                        (*times).fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-                        Err::<File, _>(warp::reject::custom(GoAway))
-                    }
-                });
-
-            let times = times_accessed.clone();
-            let not_found = warp::path("not-found")
-                .and(warp::fs::dir(fixture("symbols")))
-                .and_then(move |_| {
-                    let times = Arc::clone(&times);
-                    async move {
-                        (*times).fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-                        Err::<File, _>(warp::reject::not_found())
-                    }
-                });
-
-            let times = times_accessed.clone();
-            let pending = warp::path("pending")
-                .and(warp::fs::dir(fixture("symbols")))
-                .and_then(move |_| {
-                    let times = Arc::clone(&times);
-                    (*times).fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-                    std::future::pending::<Result<File, Rejection>>()
-                });
-
-            let times = times_accessed.clone();
-            let accept = warp::path("pending")
-                .and(warp::fs::dir(fixture("symbols")))
-                .map(move |file| {
-                    let times = Arc::clone(&times);
-                    (*times).fetch_add(1, Ordering::SeqCst);
-
-                    file
-                });
-
-            let server = Server::new(reject.or(not_found).or(pending).or(accept));
-
-            // The sources use the same identifier ("local") as the local file system source to avoid
-            // differences when changing the bucket in tests.
-
-            let accept_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-                id: SourceId::new("accept"),
-                url: server.url("accept/"),
-                headers: Default::default(),
-                files: Default::default(),
-            }));
-
-            let reject_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-                id: SourceId::new("reject"),
-                url: server.url("reject/"),
-                headers: Default::default(),
-                files: Default::default(),
-            }));
-
-            let pending_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-                id: SourceId::new("pending"),
-                url: server.url("pending/"),
-                headers: Default::default(),
-                files: Default::default(),
-            }));
-
-            let not_found_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-                id: SourceId::new("not-found"),
-                url: server.url("not-found/"),
-                headers: Default::default(),
-                files: Default::default(),
-            }));
-
-            FailingSymbolServer {
-                server,
-                times_accessed,
-                accept_source,
-                reject_source,
-                pending_source,
-                not_found_source,
-            }
-        }
-    }
     fn objects_actor() -> ObjectsActor {
         let meta_cache = Cache::from_config(
             "meta",
@@ -429,7 +320,7 @@ mod tests {
     async fn test_negative_cache() {
         test::setup();
 
-        let server = FailingSymbolServer::new();
+        let server = test::FailingSymbolServer::new();
 
         let objects_actor = objects_actor();
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -275,24 +275,24 @@ impl CacheItemRequest for FetchFileDataRequest {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::cache::Cache;
+    use crate::cache::{Cache, CacheStatus};
     use crate::config::{CacheConfig, CacheConfigs, Config};
     use crate::services::download::DownloadService;
     use crate::services::objects::data_cache::Scope;
     use crate::services::objects::{FindObject, ObjectPurpose, ObjectsActor};
     use crate::sources::FileType;
-    use crate::test;
+    use crate::test::{self, tempdir};
 
     use symbolic::common::DebugId;
+    use tempfile::TempDir;
 
-    fn objects_actor() -> ObjectsActor {
+    fn objects_actor(tempdir: &TempDir) -> ObjectsActor {
         let meta_cache = Cache::from_config(
             "meta",
-            None,
+            Some(tempdir.path().join("meta")),
             None,
             CacheConfig::from(CacheConfigs::default().derived),
         )
@@ -300,7 +300,7 @@ mod tests {
 
         let data_cache = Cache::from_config(
             "data",
-            None,
+            Some(tempdir.path().join("data")),
             None,
             CacheConfig::from(CacheConfigs::default().downloaded),
         )
@@ -308,7 +308,7 @@ mod tests {
 
         let config = Arc::new(Config {
             connect_to_reserved_ips: true,
-            download_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_millis(10),
             ..Config::default()
         });
 
@@ -321,20 +321,61 @@ mod tests {
         test::setup();
 
         let server = test::FailingSymbolServer::new();
+        let cachedir = tempdir();
+        let objects_actor = objects_actor(&cachedir);
 
-        let objects_actor = objects_actor();
+        test::spawn_compat(move || async move {
+            let find_object = FindObject {
+                // A request for a bcsymbolmap will expand to only one file that is being looked up.
+                // Other filetypes will lead to multiple requests, trying different file extensions, etc
+                filetypes: &[FileType::BcSymbolMap],
+                purpose: ObjectPurpose::Debug,
+                scope: Scope::Global,
+                identifier: DebugId::default().into(),
+                sources: Arc::new([]),
+            };
 
-        let find_object = FindObject {
-            filetypes: FileType::all(),
-            purpose: ObjectPurpose::Debug,
-            scope: Scope::Global,
-            identifier: DebugId::default().into(),
-            sources: Arc::new([server.reject_source]),
-        };
+            // for each of the different symbol sources, we assert that:
+            // * we get a negative cache result no matter how often we try
+            // * we hit the symbol source exactly once for the initial request
+            // * the second try should *not* hit the symbol source, but should rather be served by the cache
 
-        objects_actor.find(find_object.clone()).await.unwrap();
-        assert_eq!(server.times_accessed.load(Ordering::SeqCst), 1);
-        objects_actor.find(find_object).await.unwrap();
-        assert_eq!(server.times_accessed.load(Ordering::SeqCst), 1);
+            // server rejects the request
+            let find_object = FindObject {
+                sources: Arc::new([server.reject_source.clone()]),
+                ..find_object
+            };
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 1);
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 0);
+
+            // server responds with not found
+            let find_object = FindObject {
+                sources: Arc::new([server.not_found_source.clone()]),
+                ..find_object
+            };
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 1);
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 0);
+
+            // server accepts the request, but never sends any reply
+            let find_object = FindObject {
+                sources: Arc::new([server.pending_source.clone()]),
+                ..find_object
+            };
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 1);
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
+            assert_eq!(server.accesses(), 0);
+        })
+        .await;
     }
 }


### PR DESCRIPTION
Currently, when a file that should be downloaded can't be found, `FetchFileDataRequest::compute` returns `Ok(CacheStatus::Negative)` to signal that the download shouldn't be retried for a while. This change extends this behavior to download errors. There is also a unit test, but I still need to figure out the easiest way to get the download to fail.