### PR TITLE
meta(mkdocs): Fill in a missing mandatory config value

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Sentry Symbolicator
 repo_url: https://github.com/getsentry/symbolicator
+site_url: https://getsentry.github.io/symbolicator
 site_author: Sentry
 theme:
   name: material


### PR DESCRIPTION
It looks like `site_url` is now required in a mkdocs config. Without it, `use_directory_urls` will not work, and links to specific pages must target the actual file in order to fetch useful content. Running `make docs` without the changes in this PR spits out the following warning:

```
WARNING  -  Config value: 'site_url'. Warning: This option is now required. Set to a valid URL or an empty string to avoid an error in a future release.
WARNING  -  Config value: 'site_url'. Warning: The 'use_directory_urls' option has been disabled because 'site_url' contains an empty value. Either define a valid URL
            for 'site_url' or set 'use_directory_urls' to False.
```

Links targeting directories without `site_url` and `use_directory_urls` set properly will break in unexpected ways, e.g. opening https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/ instead of https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility.html will render a nonfunctional page. There a few links in our rustdocs that do exactly that, so this change should fix those links.

#skip-changelog