### PR TITLE
ref: Update symbolic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update symbolic to write versioned CFI Caches, and fix SymCache conversion related to inline-parent offset. ([#470](https://github.com/getsentry/symbolicator/pull/470))
 - Update symbolic to allow processing PDB files with broken inlinee records. ([#477](https://github.com/getsentry/symbolicator/pull/477))
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
+- Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
 - Make the timeout for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482))
 
 ### Tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,9 +1234,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee05c709047abe5eb0571880d2887ac77299c5f0835f8e6b7f4d5404f8962921"
+checksum = "0b1800b95efee8ad4ef04517d4d69f8e209e763b1668f1179aeeedd0e454da55"
 dependencies = [
  "log",
  "plain",
@@ -3537,8 +3537,8 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "symbolic"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3549,8 +3549,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "debugid",
  "memmap",
@@ -3561,8 +3561,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "dmsort",
  "elementtree",
@@ -3590,8 +3590,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3602,8 +3602,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-minidump"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3616,8 +3616,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.2.1"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#e233aeef7820cc03c786f42963f9ac1aed9466b6"
+version = "8.3.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#a63354dd3681ed359594317d9e2b2dcb1101ff38"
 dependencies = [
  "dmsort",
  "fnv",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.1", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.3.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.26"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.2.1", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.3.0", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.9.0"


### PR DESCRIPTION
This fixes restoring registers when using compact unwinding, and fixes an oversight resolving bcsymbolmaps for inlinees.