### PR TITLE
feat: Add streaming_timeout configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Update symbolic to allow processing PDB files with broken inlinee records. ([#477](https://github.com/getsentry/symbolicator/pull/477))
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
-- Make the timeout for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482))
+- Make timeouts for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
 - Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484))
 
 ### Tools

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -243,11 +243,12 @@ pub struct Config {
     /// Number of subprocesses in the internal processing pool.
     pub processing_pool_size: usize,
 
-    /// The timeout for downloads.
+    /// The maximum timeout for downloads.
     #[serde(with = "humantime_serde")]
-    pub download_timeout: Duration,
+    pub max_download_timeout: Duration,
 
-    /// The timeout per GB for streaming downloads.
+    /// The timeout per GB for streaming downloads. If the
+    /// size of the download is not known, assume 2GB.
     #[serde(with = "humantime_serde")]
     pub streaming_timeout: Duration,
 }
@@ -313,7 +314,7 @@ impl Default for Config {
             sources: Arc::from(vec![]),
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
-            download_timeout: Duration::from_secs(300),
+            max_download_timeout: Duration::from_secs(300),
             streaming_timeout: Duration::from_secs(60),
         }
     }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -252,7 +252,9 @@ pub struct Config {
 
     /// The timeout per GB for streaming downloads.
     ///
-    /// We default this to half of the `max_download_timeout` duration, assuming a maximum download size of 2GB.
+    /// For downloads with a known size, this timeout applies per individual
+    /// download attempt. If the download size is not known, it is ignored and
+    /// only `max_download_timeout` applies.
     #[serde(with = "humantime_serde")]
     pub streaming_timeout: Duration,
 }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -315,7 +315,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
             max_download_timeout: Duration::from_secs(300),
-            streaming_timeout: Duration::from_secs(60),
+            streaming_timeout: Duration::from_secs(150),
         }
     }
 }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -244,6 +244,9 @@ pub struct Config {
     pub processing_pool_size: usize,
 
     /// The maximum timeout for downloads.
+    ///
+    /// This is the upper limit the download service will take for downloading from a single
+    /// source, regardless of how many retries are involved.
     #[serde(with = "humantime_serde")]
     pub max_download_timeout: Duration,
 

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -246,6 +246,10 @@ pub struct Config {
     /// The timeout for downloads.
     #[serde(with = "humantime_serde")]
     pub download_timeout: Duration,
+
+    /// The timeout per GB for streaming downloads.
+    #[serde(with = "humantime_serde")]
+    pub streaming_timeout: Duration,
 }
 
 impl Config {
@@ -310,6 +314,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
             download_timeout: Duration::from_secs(300),
+            streaming_timeout: Duration::from_secs(60),
         }
     }
 }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -247,8 +247,9 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub max_download_timeout: Duration,
 
-    /// The timeout per GB for streaming downloads. If the
-    /// size of the download is not known, assume 2GB.
+    /// The timeout per GB for streaming downloads.
+    ///
+    /// We default this to half of the `max_download_timeout` duration, assuming a maximum download size of 2GB.
     #[serde(with = "humantime_serde")]
     pub streaming_timeout: Duration,
 }

--- a/crates/symbolicator/src/services/download/filesystem.rs
+++ b/crates/symbolicator/src/services/download/filesystem.rs
@@ -7,14 +7,11 @@
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::fs;
-use tokio::time::error::Elapsed;
 
 use super::locations::SourceLocation;
-use super::{DownloadError, DownloadStatus, RemoteDif};
-use crate::services::download::RemoteDifUri;
+use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{FileType, FilesystemSourceConfig};
 use crate::types::ObjectId;
 
@@ -53,17 +50,15 @@ impl FilesystemRemoteDif {
 
 /// Downloader implementation that supports the [`FilesystemSourceConfig`] source.
 #[derive(Debug)]
-pub struct FilesystemDownloader {
-    download_timeout: Duration,
-}
+pub struct FilesystemDownloader {}
 
 impl FilesystemDownloader {
-    pub fn new(download_timeout: Duration) -> Self {
-        Self { download_timeout }
+    pub fn new() -> Self {
+        Self {}
     }
 
     /// Download from a filesystem source.
-    async fn download_source_inner(
+    pub async fn download_source(
         &self,
         file_source: FilesystemRemoteDif,
         dest: PathBuf,
@@ -78,19 +73,6 @@ impl FilesystemDownloader {
                 _ => Err(DownloadError::Io(e)),
             },
         }
-    }
-
-    /// Download from a filesystem source.
-    pub async fn download_source(
-        &self,
-        file_source: FilesystemRemoteDif,
-        dest: PathBuf,
-    ) -> Result<Result<DownloadStatus, DownloadError>, Elapsed> {
-        tokio::time::timeout(
-            self.download_timeout,
-            self.download_source_inner(file_source, dest),
-        )
-        .await
     }
 
     pub fn list_files(

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -239,7 +239,8 @@ impl GcsDownloader {
                         .and_then(|hv| hv.to_str().ok())
                         .and_then(|s| s.parse::<u32>().ok());
 
-                    let timeout = content_length_timeout(content_length, self.streaming_timeout);
+                    let timeout =
+                        content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -12,6 +12,7 @@ use parking_lot::Mutex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::time::error::Elapsed;
 use url::Url;
 
 use super::locations::SourceLocation;
@@ -139,13 +140,15 @@ fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, Gc
 pub struct GcsDownloader {
     token_cache: Mutex<GcsTokenCache>,
     client: reqwest::Client,
+    download_timeout: std::time::Duration,
 }
 
 impl GcsDownloader {
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, download_timeout: std::time::Duration) -> Self {
         Self {
             token_cache: Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE)),
             client,
+            download_timeout,
         }
     }
 
@@ -198,7 +201,7 @@ impl GcsDownloader {
         Ok(token)
     }
 
-    pub async fn download_source(
+    async fn download_source_inner(
         &self,
         file_source: GcsRemoteDif,
         destination: PathBuf,
@@ -254,6 +257,18 @@ impl GcsDownloader {
                 Ok(DownloadStatus::NotFound)
             }
         }
+    }
+
+    pub async fn download_source(
+        &self,
+        file_source: GcsRemoteDif,
+        destination: PathBuf,
+    ) -> Result<Result<DownloadStatus, DownloadError>, Elapsed> {
+        tokio::time::timeout(
+            self.download_timeout,
+            self.download_source_inner(file_source, destination),
+        )
+        .await
     }
 
     pub fn list_files(

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -9,13 +9,13 @@ use chrono::{DateTime, Duration, Utc};
 use futures::prelude::*;
 use jsonwebtoken::EncodingKey;
 use parking_lot::Mutex;
-use reqwest::Client;
+use reqwest::{header, Client};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
 use super::locations::SourceLocation;
-use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
+use super::{content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey};
 use crate::types::ObjectId;
 use crate::utils::futures as future_utils;
@@ -139,13 +139,15 @@ fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, Gc
 pub struct GcsDownloader {
     token_cache: Mutex<GcsTokenCache>,
     client: reqwest::Client,
+    streaming_timeout: std::time::Duration,
 }
 
 impl GcsDownloader {
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, streaming_timeout: std::time::Duration) -> Self {
         Self {
             token_cache: Mutex::new(GcsTokenCache::new(GCS_TOKEN_CACHE_SIZE)),
             client,
+            streaming_timeout,
         }
     }
 
@@ -230,9 +232,17 @@ impl GcsDownloader {
             Ok(response) => {
                 if response.status().is_success() {
                     log::trace!("Success hitting GCS {} (from {})", &key, bucket);
+
+                    let content_length = response
+                        .headers()
+                        .get(header::CONTENT_LENGTH)
+                        .and_then(|hv| hv.to_str().ok())
+                        .and_then(|s| s.parse::<u32>().ok());
+
+                    let timeout = content_length_timeout(content_length, self.streaming_timeout);
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    super::download_stream(source, stream, destination).await
+                    super::download_stream(source, stream, destination, timeout).await
                 } else {
                     log::trace!(
                         "Unexpected status code from GCS {} (from {}): {}",
@@ -326,7 +336,7 @@ mod tests {
         test::setup();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new(Client::new());
+        let downloader = GcsDownloader::new(Client::new(), std::time::Duration::from_secs(30));
 
         let object_id = ObjectId {
             code_id: Some("e514c9464eed3be5943a2c61d9241fad".parse().unwrap()),
@@ -350,7 +360,7 @@ mod tests {
         test::setup();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new(Client::new());
+        let downloader = GcsDownloader::new(Client::new(), std::time::Duration::from_secs(30));
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");
@@ -377,7 +387,7 @@ mod tests {
         test::setup();
 
         let source = gcs_source(gcs_source_key!());
-        let downloader = GcsDownloader::new(Client::new());
+        let downloader = GcsDownloader::new(Client::new(), std::time::Duration::from_secs(30));
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");
@@ -404,7 +414,7 @@ mod tests {
         };
 
         let source = gcs_source(broken_credentials);
-        let downloader = GcsDownloader::new(Client::new());
+        let downloader = GcsDownloader::new(Client::new(), std::time::Duration::from_secs(30));
 
         let tempdir = test::tempdir();
         let target_path = tempdir.path().join("myfile");

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -12,8 +12,8 @@ use reqwest::{header, Client};
 use url::Url;
 
 use super::{
-    content_length_timeout, with_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri,
-    SourceLocation, USER_AGENT,
+    content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri, SourceLocation,
+    USER_AGENT,
 };
 use crate::sources::{FileType, HttpSourceConfig};
 use crate::types::ObjectId;
@@ -105,11 +105,7 @@ impl HttpDownloader {
 
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    with_timeout(
-                        timeout,
-                        super::download_stream(file_source, stream, destination),
-                    )
-                    .await
+                    super::download_stream(file_source, stream, destination, timeout).await
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -101,7 +101,8 @@ impl HttpDownloader {
                         .and_then(|hv| hv.to_str().ok())
                         .and_then(|s| s.parse::<u32>().ok());
 
-                    let timeout = content_length_timeout(content_length, self.streaming_timeout);
+                    let timeout =
+                        content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
 
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -105,7 +105,7 @@ impl HttpDownloader {
 
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    super::download_stream(file_source, stream, destination, timeout).await
+                    super::download_stream(source, stream, destination, timeout).await
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -183,7 +183,7 @@ impl S3Downloader {
             self.streaming_timeout,
         );
 
-        super::download_stream(file_source, stream, destination, timeout).await
+        super::download_stream(source, stream, destination, timeout).await
     }
 
     pub fn list_files(

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -3,19 +3,22 @@
 //! Specifically this supports the [`S3SourceConfig`] source.
 
 use std::any::type_name;
+use std::convert::TryFrom;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::TryStreamExt;
 use parking_lot::Mutex;
 use rusoto_s3::S3;
+use tokio::time::error::Elapsed;
 
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region::Region;
 
 use super::locations::SourceLocation;
-use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
+use super::{content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{AwsCredentialsProvider, FileType, S3SourceConfig, S3SourceKey};
 use crate::types::ObjectId;
 
@@ -72,6 +75,8 @@ impl S3RemoteDif {
 pub struct S3Downloader {
     http_client: Arc<rusoto_core::HttpClient>,
     client_cache: Mutex<ClientCache>,
+    download_timeout: Duration,
+    streaming_timeout: Duration,
 }
 
 impl fmt::Debug for S3Downloader {
@@ -84,10 +89,12 @@ impl fmt::Debug for S3Downloader {
 }
 
 impl S3Downloader {
-    pub fn new() -> Self {
+    pub fn new(download_timeout: Duration, streaming_timeout: Duration) -> Self {
         Self {
             http_client: Arc::new(rusoto_core::HttpClient::new().unwrap()),
             client_cache: Mutex::new(ClientCache::new(S3_CLIENT_CACHE_SIZE)),
+            download_timeout,
+            streaming_timeout,
         }
     }
 
@@ -135,7 +142,7 @@ impl S3Downloader {
         &self,
         file_source: S3RemoteDif,
         destination: PathBuf,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<Result<DownloadStatus, DownloadError>, Elapsed> {
         let key = file_source.key();
         let bucket = file_source.bucket();
         log::debug!("Fetching from s3: {} (from {})", &key, &bucket);
@@ -160,19 +167,31 @@ impl S3Downloader {
                 // - If `ListBucket` is premitted, a 404 is returned for missing objects.
                 // - Otherwise, a 403 ("access denied") is returned.
                 log::debug!("Skipping response from s3://{}/{}: {}", bucket, &key, err);
-                return Ok(DownloadStatus::NotFound);
+                return Ok(Ok(DownloadStatus::NotFound));
             }
         };
+
+        let timeout = content_length_timeout(
+            response
+                .content_length
+                .and_then(|cl| u32::try_from(cl).ok()),
+            self.streaming_timeout,
+            self.download_timeout,
+        );
 
         let stream = match response.body {
             Some(body) => body.map_err(DownloadError::Io),
             None => {
                 log::debug!("Empty response from s3:{}{}", bucket, &key);
-                return Ok(DownloadStatus::NotFound);
+                return Ok(Ok(DownloadStatus::NotFound));
             }
         };
 
-        super::download_stream(source, stream, destination).await
+        tokio::time::timeout(
+            timeout,
+            super::download_stream(file_source, stream, destination),
+        )
+        .await
     }
 
     pub fn list_files(

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -176,12 +176,10 @@ impl S3Downloader {
             }
         };
 
-        let timeout = content_length_timeout(
-            response
-                .content_length
-                .and_then(|cl| u32::try_from(cl).ok()),
-            self.streaming_timeout,
-        );
+        let content_length = response
+            .content_length
+            .and_then(|cl| u32::try_from(cl).ok());
+        let timeout = content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
 
         super::download_stream(source, stream, destination, timeout).await
     }

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -17,9 +17,7 @@ use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region::Region;
 
 use super::locations::SourceLocation;
-use super::{
-    content_length_timeout, with_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri,
-};
+use super::{content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
 use crate::sources::{AwsCredentialsProvider, FileType, S3SourceConfig, S3SourceKey};
 use crate::types::ObjectId;
 
@@ -185,11 +183,7 @@ impl S3Downloader {
             self.streaming_timeout,
         );
 
-        with_timeout(
-            timeout,
-            super::download_stream(file_source, stream, destination),
-        )
-        .await
+        super::download_stream(file_source, stream, destination, timeout).await
     }
 
     pub fn list_files(

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -16,8 +16,8 @@ use thiserror::Error;
 use url::Url;
 
 use super::{
-    content_length_timeout, with_timeout, DownloadError, DownloadStatus, FileType, RemoteDif,
-    RemoteDifUri, USER_AGENT,
+    content_length_timeout, DownloadError, DownloadStatus, FileType, RemoteDif, RemoteDifUri,
+    USER_AGENT,
 };
 use crate::config::Config;
 use crate::sources::SentrySourceConfig;
@@ -304,7 +304,7 @@ impl SentryDownloader {
                     let timeout = content_length_timeout(content_length, self.streaming_timeout);
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    with_timeout(timeout, super::download_stream(source, stream, destination)).await
+                    super::download_stream(source, stream, destination, timeout).await
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -301,7 +301,8 @@ impl SentryDownloader {
                         .and_then(|hv| hv.to_str().ok())
                         .and_then(|s| s.parse::<u32>().ok());
 
-                    let timeout = content_length_timeout(content_length, self.streaming_timeout);
+                    let timeout =
+                        content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -308,7 +308,7 @@ mod tests {
 
         let config = Arc::new(Config {
             connect_to_reserved_ips: true,
-            download_timeout: Duration::from_millis(10),
+            max_download_timeout: Duration::from_millis(10),
             ..Config::default()
         });
 


### PR DESCRIPTION
This adds a configuration option `streaming_timeout` (name, default value, and documentation subject to change) that controls how long it may take to download 1GB from `http`, `sentry`, and `s3` sources.

Unfortunately this requires a fair bit of refactoring. Currently the timeout logic is contained in `DownloadService::download`, which delegates the download to one of 5 other methods based on the type of source and wraps the whole thing in a timeout future. With these changes, the timeout can't be known in `DownloadService::download`, but only in the individual download methods. This means that the timeout logic must be pushed into those methods.

There's an additional problem that I haven't solved yet in the `sentry` case: the `download_source` method calls another method `download_source_once` wrapped in a `retry`. The content length can only be known inside `download_source_once`, since that method makes the actual http request, but the timeout should apply to the entire `retry`, so it needs to be known before `download_source_once` even runs. How can I square this?