### PR TITLE
Revert "feat: Cache download failures (#484)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
 - Make timeouts for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
-- Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484))
 
 ### Tools
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -31,8 +31,8 @@ pub enum CacheStatus {
     /// A cache item that represents the presence of something. E.g. we succeeded in downloading an
     /// object file and cached that file.
     Positive,
-    /// A cache item that represents the absence of something. E.g. we encountered a 404 or an error
-    /// while trying to download a file, and cached that fact. Represented by an empty file.
+    /// A cache item that represents the absence of something. E.g. we encountered a 404 while
+    /// trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache. See
     /// docs for [`MALFORMED_MARKER`].

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -223,7 +223,6 @@ impl ConfigureScope for RemoteDif {
         scope.set_tag("source.id", self.source_id());
         scope.set_tag("source.type", self.source_type_name());
         scope.set_tag("source.is_public", self.is_public());
-        scope.set_tag("source.uri", self.uri());
     }
 }
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -21,7 +21,6 @@ use symbolic::debuginfo::{Archive, Object};
 use tempfile::tempfile_in;
 
 use crate::cache::{CacheKey, CacheStatus};
-use crate::logging::LogError;
 use crate::services::cacher::{CacheItemRequest, CachePath};
 use crate::services::download::{DownloadStatus, RemoteDif};
 use crate::types::{ObjectId, Scope};
@@ -157,20 +156,15 @@ impl CacheItemRequest for FetchFileDataRequest {
         let future = async move {
             let status = downloader
                 .download(file_id, download_file.path().to_owned())
-                .await;
+                .await
+                .map_err(Self::Error::from)?;
 
             match status {
-                Ok(DownloadStatus::NotFound) => {
+                DownloadStatus::NotFound => {
                     log::debug!("No debug file found for {}", cache_key);
                     return Ok(CacheStatus::Negative);
                 }
-
-                Err(e) => {
-                    log::error!("Error while downloading file: {}", LogError(&e));
-                    return Ok(CacheStatus::Negative);
-                }
-
-                Ok(DownloadStatus::Completed) => {
+                DownloadStatus::Completed => {
                     // fall-through
                 }
             }
@@ -270,112 +264,5 @@ impl CacheItemRequest for FetchFileDataRequest {
         object_handle.configure_scope();
 
         object_handle
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use crate::cache::{Cache, CacheStatus};
-    use crate::config::{CacheConfig, CacheConfigs, Config};
-    use crate::services::download::DownloadService;
-    use crate::services::objects::data_cache::Scope;
-    use crate::services::objects::{FindObject, ObjectPurpose, ObjectsActor};
-    use crate::sources::FileType;
-    use crate::test::{self, tempdir};
-
-    use symbolic::common::DebugId;
-    use tempfile::TempDir;
-
-    fn objects_actor(tempdir: &TempDir) -> ObjectsActor {
-        let meta_cache = Cache::from_config(
-            "meta",
-            Some(tempdir.path().join("meta")),
-            None,
-            CacheConfig::from(CacheConfigs::default().derived),
-        )
-        .unwrap();
-
-        let data_cache = Cache::from_config(
-            "data",
-            Some(tempdir.path().join("data")),
-            None,
-            CacheConfig::from(CacheConfigs::default().downloaded),
-        )
-        .unwrap();
-
-        let config = Arc::new(Config {
-            connect_to_reserved_ips: true,
-            max_download_timeout: Duration::from_millis(10),
-            ..Config::default()
-        });
-
-        let download_svc = DownloadService::new(config);
-        ObjectsActor::new(meta_cache, data_cache, download_svc)
-    }
-
-    #[tokio::test]
-    async fn test_negative_cache() {
-        test::setup();
-
-        let server = test::FailingSymbolServer::new();
-        let cachedir = tempdir();
-        let objects_actor = objects_actor(&cachedir);
-
-        test::spawn_compat(move || async move {
-            let find_object = FindObject {
-                // A request for a bcsymbolmap will expand to only one file that is being looked up.
-                // Other filetypes will lead to multiple requests, trying different file extensions, etc
-                filetypes: &[FileType::BcSymbolMap],
-                purpose: ObjectPurpose::Debug,
-                scope: Scope::Global,
-                identifier: DebugId::default().into(),
-                sources: Arc::new([]),
-            };
-
-            // for each of the different symbol sources, we assert that:
-            // * we get a negative cache result no matter how often we try
-            // * we hit the symbol source exactly once for the initial request
-            // * the second try should *not* hit the symbol source, but should rather be served by the cache
-
-            // server rejects the request (500)
-            let find_object = FindObject {
-                sources: Arc::new([server.reject_source.clone()]),
-                ..find_object
-            };
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 1);
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 0);
-
-            // server responds with not found (404)
-            let find_object = FindObject {
-                sources: Arc::new([server.not_found_source.clone()]),
-                ..find_object
-            };
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 1);
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 0);
-
-            // server accepts the request, but never sends any reply (timeout)
-            let find_object = FindObject {
-                sources: Arc::new([server.pending_source.clone()]),
-                ..find_object
-            };
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 1);
-            let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
-            assert_eq!(server.accesses(), 0);
-        })
-        .await;
     }
 }

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -19,14 +19,11 @@
 use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use futures::{FutureExt, TryFutureExt};
 use log::LevelFilter;
 use reqwest::Url;
-use warp::filters::fs::File;
-use warp::reject::{Reject, Rejection};
 use warp::Filter;
 
 use crate::sources::{
@@ -242,89 +239,5 @@ pub(crate) fn symbol_server() -> (Server, SourceConfig) {
     (server, source)
 }
 
-#[derive(Debug, Clone, Copy)]
-struct GoAway;
-
-impl Reject for GoAway {}
-
-pub(crate) struct FailingSymbolServer {
-    #[allow(unused)]
-    server: Server,
-    times_accessed: Arc<AtomicUsize>,
-    pub(crate) reject_source: SourceConfig,
-    pub(crate) pending_source: SourceConfig,
-    pub(crate) not_found_source: SourceConfig,
-}
-
-impl FailingSymbolServer {
-    pub(crate) fn new() -> Self {
-        let times_accessed = Arc::new(AtomicUsize::new(0));
-
-        let times = times_accessed.clone();
-        let reject = warp::path("reject").and_then(move || {
-            let times = Arc::clone(&times);
-            async move {
-                (*times).fetch_add(1, Ordering::SeqCst);
-
-                Err::<File, _>(warp::reject::custom(GoAway))
-            }
-        });
-
-        let times = times_accessed.clone();
-        let not_found = warp::path("not-found").and_then(move || {
-            let times = Arc::clone(&times);
-            async move {
-                (*times).fetch_add(1, Ordering::SeqCst);
-
-                Err::<File, _>(warp::reject::not_found())
-            }
-        });
-
-        let times = times_accessed.clone();
-        let pending = warp::path("pending").and_then(move || {
-            (*times).fetch_add(1, Ordering::SeqCst);
-
-            std::future::pending::<Result<File, Rejection>>()
-        });
-
-        let server = Server::new(reject.or(not_found).or(pending));
-
-        let files_config =
-            CommonSourceConfig::with_layout(crate::sources::DirectoryLayoutType::Unified);
-
-        let reject_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-            id: SourceId::new("reject"),
-            url: server.url("reject/"),
-            headers: Default::default(),
-            files: files_config.clone(),
-        }));
-
-        let pending_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-            id: SourceId::new("pending"),
-            url: server.url("pending/"),
-            headers: Default::default(),
-            files: files_config.clone(),
-        }));
-
-        let not_found_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
-            id: SourceId::new("not-found"),
-            url: server.url("not-found/"),
-            headers: Default::default(),
-            files: files_config,
-        }));
-
-        FailingSymbolServer {
-            server,
-            times_accessed,
-            reject_source,
-            pending_source,
-            not_found_source,
-        }
-    }
-
-    pub(crate) fn accesses(&self) -> usize {
-        self.times_accessed.swap(0, Ordering::SeqCst)
-    }
-}
 // make sure procspawn works.
 procspawn::enable_test_support!();


### PR DESCRIPTION
This reverts commit eb7f3077152297d9115b96e7db624e7299cd220b.

The change leads to a regression on the user end because files with download errors will show up as not found. See also [here](https://getsentry.atlassian.net/browse/NATIVE-58?atlOrigin=eyJpIjoiMDVmYTg3Zjk2NmZiNDUwYWI1OWYwYTlhZTJkZDEyYmIiLCJwIjoiaiJ9).

#skip-changelog