### PR TITLE
feat(download): Allow configuring the timeout on the initial HEAD request on a source download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Update symbolic to allow processing PDB files with broken inlinee records. ([#477](https://github.com/getsentry/symbolicator/pull/477))
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
-- Make timeouts for downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
+- Make various timeouts related to downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489), [#491](https://github.com/getsentry/symbolicator/pull/491))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 
 ### Tools

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -250,6 +250,13 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub max_download_timeout: Duration,
 
+    /// The timeout for the initial HEAD request in a download.
+    ///
+    /// This timeout applies to each individual attempt to establish a
+    /// connection with a symbol source if retries take place.
+    #[serde(with = "humantime_serde")]
+    pub connect_timeout: Duration,
+
     /// The timeout per GB for streaming downloads.
     ///
     /// For downloads with a known size, this timeout applies per individual
@@ -321,6 +328,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
             max_download_timeout: Duration::from_secs(300),
+            connect_timeout: Duration::from_secs(300),
             streaming_timeout: Duration::from_secs(150),
         }
     }

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -53,13 +53,15 @@ impl HttpRemoteDif {
 #[derive(Debug)]
 pub struct HttpDownloader {
     client: Client,
+    connect_timeout: Duration,
     streaming_timeout: Duration,
 }
 
 impl HttpDownloader {
-    pub fn new(client: Client, streaming_timeout: Duration) -> Self {
+    pub fn new(client: Client, connect_timeout: Duration, streaming_timeout: Duration) -> Self {
         Self {
             client,
+            connect_timeout,
             streaming_timeout,
         }
     }
@@ -84,10 +86,11 @@ impl HttpDownloader {
         }
         let source = RemoteDif::from(file_source);
         let request = builder.header(header::USER_AGENT, USER_AGENT).send();
+        let request = tokio::time::timeout(self.connect_timeout, request);
         let request = super::measure_download_time(source.source_metric_key(), request);
 
         match request.await {
-            Ok(response) => {
+            Ok(Ok(response)) => {
                 if response.status().is_success() {
                     log::trace!("Success hitting {}", download_url);
 
@@ -112,9 +115,13 @@ impl HttpDownloader {
                     Ok(DownloadStatus::NotFound)
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 log::trace!("Skipping response from {}: {}", download_url, e);
                 Ok(DownloadStatus::NotFound) // must be wrong type
+            }
+            Err(_) => {
+                // Timeout
+                Err(DownloadError::Canceled)
             }
         }
     }
@@ -160,7 +167,11 @@ mod tests {
         let loc = SourceLocation::new("hello.txt");
         let file_source = HttpRemoteDif::new(http_source, loc);
 
-        let downloader = HttpDownloader::new(Client::new(), Duration::from_secs(30));
+        let downloader = HttpDownloader::new(
+            Client::new(),
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+        );
         let download_status = downloader
             .download_source(file_source, dest.clone())
             .await
@@ -187,7 +198,11 @@ mod tests {
         let loc = SourceLocation::new("i-do-not-exist");
         let file_source = HttpRemoteDif::new(http_source, loc);
 
-        let downloader = HttpDownloader::new(Client::new(), Duration::from_secs(30));
+        let downloader = HttpDownloader::new(
+            Client::new(),
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+        );
         let download_status = downloader.download_source(file_source, dest).await.unwrap();
 
         assert_eq!(download_status, DownloadStatus::NotFound);

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -81,14 +81,26 @@ impl DownloadService {
         let trusted_client = crate::utils::http::create_client(&config, true);
         let restricted_client = crate::utils::http::create_client(&config, false);
 
-        let streaming_timeout = config.streaming_timeout;
+        let Config {
+            connect_timeout,
+            streaming_timeout,
+            ..
+        } = *config;
         Arc::new(Self {
             config,
             worker: tokio::runtime::Handle::current(),
-            sentry: sentry::SentryDownloader::new(trusted_client, streaming_timeout),
-            http: http::HttpDownloader::new(restricted_client.clone(), streaming_timeout),
-            s3: s3::S3Downloader::new(streaming_timeout),
-            gcs: gcs::GcsDownloader::new(restricted_client, streaming_timeout),
+            sentry: sentry::SentryDownloader::new(
+                trusted_client,
+                connect_timeout,
+                streaming_timeout,
+            ),
+            http: http::HttpDownloader::new(
+                restricted_client.clone(),
+                connect_timeout,
+                streaming_timeout,
+            ),
+            s3: s3::S3Downloader::new(connect_timeout, streaming_timeout),
+            gcs: gcs::GcsDownloader::new(restricted_client, connect_timeout, streaming_timeout),
             fs: filesystem::FilesystemDownloader::new(),
         })
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,10 @@ metrics:
   sources. See [Security](#security). Defaults to `false`.
 - `processing_pool_size`: The number of subprocesses in Symbolicator's internal
   processing pool. Defaults to the total number of logical CPUs on the machine.
-- `download_timeout`: The timeout for downloading debug files.
+- `max_download_timeout`: The timeout for downloading debug files.
+- `connect_timeout`: The timeout for establishing a connection to a symbol
+  server to download debug files.
+- `streaming_timeout`: The timeout for streaming the contents of a debug file.
 - `caches`: Fine-tune cache expiry.
   All time units can be either a time expression like `1s`.  Units
   can be `s`, `seconds`, `m`, `minutes`, `h`, `hours`, `d`, `days`,


### PR DESCRIPTION
Does what it says on the tin. This uses the same timeout as the maximum timeout on the entire download, just to stay mostly consistent for now. I expect we may change some of these defaults as more measurements of actual durations start filtering in from https://github.com/getsentry/symbolicator/pull/483's changes.

I considered pulling out the three timeouts into their own dedicated config in the same way `CacheConfigs` have their own dedicated structure, but I wasn't sure if that was overkill for this. Open to doing exactly that if any of us feel strongly enough about doing this though.