### PR TITLE
feat(config): Add tests for config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
 - Make various timeouts related to downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489), [#491](https://github.com/getsentry/symbolicator/pull/491))
-- Introduced the `max_download_timeout` config setting. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
-- Introduced the `streaming_timeout` config setting. ([#489](https://github.com/getsentry/symbolicator/pull/489))
-- Introduced the `connect_timeout` config setting. ([#491](https://github.com/getsentry/symbolicator/pull/491))
+- Introduced the `max_download_timeout` config setting for source downloads. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
+- Introduced the `streaming_timeout` config setting for source downloads. ([#489](https://github.com/getsentry/symbolicator/pull/489))
+- Introduced the `connect_timeout` config setting for source downloads. ([#491](https://github.com/getsentry/symbolicator/pull/491))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 
 ### Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Update symbolic to correctly apply bcsymbolmaps to symbol and filenames coming from DWARF. ([#479](https://github.com/getsentry/symbolicator/pull/479))
 - Update symbolic to correctly restore registers when using compact unwinding. ([#487](https://github.com/getsentry/symbolicator/pull/487))
 - Make various timeouts related to downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489), [#491](https://github.com/getsentry/symbolicator/pull/491))
+- Introduced the `max_download_timeout` config setting. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
+- Introduced the `streaming_timeout` config setting. ([#489](https://github.com/getsentry/symbolicator/pull/489))
+- Introduced the `connect_timeout` config setting. ([#491](https://github.com/getsentry/symbolicator/pull/491))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 
 ### Tools

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -209,7 +209,7 @@ pub struct CacheConfigs {
     pub diagnostics: DiagnosticsCacheConfig,
 }
 
-/// See README.md for more information on config values.
+/// See docs/index.md for more information on config values.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -421,6 +421,44 @@ mod tests {
     }
 
     #[test]
+    fn test_unspecified_dl_timeouts() {
+        let yaml = r#"
+            sources: []
+        "#;
+        let cfg = Config::from_reader(yaml.as_bytes()).unwrap();
+        let default_cfg = Config::default();
+        assert_eq!(cfg.max_download_timeout, default_cfg.max_download_timeout);
+        assert_eq!(cfg.connect_timeout, default_cfg.connect_timeout);
+        assert_eq!(cfg.streaming_timeout, default_cfg.streaming_timeout);
+    }
+
+    #[test]
+    fn test_zero_second_dl_timeouts() {
+        // 0s download timeouts will not be set to defaults
+        let yaml = r#"
+            max_download_timeout: 0s
+            connect_timeout: 0s
+            streaming_timeout: 0s
+        "#;
+        let cfg = Config::from_reader(yaml.as_bytes()).unwrap();
+        assert_eq!(cfg.max_download_timeout, Duration::from_secs(0));
+        assert_eq!(cfg.connect_timeout, Duration::from_secs(0));
+        assert_eq!(cfg.streaming_timeout, Duration::from_secs(0));
+    }
+
+    #[test]
+    fn test_null_dl_timeouts() {
+        // Null download timeouts aren't supported unlike cache timeouts
+        let yaml = r#"
+            max_download_timeout: null
+            connect_timeout: null
+            streaming_timeout: null
+        "#;
+        let result = Config::from_reader(yaml.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_unknown_fields() {
         // Unknown fields should not cause failure
         let yaml = r#"
@@ -430,5 +468,13 @@ mod tests {
         "#;
         let cfg = Config::from_reader(yaml.as_bytes());
         assert!(cfg.is_ok());
+    }
+
+    #[test]
+    fn test_empty_file() {
+        // Empty files aren't supported
+        let yaml = r#""#;
+        let result = Config::from_reader(yaml.as_bytes());
+        assert!(result.is_err());
     }
 }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -447,18 +447,6 @@ mod tests {
     }
 
     #[test]
-    fn test_null_dl_timeouts() {
-        // Null download timeouts aren't supported unlike cache timeouts
-        let yaml = r#"
-            max_download_timeout: null
-            connect_timeout: null
-            streaming_timeout: null
-        "#;
-        let result = Config::from_reader(yaml.as_bytes());
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_unknown_fields() {
         // Unknown fields should not cause failure
         let yaml = r#"

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,15 +73,18 @@ metrics:
   sources. See [Security](#security). Defaults to `false`.
 - `processing_pool_size`: The number of subprocesses in Symbolicator's internal
   processing pool. Defaults to the total number of logical CPUs on the machine.
+
+> All time units for the following configuration settings can be either a time
+expression like `1s`.  Units can be `s`, `seconds`, `m`, `minutes`, `h`,
+`hours`, `d`, `days`, `w`, `weeks`, `M`, `months`, `y`, `years`.
+
 - `max_download_timeout`: The timeout for downloading debug files.
 - `connect_timeout`: The timeout for establishing a connection to a symbol
   server to download debug files.
 - `streaming_timeout`: The timeout for streaming the contents of a debug file.
 - `caches`: Fine-tune cache expiry.
-  All time units can be either a time expression like `1s`.  Units
-  can be `s`, `seconds`, `m`, `minutes`, `h`, `hours`, `d`, `days`,
-  `w`, `weeks`, `M`, `months`, `y`, `years`.  Or they can be `null`
-  in which case the cache will never expire.
+
+> Time units for caches may also be `null` to disable cache expiration.
 
   - `downloaded`: Fine-tune caches for downloaded files.
      - `max_unused_for`: Maximum duration to keep a file since last


### PR DESCRIPTION
Adds some tests for symbolicator's config focused on download timeouts. Also includes some nitpicky changes to the changelog and documentation.

#skip-changelog 