### PR TITLE
feat(download): Set default timeout for a download's HEAD request to 15s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Make various timeouts related to downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489), [#491](https://github.com/getsentry/symbolicator/pull/491))
 - Introduced the `max_download_timeout` config setting for source downloads. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
 - Introduced the `streaming_timeout` config setting for source downloads. ([#489](https://github.com/getsentry/symbolicator/pull/489))
-- Introduced the `connect_timeout` config setting for source downloads. ([#491](https://github.com/getsentry/symbolicator/pull/491))
+- Introduced the `connect_timeout` config setting for source downloads, which has a default of 60s. ([#491](https://github.com/getsentry/symbolicator/pull/491), [#496](https://github.com/getsentry/symbolicator/pull/496))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Make various timeouts related to downloading files configurable. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489), [#491](https://github.com/getsentry/symbolicator/pull/491))
 - Introduced the `max_download_timeout` config setting for source downloads. ([#482](https://github.com/getsentry/symbolicator/pull/482), [#489](https://github.com/getsentry/symbolicator/pull/489))
 - Introduced the `streaming_timeout` config setting for source downloads. ([#489](https://github.com/getsentry/symbolicator/pull/489))
-- Introduced the `connect_timeout` config setting for source downloads, which has a default of 60s. ([#491](https://github.com/getsentry/symbolicator/pull/491), [#496](https://github.com/getsentry/symbolicator/pull/496))
+- Introduced the `connect_timeout` config setting for source downloads, which has a default of 15s. ([#491](https://github.com/getsentry/symbolicator/pull/491), [#496](https://github.com/getsentry/symbolicator/pull/496))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
 

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -328,7 +328,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
             max_download_timeout: Duration::from_secs(300),
-            connect_timeout: Duration::from_secs(60),
+            connect_timeout: Duration::from_secs(15),
             streaming_timeout: Duration::from_secs(150),
         }
     }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -328,7 +328,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             processing_pool_size: num_cpus::get(),
             max_download_timeout: Duration::from_secs(300),
-            connect_timeout: Duration::from_secs(300),
+            connect_timeout: Duration::from_secs(60),
             streaming_timeout: Duration::from_secs(150),
         }
     }


### PR DESCRIPTION
See title. This obviously isn't final, but based on about a week's worth of data so far it seems like lowering the timeout to 15s should be reasonable and allow the 95th percentile of requests to complete without timing out.