### PR TITLE
Restore caching of download failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Introduced the `connect_timeout` config setting for source downloads. ([#491](https://github.com/getsentry/symbolicator/pull/491))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
+- Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484))
 
 ### Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Introduced the `connect_timeout` config setting for source downloads. ([#491](https://github.com/getsentry/symbolicator/pull/491))
 - GCS, S3, HTTP, and local filesystem sources: Attempt to retry failed downloads at least once. ([#485](https://github.com/getsentry/symbolicator/pull/485))
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
-- Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484))
+- Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484), [#501](https://github.com/getsentry/symbolicator/pull/501))
 
 ### Tools
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -31,11 +31,11 @@ pub enum CacheStatus {
     /// A cache item that represents the presence of something. E.g. we succeeded in downloading an
     /// object file and cached that file.
     Positive,
-    /// A cache item that represents the absence of something. E.g. we encountered a 404 or an error
-    /// while trying to download a file, and cached that fact. Represented by an empty file.
+    /// A cache item that represents the absence of something. E.g. we encountered a 404 or a client
+    /// error while trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
-    /// We are unable to create or use the cache item. E.g. we failed to create a symcache. See
-    /// docs for [`MALFORMED_MARKER`].
+    /// We are unable to create or use the cache item. E.g. we failed to create a symcache, or
+    /// encountered a non-400 error while downloading a file. See docs for [`MALFORMED_MARKER`].
     Malformed,
 }
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -35,7 +35,7 @@ pub enum CacheStatus {
     /// error while trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache, or
-    /// encountered a non-400 error while downloading a file. See docs for [`MALFORMED_MARKER`].
+    /// encountered an error while downloading a file. See docs for [`MALFORMED_MARKER`].
     Malformed,
 }
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -31,8 +31,8 @@ pub enum CacheStatus {
     /// A cache item that represents the presence of something. E.g. we succeeded in downloading an
     /// object file and cached that file.
     Positive,
-    /// A cache item that represents the absence of something. E.g. we encountered a 404 while
-    /// trying to download a file, and cached that fact. Represented by an empty file.
+    /// A cache item that represents the absence of something. E.g. we encountered a 404 or an error
+    /// while trying to download a file, and cached that fact. Represented by an empty file.
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache. See
     /// docs for [`MALFORMED_MARKER`].

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -223,6 +223,7 @@ impl ConfigureScope for RemoteDif {
         scope.set_tag("source.id", self.source_id());
         scope.set_tag("source.type", self.source_type_name());
         scope.set_tag("source.is_public", self.is_public());
+        scope.set_tag("source.uri", self.uri());
     }
 }
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -308,7 +308,7 @@ mod tests {
 
         let config = Arc::new(Config {
             connect_to_reserved_ips: true,
-            download_timeout: Duration::from_millis(10),
+            max_download_timeout: Duration::from_millis(10),
             ..Config::default()
         });
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -167,7 +167,7 @@ impl CacheItemRequest for FetchFileDataRequest {
 
                 Err(e) => {
                     log::error!("Error while downloading file: {}", LogError(&e));
-                    return Ok(CacheStatus::Negative);
+                    return Ok(CacheStatus::Malformed);
                 }
 
                 Ok(DownloadStatus::Completed) => {

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -130,9 +130,9 @@ impl CacheItemRequest for FetchFileDataRequest {
     /// debug ID of our request is extracted first.  Finally the object is parsed with
     /// symbolic to ensure it is not malformed.
     ///
-    /// If there is an error with downloading or decompression then an `Err` of
-    /// [`ObjectError`] is returned.  However if only the final object file parsing failed
-    /// then an `Ok` with [`CacheStatus::Malformed`] is returned.
+    /// If there is an error decompression then an `Err` of [`ObjectError`] is returned.  If the
+    /// parsing the final object file failed, or there is an error downloading the file an `Ok` with
+    /// [`CacheStatus::Malformed`] is returned.
     ///
     /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
     /// returned.
@@ -346,10 +346,10 @@ mod tests {
                 ..find_object
             };
             let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Malformed);
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
             assert_eq!(server.accesses(), 1);
             let result = objects_actor.find(find_object.clone()).await.unwrap();
-            assert_eq!(result.meta.unwrap().status, CacheStatus::Malformed);
+            assert_eq!(result.meta.unwrap().status, CacheStatus::Negative);
             assert_eq!(server.accesses(), 0);
         })
         .await;


### PR DESCRIPTION
This re-applies the changes in https://github.com/getsentry/symbolicator/pull/484, with one difference: Download failures are stored as `CacheStatus::Malformed` instead of `CacheStatus::Negative`.

This is meant to be a stopgap against repeatedly re-downloading files. A known caveat to the changes in this diff is that it is currently not possible in a cached failure to distinguish between download failures and malformed object files. A follow-up PR that attempts to address that drawback will be opened later.