### PR TITLE
Fill `CacheStatus::Malformed` with more info about the exact error

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -99,6 +99,7 @@ pub enum CacheStatus {
     Malformed(MalformedCause),
 }
 
+// Used for metrics
 impl AsRef<str> for CacheStatus {
     fn as_ref(&self) -> &str {
         match self {
@@ -268,9 +269,13 @@ impl Cache {
         // States a cache item can be in:
         // * negative/empty: An empty file. Represents a failed download. mtime is used to indicate
         //   when the failed download happened (when the file was created)
-        // * malformed: A file with the content `b"malformed"`, `b"malformedbadobject"` or
-        //   `b"malformeddownloaderror". Represents a failed symcache conversion. mtime indicates
-        //   when we attempted to convert.
+        // * malformed: A file that starts with `b"malformed"`. Its contents should be one of the
+        //   following permutations:
+        //   - `b"malformed"` + b"some error description"
+        //   - `b"malformedbadobject"` + b"some error description"
+        //   - `b"malformeddownloaderror"` + b"some error description"
+        //   Like negative/empty, it represents a failed download and mtime represents when the
+        //   failure occurred. This covers all non-400 download errors.
         // * ok (don't really have a name): File has any other content, mtime is used to keep track
         //   of last use.
         let metadata = path.metadata()?;

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -154,7 +154,7 @@ impl FetchFileRequest {
             }
             Err(DownloadError::Canceled) => {
                 log::debug!("Timed out while downloading DIF for {}", cache_key);
-                let cause = MalformedCause::DownloadError(String::from("timeout"));
+                let cause = MalformedCause::Timeout;
                 Ok(CacheStatus::Malformed(cause))
             }
             Err(err @ DownloadError::Reqwest(_)) => {

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -94,11 +94,12 @@ impl FetchFileRequest {
         let download_file = self.cache.tempfile()?;
         let cache_key = self.get_cache_key();
 
-        match self
+        let status = self
             .download_svc
             .download(self.file_source, download_file.path().to_path_buf())
-            .await
-        {
+            .await;
+
+        match status {
             Ok(DownloadStatus::NotFound) => {
                 log::debug!("No auxiliary DIF file found for {}", cache_key);
                 Ok(CacheStatus::Negative)

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -110,8 +110,9 @@ impl FetchFileRequest {
                 let mut decompressed =
                     match decompress_object_file(&download_file, decompressed_path) {
                         Ok(file) => file,
-                        Err(_) => {
-                            return Ok(CacheStatus::Malformed(MalformedCause::BadObject));
+                        Err(err) => {
+                            let cause = MalformedCause::BadObject(format!("{}", err));
+                            return Ok(CacheStatus::Malformed(cause));
                         }
                     };
 
@@ -125,7 +126,9 @@ impl FetchFileRequest {
                             let kind = self.kind.to_string();
                             metric!(counter("services.bitcode.loaderrror") += 1, "kind" => &kind);
                             log::debug!("Failed to parse bcsymbolmap: {}", err);
-                            return Ok(CacheStatus::Malformed(MalformedCause::BadObject));
+
+                            let cause = MalformedCause::BadObject(format!("{}", err));
+                            return Ok(CacheStatus::Malformed(cause));
                         }
                     }
                     AuxDifKind::UuidMap => {
@@ -133,7 +136,9 @@ impl FetchFileRequest {
                             let kind = self.kind.to_string();
                             metric!(counter("services.bitcode.loaderrror") += 1, "kind" => &kind);
                             log::debug!("Failed to parse plist: {}", err);
-                            return Ok(CacheStatus::Malformed(MalformedCause::BadObject));
+
+                            let cause = MalformedCause::BadObject(format!("{}", err));
+                            return Ok(CacheStatus::Malformed(cause));
                         }
                     }
                 }

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -13,7 +13,7 @@ use symbolic::{
 };
 use thiserror::Error;
 
-use crate::cache::{Cache, CacheKey, CacheStatus};
+use crate::cache::{Cache, CacheKey, CacheStatus, MalformedCause};
 use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
 use crate::services::objects::{
     FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
@@ -136,8 +136,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
                 let status = if let Err(e) = write_cficache(&path, &*object) {
                     log::warn!("Could not write cficache: {}", e);
                     sentry::capture_error(&e);
-
-                    CacheStatus::Malformed
+                    CacheStatus::Malformed(MalformedCause::BadObject)
                 } else {
                     CacheStatus::Positive
                 };

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -78,8 +78,8 @@ pub struct CfiCacheFile {
 
 impl CfiCacheFile {
     /// Returns the status of this cache file.
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     /// Returns the features of the object file this symcache was constructed from.
@@ -129,14 +129,14 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
             let future = async move {
-                if object.status() != CacheStatus::Positive {
-                    return Ok(object.status());
+                if object.status() != &CacheStatus::Positive {
+                    return Ok(object.status().clone());
                 }
 
                 let status = if let Err(e) = write_cficache(&path, &*object) {
                     log::warn!("Could not write cficache: {}", e);
                     sentry::capture_error(&e);
-                    CacheStatus::Malformed(MalformedCause::BadObject)
+                    CacheStatus::Malformed(MalformedCause::BadObject(format!("{}", e)))
                 } else {
                     CacheStatus::Positive
                 };
@@ -179,7 +179,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         candidates.set_unwind(
             self.meta_handle.source_id().clone(),
             &self.meta_handle.uri(),
-            ObjectUseInfo::from_derived_status(status, self.meta_handle.status()),
+            ObjectUseInfo::from_derived_status(&status, self.meta_handle.status()),
         );
 
         CfiCacheFile {

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -256,7 +256,7 @@ impl GcsDownloader {
 
                     super::download_stream(source, stream, destination, timeout).await
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from GCS {} (from {}): {}",
                         &key,
                         &bucket,
@@ -264,7 +264,7 @@ impl GcsDownloader {
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from GCS {} (from {}): {}",
                         &key,
                         &bucket,
@@ -274,7 +274,7 @@ impl GcsDownloader {
                 }
             }
             Ok(Err(e)) => {
-                log::trace!(
+                log::debug!(
                     "Skipping response from GCS {} (from {}): {} ({:?})",
                     &key,
                     &bucket,

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -207,12 +207,11 @@ impl GcsDownloader {
 
     /// Downloads a source hosted on GCS.
     ///
-    /// # Errors
-    /// - [`GcsError::InvalidUrl`]: the url was malformed and/or could not be parsed
-    /// - [`DownloadError::Reqwest`]: unable to begin streaming the source, or the initial HEAD
-    ///   request encountered an error
-    /// - [`DownloadError::Rejected`]: the initial HEAD request received a non-successful response
-    /// - [`DownloadError::Cancelled`]: the request timed out
+    /// # Directly thrown errors
+    /// - [`GcsError::InvalidUrl`]
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: GcsRemoteDif,

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -205,6 +205,14 @@ impl GcsDownloader {
         Ok(token)
     }
 
+    /// Downloads a source hosted on GCS.
+    ///
+    /// # Errors
+    /// - [`GcsError::InvalidUrl`]: the url was malformed and/or could not be parsed
+    /// - [`DownloadError::Reqwest`]: unable to begin streaming the source, or the initial HEAD
+    ///   request encountered an error
+    /// - [`DownloadError::Rejected`]: the initial HEAD request received a non-successful response
+    /// - [`DownloadError::Cancelled`]: the request timed out
     pub async fn download_source(
         &self,
         file_source: GcsRemoteDif,
@@ -248,6 +256,14 @@ impl GcsDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from GCS {} (from {}): {}",
+                        &key,
+                        &bucket,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from GCS {} (from {}): {}",
@@ -255,7 +271,7 @@ impl GcsDownloader {
                         &bucket,
                         response.status()
                     );
-                    Ok(DownloadStatus::NotFound)
+                    Err(DownloadError::Rejected(response.status()))
                 }
             }
             Ok(Err(e)) => {
@@ -266,7 +282,7 @@ impl GcsDownloader {
                     &e,
                     &e
                 );
-                Ok(DownloadStatus::NotFound)
+                Err(DownloadError::Reqwest(e))
             }
             Err(_) => {
                 // Timeout

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -68,12 +68,10 @@ impl HttpDownloader {
 
     /// Downloads a source hosted on an HTTP server.
     ///
-    /// # Errors
-    /// - [`GcsError::InvalidUrl`]: the url was malformed and/or could not be parsed
-    /// - [`DownloadError::Reqwest`]: unable to begin streaming the source, or the initial HEAD
-    ///   request encountered an error
-    /// - [`DownloadError::Rejected`]: the initial HEAD request received a non-successful response
-    /// - [`DownloadError::Cancelled`]: the request timed out
+    /// # Directly thrown errors
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: HttpRemoteDif,

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -113,14 +113,14 @@ impl HttpDownloader {
 
                     super::download_stream(source, stream, destination, timeout).await
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from {}: {}",
                         download_url,
                         response.status()
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
@@ -129,7 +129,7 @@ impl HttpDownloader {
                 }
             }
             Ok(Err(e)) => {
-                log::trace!("Skipping response from {}: {}", download_url, e);
+                log::debug!("Skipping response from {}: {}", download_url, e);
                 Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             Err(_) => {

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -38,6 +38,8 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 pub enum DownloadError {
     #[error("failed to download")]
     Io(#[source] std::io::Error),
+    /// Generally used when unable to begin streaming the source, or the initial HEAD request
+    /// encountered an error
     #[error("failed to download")]
     Reqwest(#[source] reqwest::Error),
     #[error("bad file destination")]
@@ -50,6 +52,8 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
+    /// Typically means the initial HEAD request received a non-200, non-400 response. 400s are
+    /// covered elsewhere.
     #[error("rejected by server")]
     Rejected(StatusCode),
 }

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -141,10 +141,10 @@ impl DownloadService {
             Ok(status) => {
                 match status {
                     DownloadStatus::Completed => {
-                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
+                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
                     }
                     DownloadStatus::NotFound => {
-                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
                     }
                 };
                 Ok(status)

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -54,7 +54,7 @@ pub enum DownloadError {
     Sentry(#[from] sentry::SentryError),
     /// Typically means the initial HEAD request received a non-200, non-400 response. 400s are
     /// covered elsewhere.
-    #[error("rejected by server")]
+    #[error("rejected by server ({0})")]
     Rejected(StatusCode),
 }
 
@@ -246,9 +246,9 @@ impl DownloadService {
 /// This is common functionality used by many downloaders.
 ///
 /// # Errors
-/// - [`DownloadError::BadDestination`]: could not create a file at the given destination
-/// - [`DownloadError::Write`]: unable to write a chunk of the source to the destination
-/// - [`DownloadError::Cancelled`]: stream timed out
+/// - [`DownloadError::BadDestination`]
+/// - [`DownloadError::Write`]
+/// - [`DownloadError::Canceled`]
 async fn download_stream(
     source: impl Into<RemoteDif>,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -137,6 +137,11 @@ impl S3Downloader {
         rusoto_s3::S3Client::new_with(self.http_client.clone(), provider, region)
     }
 
+    /// Downloads a source hosted on an S3 bucket.
+    ///
+    /// # Errors
+    /// - [`DownloadError::Io`]: unable to begin streaming the source
+    /// - [`DownloadError::Cancelled`]: the request timed out
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -139,9 +139,9 @@ impl S3Downloader {
 
     /// Downloads a source hosted on an S3 bucket.
     ///
-    /// # Errors
-    /// - [`DownloadError::Io`]: unable to begin streaming the source
-    /// - [`DownloadError::Cancelled`]: the request timed out
+    /// # Directly thrown errors
+    /// - [`DownloadError::Io`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -284,14 +284,14 @@ impl SentryDownloader {
 
                     super::download_stream(source, stream, destination, timeout).await
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from {}: {}",
                         download_url,
                         response.status()
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
@@ -300,7 +300,7 @@ impl SentryDownloader {
                 }
             }
             Ok(Err(e)) => {
-                log::trace!("Skipping response from {}: {}", download_url, e);
+                log::debug!("Skipping response from {}: {}", download_url, e);
                 Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             // Timed out

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -246,11 +246,10 @@ impl SentryDownloader {
 
     /// Downloads a source hosted on Sentry.
     ///
-    /// # Errors
-    /// - [`DownloadError::Reqwest`]: unable to begin streaming the source, or the initial HEAD
-    ///   request encountered an error
-    /// - [`DownloadError::Rejected`]: the initial HEAD request received a non-successful response
-    /// - [`DownloadError::Cancelled`]: the request timed out
+    /// # Directly thrown errors
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: SentryRemoteDif,

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -244,6 +244,13 @@ impl SentryDownloader {
         Ok(file_ids)
     }
 
+    /// Downloads a source hosted on Sentry.
+    ///
+    /// # Errors
+    /// - [`DownloadError::Reqwest`]: unable to begin streaming the source, or the initial HEAD
+    ///   request encountered an error
+    /// - [`DownloadError::Rejected`]: the initial HEAD request received a non-successful response
+    /// - [`DownloadError::Cancelled`]: the request timed out
     pub async fn download_source(
         &self,
         file_source: SentryRemoteDif,
@@ -277,18 +284,25 @@ impl SentryDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from {}: {}",
+                        download_url,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
                     );
-                    Ok(DownloadStatus::NotFound)
+                    Err(DownloadError::Rejected(response.status()))
                 }
             }
             Ok(Err(e)) => {
                 log::trace!("Skipping response from {}: {}", download_url, e);
-                Ok(DownloadStatus::NotFound) // must be wrong type
+                Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             // Timed out
             Err(_) => Err(DownloadError::Canceled),

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -479,7 +479,8 @@ mod tests {
                 result.meta.unwrap().status,
                 CacheStatus::Malformed(MalformedCause::Timeout)
             );
-            // Timeouts don't retry ):
+            // TODO: test out all 3 different types of timeouts, this only covers the top
+            // level timeout that spans both the HEAD and the stream portions of a download
             assert_eq!(server.accesses(), 1);
             let result = objects_actor.find(find_object.clone()).await.unwrap();
             assert_eq!(

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -70,8 +70,8 @@ impl ObjectMetaHandle {
         self.file_source.uri()
     }
 
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     pub fn scope(&self) -> &Scope {
@@ -131,7 +131,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
                         }
                     }
 
-                    Ok(object_handle.status)
+                    Ok(object_handle.status.clone())
                 })
         };
 

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -455,6 +455,9 @@ fn create_candidate_info(
                         details: details.clone(),
                     }
                 }
+                CacheStatus::Malformed(MalformedCause::Timeout) => ObjectDownloadInfo::Error {
+                    details: String::from("download timed out"),
+                },
                 CacheStatus::Malformed(MalformedCause::Unknown(details)) => {
                     ObjectDownloadInfo::Error {
                         details: details.clone(),

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -175,15 +175,31 @@ impl CfiCacheModules {
                     let cfi_status = match cfi_cache.status() {
                         CacheStatus::Positive => ObjectFileStatus::Found,
                         CacheStatus::Negative => ObjectFileStatus::Missing,
-                        CacheStatus::Malformed(MalformedCause::BadObject)
-                        | CacheStatus::Malformed(MalformedCause::Unknown) => {
+                        CacheStatus::Malformed(MalformedCause::BadObject(details)) => {
                             let err = CfiCacheError::ObjectParsing(ObjectError::Malformed);
-                            log::warn!("Error while parsing cficache: {}", LogError(&err));
+                            log::warn!(
+                                "Error while parsing cficache: {} ({})",
+                                LogError(&err),
+                                details
+                            );
                             ObjectFileStatus::from(&err)
                         }
-                        CacheStatus::Malformed(MalformedCause::DownloadError) => {
+                        CacheStatus::Malformed(MalformedCause::DownloadError(details)) => {
                             let err = CfiCacheError::Fetching(ObjectError::Malformed);
-                            log::warn!("Error while parsing cficache: {}", LogError(&err));
+                            log::warn!(
+                                "Error while parsing cficache: {} ({})",
+                                LogError(&err),
+                                details
+                            );
+                            ObjectFileStatus::from(&err)
+                        }
+                        CacheStatus::Malformed(MalformedCause::Unknown(details)) => {
+                            let err = CfiCacheError::Canceled;
+                            log::warn!(
+                                "Error while parsing cficache: {} ({})",
+                                LogError(&err),
+                                details
+                            );
                             ObjectFileStatus::from(&err)
                         }
                     };

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -193,6 +193,14 @@ impl CfiCacheModules {
                             );
                             ObjectFileStatus::from(&err)
                         }
+                        CacheStatus::Malformed(MalformedCause::Timeout) => {
+                            let err = CfiCacheError::Fetching(ObjectError::Timeout);
+                            log::warn!(
+                                "Error while parsing cficache: {} (download timed out)",
+                                LogError(&err),
+                            );
+                            ObjectFileStatus::from(&err)
+                        }
                         CacheStatus::Malformed(MalformedCause::Unknown(details)) => {
                             let err = CfiCacheError::Canceled;
                             log::warn!(

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -853,6 +853,9 @@ impl SymCacheLookup {
                     Ok(symcache) => match symcache.parse() {
                         Ok(Some(_)) => (Some(symcache), ObjectFileStatus::Found),
                         Ok(None) => (Some(symcache), ObjectFileStatus::Missing),
+                        Err(SymCacheError::Fetching(ObjectError::Malformed)) => {
+                            (Some(symcache), ObjectFileStatus::FetchingFailed)
+                        }
                         Err(e) => (None, (&e).into()),
                     },
                     Err(e) => (None, (&*e).into()),

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -105,10 +105,12 @@ impl SymCacheFile {
             )),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed(MalformedCause::BadObject(_)) => Err(SymCacheError::Malformed),
-            CacheStatus::Malformed(MalformedCause::DownloadError(_)) => {
-                Err(SymCacheError::Fetching(ObjectError::Malformed))
-            }
-            CacheStatus::Malformed(MalformedCause::Unknown(_)) => {
+            CacheStatus::Malformed(MalformedCause::DownloadError(_))
+            | CacheStatus::Malformed(MalformedCause::Timeout)
+            | CacheStatus::Malformed(MalformedCause::Unknown(_)) => {
+                // This isn't the most correct error to return but `parse()` _should_ never be
+                // invoked when the cache isn't positive to begin with. If we've gotten this far
+                // then there're bigger problems higher up in the call stack to deal with.
                 Err(SymCacheError::Fetching(ObjectError::Malformed))
             }
         }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::cache::CacheStatus;
+use crate::cache::{CacheStatus, MalformedCause};
 use crate::services::download::RemoteDifUri;
 use crate::sources::SourceId;
 
@@ -150,7 +150,11 @@ impl ObjectUseInfo {
                     ObjectUseInfo::None
                 }
             }
-            CacheStatus::Malformed => ObjectUseInfo::Malformed,
+            CacheStatus::Malformed(MalformedCause::BadObject)
+            | CacheStatus::Malformed(MalformedCause::Unknown) => ObjectUseInfo::Malformed,
+            CacheStatus::Malformed(MalformedCause::DownloadError) => ObjectUseInfo::Error {
+                details: String::from("unable to download file"),
+            },
         }
     }
 }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -156,6 +156,9 @@ impl ObjectUseInfo {
                     details: details.clone(),
                 }
             }
+            CacheStatus::Malformed(MalformedCause::Timeout) => ObjectUseInfo::Error {
+                details: String::from("Download timed out"),
+            },
             CacheStatus::Malformed(MalformedCause::Unknown(details)) => ObjectUseInfo::Error {
                 details: details.clone(),
             },

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -136,11 +136,11 @@ impl ObjectUseInfo {
     ///
     /// [`symcaches`]: crate::services::symcaches
     /// [`cficaches`]: crate::services::cficaches
-    pub fn from_derived_status(derived: CacheStatus, original: CacheStatus) -> Self {
+    pub fn from_derived_status(derived: &CacheStatus, original: &CacheStatus) -> Self {
         match derived {
             CacheStatus::Positive => ObjectUseInfo::Ok,
             CacheStatus::Negative => {
-                if original == CacheStatus::Positive {
+                if original == &CacheStatus::Positive {
                     ObjectUseInfo::Error {
                         details: String::from("Object file no longer available"),
                     }
@@ -150,10 +150,14 @@ impl ObjectUseInfo {
                     ObjectUseInfo::None
                 }
             }
-            CacheStatus::Malformed(MalformedCause::BadObject)
-            | CacheStatus::Malformed(MalformedCause::Unknown) => ObjectUseInfo::Malformed,
-            CacheStatus::Malformed(MalformedCause::DownloadError) => ObjectUseInfo::Error {
-                details: String::from("unable to download file"),
+            CacheStatus::Malformed(MalformedCause::BadObject(_)) => ObjectUseInfo::Malformed,
+            CacheStatus::Malformed(MalformedCause::DownloadError(details)) => {
+                ObjectUseInfo::Error {
+                    details: details.clone(),
+                }
+            }
+            CacheStatus::Malformed(MalformedCause::Unknown(details)) => ObjectUseInfo::Error {
+                details: details.clone(),
             },
         }
     }


### PR DESCRIPTION
Malformed is now overloaded to mean both malformed object/debug file and download error. This is a first shot at trying to add in a way to distinguish between the two. This is mostly a POC and is fairly messy, dirty code.