### PR TITLE
Introduce a dedicated cache status for download errors

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -226,7 +226,7 @@ impl Cache {
 
         log::trace!("File length: {}", metadata.len());
 
-        let is_malformed = if MALFORMED_MARKER.len() as u64 == metadata.len() {
+        let is_malformed = if metadata.len() == MALFORMED_MARKER.len() as u64 {
             let mut file = File::open(path)?;
             let mut buf = vec![0; MALFORMED_MARKER.len()];
             file.read_exact(&mut buf)?;
@@ -237,7 +237,7 @@ impl Cache {
             false
         };
 
-        let is_download_error = if DOWNLOAD_ERROR_MARKER.len() as u64 == metadata.len() {
+        let is_download_error = if metadata.len() == DOWNLOAD_ERROR_MARKER.len() as u64 {
             let mut file = File::open(path)?;
             let mut buf = vec![0; DOWNLOAD_ERROR_MARKER.len()];
             file.read_exact(&mut buf)?;

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -95,13 +95,19 @@ impl FetchFileRequest {
         match self
             .download_svc
             .download(self.file_source, download_file.path().to_path_buf())
-            .await?
+            .await
         {
-            DownloadStatus::NotFound => {
+            Err(_download_error) => {
+                log::debug!("Unable to download DIF for {}", cache_key);
+                // TODO: stuff download error message in
+                // let error_msg = format!("{}", download_error);
+                Ok(CacheStatus::DownloadError)
+            }
+            Ok(DownloadStatus::NotFound) => {
                 log::debug!("No auxiliary DIF file found for {}", cache_key);
                 Ok(CacheStatus::Negative)
             }
-            DownloadStatus::Completed => {
+            Ok(DownloadStatus::Completed) => {
                 let download_dir = download_file
                     .path()
                     .parent()

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -186,9 +186,11 @@ impl<T: CacheItemRequest> Cacher<T> {
         }
 
         // This is also reported for "negative cache hits": When we cached the 404 response from a
-        // server as empty file.
+        // server as empty file, as well as other download errors.
         metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
         metric!(
+            // TODO: what does it mean when this is a cache status that wraps around variable length
+            // content? should we fix these to just the marker length if this is Malformed and DownloadError?
             time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
             "hit" => "true"
         );

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -189,8 +189,6 @@ impl<T: CacheItemRequest> Cacher<T> {
         // server as empty file, as well as other download errors.
         metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
         metric!(
-            // TODO: what does it mean when this is a cache status that wraps around variable length
-            // content? should we fix these to just the marker length if this is Malformed and DownloadError?
             time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
             "hit" => "true"
         );

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -78,8 +78,8 @@ pub struct CfiCacheFile {
 
 impl CfiCacheFile {
     /// Returns the status of this cache file.
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     /// Returns the features of the object file this symcache was constructed from.
@@ -129,8 +129,8 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
             let future = async move {
-                if object.status() != CacheStatus::Positive {
-                    return Ok(object.status());
+                if object.status() != &CacheStatus::Positive {
+                    return Ok(object.status().clone());
                 }
 
                 let status = if let Err(e) = write_cficache(&path, &*object) {
@@ -183,7 +183,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         candidates.set_unwind(
             self.meta_handle.source_id().clone(),
             &self.meta_handle.uri(),
-            ObjectUseInfo::from_derived_status(status, self.meta_handle.status()),
+            ObjectUseInfo::from_derived_status(&status, self.meta_handle.status()),
         );
 
         CfiCacheFile {

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -136,7 +136,10 @@ impl CacheItemRequest for FetchCfiCacheInternal {
                 let status = if let Err(e) = write_cficache(&path, &*object) {
                     log::warn!("Could not write cficache: {}", e);
                     sentry::capture_error(&e);
-
+                    // Cheating a little here: Even though this is a `CfiCacheError` which includes
+                    // variants not related to conversion, `write_cficache` only does work related
+                    // to conversion and therefore any error captured by this is due to the
+                    // conversion process failing. Marking those errors as Malformed is fine.
                     CacheStatus::Malformed
                 } else {
                     CacheStatus::Positive

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -205,6 +205,13 @@ impl GcsDownloader {
         Ok(token)
     }
 
+    /// Downloads a source hosted on GCS.
+    ///
+    /// # Directly thrown errors
+    /// - [`GcsError::InvalidUrl`]
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: GcsRemoteDif,
@@ -248,6 +255,15 @@ impl GcsDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                // If it's a client error, chances are either it's a 404 or it's permission-related.
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from GCS {} (from {}): {}",
+                        &key,
+                        &bucket,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from GCS {} (from {}): {}",
@@ -255,7 +271,7 @@ impl GcsDownloader {
                         &bucket,
                         response.status()
                     );
-                    Ok(DownloadStatus::NotFound)
+                    Err(DownloadError::Rejected(response.status()))
                 }
             }
             Ok(Err(e)) => {
@@ -266,7 +282,7 @@ impl GcsDownloader {
                     &e,
                     &e
                 );
-                Ok(DownloadStatus::NotFound)
+                Err(DownloadError::Reqwest(e))
             }
             Err(_) => {
                 // Timeout

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -66,6 +66,12 @@ impl HttpDownloader {
         }
     }
 
+    /// Downloads a source hosted on an HTTP server.
+    ///
+    /// # Directly thrown errors
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: HttpRemoteDif,
@@ -106,18 +112,26 @@ impl HttpDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                // If it's a client error, chances are either it's a 404 or it's permission-related.
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from {}: {}",
+                        download_url,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
                     );
-                    Ok(DownloadStatus::NotFound)
+                    Err(DownloadError::Rejected(response.status()))
                 }
             }
             Ok(Err(e)) => {
                 log::trace!("Skipping response from {}: {}", download_url, e);
-                Ok(DownloadStatus::NotFound) // must be wrong type
+                Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             Err(_) => {
                 // Timeout

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use ::sentry::{Hub, SentryFutureExt};
 use futures::prelude::*;
+use reqwest::StatusCode;
 use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -37,6 +38,8 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 pub enum DownloadError {
     #[error("failed to download")]
     Io(#[source] std::io::Error),
+    /// Generally used when unable to begin streaming the source, or the initial HEAD request
+    /// encountered an error
     #[error("failed to download")]
     Reqwest(#[source] reqwest::Error),
     #[error("bad file destination")]
@@ -49,6 +52,10 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
+    /// Typically means the initial HEAD request received a non-200, non-400 response. 400s are
+    /// covered elsewhere.
+    #[error("failed to download")]
+    Rejected(StatusCode),
 }
 
 /// Completion status of a successful download request.
@@ -131,16 +138,15 @@ impl DownloadService {
         });
 
         match result.await {
-            Ok(DownloadStatus::NotFound) => {
-                log::debug!(
-                    "Did not fetch debug file from {:?}: {:?}",
-                    source,
-                    DownloadStatus::NotFound
-                );
-                Ok(DownloadStatus::NotFound)
-            }
             Ok(status) => {
-                log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                match status {
+                    DownloadStatus::Completed => {
+                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
+                    }
+                    DownloadStatus::NotFound => {
+                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                    }
+                };
                 Ok(status)
             }
             Err(err) => {
@@ -238,6 +244,11 @@ impl DownloadService {
 /// Download the source from a stream.
 ///
 /// This is common functionality used by many downloaders.
+///
+/// # Errors
+/// - [`DownloadError::BadDestination`]
+/// - [`DownloadError::Write`]
+/// - [`DownloadError::Cancelled`]
 async fn download_stream(
     source: impl Into<RemoteDif>,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -147,10 +147,10 @@ impl DownloadService {
             Ok(status) => {
                 match status {
                     DownloadStatus::Completed => {
-                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
+                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
                     }
                     DownloadStatus::NotFound => {
-                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
                     }
                 };
                 Ok(status)
@@ -254,7 +254,7 @@ impl DownloadService {
 /// # Errors
 /// - [`DownloadError::BadDestination`]
 /// - [`DownloadError::Write`]
-/// - [`DownloadError::Cancelled`]
+/// - [`DownloadError::Canceled`]
 async fn download_stream(
     source: impl Into<RemoteDif>,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -52,7 +52,9 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
-    /// Typically means the initial HEAD request received a non-200, non-400 response. 400s are
+    #[error("failed to fetch data from S3")]
+    S3(#[source] s3::S3Error),
+    /// Typically means the initial HEAD request received a non-200 or non-400 response. 400s are
     /// covered elsewhere.
     #[error("failed to download")]
     Rejected(StatusCode),

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -36,6 +36,10 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 /// Errors happening while downloading from sources.
 #[derive(Debug, Error)]
 pub enum DownloadError {
+    // A download failure retrieved from cache
+    #[error("failed to download")]
+    // TODO: wrap around a string and return that instead
+    CachedFailure,
     #[error("failed to download")]
     Io(#[source] std::io::Error),
     /// Generally used when unable to begin streaming the source, or the initial HEAD request

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -145,6 +145,7 @@ impl S3Downloader {
     /// # Directly thrown errors
     /// - [`DownloadError::Io`]
     /// - [`DownloadError::Canceled`]
+    /// - [`DownloadError::S3`]
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -137,6 +137,11 @@ impl S3Downloader {
         rusoto_s3::S3Client::new_with(self.http_client.clone(), provider, region)
     }
 
+    /// Downloads a source hosted on an S3 bucket.
+    ///
+    /// # Directly thrown errors
+    /// - [`DownloadError::Io`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,
@@ -164,7 +169,7 @@ impl S3Downloader {
                 // For missing files, Amazon returns different status codes based on the given
                 // permissions.
                 // - To fetch existing objects, `GetObject` is required.
-                // - If `ListBucket` is premitted, a 404 is returned for missing objects.
+                // - If `ListBucket` is permitted, a 404 is returned for missing objects.
                 // - Otherwise, a 403 ("access denied") is returned.
                 log::debug!("Skipping response from s3://{}/{}: {}", bucket, &key, err);
                 return Ok(DownloadStatus::NotFound);

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 
 use futures::TryStreamExt;
 use parking_lot::Mutex;
-use rusoto_s3::S3;
+use rusoto_core::RusotoError;
+use rusoto_s3::{GetObjectError, S3};
 
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region::Region;
@@ -86,6 +87,8 @@ impl fmt::Debug for S3Downloader {
             .finish()
     }
 }
+
+pub type S3Error = RusotoError<GetObjectError>;
 
 impl S3Downloader {
     pub fn new(connect_timeout: Duration, streaming_timeout: Duration) -> Self {
@@ -172,7 +175,12 @@ impl S3Downloader {
                 // - If `ListBucket` is permitted, a 404 is returned for missing objects.
                 // - Otherwise, a 403 ("access denied") is returned.
                 log::debug!("Skipping response from s3://{}/{}: {}", bucket, &key, err);
-                return Ok(DownloadStatus::NotFound);
+
+                if matches!(err, RusotoError::Service(_)) {
+                    return Ok(DownloadStatus::NotFound);
+                } else {
+                    return Err(DownloadError::S3(err));
+                }
             }
             Err(_) => {
                 // Timed out

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -244,6 +244,12 @@ impl SentryDownloader {
         Ok(file_ids)
     }
 
+    /// Downloads a source hosted on Sentry.
+    ///
+    /// # Directly thrown errors
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: SentryRemoteDif,
@@ -277,18 +283,26 @@ impl SentryDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                // If it's a client error, chances are either it's a 404 or it's permission-related.
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from {}: {}",
+                        download_url,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
                     );
-                    Ok(DownloadStatus::NotFound)
+                    Err(DownloadError::Rejected(response.status()))
                 }
             }
             Ok(Err(e)) => {
                 log::trace!("Skipping response from {}: {}", download_url, e);
-                Ok(DownloadStatus::NotFound) // must be wrong type
+                Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             // Timed out
             Err(_) => Err(DownloadError::Canceled),

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -133,12 +133,16 @@ impl CacheItemRequest for FetchFileDataRequest {
     /// debug ID of our request is extracted first.  Finally the object is parsed with
     /// symbolic to ensure it is not malformed.
     ///
-    /// If there is an error decompression then an `Err` of [`ObjectError`] is returned.  If the
-    /// parsing the final object file failed, or there is an error downloading the file an `Ok` with
-    /// [`CacheStatus::Malformed`] is returned.
+    /// If there is an error during decompression then an `Err` of [`ObjectError`] is returned.
     ///
-    /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
+    /// If parsing the final object file failed, an `Ok` with [`CacheStatus::Malformed`] is
     /// returned.
+    ///
+    /// If there is an error downloading the object file, an `Ok` with [`CacheStatus::Error`] is
+    /// returned.
+    ///
+    /// If the object file did not exist on the source an `Ok` with [`CacheStatus::Negative`] will
+    /// be returned.
     fn compute(&self, path: &Path) -> BoxedFuture<Result<CacheStatus, Self::Error>> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file data for {}", cache_key);

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -68,6 +68,8 @@ impl ObjectHandle {
         self.status == CacheStatus::Positive
     }
 
+    // Interestingly all usages of parse() check to make sure that self.status == Positive before
+    // actually invoking parse()
     pub fn parse(&self) -> Result<Option<Object<'_>>, ObjectError> {
         match self.status {
             CacheStatus::Positive => Ok(Some(Object::parse(&self.data)?)),

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -70,8 +70,8 @@ impl ObjectMetaHandle {
         self.file_source.uri()
     }
 
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     pub fn scope(&self) -> &Scope {
@@ -130,7 +130,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
                         }
                     }
 
-                    Ok(object_handle.status)
+                    Ok(object_handle.status.clone())
                 })
         };
 

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -43,6 +43,7 @@ impl fmt::Display for ObjectError {
         write!(f, "ObjectError: ")?;
         match self {
             ObjectError::Io(_, _) => write!(f, "failed to download (I/O error)")?,
+            // TODO: does this overwrite the inner error's display string?
             ObjectError::Download(_) => write!(f, "failed to download")?,
             ObjectError::Persisting(_) => write!(f, "failed persisting data")?,
             ObjectError::NoTempDir => write!(f, "unable to get directory for tempfiles")?,
@@ -324,7 +325,7 @@ impl ObjectsActor {
     }
 }
 
-/// Select the best [ObjectMetaHandle`] out of all lookups from the meta-cache.
+/// Select the best [`ObjectMetaHandle`] out of all lookups from the meta-cache.
 ///
 /// The lookups are expected to be in order or preference, so if two files are equally good
 /// the first one will be chosen.  If the file list is emtpy, `None` is returned in the
@@ -394,6 +395,8 @@ fn object_has_features(meta_handle: &ObjectMetaHandle, purpose: ObjectPurpose) -
             ObjectPurpose::Source => meta_handle.features.has_sources,
         }
     } else {
+        // TODO: shouldn't this be false if the cache status isn't positive? it has no features, not
+        // some features?
         true
     }
 }
@@ -447,6 +450,10 @@ fn create_candidate_info(
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed => ObjectDownloadInfo::Malformed,
+                CacheStatus::DownloadError => ObjectDownloadInfo::Error {
+                    // TODO: add download error
+                    details: String::from("add download error to this later"),
+                },
             };
             ObjectCandidate {
                 source: meta_handle.file_source.source_id().clone(),

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -444,15 +444,14 @@ fn create_candidate_info(
 ) -> ObjectCandidate {
     match meta_lookup {
         Ok(meta_handle) => {
-            let download = match meta_handle.status {
+            let download = match &meta_handle.status {
                 CacheStatus::Positive => ObjectDownloadInfo::Ok {
                     features: meta_handle.features(),
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed => ObjectDownloadInfo::Malformed,
-                CacheStatus::DownloadError => ObjectDownloadInfo::Error {
-                    // TODO: add download error
-                    details: String::from("add download error to this later"),
+                CacheStatus::DownloadError(err_msg) => ObjectDownloadInfo::Error {
+                    details: err_msg.clone(),
                 },
             };
             ObjectCandidate {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -187,7 +187,7 @@ impl CfiCacheModules {
                         }
                         // This is only ever found in cfi caches if the underlying object in the
                         // data cache has a download error
-                        CacheStatus::DownloadError => ObjectFileStatus::FetchingFailed,
+                        CacheStatus::DownloadError(_) => ObjectFileStatus::FetchingFailed,
                     };
                     let cfi_path = match cfi_cache.status() {
                         CacheStatus::Positive => Some(cfi_cache.path().to_owned()),
@@ -840,7 +840,7 @@ impl SymCacheLookup {
                         Ok(Some(_)) => (Some(symcache), ObjectFileStatus::Found),
                         Ok(None) => (Some(symcache), ObjectFileStatus::Missing),
                         Err(SymCacheError::Fetching(ObjectError::Download(
-                            DownloadError::CachedFailure,
+                            DownloadError::CachedFailure(_),
                         ))) => (Some(symcache), ObjectFileStatus::FetchingFailed),
                         Err(e) => (None, (&e).into()),
                     },

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -184,6 +184,10 @@ async fn fetch_difs_and_compute_symcache(
             Err(err) => {
                 log::warn!("Failed to write symcache: {}", err);
                 sentry::capture_error(&err);
+                // Cheating a little here: Even though this is a `SymCacheError` which includes
+                // variants not related to conversion, `write_symcache` only does work related
+                // to conversion and therefore any error captured by this is due to the conversion
+                // process failing. Marking those errors as Malformed is fine.
                 CacheStatus::Malformed
             }
         };

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -27,6 +27,8 @@ use crate::types::{
 use crate::utils::futures::{BoxedFuture, ThreadPool};
 use crate::utils::sentry::ConfigureScope;
 
+use super::download::DownloadError;
+
 /// This marker string is appended to symcaches to indicate that they were created using a `BcSymbolMap`.
 const SYMBOLMAP_MARKER: &[u8] = b"WITH_SYMBOLMAP";
 
@@ -105,6 +107,9 @@ impl SymCacheFile {
             )),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(SymCacheError::Malformed),
+            CacheStatus::DownloadError => Err(SymCacheError::Fetching(ObjectError::Download(
+                DownloadError::CachedFailure,
+            ))),
         }
     }
 

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -150,7 +150,10 @@ impl ObjectUseInfo {
                     ObjectUseInfo::None
                 }
             }
+            // If the original wasn't malformed to begin with but the derived caches are, does that
+            // necessarily mean that the object was unusable?
             CacheStatus::Malformed => ObjectUseInfo::Malformed,
+            // derived == DownloadError and original != DownloadError should never happen
             CacheStatus::DownloadError => ObjectUseInfo::Error {
                 // TODO: add download error
                 details: String::from("add download error to this later"),

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -151,6 +151,10 @@ impl ObjectUseInfo {
                 }
             }
             CacheStatus::Malformed => ObjectUseInfo::Malformed,
+            CacheStatus::DownloadError => ObjectUseInfo::Error {
+                // TODO: add download error
+                details: String::from("add download error to this later"),
+            },
         }
     }
 }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -136,11 +136,11 @@ impl ObjectUseInfo {
     ///
     /// [`symcaches`]: crate::services::symcaches
     /// [`cficaches`]: crate::services::cficaches
-    pub fn from_derived_status(derived: CacheStatus, original: CacheStatus) -> Self {
+    pub fn from_derived_status(derived: &CacheStatus, original: &CacheStatus) -> Self {
         match derived {
             CacheStatus::Positive => ObjectUseInfo::Ok,
             CacheStatus::Negative => {
-                if original == CacheStatus::Positive {
+                if original == &CacheStatus::Positive {
                     ObjectUseInfo::Error {
                         details: String::from("Object file no longer available"),
                     }
@@ -154,9 +154,8 @@ impl ObjectUseInfo {
             // necessarily mean that the object was unusable?
             CacheStatus::Malformed => ObjectUseInfo::Malformed,
             // derived == DownloadError and original != DownloadError should never happen
-            CacheStatus::DownloadError => ObjectUseInfo::Error {
-                // TODO: add download error
-                details: String::from("add download error to this later"),
+            CacheStatus::DownloadError(err_msg) => ObjectUseInfo::Error {
+                details: err_msg.clone(),
             },
         }
     }


### PR DESCRIPTION
Proof of concept. Meant to be a point of comparison against #502's changes. Things left to be done:

- ~~Stuffing a human-readable error into the new cache status~~
- ~~Reading and writing the human readable error into the cache file~~
- ~~Update integration tests to expect the right error details instead of the placeholder~~