### PR TITLE
fix: prevent useless recompilations

### DIFF
--- a/crates/symbolicator/build.rs
+++ b/crates/symbolicator/build.rs
@@ -17,7 +17,7 @@ fn emit_version_var() -> Result<(), io::Error> {
     let ver = String::from_utf8_lossy(&cmd.stdout);
 
     println!("cargo:rustc-env=SYMBOLICATOR_GIT_VERSION={}", ver);
-    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=SYMBOLICATOR_GIT_VERSION");
 
     Ok(())
 }
@@ -38,7 +38,7 @@ fn emit_release_var() -> Result<(), io::Error> {
     let ver = String::from_utf8_lossy(&cmd.stdout);
 
     println!("cargo:rustc-env=SYMBOLICATOR_RELEASE={}", ver);
-    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=SYMBOLICATOR_RELEASE");
 
     Ok(())
 }


### PR DESCRIPTION
By moving the crate into `crates` the build script now no longer finds the git index and recompiles permanently. The better way to prevent this is to use `rerun-if-env-changed`.

#skip-changelog