### PR TITLE
fix: Avoid serializing minidumps over procspawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Internal
 
 - Measure how long it takes to download sources from external servers. ([#483](https://github.com/getsentry/symbolicator/pull/483))
+- Avoid serialization overhead when processing large minidumps out-of-process. ([#508](https://github.com/getsentry/symbolicator/pull/508))
 
 ## 0.3.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,6 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2"
@@ -3619,7 +3616,6 @@ dependencies = [
  "apple-crash-report-parser",
  "backtrace",
  "base64 0.13.0",
- "bytes 1.0.1",
  "cadence",
  "chrono",
  "console",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.38"
 apple-crash-report-parser = "0.4.2"
 backtrace = "0.3.55"
 base64 = "0.13.0"
-bytes = { version = "1.0.1", features = ["serde"] }
 cadence = "0.25.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 console = "0.14.0"

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -32,7 +32,11 @@ async fn handle_apple_crash_report_request(
 
         let content_disposition = field.content_disposition();
         match content_disposition.as_ref().and_then(|d| d.get_name()) {
-            Some("apple_crash_report") => report = Some(read_multipart_file(field).await?),
+            Some("apple_crash_report") => {
+                let mut report_file = tempfile::tempfile()?;
+                read_multipart_file(field, &mut report_file).await?;
+                report = Some(report_file)
+            }
             Some("sources") => sources = read_multipart_sources(field).await?.into(),
             Some("options") => options = read_multipart_request_options(field).await?,
             _ => (), // Always ignore unknown fields.

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -33,10 +33,13 @@ async fn handle_minidump_request(
         let content_disposition = field.content_disposition();
         match content_disposition.as_ref().and_then(|d| d.get_name()) {
             Some("upload_file_minidump") => {
-                let minidump_file = tempfile::Builder::new()
-                    .prefix("minidump")
-                    .suffix(".dmp")
-                    .tempfile()?;
+                let mut minidump_file = tempfile::Builder::new();
+                minidump_file.prefix("minidump").suffix(".dmp");
+                let minidump_file = if let Some(tmp_dir) = state.config().cache_dir("tmp") {
+                    minidump_file.tempfile_in(tmp_dir)
+                } else {
+                    minidump_file.tempfile()
+                }?;
                 let (mut file, temp_path) = minidump_file.into_parts();
 
                 read_multipart_file(field, &mut file).await?;

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2284,7 +2284,7 @@ mod tests {
 
     use crate::config::Config;
     use crate::services::Service;
-    use crate::test;
+    use crate::test::{self, fixture};
 
     /// Setup tests and create a test service.
     ///
@@ -2520,7 +2520,7 @@ mod tests {
         let (service, _cache_dir) = setup_service();
         let (_symsrv, source) = test::symbol_server();
 
-        let report_file = std::fs::File::open("apple_crash_report.txt")?;
+        let report_file = std::fs::File::open(fixture("apple_crash_report.txt"))?;
         let response = test::spawn_compat(move || async move {
             let request_id = service.symbolication().process_apple_crash_report(
                 Scope::Global,

--- a/crates/symbolicator/src/utils/multipart.rs
+++ b/crates/symbolicator/src/utils/multipart.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::Write;
+use std::io::{Seek, SeekFrom, Write};
 
 use actix_web::{dev::Payload, error, multipart, Error};
 use futures::{compat::Stream01CompatExt, StreamExt};
@@ -41,6 +41,7 @@ pub async fn read_multipart_file(
     while let Some(chunk) = stream.next().await {
         file.write_all(&chunk?)?;
     }
+    file.seek(SeekFrom::Start(0))?;
 
     Ok(())
 }


### PR DESCRIPTION
Instead of passing (and serializing) a byte buffer to procspawn, this will rather create a tempfile and pass that path via procspawn.

This seems to be a small win when processing a 20M minidump, though note that I was timing `cargo run -p process-event` so timings include overhead from both cargo and uploading of the minidump.

before:
  Time (mean ± σ):      1.611 s ±  0.041 s    [User: 274.8 ms, System: 102.0 ms]
  Range (min … max):    1.548 s …  1.697 s    10 runs
after:
  Time (mean ± σ):      1.526 s ±  0.024 s    [User: 275.7 ms, System: 101.5 ms]
  Range (min … max):    1.496 s …  1.573 s    10 runs

Due to some error handling and borrowcheck shenanigans, the minidumps are now persisted in the diagnostics cache for *all* errors during processing, while previously timeouts were ignored.