### PR TITLE
feat(cache): Add a new cache status `CacheSpecificError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
 - Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484), [#501](https://github.com/getsentry/symbolicator/pull/501))
 - New configuration option `hostname_tag` ([#513](https://github.com/getsentry/symbolicator/pull/513))
+- Introduced a new cache status to represent download failures that aren't related to the file being missing. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Refresh symcaches when a new `BcSymbolMap` becomes available. ([#493](https://github.com/getsentry/symbolicator/pull/493))
 - Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484), [#501](https://github.com/getsentry/symbolicator/pull/501))
 - New configuration option `hostname_tag` ([#513](https://github.com/getsentry/symbolicator/pull/513))
-- Introduced a new cache status to represent download failures that aren't related to the file being missing. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
+- Introduced a new cache status to represent failures specific to the cache: Download failures that aren't related to the file being missing in download caches and conversion errors in derived caches. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
 
 ### Fixes
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -327,8 +327,8 @@ impl From<CacheStatus> for ExpirationStrategy {
         match status {
             CacheStatus::Positive => Self::None,
             CacheStatus::Negative => Self::Negative,
-            CacheStatus::Malformed(_) => Self::Malformed,
-            CacheStatus::DownloadError(_) => Self::Malformed,
+            CacheStatus::Malformed => Self::Malformed,
+            CacheStatus::DownloadError => Self::Malformed,
         }
     }
 }
@@ -678,6 +678,10 @@ mod tests {
 
         File::create(tempdir.path().join("foo/killthis"))?.write_all(b"malformed")?;
         File::create(tempdir.path().join("foo/killthis2"))?.write_all(b"malformedhonk")?;
+        File::create(tempdir.path().join("foo/killthis3"))?.write_all(b"dlerr")?;
+        File::create(tempdir.path().join("foo/killthis4"))?.write_all(b"dlerrhonk")?;
+        File::create(tempdir.path().join("foo/killthis5"))?.write_all(b"dlerrmalformed")?;
+        File::create(tempdir.path().join("foo/killthis6"))?.write_all(b"malformeddlerr")?;
 
         sleep(Duration::from_millis(10));
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -50,7 +50,7 @@ pub enum CacheStatus {
     /// encountered an error while downloading a file. See docs for [`MALFORMED_MARKER`].
     Malformed,
     /// Currently unused. All cache statuses detected as this variant will be converted to
-    /// [`CacheStatus::Malformed`].
+    /// [`CacheStatus::Malformed`].  See docs for [`DOWNLOAD_ERROR_MARKER`].
     #[allow(dead_code)]
     DownloadError,
 }

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -72,6 +72,7 @@ impl ObjectHandle {
             CacheStatus::Positive => Ok(Some(Object::parse(&self.data)?)),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(ObjectError::Malformed),
+            CacheStatus::DownloadError => Err(ObjectError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -72,7 +72,7 @@ impl ObjectHandle {
             CacheStatus::Positive => Ok(Some(Object::parse(&self.data)?)),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(ObjectError::Malformed),
-            CacheStatus::DownloadError => Err(ObjectError::Malformed),
+            CacheStatus::CacheSpecificError => Err(ObjectError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -447,6 +447,7 @@ fn create_candidate_info(
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed => ObjectDownloadInfo::Malformed,
+                CacheStatus::DownloadError => ObjectDownloadInfo::Malformed,
             };
             ObjectCandidate {
                 source: meta_handle.file_source.source_id().clone(),

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -447,7 +447,7 @@ fn create_candidate_info(
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed => ObjectDownloadInfo::Malformed,
-                CacheStatus::DownloadError => ObjectDownloadInfo::Malformed,
+                CacheStatus::CacheSpecificError => ObjectDownloadInfo::Malformed,
             };
             ObjectCandidate {
                 source: meta_handle.file_source.source_id().clone(),

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -180,7 +180,7 @@ impl CfiCacheModules {
                             log::warn!("Error while parsing cficache: {}", LogError(&err));
                             ObjectFileStatus::from(&err)
                         }
-                        CacheStatus::DownloadError => ObjectFileStatus::Malformed,
+                        CacheStatus::CacheSpecificError => ObjectFileStatus::Malformed,
                     };
                     let cfi_path = match cfi_cache.status() {
                         CacheStatus::Positive => Some(cfi_cache.path().to_owned()),

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -180,6 +180,7 @@ impl CfiCacheModules {
                             log::warn!("Error while parsing cficache: {}", LogError(&err));
                             ObjectFileStatus::from(&err)
                         }
+                        CacheStatus::DownloadError => ObjectFileStatus::Malformed,
                     };
                     let cfi_path = match cfi_cache.status() {
                         CacheStatus::Positive => Some(cfi_cache.path().to_owned()),

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -105,7 +105,7 @@ impl SymCacheFile {
             )),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(SymCacheError::Malformed),
-            CacheStatus::DownloadError => Err(SymCacheError::Malformed),
+            CacheStatus::CacheSpecificError => Err(SymCacheError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -105,6 +105,7 @@ impl SymCacheFile {
             )),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed => Err(SymCacheError::Malformed),
+            CacheStatus::DownloadError => Err(SymCacheError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -151,6 +151,7 @@ impl ObjectUseInfo {
                 }
             }
             CacheStatus::Malformed => ObjectUseInfo::Malformed,
+            CacheStatus::DownloadError => ObjectUseInfo::Malformed,
         }
     }
 }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -151,7 +151,7 @@ impl ObjectUseInfo {
                 }
             }
             CacheStatus::Malformed => ObjectUseInfo::Malformed,
-            CacheStatus::DownloadError => ObjectUseInfo::Malformed,
+            CacheStatus::CacheSpecificError => ObjectUseInfo::Malformed,
         }
     }
 }


### PR DESCRIPTION
This is the start of a series of PRs whose end goal is to allow symbolicator to separate download errors from IO and conversion errors. The end goal is to be able to apply different expiration strategies and include additional diagnostic information to these entries in order to make it easier to debug why a source file might be missing. 

The PRs are being broken down as follows:
1. 👉 Introduce the new cache status without changing the existing functionality, convert the new status to Malformed if needed (#509) 👈 you are here
2. Extend both the new cache status and the Malformed cache status to accept an arbitrary string that describes the root cause of the issue (#510)
3. Identify and split out code paths that should be using the new cache status without changing their return value (#511)
4. Begin actually using the new cache status by returning it in places identified in the previous step and writing + reading those to and from the cache (#512)

Each PR incrementally builds upon the changes of the previous one, but is split up in a way to make it easy to revert an entire PR's changes without breaking the cache.

Currently download (most non-400s) and conversion are both stored as Malformed cache entries, and this is a proposal to create a dedicated cache status to represent these download errors. There are a certain set of errors where the file is known to be present, but have failed to download due to transient/ephemeral errors during the download process. This PR makes no functional changes to symbolicator.