### PR TITLE
feat(cache): Stuff error messages into `Malformed` and `CacheSpecificError` cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484), [#501](https://github.com/getsentry/symbolicator/pull/501))
 - New configuration option `hostname_tag` ([#513](https://github.com/getsentry/symbolicator/pull/513))
 - Introduced a new cache status to represent failures specific to the cache: Download failures that aren't related to the file being missing in download caches and conversion errors in derived caches. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
+- Malformed and Cache-specific Error cache entries now contain some diagnostic info. ([#510](https://github.com/getsentry/symbolicator/pull/510))
 
 ### Fixes
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -41,7 +41,7 @@ pub const MALFORMED_MARKER: &[u8] = b"malformed";
 /// are covered by the negative cache state.
 pub const CACHE_SPECIFIC_ERROR_MARKER: &[u8] = b"cachespecificerror";
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum CacheStatus {
     /// A cache item that represents the presence of something. E.g. we succeeded in downloading an
     /// object file and cached that file.
@@ -51,7 +51,7 @@ pub enum CacheStatus {
     Negative,
     /// We are unable to create or use the cache item. E.g. we failed to create a symcache, or
     /// encountered an error while downloading a file. See docs for [`MALFORMED_MARKER`].
-    Malformed,
+    Malformed(String),
     /// Currently unused. All cache statuses detected as this variant will be converted to
     /// [`CacheStatus::Malformed`].  See docs for [`CACHE_SPECIFIC_ERROR_MARKER`].
     #[allow(dead_code)]
@@ -63,7 +63,7 @@ impl AsRef<str> for CacheStatus {
         match self {
             CacheStatus::Positive => "positive",
             CacheStatus::Negative => "negative",
-            CacheStatus::Malformed => "malformed",
+            CacheStatus::Malformed(_) => "malformed",
             CacheStatus::CacheSpecificError => "cache-specific error",
         }
     }
@@ -71,8 +71,14 @@ impl AsRef<str> for CacheStatus {
 
 impl CacheStatus {
     pub fn from_content(s: &[u8]) -> CacheStatus {
-        if s.starts_with(MALFORMED_MARKER) || s.starts_with(CACHE_SPECIFIC_ERROR_MARKER) {
-            CacheStatus::Malformed
+        if s.starts_with(MALFORMED_MARKER) {
+            let raw_message = s.get(MALFORMED_MARKER.len()..).unwrap_or_default();
+            let err_msg = String::from_utf8_lossy(raw_message);
+            CacheStatus::Malformed(err_msg.into_owned())
+        } else if s.starts_with(CACHE_SPECIFIC_ERROR_MARKER) {
+            CacheStatus::Malformed(String::from(
+                "failed to create entry due to a cache-specific problem",
+            ))
         } else if s.is_empty() {
             CacheStatus::Negative
         } else {
@@ -85,7 +91,7 @@ impl CacheStatus {
     /// If the status was [`CacheStatus::Positive`] this copies the data from the temporary
     /// file to the final cache location.  Otherwise it writes corresponding marker in the
     /// cache location.
-    pub fn persist_item(self, path: &Path, file: NamedTempFile) -> Result<(), io::Error> {
+    pub fn persist_item(&self, path: &Path, file: NamedTempFile) -> Result<(), io::Error> {
         let dir = path.parent().ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "no parent directory to persist item")
         })?;
@@ -97,9 +103,10 @@ impl CacheStatus {
             CacheStatus::Negative => {
                 File::create(path)?;
             }
-            CacheStatus::Malformed => {
+            CacheStatus::Malformed(details) => {
                 let mut f = File::create(path)?;
                 f.write_all(MALFORMED_MARKER)?;
+                f.write_all(details.as_bytes())?;
             }
             CacheStatus::CacheSpecificError => {
                 let mut f = File::create(path)?;
@@ -339,7 +346,7 @@ fn expiration_strategy(cache_config: &CacheConfig, path: &Path) -> io::Result<Ex
     let strategy = match CacheStatus::from_content(&buf) {
         CacheStatus::Positive => ExpirationStrategy::None,
         CacheStatus::Negative => ExpirationStrategy::Negative,
-        CacheStatus::Malformed => ExpirationStrategy::Malformed,
+        CacheStatus::Malformed(_) => ExpirationStrategy::Malformed,
         // The nature of cache-specific errors depends on the cache type so different
         // strategies are used based on which cache's file is being assessed here.
         // This won't kick in until `CacheStatus::from_content` stops classifying

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -110,8 +110,8 @@ impl FetchFileRequest {
                 let mut decompressed =
                     match decompress_object_file(&download_file, decompressed_path) {
                         Ok(file) => file,
-                        Err(_) => {
-                            return Ok(CacheStatus::Malformed);
+                        Err(err) => {
+                            return Ok(CacheStatus::Malformed(err.to_string()));
                         }
                     };
 
@@ -125,7 +125,7 @@ impl FetchFileRequest {
                             let kind = self.kind.to_string();
                             metric!(counter("services.bitcode.loaderrror") += 1, "kind" => &kind);
                             log::debug!("Failed to parse bcsymbolmap: {}", err);
-                            return Ok(CacheStatus::Malformed);
+                            return Ok(CacheStatus::Malformed(err.to_string()));
                         }
                     }
                     AuxDifKind::UuidMap => {
@@ -133,7 +133,7 @@ impl FetchFileRequest {
                             let kind = self.kind.to_string();
                             metric!(counter("services.bitcode.loaderrror") += 1, "kind" => &kind);
                             log::debug!("Failed to parse plist: {}", err);
-                            return Ok(CacheStatus::Malformed);
+                            return Ok(CacheStatus::Malformed(err.to_string()));
                         }
                     }
                 }

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -78,8 +78,8 @@ pub struct CfiCacheFile {
 
 impl CfiCacheFile {
     /// Returns the status of this cache file.
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     /// Returns the features of the object file this symcache was constructed from.
@@ -129,15 +129,15 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         let threadpool = self.threadpool.clone();
         let result = object.and_then(move |object| {
             let future = async move {
-                if object.status() != CacheStatus::Positive {
-                    return Ok(object.status());
+                if object.status() != &CacheStatus::Positive {
+                    return Ok(object.status().clone());
                 }
 
                 let status = if let Err(e) = write_cficache(&path, &*object) {
                     log::warn!("Could not write cficache: {}", e);
                     sentry::capture_error(&e);
 
-                    CacheStatus::Malformed
+                    CacheStatus::Malformed(e.to_string())
                 } else {
                     CacheStatus::Positive
                 };
@@ -180,7 +180,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         candidates.set_unwind(
             self.meta_handle.source_id().clone(),
             &self.meta_handle.uri(),
-            ObjectUseInfo::from_derived_status(status, self.meta_handle.status()),
+            ObjectUseInfo::from_derived_status(&status, self.meta_handle.status()),
         );
 
         CfiCacheFile {

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -72,7 +72,8 @@ impl ObjectHandle {
             CacheStatus::Positive => Ok(Some(Object::parse(&self.data)?)),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed(_) => Err(ObjectError::Malformed),
-            CacheStatus::CacheSpecificError => Err(ObjectError::Malformed),
+            // TODO: replace with ObjectError::Error once we want to start writing CacheSpecificErrors to cache
+            CacheStatus::CacheSpecificError(_) => Err(ObjectError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -70,8 +70,8 @@ impl ObjectMetaHandle {
         self.file_source.uri()
     }
 
-    pub fn status(&self) -> CacheStatus {
-        self.status
+    pub fn status(&self) -> &CacheStatus {
+        &self.status
     }
 
     pub fn scope(&self) -> &Scope {
@@ -131,7 +131,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
                         }
                     }
 
-                    Ok(object_handle.status)
+                    Ok(object_handle.status.clone())
                 })
         };
 

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -446,7 +446,7 @@ fn create_candidate_info(
                     features: meta_handle.features(),
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
-                CacheStatus::Malformed => ObjectDownloadInfo::Malformed,
+                CacheStatus::Malformed(_) => ObjectDownloadInfo::Malformed,
                 CacheStatus::CacheSpecificError => ObjectDownloadInfo::Malformed,
             };
             ObjectCandidate {

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -447,7 +447,8 @@ fn create_candidate_info(
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed(_) => ObjectDownloadInfo::Malformed,
-                CacheStatus::CacheSpecificError => ObjectDownloadInfo::Malformed,
+                // TODO: use ObjectDownloadInfo::Error once we want to start writing CacheSpecificErrors to cache
+                CacheStatus::CacheSpecificError(_) => ObjectDownloadInfo::Malformed,
             };
             ObjectCandidate {
                 source: meta_handle.file_source.source_id().clone(),

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -175,9 +175,13 @@ impl CfiCacheModules {
                     let cfi_status = match cfi_cache.status() {
                         CacheStatus::Positive => ObjectFileStatus::Found,
                         CacheStatus::Negative => ObjectFileStatus::Missing,
-                        CacheStatus::Malformed => {
+                        CacheStatus::Malformed(details) => {
                             let err = CfiCacheError::ObjectParsing(ObjectError::Malformed);
-                            log::warn!("Error while parsing cficache: {}", LogError(&err));
+                            log::warn!(
+                                "Error while parsing cficache: {} ({})",
+                                LogError(&err),
+                                details
+                            );
                             ObjectFileStatus::from(&err)
                         }
                         CacheStatus::CacheSpecificError => ObjectFileStatus::Malformed,

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -184,7 +184,8 @@ impl CfiCacheModules {
                             );
                             ObjectFileStatus::from(&err)
                         }
-                        CacheStatus::CacheSpecificError => ObjectFileStatus::Malformed,
+                        // TODO: revisit this once CacheSpecificError starts being used
+                        CacheStatus::CacheSpecificError(_) => ObjectFileStatus::Malformed,
                     };
                     let cfi_path = match cfi_cache.status() {
                         CacheStatus::Positive => Some(cfi_cache.path().to_owned()),

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -105,7 +105,8 @@ impl SymCacheFile {
             )),
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed(_) => Err(SymCacheError::Malformed),
-            CacheStatus::CacheSpecificError => Err(SymCacheError::Malformed),
+            // TODO: revisit once we want to start writing CacheSpecificError to cache
+            CacheStatus::CacheSpecificError(_) => Err(SymCacheError::Malformed),
         }
     }
 

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -104,7 +104,7 @@ impl SymCacheFile {
                 SymCache::parse(&self.data).map_err(SymCacheError::Parsing)?,
             )),
             CacheStatus::Negative => Ok(None),
-            CacheStatus::Malformed => Err(SymCacheError::Malformed),
+            CacheStatus::Malformed(_) => Err(SymCacheError::Malformed),
             CacheStatus::CacheSpecificError => Err(SymCacheError::Malformed),
         }
     }
@@ -170,8 +170,8 @@ async fn fetch_difs_and_compute_symcache(
         .await
         .map_err(SymCacheError::Fetching)?;
 
-    if object_handle.status() != CacheStatus::Positive {
-        return Ok(object_handle.status());
+    if object_handle.status() != &CacheStatus::Positive {
+        return Ok(object_handle.status().clone());
     }
 
     let compute_future = async move {
@@ -180,7 +180,7 @@ async fn fetch_difs_and_compute_symcache(
             Err(err) => {
                 log::warn!("Failed to write symcache: {}", err);
                 sentry::capture_error(&err);
-                CacheStatus::Malformed
+                CacheStatus::Malformed(err.to_string())
             }
         };
         Ok(status)
@@ -247,7 +247,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
         candidates.set_debug(
             self.object_meta.source_id().clone(),
             &self.object_meta.uri(),
-            ObjectUseInfo::from_derived_status(status, self.object_meta.status()),
+            ObjectUseInfo::from_derived_status(&status, self.object_meta.status()),
         );
 
         SymCacheFile {

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -136,11 +136,11 @@ impl ObjectUseInfo {
     ///
     /// [`symcaches`]: crate::services::symcaches
     /// [`cficaches`]: crate::services::cficaches
-    pub fn from_derived_status(derived: CacheStatus, original: CacheStatus) -> Self {
+    pub fn from_derived_status(derived: &CacheStatus, original: &CacheStatus) -> Self {
         match derived {
             CacheStatus::Positive => ObjectUseInfo::Ok,
             CacheStatus::Negative => {
-                if original == CacheStatus::Positive {
+                if original == &CacheStatus::Positive {
                     ObjectUseInfo::Error {
                         details: String::from("Object file no longer available"),
                     }
@@ -150,7 +150,7 @@ impl ObjectUseInfo {
                     ObjectUseInfo::None
                 }
             }
-            CacheStatus::Malformed => ObjectUseInfo::Malformed,
+            CacheStatus::Malformed(_) => ObjectUseInfo::Malformed,
             CacheStatus::CacheSpecificError => ObjectUseInfo::Malformed,
         }
     }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -151,7 +151,8 @@ impl ObjectUseInfo {
                 }
             }
             CacheStatus::Malformed(_) => ObjectUseInfo::Malformed,
-            CacheStatus::CacheSpecificError => ObjectUseInfo::Malformed,
+            // TODO: Use ObjectUseInfo::Error once we want to start writing CacheSpecificErrors to cache
+            CacheStatus::CacheSpecificError(_) => ObjectUseInfo::Malformed,
         }
     }
 }


### PR DESCRIPTION
Welcome to part 2 of my PR series on making symbolicator's cache statuses gooder. **Before reviewing or merging this PR, you may be interested in taking a look at part 1 first for some context: https://github.com/getsentry/symbolicator/pull/509**

If you've already seen #509 or you're brave enough to be look at these changes as-is because you reviewed an eerily similar set of changes in a previous PR, then let's continue.

This belongs to the following chain of PRs:

1. Introduce the new cache status without changing the existing functionality, convert the new status to Malformed if needed (#509)
1. Update cache expiration strategy selection so different caches will expire entries triggered by cache-specific problems after a timeout that makes sense for the cache (#516) 
1. 👉 Extend both the new cache status and the Malformed cache status to accept an arbitrary string that describes the root cause of the issue (#510) 👈 you are here
1. Identify and split out code paths that should be using the new cache status without changing their return value
1. Begin actually using the new cache status by returning it in places identified in the previous step and writing + reading those to and from the cache

This PR does one thing: it stuffs an error string returned by the `Display` impl of the error into `Malformed` and `CacheSpecificError` entries, and adds all of the plumbing needed to write and read them from their respective cache files. This makes no functional changes to symbolicator.