### PR TITLE
feat(cache): Infrastructure to distinguish between errors caused by malformed objects vs cache-specific errors

### DIFF
--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -257,7 +257,7 @@ impl GcsDownloader {
                     super::download_stream(source, stream, destination, timeout).await
                 // If it's a client error, chances are either it's a 404 or it's permission-related.
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from GCS {} (from {}): {}",
                         &key,
                         &bucket,
@@ -265,7 +265,7 @@ impl GcsDownloader {
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from GCS {} (from {}): {}",
                         &key,
                         &bucket,
@@ -277,7 +277,7 @@ impl GcsDownloader {
                 }
             }
             Ok(Err(e)) => {
-                log::trace!(
+                log::debug!(
                     "Skipping response from GCS {} (from {}): {} ({:?})",
                     &key,
                     &bucket,

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -114,14 +114,14 @@ impl HttpDownloader {
                     super::download_stream(source, stream, destination, timeout).await
                 // If it's a client error, chances are either it's a 404 or it's permission-related.
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from {}: {}",
                         download_url,
                         response.status()
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -46,17 +46,27 @@ pub enum DownloadError {
     Write(#[source] std::io::Error),
     #[error("download was cancelled")]
     Canceled,
-    #[error("failed to fetch data from GCS: {0}")]
+    #[error("failed to fetch data from GCS")]
     Gcs(#[from] gcs::GcsError),
-    #[error("failed to fetch data from Sentry: {0}")]
+    #[error("failed to fetch data from Sentry")]
     Sentry(#[from] sentry::SentryError),
-    #[allow(unused)]
     #[error("failed to fetch data from S3")]
     S3(#[from] s3::S3Error),
     /// Typically means the initial HEAD request received a non-200, non-400 response.
     #[allow(unused)]
     #[error("failed to download: {0}")]
     Rejected(StatusCode),
+}
+
+impl DownloadError {
+    pub fn for_cache(&self) -> String {
+        match self {
+            DownloadError::Gcs(inner) => format!("{}: {}", self, inner),
+            DownloadError::Sentry(inner) => format!("{}: {}", self, inner),
+            DownloadError::S3(inner) => format!("{}: {}", self, inner),
+            _ => format!("{}", self),
+        }
+    }
 }
 
 /// Completion status of a successful download request.

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -35,9 +35,9 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 /// Errors happening while downloading from sources.
 #[derive(Debug, Error)]
 pub enum DownloadError {
-    #[error("failed to download")]
+    #[error("failed to download (IO)")]
     Io(#[source] std::io::Error),
-    #[error("failed to download")]
+    #[error("failed to download (streaming file)")]
     Reqwest(#[source] reqwest::Error),
     #[error("bad file destination")]
     BadDestination(#[source] std::io::Error),
@@ -45,9 +45,9 @@ pub enum DownloadError {
     Write(#[source] std::io::Error),
     #[error("download was cancelled")]
     Canceled,
-    #[error("failed to fetch data from GCS")]
+    #[error("failed to fetch data from GCS: {0}")]
     Gcs(#[from] gcs::GcsError),
-    #[error("failed to fetch data from Sentry")]
+    #[error("failed to fetch data from Sentry: {0}")]
     Sentry(#[from] sentry::SentryError),
 }
 

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -49,6 +49,8 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry: {0}")]
     Sentry(#[from] sentry::SentryError),
+    #[error("failed to fetch data from S3")]
+    S3(#[source] s3::S3Error),
 }
 
 /// Completion status of a successful download request.

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -140,10 +140,10 @@ impl DownloadService {
             Ok(status) => {
                 match status {
                     DownloadStatus::Completed => {
-                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
+                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
                     }
                     DownloadStatus::NotFound => {
-                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
                     }
                 };
                 Ok(status)

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -50,9 +50,11 @@ pub enum DownloadError {
     Gcs(#[from] gcs::GcsError),
     #[error("failed to fetch data from Sentry: {0}")]
     Sentry(#[from] sentry::SentryError),
+    #[allow(unused)]
     #[error("failed to fetch data from S3")]
     S3(#[source] s3::S3Error),
     /// Typically means the initial HEAD request received a non-200, non-400 response.
+    #[allow(unused)]
     #[error("failed to download: {0}")]
     Rejected(StatusCode),
 }
@@ -247,7 +249,7 @@ impl DownloadService {
 /// # Errors
 /// - [`DownloadError::BadDestination`]
 /// - [`DownloadError::Write`]
-/// - [`DownloadError::Cancelled`]
+/// - [`DownloadError::Canceled`]
 async fn download_stream(
     source: impl Into<RemoteDif>,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -52,7 +52,7 @@ pub enum DownloadError {
     Sentry(#[from] sentry::SentryError),
     #[allow(unused)]
     #[error("failed to fetch data from S3")]
-    S3(#[source] s3::S3Error),
+    S3(#[from] s3::S3Error),
     /// Typically means the initial HEAD request received a non-200, non-400 response.
     #[allow(unused)]
     #[error("failed to download: {0}")]

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -36,9 +36,9 @@ const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 /// Errors happening while downloading from sources.
 #[derive(Debug, Error)]
 pub enum DownloadError {
-    #[error("failed to download (IO)")]
+    #[error("failed to perform an IO operation")]
     Io(#[source] std::io::Error),
-    #[error("failed to download (streaming file)")]
+    #[error("failed to stream file")]
     Reqwest(#[source] reqwest::Error),
     #[error("bad file destination")]
     BadDestination(#[source] std::io::Error),

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -182,7 +182,7 @@ impl S3Downloader {
                     }
                 }
                 // TODO: use this once we start writing DownloadErrors to cache
-                // return Err(DownloadError::S3(err));
+                // return Err(err.into());
                 return Ok(DownloadStatus::NotFound);
             }
             Err(_) => {

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -140,6 +140,11 @@ impl S3Downloader {
         rusoto_s3::S3Client::new_with(self.http_client.clone(), provider, region)
     }
 
+    /// Downloads a source hosted on an S3 bucket.
+    ///
+    /// # Directly thrown errors
+    /// - [`DownloadError::Io`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,
@@ -167,7 +172,7 @@ impl S3Downloader {
                 // For missing files, Amazon returns different status codes based on the given
                 // permissions.
                 // - To fetch existing objects, `GetObject` is required.
-                // - If `ListBucket` is premitted, a 404 is returned for missing objects.
+                // - If `ListBucket` is permitted, a 404 is returned for missing objects.
                 // - Otherwise, a 403 ("access denied") is returned.
                 log::debug!("Skipping response from s3://{}/{}: {}", bucket, &key, err);
 

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -285,14 +285,14 @@ impl SentryDownloader {
                     super::download_stream(source, stream, destination, timeout).await
                 // If it's a client error, chances are either it's a 404 or it's permission-related.
                 } else if response.status().is_client_error() {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected client error status code from {}: {}",
                         download_url,
                         response.status()
                     );
                     Ok(DownloadStatus::NotFound)
                 } else {
-                    log::trace!(
+                    log::debug!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
@@ -303,7 +303,7 @@ impl SentryDownloader {
                 }
             }
             Ok(Err(e)) => {
-                log::trace!("Skipping response from {}: {}", download_url, e);
+                log::debug!("Skipping response from {}: {}", download_url, e);
                 Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             // Timed out

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -244,6 +244,12 @@ impl SentryDownloader {
         Ok(file_ids)
     }
 
+    /// Downloads a source hosted on Sentry.
+    ///
+    /// # Directly thrown errors
+    /// - [`DownloadError::Reqwest`]
+    /// - [`DownloadError::Rejected`]
+    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: SentryRemoteDif,
@@ -277,18 +283,28 @@ impl SentryDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                // If it's a client error, chances are either it's a 404 or it's permission-related.
+                } else if response.status().is_client_error() {
+                    log::trace!(
+                        "Unexpected client error status code from {}: {}",
+                        download_url,
+                        response.status()
+                    );
+                    Ok(DownloadStatus::NotFound)
                 } else {
                     log::trace!(
                         "Unexpected status code from {}: {}",
                         download_url,
                         response.status()
                     );
+                    // TODO: use this once we start writing DownloadErrors to cache
+                    // Err(DownloadError::Rejected(response.status()))
                     Ok(DownloadStatus::NotFound)
                 }
             }
             Ok(Err(e)) => {
                 log::trace!("Skipping response from {}: {}", download_url, e);
-                Ok(DownloadStatus::NotFound) // must be wrong type
+                Err(DownloadError::Reqwest(e)) // must be wrong type
             }
             // Timed out
             Err(_) => Err(DownloadError::Canceled),

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -169,7 +169,7 @@ impl CacheItemRequest for FetchFileDataRequest {
 
                 Err(e) => {
                     log::error!("Error while downloading file: {}", LogError(&e));
-                    return Ok(CacheStatus::Malformed(e.to_string()));
+                    return Ok(CacheStatus::Malformed(e.for_cache()));
                 }
 
                 Ok(DownloadStatus::Completed) => {


### PR DESCRIPTION
This is part 3 of a series of PRs focused on cache statuses. Like the others, if you haven't taken a look at the previous PRs and have no context on these changes, it may be helpful to take a look at those first: #509 #510 

1. Introduce the new cache status without changing the existing functionality, convert the new status to Malformed if needed (#509)
1. Update cache expiration strategy selection so different caches will expire entries triggered by cache-specific problems after a timeout that makes sense for the cache (#516) 
1. Extend both the new cache status and the Malformed cache status to accept an arbitrary string that describes the root cause of the issue (#510)
1. 👉 Identify and split out code paths that should be using the new cache status without changing their return value (#511)👈 you are here
1. Begin actually using the new cache status by returning it in places identified in the previous step and writing + reading those to and from the cache (#512)

This PR is focused on the downloaders. It adds documentation and extends them as needed so it's easy to (eventually) tell the difference between a malformed object and a cache-specific error. This PR makes no functional changes to symbolicator, and simply makes some changes in preparation for step 4.

#skip-changelog