### PR TITLE
fix: Skip trailing garbage frames after `_start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Cache download failures and do not retry the download for a while ([#484](https://github.com/getsentry/symbolicator/pull/484), [#501](https://github.com/getsentry/symbolicator/pull/501))
 - New configuration option `hostname_tag` ([#513](https://github.com/getsentry/symbolicator/pull/513))
 
+### Fixes
+
+- Skip trailing garbage frames after `_start`. ([#514](https://github.com/getsentry/symbolicator/pull/514))
+
 ### Tools
 
 - `symsorter` no longer emits files with empty debug identifiers. ([#469](https://github.com/getsentry/symbolicator/pull/469))


### PR DESCRIPTION
Our lack of support for `DW_CFA_undefined` can lead to conditions where we read a garbage return address via CFI. We observed this specifically for the `_start` function as generated for some linux compiler/libc combinations.

This works around this by explicitly skipping a trailing unmapped frame following `_start`.

Fixes https://getsentry.atlassian.net/browse/ISSUE-1247