### PR TITLE
WIP: Use tracing::instrument on some processing functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +471,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -1782,6 +1791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,8 +3117,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "sentry"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "httpdate",
  "reqwest 0.11.3",
@@ -3101,14 +3127,14 @@ dependencies = [
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
+ "sentry-tracing",
  "tokio 1.6.1",
 ]
 
 [[package]]
 name = "sentry-backtrace"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3119,8 +3145,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "hostname",
  "lazy_static",
@@ -3134,8 +3159,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -3148,8 +3172,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074552b0aa8a3afb705c0b8c44e1d6e01123179315d09825342566f7d0430c42"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -3159,8 +3182,7 @@ dependencies = [
 [[package]]
 name = "sentry-log"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66da5759b0704a2fb0d420863b0795ea3429739e188ff67fff82bb13dcd3cc50"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "log",
  "sentry-core",
@@ -3169,21 +3191,31 @@ dependencies = [
 [[package]]
 name = "sentry-panic"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
 ]
 
 [[package]]
+name = "sentry-tracing"
+version = "0.23.0"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
+dependencies = [
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "sentry-types"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
+source = "git+https://github.com/getsentry/sentry-rust#78f1a72753425b36cd11f3c092ffee6d9ff4452f"
 dependencies = [
  "chrono",
  "debugid",
+ "getrandom 0.2.3",
+ "hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -3300,6 +3332,15 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3655,6 +3696,9 @@ dependencies = [
  "thiserror",
  "tokio 0.1.22",
  "tokio 1.6.1",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url 2.2.2",
  "uuid 0.8.2",
  "warp",
@@ -3780,6 +3824,15 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -4158,7 +4211,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4168,6 +4233,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.6.1",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -38,13 +38,16 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_s3 = "0.46.0"
-sentry = { version = "0.23.0", features = ["debug-images", "log"] }
+sentry = { version = "0.23.0", git = "https://github.com/getsentry/sentry-rust", features = ["debug-images", "log", "tracing"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.3.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
+tracing = "0.1.26"
+tracing-log = "0.1.2"
+tracing-subscriber = "0.2.19"
 thiserror = "1.0.26"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }
 tokio01 = { version = "0.1.22", package = "tokio" }

--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -153,7 +153,7 @@ pub fn init_logging(config: &Config) {
     log::set_max_level(logger.filter());
 
     let breadcrumb_logger = Box::new(BreadcrumbLogger::new(logger));
-    log::set_boxed_logger(breadcrumb_logger).unwrap();
+    log::set_boxed_logger(breadcrumb_logger); //.unwrap();
 }
 
 /// A wrapper around an [`Error`](std::error::Error) that prints its causes.

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1435,6 +1435,7 @@ pub struct SymbolicateStacktraces {
 }
 
 impl SymbolicationActor {
+    #[tracing::instrument(skip(self, request))]
     async fn do_symbolicate(
         self,
         request: SymbolicateStacktraces,
@@ -1737,6 +1738,7 @@ impl SymbolicationActor {
         }
     }
 
+    #[tracing::instrument(skip(self, scope, requests, sources))]
     async fn load_cfi_caches(
         &self,
         scope: Scope,
@@ -1786,6 +1788,7 @@ impl SymbolicationActor {
     /// have a full debug id.  This is intended to skip over modules like `mmap`ed fonts or
     /// similar which are mapped in the address space but do not actually contain executable
     /// modules.
+    #[tracing::instrument(skip(self, minidump_file, cfi_caches))]
     async fn stackwalk_minidump_with_cfi(
         &self,
         minidump_file: &TempPath,
@@ -1897,13 +1900,13 @@ impl SymbolicationActor {
             )
         };
 
-        Ok(self
-            .threadpool
+        self.threadpool
             .spawn_handle(lazy.bind_hub(sentry::Hub::current()))
             .await?
-            .context("Minidump stackwalk future cancelled")?)
+            .context("Minidump stackwalk future cancelled")
     }
 
+    #[tracing::instrument(skip(self, scope, minidump_file, sources, options))]
     async fn do_stackwalk_minidump(
         self,
         scope: Scope,
@@ -2008,6 +2011,7 @@ impl SymbolicationActor {
             .unwrap_or(Err(SymbolicationError::Timeout))
     }
 
+    #[tracing::instrument(skip(self, scope, minidump_file, sources, options))]
     async fn do_process_minidump(
         self,
         scope: Scope,


### PR DESCRIPTION
This can generate traces like this one: https://sentry.io/organizations/sentry-test/performance/rust:daa7a6a37bde40c48165da73693a21a5/?project=1041156

Some problems with this though:
* the `tracing_subscriber::fmt` clashes with env_logger I think. I think rewriting our logging to be completely based on tracing would be a nice idea. But gotta do it in such a way that we don’t break the loggers/configs that do exist.
* we gotta explicitly list all the args as `skip` that we don’t want. In our case, we really want none of them, so its kind of a pain in the rear to instrument. There are a couple of issues/feature requests in the tracing repo for this and even a WIP PR to skip all the args, but it takes some time.