### PR TITLE
`CacheStatus::CacheSpecificError` entries have different timeout behaviours based on the type of cache they belong to

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -342,6 +342,8 @@ fn expiration_strategy(cache_config: &CacheConfig, path: &Path) -> io::Result<Ex
         CacheStatus::Malformed => ExpirationStrategy::Malformed,
         // The nature of cache-specific errors depends on the cache type so different
         // strategies are used based on which cache's file is being assessed here.
+        // This won't kick in until `CacheStatus::from_content` stops classifying
+        // files with CacheSpecificError contents as Malformed.
         CacheStatus::CacheSpecificError => match cache_config {
             CacheConfig::Downloaded(_) => ExpirationStrategy::Negative,
             CacheConfig::Derived(_) => ExpirationStrategy::Malformed,


### PR DESCRIPTION
This PR was quickly shoved in between the original first (#509) and second (#510) PRs to avoid review churn.

This is a member of a series of chained PRs:
1. Introduce the new cache status without changing the existing functionality, convert the new status to Malformed if needed (#509)
1. 👉 Update cache expiration strategy selection so different caches will expire entries triggered by cache-specific problems after a timeout that makes sense for the cache (#516) 👈 you are here
1. Extend both the new cache status and the Malformed cache status to accept an arbitrary string that describes the root cause of the issue (#510)
1. Identify and split out code paths that should be using the new cache status without changing their return value (#511)
1. Begin actually using the new cache status by returning it in places identified in the previous step and writing + reading those to and from the cache (#512)

This makes no functional changes to symbolicator.

#skip-changelog