### PR TITLE
feat(metrics): Add option to send environment with every metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - New configuration option `hostname_tag` ([#513](https://github.com/getsentry/symbolicator/pull/513))
 - Introduced a new cache status to represent failures specific to the cache: Download failures that aren't related to the file being missing in download caches and conversion errors in derived caches. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
 - Malformed and Cache-specific Error cache entries now contain some diagnostic info. ([#510](https://github.com/getsentry/symbolicator/pull/510))
+- New configuration option `environment_tag` ([#517](https://github.com/getsentry/symbolicator/pull/517))
 
 ### Fixes
 

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -79,12 +79,16 @@ pub fn execute() -> Result<()> {
         if let Some(hostname_tag) = config.metrics.hostname_tag.clone() {
             if let Some(hostname) = hostname::get().ok().and_then(|s| s.into_string().ok()) {
                 tags.insert(hostname_tag, hostname);
+            } else {
+                log::error!("could not read host name");
             }
         };
         if let Some(environment_tag) = config.metrics.environment_tag.clone() {
             if let Some(environment) = sentry.options().environment.as_ref().map(|s| s.to_string())
             {
                 tags.insert(environment_tag, environment);
+            } else {
+                log::error!("environment name not available");
             }
         };
 

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -57,6 +57,8 @@ pub struct Metrics {
     pub prefix: String,
     /// A tag name to report the hostname to, for each metric. Defaults to not sending such a tag.
     pub hostname_tag: Option<String>,
+    /// A tag name to report the environment to, for each metric. Defaults to not sending such a tag.
+    pub environment_tag: Option<String>,
 }
 
 impl Default for Metrics {
@@ -68,6 +70,7 @@ impl Default for Metrics {
             },
             prefix: "symbolicator".into(),
             hostname_tag: None,
+            environment_tag: None,
         }
     }
 }

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -1,16 +1,11 @@
 //! Provides access to the metrics sytem.
+use std::collections::BTreeMap;
 use std::net::ToSocketAddrs;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use cadence::{Metric, MetricBuilder, StatsdClient, UdpMetricSink};
 use parking_lot::RwLock;
-
-// Type aliases to make the definition of [`MetricsClient`] more readable.
-type Hostname = String;
-type HostnameTag = String;
-type Environment = String;
-type EnvironmentTag = String;
 
 lazy_static::lazy_static! {
     static ref METRICS_CLIENT: RwLock<Option<Arc<MetricsClient>>> = RwLock::new(None);
@@ -36,10 +31,9 @@ pub mod prelude {
 pub struct MetricsClient {
     /// The raw statsd client.
     pub statsd_client: StatsdClient,
-    /// The hostname and the tag to report it to.
-    pub hostname: Option<(HostnameTag, Hostname)>,
-    /// The environment and the tag to report it to.
-    pub environment: Option<(EnvironmentTag, Environment)>,
+
+    /// A collection of tags and values that will be sent with every metric.
+    tags: BTreeMap<String, String>,
 }
 
 impl MetricsClient {
@@ -48,11 +42,8 @@ impl MetricsClient {
     where
         T: Metric + From<String>,
     {
-        if let Some((tag, name)) = self.hostname.as_ref() {
-            metric = metric.with_tag(tag, name);
-        }
-        if let Some((tag, name)) = self.environment.as_ref() {
-            metric = metric.with_tag(tag, name);
+        for (tag, value) in self.tags.iter() {
+            metric = metric.with_tag(tag, value);
         }
         metric.send()
     }
@@ -78,12 +69,7 @@ pub fn set_client(client: MetricsClient) {
 }
 
 /// Tell the metrics system to report to statsd.
-pub fn configure_statsd<A: ToSocketAddrs>(
-    prefix: &str,
-    host: A,
-    hostname: Option<(HostnameTag, Hostname)>,
-    environment: Option<(EnvironmentTag, Environment)>,
-) {
+pub fn configure_statsd<A: ToSocketAddrs>(prefix: &str, host: A, tags: BTreeMap<String, String>) {
     let addrs: Vec<_> = host.to_socket_addrs().unwrap().collect();
     if !addrs.is_empty() {
         log::info!("Reporting metrics to statsd at {}", addrs[0]);
@@ -94,8 +80,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(
     let statsd_client = StatsdClient::from_sink(prefix, sink);
     set_client(MetricsClient {
         statsd_client,
-        hostname,
-        environment,
+        tags,
     });
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ metrics:
       which disables metric submission.
     - `prefix`: A prefix for every metric, defaults to `symbolicator`.
     - `hostname_tag`: If set, report the current hostname under the given tag name for all metrics.
+    - `environment_tag`: If set, report the current environment under the given tag name for all metrics.
 - `sentry_dsn`: DSN to a Sentry project for internal error reporting. Defaults
   to `null`, which disables reporting to Sentry.
 - `sources`: An optional list of preconfigured sources. If these are configured


### PR DESCRIPTION
Analogous to https://github.com/getsentry/symbolicator/pull/513.

Symbolicator obtains the environment from its Sentry client, which in turn determines it based on the `SENTRY_ENVIRONMENT` variable or the build config if that's not set.

This addresses https://getsentry.atlassian.net/browse/NATIVE-165.