### PR TITLE
feat(cache): Mention when a download failure is due to insufficient permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Malformed and Cache-specific Error cache entries now contain some diagnostic info. ([#510](https://github.com/getsentry/symbolicator/pull/510))
 - New configuration option `environment_tag` ([#517](https://github.com/getsentry/symbolicator/pull/517))
 - Source candidates which symbolicator has failed to download due to non-400 errors are now being returned in symbolication payloads. These candidates include additional diagnostic info which briefly describes the download error. ([#512](https://github.com/getsentry/symbolicator/pull/512))
-- If a DIF object candidate could not be downloaded due to a lack permissions, their respective entry in a symbolication response will now mention something about permissions instead of marking the candidate as just Missing. ([#512](https://github.com/getsentry/symbolicator/pull/512))
+- If a DIF object candidate could not be downloaded due to a lack of permissions, their respective entry in a symbolication response will now mention something about permissions instead of marking the candidate as just Missing. ([#512](https://github.com/getsentry/symbolicator/pull/512), [#518](https://github.com/getsentry/symbolicator/pull/518))
 
 ### Fixes
 

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Duration, Utc};
 use futures::prelude::*;
 use jsonwebtoken::EncodingKey;
 use parking_lot::Mutex;
-use reqwest::{header, Client};
+use reqwest::{header, Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -255,6 +255,13 @@ impl GcsDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                } else if response.status() == StatusCode::FORBIDDEN {
+                    log::debug!(
+                        "Insufficient permissions to download from GCS {} (from {})",
+                        &key,
+                        &bucket,
+                    );
+                    Err(DownloadError::Permissions)
                 // If it's a client error, chances are either it's a 404 or it's permission-related.
                 } else if response.status().is_client_error() {
                     log::debug!(

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -255,7 +255,10 @@ impl GcsDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
-                } else if response.status() == StatusCode::FORBIDDEN {
+                } else if matches!(
+                    response.status(),
+                    StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
+                ) {
                     log::debug!(
                         "Insufficient permissions to download from GCS {} (from {})",
                         &key,

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -112,7 +112,10 @@ impl HttpDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
-                } else if response.status() == StatusCode::FORBIDDEN {
+                } else if matches!(
+                    response.status(),
+                    StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
+                ) {
                     log::debug!("Insufficient permissions to download from {}", download_url);
                     Err(DownloadError::Permissions)
                 // If it's a client error, chances are either it's a 404 or it's permission-related.

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use futures::prelude::*;
-use reqwest::{header, Client};
+use reqwest::{header, Client, StatusCode};
 use url::Url;
 
 use super::{
@@ -112,6 +112,9 @@ impl HttpDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
+                } else if response.status() == StatusCode::FORBIDDEN {
+                    log::debug!("Insufficient permissions to download from {}", download_url);
+                    Err(DownloadError::Permissions)
                 // If it's a client error, chances are either it's a 404 or it's permission-related.
                 } else if response.status().is_client_error() {
                     log::debug!(

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -64,7 +64,7 @@ pub enum DownloadError {
 
 impl DownloadError {
     /// This produces a user-facing string representation of a download error if it is a variant
-    /// that needs to be stored as a acheStatusCacheSpecificError entry in the download cache.
+    /// that needs to be stored as a `CacheStatus::CacheSpecificError` entry in the download cache.
     pub fn for_cache(&self) -> String {
         match self {
             DownloadError::Gcs(inner) => format!("{}: {}", self, inner),
@@ -76,8 +76,9 @@ impl DownloadError {
         }
     }
 
-    /// This produces a user-facing string representation of a download error if it is a variant
-    /// that needs to be stored as a CacheSpecificError entry in the download cache.
+    /// If a given cache entry is `CacheStatus::CacheSpecificError`, this parses and extracts its
+    /// contents into a `DownloadError`. This will return none if a
+    /// non-`CacheStatus::CacheSpecificError` is provided.
     pub fn from_cache(status: &CacheStatus) -> Option<Self> {
         match status {
             CacheStatus::Positive => None,

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -64,7 +64,7 @@ pub enum DownloadError {
 
 impl DownloadError {
     /// This produces a user-facing string representation of a download error if it is a variant
-    /// that needs to be stored as a `CacheStatus::CacheSpecificError` entry in the download cache.
+    /// that needs to be stored as a [`CacheStatus::CacheSpecificError`] entry in the download cache.
     pub fn for_cache(&self) -> String {
         match self {
             DownloadError::Gcs(inner) => format!("{}: {}", self, inner),
@@ -76,9 +76,9 @@ impl DownloadError {
         }
     }
 
-    /// If a given cache entry is `CacheStatus::CacheSpecificError`, this parses and extracts its
-    /// contents into a `DownloadError`. This will return none if a
-    /// non-`CacheStatus::CacheSpecificError` is provided.
+    /// If a given cache entry is [`CacheStatus::CacheSpecificError`], this parses and extracts its
+    /// contents into a [`DownloadError`]. This will return none if a
+    /// non-[`CacheStatus::CacheSpecificError`] is provided.
     pub fn from_cache(status: &CacheStatus) -> Option<Self> {
         match status {
             CacheStatus::Positive => None,

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -283,7 +283,10 @@ impl SentryDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
-                } else if response.status() == StatusCode::FORBIDDEN {
+                } else if matches!(
+                    response.status(),
+                    StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
+                ) {
                     log::debug!("Insufficient permissions to download from {}", download_url);
                     Err(DownloadError::Permissions)
                 } else if response.status().is_client_error() {

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -283,7 +283,9 @@ impl SentryDownloader {
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
                     super::download_stream(source, stream, destination, timeout).await
-                // If it's a client error, chances are either it's a 404 or it's permission-related.
+                } else if response.status() == StatusCode::FORBIDDEN {
+                    log::debug!("Insufficient permissions to download from {}", download_url);
+                    Err(DownloadError::Permissions)
                 } else if response.status().is_client_error() {
                     log::debug!(
                         "Unexpected client error status code from {}: {}",

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -292,7 +292,7 @@ mod tests {
 
     use crate::cache::{Cache, CacheStatus};
     use crate::config::{CacheConfig, CacheConfigs, Config};
-    use crate::services::download::DownloadService;
+    use crate::services::download::{DownloadError, DownloadService};
     use crate::services::objects::data_cache::Scope;
     use crate::services::objects::{FindObject, ObjectPurpose, ObjectsActor};
     use crate::sources::FileType;
@@ -493,13 +493,13 @@ mod tests {
             let result = objects_actor.find(find_object.clone()).await.unwrap();
             assert_eq!(
                 result.meta.clone().unwrap().status,
-                CacheStatus::CacheSpecificError(String::from("insufficient permissions"))
+                CacheStatus::CacheSpecificError(DownloadError::Permissions.to_string())
             );
             assert_eq!(server.accesses(), 1 + 3); // 1 initial attempt + 3 retries
             let result = objects_actor.find(find_object.clone()).await.unwrap();
             assert_eq!(
                 result.meta.unwrap().status,
-                CacheStatus::CacheSpecificError(String::from("insufficient permissions"))
+                CacheStatus::CacheSpecificError(DownloadError::Permissions.to_string())
             );
             assert_eq!(server.accesses(), 0);
         })

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -75,7 +75,8 @@ impl ObjectHandle {
             CacheStatus::Negative => Ok(None),
             CacheStatus::Malformed(_) => Err(ObjectError::Malformed),
             CacheStatus::CacheSpecificError(message) => Err(ObjectError::Download(
-                DownloadError::CachedError(message.clone()),
+                DownloadError::from_cache(&self.status)
+                    .unwrap_or_else(|| DownloadError::CachedError(message.clone())),
             )),
         }
     }
@@ -454,6 +455,51 @@ mod tests {
             assert_eq!(
                 result.meta.unwrap().status,
                 CacheStatus::CacheSpecificError(String::from("download was cancelled"))
+            );
+            assert_eq!(server.accesses(), 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_download_error_cache_forbidden() {
+        test::setup();
+
+        let server = test::FailingSymbolServer::new();
+        let cachedir = tempdir();
+        let objects_actor = objects_actor(&cachedir);
+
+        test::spawn_compat(move || async move {
+            let find_object = FindObject {
+                // A request for a bcsymbolmap will expand to only one file that is being looked up.
+                // Other filetypes will lead to multiple requests, trying different file extensions, etc
+                filetypes: &[FileType::BcSymbolMap],
+                purpose: ObjectPurpose::Debug,
+                scope: Scope::Global,
+                identifier: DebugId::default().into(),
+                sources: Arc::new([]),
+            };
+
+            // for each of the different symbol sources, we assert that:
+            // * we get a cache-specific error no matter how often we try
+            // * we hit the symbol source exactly once for the initial request, followed by 3 retries
+            // * the second try should *not* hit the symbol source, but should rather be served by the cache
+
+            // server rejects the request (403)
+            let find_object = FindObject {
+                sources: Arc::new([server.forbidden_source.clone()]),
+                ..find_object
+            };
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(
+                result.meta.clone().unwrap().status,
+                CacheStatus::CacheSpecificError(String::from("insufficient permissions"))
+            );
+            assert_eq!(server.accesses(), 1 + 3); // 1 initial attempt + 3 retries
+            let result = objects_actor.find(find_object.clone()).await.unwrap();
+            assert_eq!(
+                result.meta.unwrap().status,
+                CacheStatus::CacheSpecificError(String::from("insufficient permissions"))
             );
             assert_eq!(server.accesses(), 0);
         })

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -447,9 +447,16 @@ fn create_candidate_info(
                 },
                 CacheStatus::Negative => ObjectDownloadInfo::NotFound,
                 CacheStatus::Malformed(_) => ObjectDownloadInfo::Malformed,
-                CacheStatus::CacheSpecificError(message) => ObjectDownloadInfo::Error {
-                    details: message.clone(),
-                },
+                CacheStatus::CacheSpecificError(message) => {
+                    match DownloadError::from_cache(&meta_handle.status) {
+                        Some(DownloadError::Permissions) => ObjectDownloadInfo::NoPerm {
+                            details: String::default(),
+                        },
+                        Some(_) | None => ObjectDownloadInfo::Error {
+                            details: message.clone(),
+                        },
+                    }
+                }
             };
             ObjectCandidate {
                 source: meta_handle.file_source.source_id().clone(),


### PR DESCRIPTION
If we know that the reason why we weren't able to download a file was due to permissions we now record that fact and return it in the symbolication response.

This bases itself off of #512 to avoid conflicts with the download error work that's currently open in PRs.