### PR TITLE
fix: Do not debug-print RemoteDif

### DIFF
--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -278,10 +278,9 @@ impl GcsDownloader {
             }
             Ok(Err(e)) => {
                 log::debug!(
-                    "Skipping response from GCS {} (from {}): {} ({:?})",
+                    "Skipping response from GCS {} (from {}): {}",
                     &key,
                     &bucket,
-                    &e,
                     &e
                 );
                 // TODO: switch to this once we start writing DownloadErrors

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -152,16 +152,16 @@ impl DownloadService {
             Ok(status) => {
                 match status {
                     DownloadStatus::Completed => {
-                        log::debug!("Fetched debug file from {:?}: {:?}", source, status);
+                        log::debug!("Fetched debug file from {}: {:?}", source, status);
                     }
                     DownloadStatus::NotFound => {
-                        log::debug!("Did not fetch debug file from {:?}: {:?}", source, status);
+                        log::debug!("Did not fetch debug file from {}: {:?}", source, status);
                     }
                 };
                 Ok(status)
             }
             Err(err) => {
-                log::debug!("Failed to fetch debug file from {:?}: {}", source, err);
+                log::debug!("Failed to fetch debug file from {}: {}", source, err);
                 Err(err)
             }
         }


### PR DESCRIPTION
The previous debug-print would expose all the sensitive credentials in our logs.

This is https://getsentry.atlassian.net/browse/NATIVE-175

#skip-changelog