### PR TITLE
feat: Add config option for max concurrent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Introduced a new cache status to represent failures specific to the cache: Download failures that aren't related to the file being missing in download caches and conversion errors in derived caches. It is currently unused. ([#509](https://github.com/getsentry/symbolicator/pull/509))
 - Malformed and Cache-specific Error cache entries now contain some diagnostic info. ([#510](https://github.com/getsentry/symbolicator/pull/510))
 - New configuration option `environment_tag` ([#517](https://github.com/getsentry/symbolicator/pull/517))
+- Introduced the `max_concurrent_requests` config setting, which limits the number of requests that will be processed concurrently. It defaults to `None`, i.e., no limit. ([#521](https://github.com/getsentry/symbolicator/pull/521))
 
 ### Fixes
 

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -273,6 +273,11 @@ pub struct Config {
     /// download 1GB.
     #[serde(with = "humantime_serde")]
     pub streaming_timeout: Duration,
+
+    /// The maximum number of requests that symbolicator will process concurrently.
+    ///
+    /// A value of `None` indicates no limit.
+    pub max_concurrent_requests: Option<usize>,
 }
 
 impl Config {
@@ -341,6 +346,7 @@ impl Default for Config {
             connect_timeout: Duration::from_secs(15),
             // Allow a 4MB/s connection to download 1GB without timing out
             streaming_timeout: Duration::from_secs(250),
+            max_concurrent_requests: None,
         }
     }
 }

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -49,9 +49,7 @@ async fn handle_apple_crash_report_request(
     let request_id = symbolication
         .process_apple_crash_report(params.scope, report, sources, options)
         .ok_or_else(|| {
-            error::ErrorServiceUnavailable(
-                "Symbolicator is currently processing the maximum number of requests.",
-            )
+            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
         })?;
 
     match symbolication.get_response(request_id, params.timeout).await {

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -46,11 +46,8 @@ async fn handle_apple_crash_report_request(
     let report = report.ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
 
     let symbolication = state.symbolication();
-    let request_id = symbolication
-        .process_apple_crash_report(params.scope, report, sources, options)
-        .ok_or_else(|| {
-            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
-        })?;
+    let request_id =
+        symbolication.process_apple_crash_report(params.scope, report, sources, options)?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -46,8 +46,10 @@ async fn handle_apple_crash_report_request(
     let report = report.ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
 
     let symbolication = state.symbolication();
-    let request_id =
-        symbolication.process_apple_crash_report(params.scope, report, sources, options);
+    // TODO: error message
+    let request_id = symbolication
+        .process_apple_crash_report(params.scope, report, sources, options)
+        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -46,10 +46,13 @@ async fn handle_apple_crash_report_request(
     let report = report.ok_or_else(|| error::ErrorBadRequest("missing apple crash report"))?;
 
     let symbolication = state.symbolication();
-    // TODO: error message
     let request_id = symbolication
         .process_apple_crash_report(params.scope, report, sources, options)
-        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
+        .ok_or_else(|| {
+            error::ErrorServiceUnavailable(
+                "Symbolicator is currently processing the maximum number of requests.",
+            )
+        })?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -55,10 +55,13 @@ async fn handle_minidump_request(
     let minidump_file = minidump.ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
 
     let symbolication = state.symbolication();
-    // TODO: error message
     let request_id = symbolication
         .process_minidump(params.scope, minidump_file, sources, options)
-        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
+        .ok_or_else(|| {
+            error::ErrorServiceUnavailable(
+                "Symbolicator is currently processing the maximum number of requests.",
+            )
+        })?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -58,9 +58,7 @@ async fn handle_minidump_request(
     let request_id = symbolication
         .process_minidump(params.scope, minidump_file, sources, options)
         .ok_or_else(|| {
-            error::ErrorServiceUnavailable(
-                "Symbolicator is currently processing the maximum number of requests.",
-            )
+            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
         })?;
 
     match symbolication.get_response(request_id, params.timeout).await {

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -55,7 +55,10 @@ async fn handle_minidump_request(
     let minidump_file = minidump.ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
 
     let symbolication = state.symbolication();
-    let request_id = symbolication.process_minidump(params.scope, minidump_file, sources, options);
+    // TODO: error message
+    let request_id = symbolication
+        .process_minidump(params.scope, minidump_file, sources, options)
+        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -55,11 +55,8 @@ async fn handle_minidump_request(
     let minidump_file = minidump.ok_or_else(|| error::ErrorBadRequest("missing minidump"))?;
 
     let symbolication = state.symbolication();
-    let request_id = symbolication
-        .process_minidump(params.scope, minidump_file, sources, options)
-        .ok_or_else(|| {
-            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
-        })?;
+    let request_id =
+        symbolication.process_minidump(params.scope, minidump_file, sources, options)?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -1,5 +1,7 @@
-use actix_web::App;
+use actix_web::http::StatusCode;
+use actix_web::{App, HttpResponse, ResponseError};
 
+use crate::services::symbolication::MaxRequestsError;
 use crate::services::Service;
 
 mod applecrashreport;
@@ -17,4 +19,10 @@ pub fn configure(app: App<Service>) -> App<Service> {
         .configure(proxy::configure)
         .configure(requests::configure)
         .configure(symbolicate::configure)
+}
+
+impl ResponseError for MaxRequestsError {
+    fn error_response(&self) -> actix_web::HttpResponse {
+        HttpResponse::new(StatusCode::SERVICE_UNAVAILABLE)
+    }
 }

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -61,7 +61,6 @@ async fn symbolicate_frames(
     };
 
     let symbolication = state.symbolication();
-    // TODO: error message
     let request_id = symbolication
         .symbolicate_stacktraces(SymbolicateStacktraces {
             scope: params.scope,
@@ -72,7 +71,11 @@ async fn symbolicate_frames(
             modules: body.modules.into_iter().map(From::from).collect(),
             options: body.options,
         })
-        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
+        .ok_or_else(|| {
+            error::ErrorServiceUnavailable(
+                "Symbolicator is currently processing the maximum number of requests.",
+            )
+        })?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -61,15 +61,18 @@ async fn symbolicate_frames(
     };
 
     let symbolication = state.symbolication();
-    let request_id = symbolication.symbolicate_stacktraces(SymbolicateStacktraces {
-        scope: params.scope,
-        signal: body.signal,
-        sources,
-        origin: StacktraceOrigin::Symbolicate,
-        stacktraces: body.stacktraces,
-        modules: body.modules.into_iter().map(From::from).collect(),
-        options: body.options,
-    });
+    // TODO: error message
+    let request_id = symbolication
+        .symbolicate_stacktraces(SymbolicateStacktraces {
+            scope: params.scope,
+            signal: body.signal,
+            sources,
+            origin: StacktraceOrigin::Symbolicate,
+            stacktraces: body.stacktraces,
+            modules: body.modules.into_iter().map(From::from).collect(),
+            options: body.options,
+        })
+        .ok_or_else(|| error::ErrorTooManyRequests("TODO"))?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -72,9 +72,7 @@ async fn symbolicate_frames(
             options: body.options,
         })
         .ok_or_else(|| {
-            error::ErrorServiceUnavailable(
-                "Symbolicator is currently processing the maximum number of requests.",
-            )
+            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
         })?;
 
     match symbolication.get_response(request_id, params.timeout).await {

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -61,19 +61,15 @@ async fn symbolicate_frames(
     };
 
     let symbolication = state.symbolication();
-    let request_id = symbolication
-        .symbolicate_stacktraces(SymbolicateStacktraces {
-            scope: params.scope,
-            signal: body.signal,
-            sources,
-            origin: StacktraceOrigin::Symbolicate,
-            stacktraces: body.stacktraces,
-            modules: body.modules.into_iter().map(From::from).collect(),
-            options: body.options,
-        })
-        .ok_or_else(|| {
-            error::ErrorServiceUnavailable("maximum number of concurrent requests reached")
-        })?;
+    let request_id = symbolication.symbolicate_stacktraces(SymbolicateStacktraces {
+        scope: params.scope,
+        signal: body.signal,
+        sources,
+        origin: StacktraceOrigin::Symbolicate,
+        stacktraces: body.stacktraces,
+        modules: body.modules.into_iter().map(From::from).collect(),
+        options: body.options,
+    })?;
 
     match symbolication.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -88,6 +88,7 @@ impl Service {
             caches.diagnostics,
             cpu_pool,
             spawnpool,
+            config.max_concurrent_requests,
         );
 
         Ok(Self {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -7,8 +7,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use actix_web::http::StatusCode;
-use actix_web::{HttpResponse, ResponseError};
 use anyhow::Context;
 use apple_crash_report_parser::AppleCrashReport;
 use chrono::{DateTime, TimeZone, Utc};
@@ -97,12 +95,6 @@ impl SymbolicationError {
 #[derive(Debug, Clone, Error)]
 #[error("maximum number of concurrent requests reached")]
 pub struct MaxRequestsError;
-
-impl ResponseError for MaxRequestsError {
-    fn error_response(&self) -> actix_web::HttpResponse {
-        HttpResponse::new(StatusCode::SERVICE_UNAVAILABLE)
-    }
-}
 
 // We want a shared future here because otherwise polling for a response would hold the global lock.
 type ComputationChannel = future::Shared<oneshot::Receiver<(Instant, SymbolicationResponse)>>;

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -428,9 +428,7 @@ impl SymbolicationActor {
         let requests = self.requests.clone();
 
         let num_requests = requests.lock().len();
-        if let Ok(num_requests) = num_requests.try_into() {
-            metric!(gauge("requests.in_flight") = num_requests);
-        }
+        metric!(gauge("requests.in_flight") = num_requests as u64);
 
         // Reject the request if `requests` already contains `max_concurrent_requests` elements.
         if let Some(max_concurrent_requests) = self.max_concurrent_requests {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2822,13 +2822,13 @@ mod tests {
             // Make three requests that never get resolved. Since the server is configured to only accept a maximum of
             // two concurrent requests, the first two should succeed and the third one should fail.
             let request = get_symbolication_request(vec![symbol_server.pending_source.clone()]);
-            symbolication.symbolicate_stacktraces(request).unwrap();
+            assert!(symbolication.symbolicate_stacktraces(request).is_ok());
 
             let request = get_symbolication_request(vec![symbol_server.pending_source.clone()]);
-            symbolication.symbolicate_stacktraces(request).unwrap();
+            assert!(symbolication.symbolicate_stacktraces(request).is_ok());
 
             let request = get_symbolication_request(vec![symbol_server.pending_source]);
-            symbolication.symbolicate_stacktraces(request).unwrap_err();
+            assert!(symbolication.symbolicate_stacktraces(request).is_err());
         })
         .await;
     }


### PR DESCRIPTION
This adds a symbolicator config option `max_concurrent_requests: Option<usize>` that limits the number of requests symbolicator processes concurrently; any incoming requests beyond this number will be rejected. When this happens, `create_symbolication_request` returns a `MaxRequestsError` that is later converted to a `503` (`Internal Server Error`) status code by actix_web.

The option's default value is currently `None`, which corresponds to the status quo of never rejecting requests. The default will change once we have gathered some production data about request numbers.

(Also there's a bonus unrelated clippy fix)