### PR TITLE
ref: Make parts of Cacher properly async

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -14,7 +14,6 @@ use tempfile::NamedTempFile;
 
 use crate::config::{CacheConfig, Config};
 use crate::logging::LogError;
-use crate::types::Scope;
 
 /// Starting content of cache items whose writing failed.
 ///
@@ -358,26 +357,6 @@ fn expiration_strategy(cache_config: &CacheConfig, path: &Path) -> io::Result<Ex
         },
     };
     Ok(strategy)
-}
-
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub struct CacheKey {
-    pub cache_key: String,
-    pub scope: Scope,
-}
-
-pub fn get_scope_path(cache_dir: Option<&Path>, scope: &Scope, cache_key: &str) -> Option<PathBuf> {
-    Some(
-        cache_dir?
-            .join(safe_path_segment(scope.as_ref()))
-            .join(safe_path_segment(cache_key)),
-    )
-}
-
-fn safe_path_segment(s: &str) -> String {
-    s.replace(".", "_") // protect against ".."
-        .replace("/", "_") // protect against absolute paths
-        .replace(":", "_") // not a threat on POSIX filesystems, but confuses OS X Finder
 }
 
 fn catch_not_found<F, R>(f: F) -> io::Result<Option<R>>

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -18,9 +18,9 @@ use symbolic::common::{ByteView, DebugId};
 use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use tempfile::tempfile_in;
 
-use crate::cache::{Cache, CacheKey, CacheStatus};
+use crate::cache::{Cache, CacheStatus};
 use crate::logging::LogError;
-use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
 use crate::sources::{FileType, SourceConfig};
 use crate::types::Scope;

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -10,7 +10,7 @@ use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::cache::CacheKey;
+use crate::services::cacher::CacheKey;
 use crate::sources::SourceId;
 use crate::types::Scope;
 use crate::utils::sentry::ConfigureScope;

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -20,9 +20,9 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::tempfile_in;
 
-use crate::cache::{CacheKey, CacheStatus};
+use crate::cache::CacheStatus;
 use crate::logging::LogError;
-use crate::services::cacher::{CacheItemRequest, CachePath};
+use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath};
 use crate::services::download::{DownloadError, DownloadStatus, RemoteDif};
 use crate::types::{ObjectId, Scope};
 use crate::utils::compression::decompress_object_file;

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 use symbolic::common::ByteView;
 use symbolic::debuginfo::Object;
 
-use crate::cache::{CacheKey, CacheStatus};
-use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
+use crate::cache::CacheStatus;
+use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{RemoteDif, RemoteDifUri};
 use crate::sources::SourceId;
 use crate::types::{ObjectFeatures, ObjectId, Scope};

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -13,9 +13,9 @@ use symbolic::debuginfo::Object;
 use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use thiserror::Error;
 
-use crate::cache::{Cache, CacheKey, CacheStatus};
+use crate::cache::{Cache, CacheStatus};
 use crate::services::bitcode::{BcSymbolMapHandle, BitcodeService};
-use crate::services::cacher::{CacheItemRequest, CachePath, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
     ObjectsActor,


### PR DESCRIPTION
This makes a few methods of `Cacher` properly async, and moves some things around in preparation of multiple cachekey lookups.

This is preparation for https://getsentry.atlassian.net/browse/NATIVE-182

#skip-changelog