### PR TITLE
ref: Make it possible to use outdated caches

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -339,8 +339,8 @@ fn expiration_strategy(cache_config: &CacheConfig, path: &Path) -> io::Result<Ex
     let mut file = File::open(path)?;
     let mut buf = vec![0; readable_amount];
 
-    log::trace!("First {} bytes: {:?}", buf.len(), buf);
     file.read_exact(&mut buf)?;
+    log::trace!("First {} bytes: {:?}", buf.len(), buf);
 
     let strategy = match CacheStatus::from_content(&buf) {
         CacheStatus::Positive => ExpirationStrategy::None,


### PR DESCRIPTION
This implements the proposed cache versioning scheme, and will try to look up fallback cache versions if no current version is found.

It tries the fallback cache keys in order and uses the first one it finds. If so, it will schedule a computation task (on the same thread pool, but not awaiting its result).
If no cache is found, the computation is done eagerly.

Should cover https://getsentry.atlassian.net/browse/NATIVE-180 and https://getsentry.atlassian.net/browse/NATIVE-182.

The next followup on this would be to create a separate bounded compute pool for these background tasks. An extremely simple solution for "bounded queue" would be to just have an `AtomicUsize` that does the bounding, and still spawn the tasks on the current runtime.

#skip-changelog