### PR TITLE
test: Increase timeout for less flaky test

### DIFF
--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -450,7 +450,7 @@ mod tests {
     async fn test_symcache_refresh() {
         test::setup();
 
-        const TIMEOUT: Duration = Duration::from_millis(500);
+        const TIMEOUT: Duration = Duration::from_secs(5);
 
         let cache_dir = test::tempdir();
         let symbol_dir = test::tempdir();


### PR DESCRIPTION
This is a cheap attempt to make the test less flaky by simply giving
it a much larger timeout.

See #512 where this was flaky.

#skip-changelog