### PR TITLE
ref: Replace last future_metrics usage with measure

### DIFF
--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -334,8 +334,8 @@ impl<T: CacheItemRequest> Cacher<T> {
             } else {
                 // A concurrent cache lookup is considered new. This does not imply a cache miss.
                 metric!(counter(&format!("caches.{}.channel.miss", name)) += 1);
-                let channel =
-                    self.create_channel(key.clone(), self.clone().compute(request, key.clone()));
+                let computation = self.clone().compute(request, key.clone());
+                let channel = self.create_channel(key.clone(), computation);
                 let evicted = current_computations.insert(key, channel.clone());
                 debug_assert!(evicted.is_none());
                 channel

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -217,7 +217,7 @@ impl DownloadService {
         let _guard = self.worker.enter();
         let job = slf.dispatch_download(source, destination).bind_hub(hub);
         let job = tokio::time::timeout(self.config.max_download_timeout, job);
-        let job = measure("service.download", m::timed_result, job);
+        let job = measure("service.download", m::timed_result, None, job);
 
         // Map all SpawnError variants into DownloadError::Canceled.
         match self.worker.spawn(job).await {
@@ -262,7 +262,7 @@ impl DownloadService {
                 // See: https://docs.rs/tokio/1.0.1/tokio/runtime/struct.Runtime.html#method.enter
                 let _guard = self.worker.enter();
                 let job = tokio::time::timeout(Duration::from_secs(30), job);
-                let job = measure("service.download.list_files", m::timed_result, job);
+                let job = measure("service.download.list_files", m::timed_result, None, job);
 
                 // Map all SpawnError variants into DownloadError::Canceled.
                 match self.worker.spawn(job).await {

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -235,7 +235,7 @@ impl SentryDownloader {
         };
 
         let search = self.cached_sentry_search(query, config);
-        let entries = measure("downloads.sentry.index", m::result, search).await?;
+        let entries = measure("downloads.sentry.index", m::result, None, search).await?;
         let file_ids = entries
             .into_iter()
             .map(|search_result| SentryRemoteDif::new(source.clone(), search_result.id).into())

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -13,8 +13,6 @@ use std::io::{self, Seek, SeekFrom};
 use std::path::Path;
 use std::time::Duration;
 
-use futures::compat::Future01CompatExt;
-use futures::future::{FutureExt, TryFutureExt};
 use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
@@ -27,6 +25,7 @@ use crate::services::download::{DownloadError, DownloadStatus, RemoteDif};
 use crate::types::{ObjectId, Scope};
 use crate::utils::compression::decompress_object_file;
 use crate::utils::futures::BoxedFuture;
+use crate::utils::futures::{m, measure, timeout_compat};
 use crate::utils::sentry::ConfigureScope;
 
 use super::meta_cache::FetchFileMetaRequest;
@@ -244,25 +243,24 @@ impl CacheItemRequest for FetchFileDataRequest {
             Ok(CacheStatus::Positive)
         };
 
-        let result = future
-            .boxed_local()
-            .map_err(|e| {
+        let future = async move {
+            future.await.map_err(|e| {
                 sentry::capture_error(&e);
                 e
             })
-            .bind_hub(Hub::current());
+        }
+        .bind_hub(Hub::current());
 
-        let type_name = self.0.file_source.source_type_name();
+        let type_name = self.0.file_source.source_type_name().into();
 
-        Box::pin(
-            future_metrics!(
-                "objects",
-                Some((Duration::from_secs(600), ObjectError::Timeout)),
-                result.compat(),
-                "source_type" => type_name,
-            )
-            .compat(),
-        )
+        let future = timeout_compat(Duration::from_secs(600), future);
+        let future = measure(
+            "objects",
+            m::timed_result,
+            Some(("source_type", type_name)),
+            future,
+        );
+        Box::pin(async move { future.await.map_err(|_| ObjectError::Timeout)? })
     }
 
     fn load(

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1475,7 +1475,7 @@ impl SymbolicationActor {
 
         let f = self.do_symbolicate_impl(request);
         let f = timeout_compat(Duration::from_secs(3600), f);
-        let f = measure("symbolicate", m::timed_result, f);
+        let f = measure("symbolicate", m::timed_result, None, f);
 
         let mut response = f
             .await
@@ -2040,7 +2040,7 @@ impl SymbolicationActor {
         };
 
         let future = timeout_compat(Duration::from_secs(3600), future);
-        let future = measure("minidump_stackwalk", m::timed_result, future);
+        let future = measure("minidump_stackwalk", m::timed_result, None, future);
         future
             .await
             .map(|ret| ret.map_err(SymbolicationError::from))
@@ -2240,7 +2240,7 @@ impl SymbolicationActor {
         };
 
         let future = timeout_compat(Duration::from_secs(1200), future);
-        let future = measure("parse_apple_crash_report", m::timed_result, future);
+        let future = measure("parse_apple_crash_report", m::timed_result, None, future);
         future
             .await
             .map(|res| res.map_err(SymbolicationError::from))

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Error;
-use futures::compat::Future01CompatExt;
-use futures::future::{FutureExt, TryFutureExt};
 use sentry::{configure_scope, Hub, SentryFutureExt};
 use symbolic::common::{Arch, ByteView};
 use symbolic::debuginfo::Object;
@@ -24,7 +22,7 @@ use crate::sources::{FileType, SourceConfig};
 use crate::types::{
     AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
 };
-use crate::utils::futures::BoxedFuture;
+use crate::utils::futures::{m, measure, timeout_compat, BoxedFuture};
 use crate::utils::sentry::ConfigureScope;
 
 /// This marker string is appended to symcaches to indicate that they were created using a `BcSymbolMap`.
@@ -216,17 +214,16 @@ impl CacheItemRequest for FetchSymCacheInternal {
             self.threadpool.clone(),
         );
 
-        let num_sources = self.request.sources.len();
+        let num_sources = self.request.sources.len().to_string().into();
 
-        Box::pin(
-            future_metrics!(
-                "symcaches",
-                Some((Duration::from_secs(1200), SymCacheError::Timeout)),
-                future.boxed_local().compat(),
-                "num_sources" => &num_sources.to_string()
-            )
-            .compat(),
-        )
+        let future = timeout_compat(Duration::from_secs(1200), future);
+        let future = measure(
+            "symcaches",
+            m::timed_result,
+            Some(("num_sources", num_sources)),
+            future,
+        );
+        Box::pin(async move { future.await.map_err(|_| SymCacheError::Timeout)? })
     }
 
     fn should_load(&self, data: &[u8]) -> bool {


### PR DESCRIPTION
This is also removes that macro completely, and is a prerequisite to making cache computation futures `Send`, so we can get rid of the `spawn_compat` nonsense in a followup.

#skip-changelog