### PR TITLE
ref: Avoid spawning separate download tasks (NATIVE-191)

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -303,13 +303,13 @@ impl BitcodeService {
         hub.configure_scope(|scope| scope.set_extra("auxdif.source", source.type_name().into()));
 
         let file_type = match dif_kind {
-            AuxDifKind::BcSymbolMap => vec![FileType::BcSymbolMap],
-            AuxDifKind::UuidMap => vec![FileType::UuidMap],
+            AuxDifKind::BcSymbolMap => &[FileType::BcSymbolMap],
+            AuxDifKind::UuidMap => &[FileType::UuidMap],
         };
         let file_sources = self
             .download_svc
-            .clone()
-            .list_files(source, file_type, uuid.into(), hub.clone())
+            .list_files(source, file_type, uuid.into())
+            .bind_hub(hub.clone())
             .await?;
 
         let mut fetch_jobs = Vec::with_capacity(file_sources.len());

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -22,7 +22,7 @@ use crate::sources::{FileType, SourceConfig};
 use crate::types::{
     AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
 };
-use crate::utils::futures::{m, measure};
+use crate::utils::futures::{m, measure, CancelOnDrop};
 use crate::utils::sentry::ConfigureScope;
 
 /// The supported cficache versions.
@@ -175,8 +175,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
                 Ok(status)
             };
 
-            threadpool
-                .spawn(future.bind_hub(Hub::current()))
+            CancelOnDrop::new(threadpool.spawn(future.bind_hub(Hub::current())))
                 .await
                 .unwrap_or(Err(CfiCacheError::Canceled))
         };

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use ::sentry::{Hub, SentryFutureExt};
 use futures::prelude::*;
 use reqwest::StatusCode;
 use thiserror::Error;
@@ -111,7 +110,6 @@ pub enum DownloadStatus {
 #[derive(Debug)]
 pub struct DownloadService {
     config: Arc<Config>,
-    worker: tokio::runtime::Handle,
     sentry: sentry::SentryDownloader,
     http: http::HttpDownloader,
     s3: s3::S3Downloader,
@@ -121,7 +119,7 @@ pub struct DownloadService {
 
 impl DownloadService {
     /// Creates a new downloader that runs all downloads in the given remote thread.
-    pub fn new(config: Arc<Config>, worker: tokio::runtime::Handle) -> Arc<Self> {
+    pub fn new(config: Arc<Config>) -> Arc<Self> {
         let trusted_client = crate::utils::http::create_client(&config, true);
         let restricted_client = crate::utils::http::create_client(&config, false);
 
@@ -132,7 +130,6 @@ impl DownloadService {
         } = *config;
         Arc::new(Self {
             config,
-            worker,
             sentry: sentry::SentryDownloader::new(
                 trusted_client,
                 connect_timeout,
@@ -151,7 +148,7 @@ impl DownloadService {
 
     /// Dispatches downloading of the given file to the appropriate source.
     async fn dispatch_download(
-        self: Arc<Self>,
+        &self,
         source: RemoteDif,
         destination: PathBuf,
     ) -> Result<DownloadStatus, DownloadError> {
@@ -200,29 +197,18 @@ impl DownloadService {
     /// The downloaded file is saved into `destination`. The file will be created if it does not
     /// exist and truncated if it does. In case of any error, the file's contents is considered
     /// garbage.
-    //
-    // NB: This takes `Arc<Self>` since it needs to spawn into the worker pool internally. Spawning
-    // requires futures to be `'static`, which means there cannot be any references to an externally
-    // owned downloader.
     pub async fn download(
-        self: Arc<Self>,
+        &self,
         source: RemoteDif,
         destination: PathBuf,
     ) -> Result<DownloadStatus, DownloadError> {
-        let hub = Hub::current();
-        let slf = self.clone();
-
-        // NB: Enter the tokio 1 runtime, which is required to create the timeout.
-        // See: https://docs.rs/tokio/1.0.1/tokio/runtime/struct.Runtime.html#method.enter
-        let _guard = self.worker.enter();
-        let job = slf.dispatch_download(source, destination).bind_hub(hub);
+        let job = self.dispatch_download(source, destination);
         let job = tokio::time::timeout(self.config.max_download_timeout, job);
         let job = measure("service.download", m::timed_result, None, job);
 
-        // Map all SpawnError variants into DownloadError::Canceled.
-        match self.worker.spawn(job).await {
-            Ok(Ok(result)) => result,
-            Ok(Err(_)) | Err(_) => Err(DownloadError::Canceled),
+        match job.await {
+            Ok(result) => result,
+            Err(_) => Err(DownloadError::Canceled),
         }
     }
 
@@ -238,42 +224,28 @@ impl DownloadService {
     /// will respect this and they may return all DIFs matching the `object_id`.  After
     /// downloading you may still need to filter the files.
     pub async fn list_files(
-        self: Arc<Self>,
+        &self,
         source: SourceConfig,
-        filetypes: Vec<FileType>,
+        filetypes: &[FileType],
         object_id: ObjectId,
-        hub: Arc<Hub>,
     ) -> Result<Vec<RemoteDif>, DownloadError> {
         match source {
             SourceConfig::Sentry(cfg) => {
                 let config = self.config.clone();
-                let slf = self.clone();
 
-                // This `async move` ensures that the `list_files` future completes before `slf`
-                // goes out of scope, which ensures 'static lifetime for `spawn` below.
-                let job = async move {
-                    slf.sentry
-                        .list_files(cfg, object_id, &filetypes, config)
-                        .bind_hub(hub)
-                        .await
-                };
-
-                // NB: Enter the tokio 1 runtime, which is required to create the timeout.
-                // See: https://docs.rs/tokio/1.0.1/tokio/runtime/struct.Runtime.html#method.enter
-                let _guard = self.worker.enter();
+                let job = self.sentry.list_files(cfg, object_id, filetypes, config);
                 let job = tokio::time::timeout(Duration::from_secs(30), job);
                 let job = measure("service.download.list_files", m::timed_result, None, job);
 
-                // Map all SpawnError variants into DownloadError::Canceled.
-                match self.worker.spawn(job).await {
-                    Ok(Ok(result)) => result,
-                    Ok(Err(_)) | Err(_) => Err(DownloadError::Canceled),
+                match job.await {
+                    Ok(result) => result,
+                    Err(_) => Err(DownloadError::Canceled),
                 }
             }
-            SourceConfig::Http(cfg) => Ok(self.http.list_files(cfg, &filetypes, object_id)),
-            SourceConfig::S3(cfg) => Ok(self.s3.list_files(cfg, &filetypes, object_id)),
-            SourceConfig::Gcs(cfg) => Ok(self.gcs.list_files(cfg, &filetypes, object_id)),
-            SourceConfig::Filesystem(cfg) => Ok(self.fs.list_files(cfg, &filetypes, object_id)),
+            SourceConfig::Http(cfg) => Ok(self.http.list_files(cfg, filetypes, object_id)),
+            SourceConfig::S3(cfg) => Ok(self.s3.list_files(cfg, filetypes, object_id)),
+            SourceConfig::Gcs(cfg) => Ok(self.gcs.list_files(cfg, filetypes, object_id)),
+            SourceConfig::Filesystem(cfg) => Ok(self.fs.list_files(cfg, filetypes, object_id)),
         }
     }
 }
@@ -518,7 +490,7 @@ mod tests {
             ..Config::default()
         });
 
-        let service = DownloadService::new(config, tokio::runtime::Handle::current());
+        let service = DownloadService::new(config);
         let dest2 = dest.clone();
 
         // Jump through some hoops here, to prove that we can .await the service.
@@ -542,14 +514,9 @@ mod tests {
         };
 
         let config = Arc::new(Config::default());
-        let svc = DownloadService::new(config, tokio::runtime::Handle::current());
+        let svc = DownloadService::new(config);
         let file_list = svc
-            .list_files(
-                source.clone(),
-                FileType::all().to_vec(),
-                objid,
-                Hub::current(),
-            )
+            .list_files(source.clone(), FileType::all(), objid)
             .await
             .unwrap();
 

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -148,7 +148,7 @@ impl SentryDownloader {
     async fn cached_sentry_search(
         &self,
         query: SearchQuery,
-        config: Arc<Config>,
+        config: &Config,
     ) -> Result<Vec<SearchResult>, DownloadError> {
         // The Sentry cache index should expire as soon as we attempt to retry negative caches.
         let cache_duration = if config.cache_dir.is_some() {
@@ -187,7 +187,7 @@ impl SentryDownloader {
         source: Arc<SentrySourceConfig>,
         object_id: ObjectId,
         file_types: &[FileType],
-        config: Arc<Config>,
+        config: &Config,
     ) -> Result<Vec<RemoteDif>, DownloadError> {
         // TODO(flub): These queries do not handle pagination.  But sentry only starts to
         // paginate at 20 results so we get away with this for now.

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -75,7 +75,7 @@ impl Service {
         let spawnpool = procspawn::Pool::new(config.processing_pool_size)
             .context("failed to create process pool")?;
 
-        let downloader = DownloadService::new(config.clone(), io_pool.clone());
+        let downloader = DownloadService::new(config.clone());
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches
             .clear_tmp(&config)

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -328,7 +328,7 @@ mod tests {
             ..Config::default()
         });
 
-        let download_svc = DownloadService::new(config, tokio::runtime::Handle::current());
+        let download_svc = DownloadService::new(config);
         ObjectsActor::new(meta_cache, data_cache, download_svc)
     }
 

--- a/crates/symbolicator/src/utils/futures.rs
+++ b/crates/symbolicator/src/utils/futures.rs
@@ -40,6 +40,7 @@ impl Drop for CallOnDrop {
 ///
 /// This type makes sure that the spawned task is being canceled/aborted in case we lose interest
 /// in it.
+#[must_use = "this will cancel the underlying task when dropped"]
 pub struct CancelOnDrop<T> {
     handle: JoinHandle<T>,
 }


### PR DESCRIPTION
Now that the main symbolicator runs on the IO pool, it is not necessary to spawn download tasks on that same pool and await those tasks. Just await those futures directly.
This also simplifies things around taking ownership of self and arguments.

This also introduces a `CancelOnDrop` wrapper which is wrapped around spawns that are otherwise never canceled when the outer future is being timed out.

#skip-changelog