### PR TITLE
fix: Increase Runtime stack size

### DIFF
--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -23,14 +23,17 @@ pub fn run(config: Config) -> Result<()> {
     // service creation fails. The HTTP server is bound before the actix system runs.
     metric!(counter("server.starting") += 1);
 
+    let megs = 1024 * 1024;
     let io_pool = tokio::runtime::Builder::new_multi_thread()
         .thread_name("symbolicator-io")
         .enable_all()
+        .thread_stack_size(8 * megs)
         .build()
         .unwrap();
     let cpu_pool = tokio::runtime::Builder::new_multi_thread()
         .thread_name("symbolicator-cpu")
         .enable_all()
+        .thread_stack_size(8 * megs)
         .build()
         .unwrap();
 


### PR DESCRIPTION
We have recently observed a number of stack overflows.
It looks like the default tokio Runtime thread size is 2M, which is lower than the default 8M,
and Rust is known to use more stack space (in favor of heap allocations).

#skip-changelog