### PR TITLE
feat: Extract client-side stack traces from Minidumps (NATIVE-195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
  "byte-tools",
- "byteorder",
+ "byteorder 1.4.3",
  "generic-array 0.12.4",
 ]
 
@@ -270,6 +270,12 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
@@ -342,7 +348,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
  "serde",
  "time",
  "winapi 0.3.9",
@@ -626,6 +632,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +717,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-primitive-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f52288f9a7ebb08959188872b58e7eaa12af9cb47da8e94158e16da7e143340"
+dependencies = [
+ "num-traits 0.2.14",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +738,28 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1454,6 +1557,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "minidump"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d841fe81bc66affdde001469bf41f563d2e7c4ae11a584a1afcb80278fb20f"
+dependencies = [
+ "chrono",
+ "encoding",
+ "failure",
+ "libc",
+ "memmap",
+ "minidump-common",
+ "num-traits 0.2.14",
+ "range-map",
+ "scroll",
+]
+
+[[package]]
+name = "minidump-common"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f6cdbbd207feb369bb5f49548c1f479af4192bd7d9daa6ac2b6c9c5f946710"
+dependencies = [
+ "bitflags",
+ "enum-primitive-derive",
+ "libc",
+ "log",
+ "num-traits 0.2.14",
+ "range-map",
+ "scroll",
+ "smart-default",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +1775,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1649,7 +1785,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -2073,6 +2218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "range-map"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87dc8ff3b0f3e32dbba6e49c592c0191a3a2cabbf6f7e5a78e1010050b9a42e1"
+dependencies = [
+ "num-traits 0.1.43",
 ]
 
 [[package]]
@@ -2675,7 +2829,7 @@ checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
  "num-bigint",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -2695,6 +2849,17 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -2906,6 +3071,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
+ "minidump",
  "num_cpus",
  "parking_lot",
  "pretty_env_logger",
@@ -2923,6 +3089,7 @@ dependencies = [
  "structopt",
  "symbolic",
  "tempfile",
+ "test-assembler",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3019,6 +3186,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "test-assembler"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ccc488d8ed3a4a31f68372ba429642245ddbdf6642054334b7fcc06264cbde9"
+dependencies = [
+ "byteorder 0.5.3",
 ]
 
 [[package]]
@@ -3289,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64 0.13.0",
- "byteorder",
+ "byteorder 1.4.3",
  "bytes",
  "http",
  "httparse",
@@ -3762,7 +3938,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "bzip2",
  "crc32fast",
  "flate2",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.4.0"
 log = { version = "0.4.13", features = ["serde"] }
 lru = "0.6.3"
 num_cpus = "1.13.0"
+minidump = "0.3"
 parking_lot = "0.11.1"
 pretty_env_logger = "0.4.0"
 procspawn = { version = "0.10.0", features = ["backtrace", "json"] }
@@ -57,3 +58,4 @@ procspawn = { version = "0.10.0", features = ["test-support"] }
 reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["multipart"] }
 sha-1 = "0.9.2"
 warp = "0.3.0"
+test-assembler = "0.1.5"

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -17,7 +17,7 @@ mod symbolicate;
 pub use error::ResponseError;
 
 use applecrashreport::handle_apple_crash_report_request as applecrashreport;
-use minidump::handle_minidump_request as minidump;
+use minidump::handle_minidump_request as handle_minidump;
 use proxy::proxy_symstore_request as proxy;
 use requests::poll_request as requests;
 use symbolicate::symbolicate_frames as symbolicate;
@@ -34,7 +34,7 @@ pub fn create_app(service: Service) -> App {
         .route("/proxy/:path", get(proxy).head(proxy))
         .route("/requests/:request_id", get(requests))
         .route("/symbolicate", post(symbolicate))
-        .route("/minidump", post(minidump))
+        .route("/minidump", post(handle_minidump))
         .route("/applecrashreport", post(applecrashreport))
         .layer(axum::AddExtensionLayer::new(service))
         .layer(SentryRequestLayer)

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -16,8 +16,8 @@ mod symbolicate;
 
 pub use error::ResponseError;
 
+use self::minidump::handle_minidump_request as minidump;
 use applecrashreport::handle_apple_crash_report_request as applecrashreport;
-use minidump::handle_minidump_request as handle_minidump;
 use proxy::proxy_symstore_request as proxy;
 use requests::poll_request as requests;
 use symbolicate::symbolicate_frames as symbolicate;
@@ -34,7 +34,7 @@ pub fn create_app(service: Service) -> App {
         .route("/proxy/:path", get(proxy).head(proxy))
         .route("/requests/:request_id", get(requests))
         .route("/symbolicate", post(symbolicate))
-        .route("/minidump", post(handle_minidump))
+        .route("/minidump", post(minidump))
         .route("/applecrashreport", post(applecrashreport))
         .layer(axum::AddExtensionLayer::new(service))
         .layer(SentryRequestLayer)

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -90,7 +90,7 @@ mod format {
 
     #[derive(Debug)]
     pub struct Format<'data> {
-        header: &'data Header,
+        header: &'data RawHeader,
         threads: &'data [RawThread],
         frames: &'data [RawFrame],
         symbol_bytes: &'data [u8],
@@ -115,7 +115,7 @@ mod format {
         /// - some padding for alignment
         /// - symbol_bytes
         pub fn parse(buf: &'data [u8]) -> Result<Self, Error> {
-            let mut header_size = mem::size_of::<Header>();
+            let mut header_size = mem::size_of::<RawHeader>();
             header_size += align_to_eight(header_size);
 
             if buf.len() < header_size {
@@ -123,7 +123,7 @@ mod format {
             }
 
             // SAFETY: we will check validity of the header down below
-            let header = unsafe { &*(buf.as_ptr() as *const Header) };
+            let header = unsafe { &*(buf.as_ptr() as *const RawHeader) };
             if header.version != MINIDUMP_FORMAT_VERSION {
                 return Err(Error::WrongVersion);
             }
@@ -229,7 +229,7 @@ mod format {
 
     #[derive(Debug)]
     #[repr(C)]
-    struct Header {
+    struct RawHeader {
         version: u32,
         num_threads: u32,
         num_frames: u32,

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -190,6 +190,7 @@ mod format {
         pub fn frames(&self) -> Result<impl Iterator<Item = Frame>, Error> {
             let start_frame = self.thread.start_frame as usize;
             let end_frame = self.thread.start_frame as usize + self.thread.num_frames as usize;
+
             let frames = self
                 .format
                 .frames
@@ -238,7 +239,7 @@ mod format {
 
     #[derive(Debug)]
     #[repr(C)]
-    pub struct RawThread {
+    struct RawThread {
         thread_id: u32,
         start_frame: u32,
         num_frames: u32,
@@ -246,7 +247,7 @@ mod format {
 
     #[derive(Debug)]
     #[repr(C)]
-    pub struct RawFrame {
+    struct RawFrame {
         instruction_addr: u64,
         symbol_offset: u32,
         symbol_len: u32,
@@ -269,6 +270,10 @@ mod tests {
     use super::*;
 
     use test_assembler::*;
+
+    // Exposing Raw[Header|Frame|Thread] and implementing helpers
+    // that construct sections out of them would make these tests
+    // significantly more readable.
 
     #[test]
     fn test_simple_minidump() {

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -1,0 +1,269 @@
+const MINIDUMP_EXTENSION_TYPE: u32 = u32::from_be_bytes([b'S', b'y', 0, 1]);
+const MINIDUMP_FORMAT_VERSION: u32 = 1;
+
+pub fn parse_stacktraces_from_minidump<'buf>(
+    buf: &'buf [u8],
+) -> Result<format::Format<'buf>, WrappedError> {
+    let dump = minidump::Minidump::read(buf)?;
+    let extension_buf = dump.get_raw_stream(MINIDUMP_EXTENSION_TYPE)?;
+
+    // TODO: rust complains about lifetime issues here?
+    //parse_stacktraces_from_raw_extension(extension_buf)
+    todo!()
+}
+
+fn parse_stacktraces_from_raw_extension(buf: &[u8]) -> Result<format::Format, WrappedError> {
+    let parsed = format::Format::parse(buf)?;
+    Ok(parsed)
+}
+
+#[derive(Debug)]
+pub enum WrappedError {
+    MinidumpError(minidump::Error),
+    FormatError(format::Error),
+}
+
+impl From<minidump::Error> for WrappedError {
+    fn from(err: minidump::Error) -> Self {
+        Self::MinidumpError(err)
+    }
+}
+impl From<format::Error> for WrappedError {
+    fn from(err: format::Error) -> Self {
+        Self::FormatError(err)
+    }
+}
+
+// TODO: well, doc comments ;-)
+mod format {
+    use super::*;
+    use std::{mem, ptr};
+
+    // TODO: create more variants for:
+    // - buffer/header is invalid (buffer not big enough)
+    // - indexes are broken (index out of bounds from threads/frames iterator)
+    // - wrapped utf-8 error, or maybe figure out how we parse symbols right now
+    //   ^ or maybe we use `from_utf8_lossy` in other places?
+    #[derive(Debug)]
+    pub struct Error;
+
+    #[derive(Debug)]
+    pub struct Format<'data> {
+        header: &'data Header,
+        threads: &'data [RawThread],
+        frames: &'data [RawFrame],
+        symbol_bytes: &'data [u8],
+    }
+
+    impl<'data> Format<'data> {
+        /// Parse our custom minidump extension binary format
+        ///
+        /// TODO: add a better explanation of the format ;-)
+        /// ^ how everything is laid out one-after-the-other in memory, how indexing works, etc
+        ///
+        /// The binary format looks a bit like this:
+        /// - Header
+        /// - num_threads Thread
+        /// - num_frames Frame
+        ///   - thread0 frame0 <- RawThread.start_frame = 0
+        ///   - thread0 frame1 <- RawThread.num_frames = 1
+        ///   - thread1 frame0
+        ///   - thread1 frame1
+        /// - symbol_bytes
+        pub fn parse(buf: &'data [u8]) -> Result<Self, Error> {
+            let header_size = mem::size_of::<Header>();
+
+            if buf.len() < header_size {
+                return Err(Error);
+            }
+
+            // SAFETY: we will check validity of the header down below
+            let header = unsafe { &*(buf.as_ptr() as *const Header) };
+            if header.version != MINIDUMP_FORMAT_VERSION {
+                return Err(Error);
+            }
+
+            let threads_size = mem::size_of::<RawThread>() * header.num_threads as usize;
+            let frames_size = mem::size_of::<RawFrame>() * header.num_frames as usize;
+
+            let expected_buf_size =
+                header_size + threads_size + frames_size + header.symbol_bytes as usize;
+
+            if buf.len() != expected_buf_size {
+                return Err(Error);
+            }
+
+            // SAFETY: we just made sure that all the pointers we are constructing via pointer
+            // arithmetic are within `buf`
+            let threads_start = unsafe { buf.as_ptr().add(header_size) };
+            let frames_start = unsafe { threads_start.add(threads_size) };
+            let symbols_start = unsafe { frames_start.add(frames_size) };
+
+            // SAFETY: the above buffer size check also made sure we are not going out of bounds
+            // here
+            let threads = unsafe {
+                &*(ptr::slice_from_raw_parts(threads_start, header.num_threads as usize)
+                    as *const [RawThread])
+            };
+            let frames = unsafe {
+                &*(ptr::slice_from_raw_parts(frames_start, header.num_frames as usize)
+                    as *const [RawFrame])
+            };
+            let symbol_bytes = unsafe {
+                &*(ptr::slice_from_raw_parts(symbols_start, header.symbol_bytes as usize)
+                    as *const [u8])
+            };
+
+            Ok(Format {
+                header,
+                threads,
+                frames,
+                symbol_bytes,
+            })
+        }
+
+        pub fn threads(&self) -> impl Iterator<Item = Thread> {
+            self.threads.iter().map(move |raw_thread| Thread {
+                format: self,
+                thread: raw_thread,
+            })
+        }
+    }
+
+    pub struct Thread<'data> {
+        format: &'data Format<'data>,
+        thread: &'data RawThread,
+    }
+
+    impl Thread<'_> {
+        pub fn thread_id(&self) -> u64 {
+            self.thread.thread_id
+        }
+        pub fn frames(&self) -> Result<impl Iterator<Item = Frame>, Error> {
+            let range = self.thread.start_frame as usize
+                ..self.thread.start_frame as usize + self.thread.num_frames as usize;
+            let frames = self.format.frames.get(range).ok_or(Error)?;
+
+            Ok(frames.iter().map(move |raw_frame| Frame {
+                format: self.format,
+                frame: raw_frame,
+            }))
+        }
+    }
+
+    pub struct Frame<'data> {
+        format: &'data Format<'data>,
+        frame: &'data RawFrame,
+    }
+
+    impl Frame<'_> {
+        pub fn instruction_addr(&self) -> u64 {
+            self.frame.instruction_addr
+        }
+
+        pub fn symbol(&self) -> Result<&str, Error> {
+            let range = self.frame.symbol_offset as usize
+                ..self.frame.symbol_offset as usize + self.frame.symbol_len as usize;
+            let bytes = self.format.symbol_bytes.get(range).ok_or(Error)?;
+
+            std::str::from_utf8(bytes).map_err(|_| Error)
+        }
+    }
+
+    #[derive(Debug)]
+    #[repr(C)]
+    struct Header {
+        version: u32,
+        num_threads: u32,
+        num_frames: u32,
+        symbol_bytes: u32,
+    }
+
+    #[derive(Debug)]
+    #[repr(C)]
+    pub struct RawThread {
+        thread_id: u64,
+        start_frame: u32,
+        num_frames: u32,
+    }
+
+    #[derive(Debug)]
+    #[repr(C)]
+    pub struct RawFrame {
+        instruction_addr: u64,
+        symbol_offset: u32,
+        symbol_len: u32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use test_assembler::*;
+
+    #[test]
+    fn test_simple_minidump() {
+        let section = Section::new()
+            .D32(MINIDUMP_FORMAT_VERSION)
+            .D32(2) // 2 threads
+            .D32(5) // with 5 frames in total
+            .D32(11) // and some symbol bytes
+            .D64(1234) // first thread id
+            .D32(0)
+            .D32(2) // first two frames belong to thread 0
+            .D64(2345) // second thread id
+            .D32(2)
+            .D32(3) // last three frames belong to thread 1
+            .D64(0xfffff7001) // first instr_addr
+            .D32(0)
+            .D32(5) // the first symbol goes from 0-5
+            .D64(0xfffff7002) // first instr_addr
+            .D32(0)
+            .D32(5) // the first symbol goes from 0-5
+            .D64(0xfffff7003) // first instr_addr
+            .D32(5)
+            .D32(6) // the first symbol goes from 0-5
+            .D64(0xfffff7004) // first instr_addr
+            .D32(5)
+            .D32(6) // the first symbol goes from 0-5
+            .D64(0xfffff7006) // first instr_addr
+            .D32(5)
+            .D32(6) // the first symbol goes from 0-5
+            .append_bytes(b"uiaeosnrtdy");
+        let buf = section.get_contents().unwrap();
+
+        let parsed = parse_stacktraces_from_raw_extension(&buf).unwrap();
+
+        let mut threads = parsed.threads();
+
+        // first thread with 2 frames
+        let thread = threads.next().unwrap();
+        assert_eq!(thread.thread_id(), 1234);
+        let mut frames = thread.frames().unwrap();
+        let frame = frames.next().unwrap();
+        assert_eq!(frame.instruction_addr(), 0xfffff7001);
+        assert_eq!(frame.symbol().unwrap(), "uiaeo");
+        let frame = frames.next().unwrap();
+        assert_eq!(frame.instruction_addr(), 0xfffff7002);
+        assert_eq!(frame.symbol().unwrap(), "uiaeo");
+        assert!(frames.next().is_none());
+
+        // second thread with 3 frames
+        let thread = threads.next().unwrap();
+        assert_eq!(thread.thread_id(), 2345);
+        let mut frames = thread.frames().unwrap();
+        let frame = frames.next().unwrap();
+        assert_eq!(frame.instruction_addr(), 0xfffff7003);
+        assert_eq!(frame.symbol().unwrap(), "snrtdy");
+        let frame = frames.next().unwrap();
+        assert_eq!(frame.instruction_addr(), 0xfffff7004);
+        assert_eq!(frame.symbol().unwrap(), "snrtdy");
+        let frame = frames.next().unwrap();
+        assert_eq!(frame.instruction_addr(), 0xfffff7006);
+        assert_eq!(frame.symbol().unwrap(), "snrtdy");
+        assert!(frames.next().is_none());
+
+        assert!(threads.next().is_none());
+    }
+}

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -254,10 +254,10 @@ mod tests {
             .D32(2) // 2 threads
             .D32(5) // with 5 frames in total
             .D32(11) // and some symbol bytes
-            .D64(1234) // first thread id
+            .D32(1234) // first thread id
             .D32(0)
             .D32(2) // first two frames belong to thread 0
-            .D64(2345) // second thread id
+            .D32(2345) // second thread id
             .D32(2)
             .D32(3) // last three frames belong to thread 1
             .D64(0xfffff7001) // first instr_addr

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -40,6 +40,7 @@ pub mod bitcode;
 pub mod cacher;
 pub mod cficaches;
 pub mod download;
+mod minidump;
 pub mod objects;
 pub mod symbolication;
 pub mod symcaches;


### PR DESCRIPTION
This adds support for reading our custom minidump extension, and transforming it into `types::RawStacktrace` which we will use in a followup PR to combine with the stacktrace that was extracted via breakpad.

The PR also contains a documentation of the binary format of our extension.

#skip-changelog