### PR TITLE
feat: Prefer client-side stack traces over breakpad ones (NATIVE-196)

### DIFF
--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -93,11 +93,6 @@
 //!          +-----------+
 //! ```
 
-// TODO: Remove this once writing the minidump extension is complete. It is fine if this file is
-// left unused for now; It is expected that this will be used in a PR that'll follow these changes
-// shortly.
-#![allow(dead_code)]
-
 use std::convert::TryFrom;
 use std::fmt;
 


### PR DESCRIPTION
Overrides the breakpad-processed stack traces by client-side stack traces extracted from our minidump extension if those are available.

#skip-changelog