### PR TITLE
fix: Log Download Errors internally

### DIFF
--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -157,6 +157,7 @@ impl CacheItemRequest for FetchFileDataRequest {
         sentry::configure_scope(|scope| {
             scope.set_transaction(Some("download_file"));
             self.0.file_source.to_scope(scope);
+            self.0.object_id.to_scope(scope);
         });
 
         let file_id = self.0.file_source.clone();

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -181,7 +181,17 @@ impl CacheItemRequest for FetchFileDataRequest {
                 }
 
                 Err(e) => {
-                    log::debug!("Error while downloading file: {}", LogError(&e));
+                    // We want to error-log "interesting" download errors so we can look them up
+                    // in our internal sentry. We downgrade to debug-log for unactionable
+                    // permissions errors. Since this function does a fresh download, it will never
+                    // hit `CachedError`, but listing it for completeness is not a bad idea either.
+                    match e {
+                        DownloadError::Permissions | DownloadError::CachedError(_) => {
+                            log::debug!("Error while downloading file: {}", LogError(&e))
+                        }
+                        _ => log::error!("Error while downloading file: {}", LogError(&e)),
+                    }
+
                     return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
                 }
 


### PR DESCRIPTION
#512 downgraded our log from `error` to `debug`, but that means we stopped reporting download errors to S4S.

This brings back S4S logging of download errors, but still skips unactionable permissions errors.

#skip-changelog