### PR TITLE
ref(symbolication): Re-apply 5MB limit to request bodies

### DIFF
--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -50,8 +50,10 @@ pub struct SymbolicationRequestBody {
 pub async fn symbolicate_frames(
     extract::Extension(state): extract::Extension<Service>,
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
-    // TODO: limit body to 5M
-    extract::Json(body): extract::Json<SymbolicationRequestBody>,
+    extract::ContentLengthLimit(extract::Json(body)): extract::ContentLengthLimit<
+        extract::Json<SymbolicationRequestBody>,
+        { 5_000 * 1024 }, // ~5MB
+    >,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     sentry::start_session();
 

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -52,7 +52,7 @@ pub async fn symbolicate_frames(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     extract::ContentLengthLimit(extract::Json(body)): extract::ContentLengthLimit<
         extract::Json<SymbolicationRequestBody>,
-        { 5_000 * 1024 }, // ~5MB
+        { 5 * 1024 * 1024 },
     >,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     sentry::start_session();

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -52,7 +52,7 @@ pub async fn symbolicate_frames(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     extract::ContentLengthLimit(extract::Json(body)): extract::ContentLengthLimit<
         extract::Json<SymbolicationRequestBody>,
-        { 5 * 1024 * 1024 },
+        { 5 * 1024 * 1024 }, // ~5MB
     >,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     sentry::start_session();


### PR DESCRIPTION
Does what it says on the tin. This applies a 5MB limit to `/symbolicate`'s request body. If this check fails, an axum `Rejection` is returned which will be automatically converted and returned as an error response.

#skip-changelog