### PR TITLE
fix(wasm-split): Use build_id from commandline

### DIFF
--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -100,9 +100,14 @@ fn main() -> Result<(), anyhow::Error> {
         }
     }
 
-    // if we do have to build a new one, just roll a random uuid v4 as build id.
+    // if we do have to build a new one, use the one from the command line or fall back to
+    // a random uuid v4 as build id.
     let build_id = build_id.unwrap_or_else(|| {
-        let new_id = Uuid::new_v4().as_bytes().to_vec();
+        let new_id = cli
+            .build_id
+            .unwrap_or_else(Uuid::new_v4)
+            .as_bytes()
+            .to_vec();
         should_write_main_module = true;
         module
             .sections


### PR DESCRIPTION
The command line had an option to provide a build_id if there wasn't
one in the object already.  But this wasn't used and a randomly
generated one was always used.

#skip-changelog