### PR TITLE
fix: Fetch ELF debug files as well just to be safe if it is a Windows minidump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Symbolication tasks are being spawned on a tokio 1 Runtime now. ([#531](https://github.com/getsentry/symbolicator/pull/531))
 - Symbolicator now allows explicitly versioning its caches. It will fall back to supported outdated cache versions immediately instead of eagerly waiting for updated cache files. Recomputations of newer cache versions are being done lazily in the background, bounded by new settings `max_lazy_redownloads` and `max_lazy_recomputations` for downloaded and derived caches respectively. ([#524](https://github.com/getsentry/symbolicator/pull/524), [#533](https://github.com/getsentry/symbolicator/pull/533), [#535](https://github.com/getsentry/symbolicator/pull/535))
 - Remove actix-web in favor of axum. This changes the web framework and also completely switches to the tokio 1 Runtime. ([#544](https://github.com/getsentry/symbolicator/pull/544))
+- Search for all known types of debug companion files during symbolication, in case there exists for example an ELF debug companion for a PE. ([#555](https://github.com/getsentry/symbolicator/pull/555))
 
 ### Fixes
 

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::config::Config;
 use crate::sources::SentrySourceConfig;
-use crate::types::{ObjectId, ObjectType};
+use crate::types::ObjectId;
 use crate::utils::futures::{self as future_utils, m, measure};
 
 /// The Sentry-specific [`RemoteDif`].
@@ -205,19 +205,10 @@ impl SentryDownloader {
                 .append_pair("debug_id", &debug_id.to_string());
         }
 
-        // Minidumps on Windows are assigned an object type of ObjectType::Pe, but it's possible
-        // that they're actually Elfs instead
-        let additional_filetype = if object_id.object_type == ObjectType::Pe {
-            Some(FileType::ElfDebug)
-        } else {
-            None
-        };
-
         // See <sentry-repo>/src/sentry/constants.py KNOWN_DIF_FORMATS for these query strings.
         index_url.query_pairs_mut().extend_pairs(
             file_types
                 .iter()
-                .chain(additional_filetype.iter())
                 .map(|file_type| match file_type {
                     FileType::UuidMap => "uuidmap",
                     FileType::BcSymbolMap => "bcsymbolmap",

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::config::Config;
 use crate::sources::SentrySourceConfig;
-use crate::types::ObjectId;
+use crate::types::{ObjectId, ObjectType};
 use crate::utils::futures::{self as future_utils, m, measure};
 
 /// The Sentry-specific [`RemoteDif`].
@@ -205,10 +205,19 @@ impl SentryDownloader {
                 .append_pair("debug_id", &debug_id.to_string());
         }
 
+        // Minidumps on Windows are assigned an object type of ObjectType::Pe, but it's possible
+        // that they're actually Elfs instead
+        let additional_filetype = if object_id.object_type == ObjectType::Pe {
+            Some(FileType::ElfDebug)
+        } else {
+            None
+        };
+
         // See <sentry-repo>/src/sentry/constants.py KNOWN_DIF_FORMATS for these query strings.
         index_url.query_pairs_mut().extend_pairs(
             file_types
                 .iter()
+                .chain(additional_filetype.iter())
                 .map(|file_type| match file_type {
                     FileType::UuidMap => "uuidmap",
                     FileType::BcSymbolMap => "bcsymbolmap",

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__add_bucket-2.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__add_bucket-2.snap
@@ -31,10 +31,6 @@ modules:
     image_size: 4096
     candidates:
       - source: local
-        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7.debug"
         download:
           status: notfound

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__add_bucket-2.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__add_bucket-2.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
-expression: response.await.unwrap()
+source: crates/symbolicator/src/services/symbolication.rs
+expression: response.unwrap()
+
 ---
 status: completed
 stacktraces:
@@ -30,6 +31,14 @@ modules:
     image_size: 4096
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/502F/C0A5/1EC1/3E47/9998/684FA139DCA7"
         download:
           status: ok
@@ -44,3 +53,4 @@ modules:
         location: "http://localhost:<port>/download/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
           status: notfound
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__apple_crash_report.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__apple_crash_report.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
-expression: response.await.unwrap()
+source: crates/symbolicator/src/services/symbolication.rs
+expression: response.unwrap()
+
 ---
 status: completed
 timestamp: 1547055742
@@ -134,7 +135,31 @@ modules:
         download:
           status: notfound
       - source: local
+        location: "http://localhost:<port>/download/2d/903291397d3d14bfca52c7fb8c5e00"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/2d/903291397d3d14bfca52c7fb8c5e00.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397D3D14BFCA52C7FB8C5E000/YetAnotherMa_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397D3D14BFCA52C7FB8C5E000/YetAnotherMac"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/YetAnotherMac/2D903291397D3D14BFCA52C7FB8C5E000/YetAnotherMac.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397d3d14bfca52c7fb8c5e00/YetAnotherMa_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397d3d14bfca52c7fb8c5e00/YetAnotherMac"
         download:
           status: notfound
   - debug_status: unused
@@ -193,3 +218,4 @@ modules:
     debug_file: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/Engine/Binaries/ThirdParty/PhysX3/Mac/libPxFoundationPROFILE.dylib
     image_addr: "0x1131fa000"
     image_size: 28671
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__apple_crash_report.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__apple_crash_report.snap
@@ -135,10 +135,6 @@ modules:
         download:
           status: notfound
       - source: local
-        location: "http://localhost:<port>/download/2d/903291397d3d14bfca52c7fb8c5e00"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/2d/903291397d3d14bfca52c7fb8c5e00.debug"
         download:
           status: notfound
@@ -152,14 +148,6 @@ modules:
           status: notfound
       - source: local
         location: "http://localhost:<port>/download/YetAnotherMac/2D903291397D3D14BFCA52C7FB8C5E000/YetAnotherMac.sym"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397d3d14bfca52c7fb8c5e00/YetAnotherMa_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/YetAnotherMac/2D903291397d3d14bfca52c7fb8c5e00/YetAnotherMac"
         download:
           status: notfound
   - debug_status: unused

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux-2.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux-2.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
+source: crates/symbolicator/src/services/symbolication.rs
 expression: cache_entries
+
 ---
 - local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5
 - local_5d_7b6259552275a3c17bd4c3fd05f5a6bf40caa5_debug
@@ -8,12 +9,19 @@ expression: cache_entries
 - local_b5_381a457906d279073822a5ceb24c4bfef94ddb
 - local_b5_381a457906d279073822a5ceb24c4bfef94ddb_debug
 - local_b5_381a457906d279073822a5ceb24c4bfef94ddb_src_zip
+- local_crash_C0BCC3F19827FE653058404B2831D9E60_cras_
+- local_crash_C0BCC3F19827FE653058404B2831D9E60_crash
 - local_crash_C0BCC3F19827FE653058404B2831D9E60_crash_src_zip
 - local_crash_C0BCC3F19827FE653058404B2831D9E60_crash_sym
 - local_f1_c3bcc0279865fe3058404b2831d9e64135386c
 - local_f1_c3bcc0279865fe3058404b2831d9e64135386c_debug
 - local_f1_c3bcc0279865fe3058404b2831d9e64135386c_src_zip
+- local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_s_
+- local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so
 - local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so_src_zip
 - local_ld-2_23_so_59627B5D2255A375C17BD4C3FD05F5A60_ld-2_23_so_sym
+- local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_s_
+- local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so
 - local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so_src_zip
 - local_libc-2_23_so_451A38B5067979D2073822A5CEB24C4B0_libc-2_23_so_sym
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux.snap
@@ -141,14 +141,6 @@ modules:
         download:
           status: notfound
       - source: local
-        location: "http://localhost:<port>/download/crash/F1C3BCC0279865fe3058404b2831d9e64135386c/cras_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/crash/F1C3BCC0279865fe3058404b2831d9e64135386c/crash"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/f1/c3bcc0279865fe3058404b2831d9e64135386c"
         download:
           status: notfound
@@ -205,14 +197,6 @@ modules:
           status: notfound
       - source: local
         location: "http://localhost:<port>/download/libc-2.23.so/451A38B5067979D2073822A5CEB24C4B0/libc-2.23.so.sym"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/libc-2.23.so/B5381A457906d279073822a5ceb24c4bfef94ddb/libc-2.23.s_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/libc-2.23.so/B5381A457906d279073822a5ceb24c4bfef94ddb/libc-2.23.so"
         download:
           status: notfound
   - debug_status: unused
@@ -294,14 +278,6 @@ modules:
           status: notfound
       - source: local
         location: "http://localhost:<port>/download/ld-2.23.so/59627B5D2255A375C17BD4C3FD05F5A60/ld-2.23.so.sym"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/ld-2.23.so/5D7B6259552275a3c17bd4c3fd05f5a6bf40caa5/ld-2.23.s_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/ld-2.23.so/5D7B6259552275a3c17bd4c3fd05f5a6bf40caa5/ld-2.23.so"
         download:
           status: notfound
   - debug_status: unused

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
-expression: response.await.unwrap()
+source: crates/symbolicator/src/services/symbolication.rs
+expression: response.unwrap()
+
 ---
 status: completed
 timestamp: 1522061032
@@ -128,7 +129,23 @@ modules:
     image_size: 106496
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/crash/C0BCC3F19827FE653058404B2831D9E60/cras_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/C0BCC3F19827FE653058404B2831D9E60/crash"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/crash/C0BCC3F19827FE653058404B2831D9E60/crash.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/F1C3BCC0279865fe3058404b2831d9e64135386c/cras_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/F1C3BCC0279865fe3058404b2831d9e64135386c/crash"
         download:
           status: notfound
       - source: local
@@ -179,7 +196,23 @@ modules:
         download:
           status: notfound
       - source: local
+        location: "http://localhost:<port>/download/libc-2.23.so/451A38B5067979D2073822A5CEB24C4B0/libc-2.23.s_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libc-2.23.so/451A38B5067979D2073822A5CEB24C4B0/libc-2.23.so"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/libc-2.23.so/451A38B5067979D2073822A5CEB24C4B0/libc-2.23.so.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libc-2.23.so/B5381A457906d279073822a5ceb24c4bfef94ddb/libc-2.23.s_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libc-2.23.so/B5381A457906d279073822a5ceb24c4bfef94ddb/libc-2.23.so"
         download:
           status: notfound
   - debug_status: unused
@@ -252,7 +285,23 @@ modules:
         download:
           status: notfound
       - source: local
+        location: "http://localhost:<port>/download/ld-2.23.so/59627B5D2255A375C17BD4C3FD05F5A60/ld-2.23.s_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/ld-2.23.so/59627B5D2255A375C17BD4C3FD05F5A60/ld-2.23.so"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/ld-2.23.so/59627B5D2255A375C17BD4C3FD05F5A60/ld-2.23.so.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/ld-2.23.so/5D7B6259552275a3c17bd4c3fd05f5a6bf40caa5/ld-2.23.s_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/ld-2.23.so/5D7B6259552275a3c17bd4c3fd05f5a6bf40caa5/ld-2.23.so"
         download:
           status: notfound
   - debug_status: unused
@@ -270,3 +319,4 @@ modules:
     debug_file: linux-gate.so
     image_addr: "0x7fff5aef1000"
     image_size: 8192
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos-2.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos-2.snap
@@ -1,14 +1,22 @@
 ---
-source: src/services/symbolication.rs
+source: crates/symbolicator/src/services/symbolication.rs
 expression: cache_entries
+
 ---
 - local_67E9_247C_814E_392B_A027_DBDE6748FCBF
 - local_67E9_247C_814E_392B_A027_DBDE6748FCBF_app
 - local_67E9_247C_814E_392B_A027_DBDE6748FCBF_src_zip
+- local_67_e9247c814e392ba027dbde6748fcbf_debug
 - local_9B2A_C56D_107C_3541_A127_9094A751F2C9
 - local_9B2A_C56D_107C_3541_A127_9094A751F2C9_app
 - local_9B2A_C56D_107C_3541_A127_9094A751F2C9_src_zip
+- local_9b_2ac56d107c3541a1279094a751f2c9_debug
+- local_crash_67E9247C814E392BA027DBDE6748FCBF0_cras_
+- local_crash_67E9247C814E392BA027DBDE6748FCBF0_crash
 - local_crash_67E9247C814E392BA027DBDE6748FCBF0_crash_src_zip
 - local_crash_67E9247C814E392BA027DBDE6748FCBF0_crash_sym
+- local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dyli_
+- local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dylib
 - local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dylib_src_zip
 - local_libdyld_dylib_9B2AC56D107C3541A1279094A751F2C90_libdyld_dylib_sym
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
-expression: response.await.unwrap()
+source: crates/symbolicator/src/services/symbolication.rs
+expression: response.unwrap()
+
 ---
 status: completed
 timestamp: 1521713398
@@ -73,6 +74,14 @@ modules:
     image_size: 69632
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/67/e9247c814e392ba027dbde6748fcbf"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/67/e9247c814e392ba027dbde6748fcbf.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/67E9/247C/814E/392B/A027/DBDE6748FCBF"
         download:
           status: notfound
@@ -81,7 +90,23 @@ modules:
         download:
           status: notfound
       - source: local
+        location: "http://localhost:<port>/download/crash/67E9247C814E392BA027DBDE6748FCBF0/cras_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/67E9247C814E392BA027DBDE6748FCBF0/crash"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/crash/67E9247C814E392BA027DBDE6748FCBF0/crash.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/67E9247C814e392ba027dbde6748fcbf/cras_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/crash/67E9247C814e392ba027dbde6748fcbf/crash"
         download:
           status: notfound
   - debug_status: unused
@@ -319,7 +344,31 @@ modules:
         download:
           status: notfound
       - source: local
+        location: "http://localhost:<port>/download/9b/2ac56d107c3541a1279094a751f2c9"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/9b/2ac56d107c3541a1279094a751f2c9.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107C3541A1279094A751F2C90/libdyld.dyli_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107C3541A1279094A751F2C90/libdyld.dylib"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107C3541A1279094A751F2C90/libdyld.dylib.sym"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107c3541a1279094a751f2c9/libdyld.dyli_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107c3541a1279094a751f2c9/libdyld.dylib"
         download:
           status: notfound
   - debug_status: unused
@@ -727,3 +776,4 @@ modules:
     debug_file: libxpc.dylib
     image_addr: "0x7fffe8134000"
     image_size: 172032
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_macos.snap
@@ -74,10 +74,6 @@ modules:
     image_size: 69632
     candidates:
       - source: local
-        location: "http://localhost:<port>/download/67/e9247c814e392ba027dbde6748fcbf"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/67/e9247c814e392ba027dbde6748fcbf.debug"
         download:
           status: notfound
@@ -99,14 +95,6 @@ modules:
           status: notfound
       - source: local
         location: "http://localhost:<port>/download/crash/67E9247C814E392BA027DBDE6748FCBF0/crash.sym"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/crash/67E9247C814e392ba027dbde6748fcbf/cras_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/crash/67E9247C814e392ba027dbde6748fcbf/crash"
         download:
           status: notfound
   - debug_status: unused
@@ -344,10 +332,6 @@ modules:
         download:
           status: notfound
       - source: local
-        location: "http://localhost:<port>/download/9b/2ac56d107c3541a1279094a751f2c9"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/9b/2ac56d107c3541a1279094a751f2c9.debug"
         download:
           status: notfound
@@ -361,14 +345,6 @@ modules:
           status: notfound
       - source: local
         location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107C3541A1279094A751F2C90/libdyld.dylib.sym"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107c3541a1279094a751f2c9/libdyld.dyli_"
-        download:
-          status: notfound
-      - source: local
-        location: "http://localhost:<port>/download/libdyld.dylib/9B2AC56D107c3541a1279094a751f2c9/libdyld.dylib"
         download:
           status: notfound
   - debug_status: unused

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows-2.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows-2.snap
@@ -1,7 +1,13 @@
 ---
-source: src/services/symbolication.rs
+source: crates/symbolicator/src/services/symbolication.rs
 expression: cache_entries
+
 ---
+- local_57_898dab25000_debug
+- local_59_0285e9e0000_debug
+- local_59_b0d8f3183000_debug
+- local_5a_49bb75c1000_debug
+- local_5a_b380779000_debug
 - local_crash_exe_5AB380779000_crash_ex_
 - local_crash_exe_5AB380779000_crash_exe
 - local_crash_pdb_3249D99D0C4049318610F4E4FB0B69361_crash_pd_
@@ -30,3 +36,4 @@ expression: cache_entries
 - local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pd_
 - local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_pdb
 - local_wrpcrt4_pdb_AE131C6727A74FA19916B5A4AEF411901_wrpcrt4_sym
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -171,10 +171,6 @@ modules:
     image_size: 36864
     candidates:
       - source: local
-        location: "http://localhost:<port>/download/5a/b380779000"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/5a/b380779000.debug"
         download:
           status: notfound
@@ -268,10 +264,6 @@ modules:
     image_addr: "0x70b70000"
     image_size: 151552
     candidates:
-      - source: local
-        location: "http://localhost:<port>/download/57/898dab25000"
-        download:
-          status: notfound
       - source: local
         location: "http://localhost:<port>/download/57/898dab25000.debug"
         download:
@@ -403,10 +395,6 @@ modules:
     image_size: 917504
     candidates:
       - source: local
-        location: "http://localhost:<port>/download/59/0285e9e0000"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/59/0285e9e0000.debug"
         download:
           status: notfound
@@ -461,10 +449,6 @@ modules:
     image_addr: "0x75810000"
     image_size: 790528
     candidates:
-      - source: local
-        location: "http://localhost:<port>/download/5a/49bb75c1000"
-        download:
-          status: notfound
       - source: local
         location: "http://localhost:<port>/download/5a/49bb75c1000.debug"
         download:
@@ -535,10 +519,6 @@ modules:
     image_addr: "0x77170000"
     image_size: 1585152
     candidates:
-      - source: local
-        location: "http://localhost:<port>/download/59/b0d8f3183000"
-        download:
-          status: notfound
       - source: local
         location: "http://localhost:<port>/download/59/b0d8f3183000.debug"
         download:

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_windows.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/symbolicator/src/services/symbolication.rs
-expression: response.await.unwrap()
+expression: response.unwrap()
+
 ---
 status: completed
 timestamp: 1521713273
@@ -170,6 +171,14 @@ modules:
     image_size: 36864
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/5a/b380779000"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/5a/b380779000.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/crash.exe/5AB380779000/crash.ex_"
         download:
           status: notfound
@@ -259,6 +268,14 @@ modules:
     image_addr: "0x70b70000"
     image_size: 151552
     candidates:
+      - source: local
+        location: "http://localhost:<port>/download/57/898dab25000"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/57/898dab25000.debug"
+        download:
+          status: notfound
       - source: local
         location: "http://localhost:<port>/download/dbgcore.dll/57898DAB25000/dbgcore.dl_"
         download:
@@ -386,6 +403,14 @@ modules:
     image_size: 917504
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/59/0285e9e0000"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/59/0285e9e0000.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/kernel32.dll/590285E9e0000/kernel32.dl_"
         download:
           status: notfound
@@ -436,6 +461,14 @@ modules:
     image_addr: "0x75810000"
     image_size: 790528
     candidates:
+      - source: local
+        location: "http://localhost:<port>/download/5a/49bb75c1000"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/5a/49bb75c1000.debug"
+        download:
+          status: notfound
       - source: local
         location: "http://localhost:<port>/download/rpcrt4.dll/5A49BB75c1000/rpcrt4.dl_"
         download:
@@ -503,6 +536,14 @@ modules:
     image_size: 1585152
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/59/b0d8f3183000"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/59/b0d8f3183000.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/ntdll.dll/59B0D8F3183000/ntdll.dl_"
         download:
           status: notfound
@@ -522,3 +563,4 @@ modules:
         location: "http://localhost:<port>/download/wntdll.pdb/971F98E5CE6041FFB2D7235BBEB345781/wntdll.sym"
         download:
           status: notfound
+

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__remove_bucket.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__remove_bucket.snap
@@ -31,10 +31,6 @@ modules:
     image_size: 4096
     candidates:
       - source: local
-        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7"
-        download:
-          status: notfound
-      - source: local
         location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7.debug"
         download:
           status: notfound

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__remove_bucket.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__remove_bucket.snap
@@ -1,6 +1,7 @@
 ---
-source: src/services/symbolication.rs
-expression: response.await.unwrap()
+source: crates/symbolicator/src/services/symbolication.rs
+expression: response.unwrap()
+
 ---
 status: completed
 stacktraces:
@@ -30,6 +31,14 @@ modules:
     image_size: 4096
     candidates:
       - source: local
+        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/50/2fc0a51ec13e479998684fa139dca7.debug"
+        download:
+          status: notfound
+      - source: local
         location: "http://localhost:<port>/download/502F/C0A5/1EC1/3E47/9998/684FA139DCA7"
         download:
           status: ok
@@ -44,3 +53,4 @@ modules:
         location: "http://localhost:<port>/download/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
           status: notfound
+

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -464,14 +464,26 @@ impl FileType {
             // union of all of the possible file types for the three below object types so avoid
             // making any assumption about the type of debug companions that can be provided for a
             // given executable.
-            ObjectType::Macho | ObjectType::Pe | ObjectType::Elf => &[
+            ObjectType::Macho => &[
+                FileType::MachCode,
                 FileType::Breakpad,
                 FileType::MachDebug,
-                FileType::MachCode,
                 FileType::Pdb,
-                FileType::Pe,
                 FileType::ElfDebug,
+            ],
+            ObjectType::Pe => &[
+                FileType::Pe,
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::Pdb,
+                FileType::ElfDebug,
+            ],
+            ObjectType::Elf => &[
                 FileType::ElfCode,
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::Pdb,
+                FileType::ElfDebug,
             ],
             ObjectType::Wasm => &[FileType::WasmCode, FileType::WasmDebug],
             _ => Self::all(),

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -458,12 +458,10 @@ impl FileType {
     #[inline]
     pub fn from_object_type(ty: ObjectType) -> &'static [Self] {
         match ty {
-            // There are instances where applications have been cross-compiled for some target
-            // platform, but their debug files are emitted as ELF files (e.g. MinGW with GCC
-            // spits out a PE for Windows but an ELF debug companion). As a result, we return a
-            // union of all of the possible file types for the three below object types so avoid
-            // making any assumption about the type of debug companions that can be provided for a
-            // given executable.
+            // There are instances where an application's debug files are ELFs despite the
+            // executable not being ELFs themselves. It probably isn't correct to assume that any
+            // specific debug file type is heavily coupled with a particular executable type so we
+            // return a union of all possible debug file types for native applications.
             ObjectType::Macho => &[
                 FileType::MachCode,
                 FileType::Breakpad,

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -458,9 +458,21 @@ impl FileType {
     #[inline]
     pub fn from_object_type(ty: ObjectType) -> &'static [Self] {
         match ty {
-            ObjectType::Macho => &[FileType::MachDebug, FileType::MachCode, FileType::Breakpad],
-            ObjectType::Pe => &[FileType::Pdb, FileType::Pe, FileType::Breakpad],
-            ObjectType::Elf => &[FileType::ElfDebug, FileType::ElfCode, FileType::Breakpad],
+            // There are instances where applications have been cross-compiled for some target
+            // platform, but their debug files are emitted as ELF files (e.g. MinGW with GCC
+            // spits out a PE for Windows but an ELF debug companion). As a result, we return a
+            // union of all of the possible file types for the three below object types so avoid
+            // making any assumption about the type of debug companions that can be provided for a
+            // given executable.
+            ObjectType::Macho | ObjectType::Pe | ObjectType::Elf => &[
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::MachCode,
+                FileType::Pdb,
+                FileType::Pe,
+                FileType::ElfDebug,
+                FileType::ElfCode,
+            ],
             ObjectType::Wasm => &[FileType::WasmCode, FileType::WasmDebug],
             _ => Self::all(),
         }

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -27,6 +27,7 @@ WINDOWS_DATA = {
     ],
 }
 
+
 def _make_successful_result(filtered=False):
     response = {
         "stacktraces": [
@@ -89,11 +90,14 @@ def _make_successful_result(filtered=False):
     }
     # if the request to symbolicator filters for only PDBs, other debug file types won't be included
     if not filtered:
-        response["modules"][0]["candidates"].insert(0, {
-            "download": {"status": "notfound"},
-            "location": "http://127.0.0.1:1234/msdl/_.dwarf/mach-uuid-sym-ff9f9f7841db88f0cdeda9e1e9bff3b5/_.dwarf",
-            "source": "microsoft",
-        })
+        response["modules"][0]["candidates"].insert(
+            0,
+            {
+                "download": {"status": "notfound"},
+                "location": "http://127.0.0.1:1234/msdl/_.dwarf/mach-uuid-sym-ff9f9f7841db88f0cdeda9e1e9bff3b5/_.dwarf",
+                "source": "microsoft",
+            },
+        )
     return response
 
 
@@ -215,6 +219,7 @@ def _make_error_result(download_error, source="microsoft", bucket_type="http"):
             },
         ]
     return response
+
 
 SUCCESS_WINDOWS_FILTERED = _make_successful_result(filtered=True)
 SUCCESS_WINDOWS = _make_successful_result()
@@ -577,7 +582,10 @@ def test_no_permission(symbolicator, hitcounter, bucket_type):
         source_specific = {"layout": {"type": "symstore"}}
     elif bucket_type == "s3":
         source_specific = {
-            "layout": {"type": "symstore"},"bucket": "symbolicator-test", "region": "us-east-1"}
+            "layout": {"type": "symstore"},
+            "bucket": "symbolicator-test",
+            "region": "us-east-1",
+        }
     elif bucket_type == "gcs":
         source_specific = {
             "layout": {"type": "symstore"},

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -579,7 +579,7 @@ def test_unreachable_bucket(symbolicator, hitcounter, statuscode, bucket_type):
 @pytest.mark.parametrize("bucket_type", ["http", "s3"])
 def test_no_permission(symbolicator, hitcounter, bucket_type):
     if bucket_type == "http":
-        source_specific = {"layout": {"type": "symstore"}}
+        source_specific = {"url": f"{hitcounter.url}/respond_statuscode/403/"}
     elif bucket_type == "s3":
         source_specific = {
             "layout": {"type": "symstore"},
@@ -599,7 +599,7 @@ def test_no_permission(symbolicator, hitcounter, bucket_type):
     source = {
         "type": bucket_type,
         "id": "broken",
-        "url": f"{hitcounter.url}/respond_statuscode/403/",
+        "layout": {"type": "symstore"},
     }
     source.update(source_specific)
 


### PR DESCRIPTION
~~A first shot at fixing a regression where we're no longer fetching
ELF DIFs for minidumps generated on Windows, likely caused by
#414.~~

Symbolicator now requests all known debug file types when encountering a minidump generated by a native executable. This means that minidumps produced by PEs, Machos and ELFs will trigger a search for PDBs, dSYMs, and ELFs if possible.