### PR TITLE
ref: Minor integration test changes

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -271,7 +271,7 @@ def hitcounter(request):
         yield app
 
 
-def assert_symbolication(output, expected):
+def assert_symbolication(output, expected, assertion_info=None):
     """Compares symbolication results, with redactions.
 
     Redactions are necessary to remove random port numbers.
@@ -298,4 +298,7 @@ def assert_symbolication(output, expected):
 
     redact(output)
     redact(expected)
-    assert output == expected
+    if assertion_info:
+        assert output == expected, assertion_info
+    else:
+        assert output == expected

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -666,7 +666,7 @@ def test_malformed_objects(symbolicator, hitcounter):
 
 
 @pytest.mark.parametrize(
-    "patterns,output",
+    "patterns,expected_output",
     [
         [["?:/windows/**"], SUCCESS_WINDOWS],
         [["?:/windows/*"], SUCCESS_WINDOWS],
@@ -675,7 +675,7 @@ def test_malformed_objects(symbolicator, hitcounter):
         [["d:/windows/**"], NO_SOURCES],
     ],
 )
-def test_path_patterns(symbolicator, hitcounter, patterns, output):
+def test_path_patterns(symbolicator, hitcounter, patterns, expected_output):
     input = dict(
         sources=[
             {
@@ -691,9 +691,9 @@ def test_path_patterns(symbolicator, hitcounter, patterns, output):
         },
         **WINDOWS_DATA,
     )
-    if output == NO_SOURCES:
-        output = copy.deepcopy(output)
-        output["modules"][0]["candidates"] = [
+    if expected_output == NO_SOURCES:
+        expected_output = copy.deepcopy(expected_output)
+        expected_output["modules"][0]["candidates"] = [
             {
                 "source": "microsoft",
                 "location": "No object files listed on this source",
@@ -709,7 +709,7 @@ def test_path_patterns(symbolicator, hitcounter, patterns, output):
     response = service.post("/symbolicate", json=input)
     response.raise_for_status()
 
-    assert_symbolication(response.json(), output)
+    assert_symbolication(response.json(), expected_output)
 
 
 def test_redirects(symbolicator, hitcounter):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -551,7 +551,9 @@ def test_unreachable_bucket(symbolicator, hitcounter, statuscode, bucket_type):
                 },
             }
         ]
-        assert_symbolication(response, expected)
+        assert_symbolication(
+            response, expected, {"status code": statuscode, "bucket type": bucket_type}
+        )
     else:
         if statuscode == 500:
             expected = _make_error_result(
@@ -572,7 +574,9 @@ def test_unreachable_bucket(symbolicator, hitcounter, statuscode, bucket_type):
                         f"/respond_statuscode/{statuscode}/",
                     )
 
-        assert_symbolication(response, expected)
+        assert_symbolication(
+            response, expected, {"status code": statuscode, "bucket type": bucket_type}
+        )
 
 
 # can't test gcs because you get JWT errors, meaningless to test sentry sources
@@ -633,7 +637,7 @@ def test_no_permission(symbolicator, hitcounter, bucket_type):
                         "/respond_statuscode/403/",
                     )
 
-    assert_symbolication(response, expected)
+    assert_symbolication(response, expected, {"bucket type": bucket_type})
 
 
 def test_malformed_objects(symbolicator, hitcounter):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -562,6 +562,7 @@ def test_unreachable_bucket(symbolicator, hitcounter, statuscode, bucket_type):
                     "details": "failed to download: 500 Internal Server Error",
                 },
                 source="broken",
+                bucket_type="http",
             )
         else:
             expected = _make_unsuccessful_result(status="missing", source="broken")
@@ -778,7 +779,9 @@ def test_reserved_ip_addresses(symbolicator, hitcounter, allow_reserved_ip, host
     else:
         assert not hitcounter.hits
         restricted_download_failure = _make_error_result(
-            download_error={"status": "error", "details": "failed to stream file"}
+            download_error={"status": "error", "details": "failed to stream file"},
+            source="microsoft",
+            bucket_type="http",
         )
         assert_symbolication(response.json(), restricted_download_failure)
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -154,7 +154,7 @@ def _make_error_result(
         "download": download_error,
         "source": source_name,
     }
-    if source_name == None:
+    if source_name is None:
         pass
     elif missing_candidates:
         module["candidates"] = [

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -554,7 +554,7 @@ def test_no_permission(symbolicator, hitcounter, bucket_type):
     response = response.json()
 
     base_url = (
-        f"s3://symbolicator-test/"
+        "s3://symbolicator-test/"
         if bucket_type == "s3"
         else f"{hitcounter.url}/respond_statuscode/403/"
     )


### PR DESCRIPTION
This makes a few quality of (my) life changes to the integration tests so it's a little easier to update and customize them as needed. I've had to muck around in this code a few times now and I'm hoping these changes make it easier to understand what's going on, and how to change the test code in response to a change in symbolicator. 

A major motivation behind the changes is to try to structure things in a way so that the tests don't need to mutate objects too much in order to get the correct expected data to assert against.

- Consolidate common parts of the stack trace and the modules into shared variables
- Merge redundant helpers that construct results for failed symbolication attempts
- Prefer passing in specific configs for error results as opposed to referring to named constants that pre-fill parameters

#skip-changelog