### PR TITLE
ref: Expose the sentry HTTP headers in the context, not tags

### DIFF
--- a/crates/symbolicator/src/utils/sentry.rs
+++ b/crates/symbolicator/src/utils/sentry.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::task::{Context, Poll};
 
 use axum::body::Body;
-use axum::http::{HeaderValue, Request};
+use axum::http::Request;
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -47,30 +47,16 @@ where
 
     fn call(&mut self, request: Request<Body>) -> Self::Future {
         sentry::configure_scope(|scope| {
-            let mut sentry_headers = BTreeMap::new();
-            let headers = request.headers();
-            fn get_str(val: &HeaderValue) -> Option<&str> {
-                val.to_str().ok()
+            let mut headers = BTreeMap::new();
+            for (header, value) in request.headers() {
+                headers.insert(
+                    header.to_string(),
+                    value.to_str().unwrap_or("<Opaque header value>").into(),
+                );
             }
-            if let Some(worker_id) = headers.get("X-Sentry-Worker-Id").and_then(get_str) {
-                sentry_headers.insert(String::from("X-Sentry-Worker-Id"), worker_id.into());
-            }
-            if let Some(project_id) = headers.get("X-Sentry-Project-Id").and_then(get_str) {
-                sentry_headers.insert(String::from("X-Sentry-Project-Id"), project_id.into());
-            }
-            if let Some(event_id) = headers.get("X-Sentry-Event-Id").and_then(get_str) {
-                sentry_headers.insert(String::from("X-Sentry-Event-Id"), event_id.into());
-            }
-
-            // TODO: We can use this in the future for distributed tracing once we make
-            // properly support that in the SDK.
-            if let Some(trace_id) = headers.get("Sentry-Trace").and_then(get_str) {
-                sentry_headers.insert(String::from("Sentry-Trace"), trace_id.into());
-            }
-
             scope.set_context(
-                "Sentry HTTP Headers",
-                sentry::protocol::Context::Other(sentry_headers),
+                "HTTP Request Headers",
+                sentry::protocol::Context::Other(headers),
             );
         });
         self.service.call(request)


### PR DESCRIPTION
Tags are indexed and we don't need to be able to search on these.
Plus adding a `sentry.project_id` in the tags is highly confusing wrt
request.scope.  Originally this stuff was exposed in the context as
part of the http headers, so lets at least do this partially again.

#skip-changelog