### PR TITLE
doc: Update and expand instructions on how to update test snapshots on sentry

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -60,11 +60,16 @@ Sentry runs a symbolicator integration test suite located at [\`tests/symbolicat
 Follow these steps to update snapshots in Sentry:
 
 1. Check out latest Sentry \`master\` and enable the virtualenv.
-2. Stop the symbolicator devservice using \`sentry devservices down symbolicator\`.
-3. Run your development symbolicator on port \`3021\`.
-4. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` and run symbolicator tests with pytest.
-5. Review snapshot changes locally, then create a PR to Sentry.
-6. Merge the Symbolicator PR, then merge the Sentry PR.
+2. Make sure your other devservices are running via \`sentry devservices up\`, and that symbolicator
+is enabled (\`symbolicator: true\`) in sentry via \`~/.sentry/config.yml\`.
+4. Stop the symbolicator devservice using \`sentry devservices down symbolicator\`. You want to use your
+own development symbolicator to update the snapshots.
+5. Run your development symbolicator on port \`3021\`, or whatever port symbolicator is configured to use
+in \`~/.sentry/config.yml\`.
+6. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` to automatically update the existing snapshots with your new
+results and run symbolicator tests with pytest (\`pytest tests/symbolicator\`).
+7. Review snapshot changes locally, then create a PR to Sentry.
+8. Merge the Symbolicator PR, then merge the Sentry PR.
 
 </details>
   `;
@@ -90,8 +95,8 @@ async function checkSnapshots() {
 
   if (changesSnapshots) {
     warn(
-      "Snapshot changes likely affect Sentry tests. Please check the symbolicator test suite in " +
-        "Sentry and update snapshots as needed."
+      "Snapshot changes likely affect Sentry tests. If the Sentry-Symbolicator Integration Tests in CI are " +
+      "failing for your PR, please check the symbolicator test suite in Sentry and update snapshots as needed."
     );
     markdown(getSnapshotDetails());
   }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -60,16 +60,16 @@ Sentry runs a symbolicator integration test suite located at [\`tests/symbolicat
 Follow these steps to update snapshots in Sentry:
 
 1. Check out latest Sentry \`master\` and enable the virtualenv.
-2. Make sure your other devservices are running via \`sentry devservices up\`, and that symbolicator
-is enabled (\`symbolicator: true\`) in sentry via \`~/.sentry/config.yml\`.
-4. Stop the symbolicator devservice using \`sentry devservices down symbolicator\`. You want to use your
+2. Enable symbolicator (\`symbolicator: true\`) in sentry via \`~/.sentry/config.yml\`.
+3. Make sure your other devservices are running via \`sentry devservices up --exclude symbolicator\`. If
+they're already running, stop symbolicator with \`sentry devservices down symbolicator\`. You want to use your
 own development symbolicator to update the snapshots.
-5. Run your development symbolicator on port \`3021\`, or whatever port symbolicator is configured to use
+4. Run your development symbolicator on port \`3021\`, or whatever port symbolicator is configured to use
 in \`~/.sentry/config.yml\`.
-6. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` to automatically update the existing snapshots with your new
+5. Export \`SENTRY_SNAPSHOTS_WRITEBACK=1\` to automatically update the existing snapshots with your new
 results and run symbolicator tests with pytest (\`pytest tests/symbolicator\`).
-7. Review snapshot changes locally, then create a PR to Sentry.
-8. Merge the Symbolicator PR, then merge the Sentry PR.
+6. Review snapshot changes locally, then create a PR to Sentry.
+7. Merge the Symbolicator PR, then merge the Sentry PR.
 
 </details>
   `;


### PR DESCRIPTION
Just a small update on the snapshot instructions to take into account the new integration tests that have been already added to CI. Also includes an additional expansion of some of the existing instructions to provide context on what is being done as well as some gotchas that can only be found if you rummage around in code in other repositories.

#skip-changelog
