### PR TITLE
ref: Avoid using owned PathBuf if a &Path is enough

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -88,13 +88,14 @@ impl FetchFileRequest {
     /// Downloads the file and saves it to `path`.
     ///
     /// Actual implementation of [`FetchFileRequest::compute`].
+    // XXX: We use a `PathBuf` here because the resulting future needs to be `'static`
     async fn fetch_file(self, path: PathBuf) -> Result<CacheStatus, Error> {
         let download_file = self.cache.tempfile()?;
         let cache_key = self.get_cache_key();
 
         let result = self
             .download_svc
-            .download(self.file_source, download_file.path().to_path_buf())
+            .download(self.file_source, download_file.path())
             .await;
 
         match result {

--- a/crates/symbolicator/src/services/download/filesystem.rs
+++ b/crates/symbolicator/src/services/download/filesystem.rs
@@ -5,7 +5,7 @@
 //! testing.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::fs;
@@ -61,12 +61,12 @@ impl FilesystemDownloader {
     pub async fn download_source(
         &self,
         file_source: FilesystemRemoteDif,
-        dest: PathBuf,
+        dest: &Path,
     ) -> Result<DownloadStatus, DownloadError> {
         // All file I/O in this function is blocking!
         let abspath = file_source.path();
         log::debug!("Fetching debug file from {:?}", abspath);
-        match fs::copy(abspath, &dest).await {
+        match fs::copy(abspath, dest).await {
             Ok(_) => Ok(DownloadStatus::Completed),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -2,7 +2,7 @@
 //!
 //! Specifically this supports the [`GcsSourceConfig`] source.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
@@ -215,7 +215,7 @@ impl GcsDownloader {
     pub async fn download_source(
         &self,
         file_source: GcsRemoteDif,
-        destination: PathBuf,
+        destination: &Path,
     ) -> Result<DownloadStatus, DownloadError> {
         let key = file_source.key();
         let bucket = file_source.source.bucket.clone();
@@ -254,7 +254,7 @@ impl GcsDownloader {
                         content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    super::download_stream(source, stream, destination, timeout).await
+                    super::download_stream(&source, stream, destination, timeout).await
                 } else if matches!(
                     response.status(),
                     StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
@@ -412,7 +412,7 @@ mod tests {
         let file_source = GcsRemoteDif::new(source, source_location);
 
         let download_status = downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .unwrap();
 
@@ -442,7 +442,7 @@ mod tests {
         let file_source = GcsRemoteDif::new(source, source_location);
 
         let download_status = downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .unwrap();
 
@@ -473,7 +473,7 @@ mod tests {
         let file_source = GcsRemoteDif::new(source, source_location);
 
         downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .expect_err("authentication should fail");
 

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -2,7 +2,7 @@
 //!
 //! Specifically this supports the [`HttpSourceConfig`] source.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -75,7 +75,7 @@ impl HttpDownloader {
     pub async fn download_source(
         &self,
         file_source: HttpRemoteDif,
-        destination: PathBuf,
+        destination: &Path,
     ) -> Result<DownloadStatus, DownloadError> {
         let download_url = match file_source.url() {
             Ok(x) => x,
@@ -111,7 +111,7 @@ impl HttpDownloader {
 
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    super::download_stream(source, stream, destination, timeout).await
+                    super::download_stream(&source, stream, destination, timeout).await
                 } else if matches!(
                     response.status(),
                     StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
@@ -177,7 +177,7 @@ mod tests {
         test::setup();
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let dest = tmpfile.path().to_owned();
+        let dest = tmpfile.path();
 
         let (_srv, source) = test::symbol_server();
         let http_source = match source {
@@ -192,10 +192,7 @@ mod tests {
             Duration::from_secs(30),
             Duration::from_secs(30),
         );
-        let download_status = downloader
-            .download_source(file_source, dest.clone())
-            .await
-            .unwrap();
+        let download_status = downloader.download_source(file_source, dest).await.unwrap();
 
         assert_eq!(download_status, DownloadStatus::Completed);
 
@@ -208,7 +205,7 @@ mod tests {
         test::setup();
 
         let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let dest = tmpfile.path().to_owned();
+        let dest = tmpfile.path();
 
         let (_srv, source) = test::symbol_server();
         let http_source = match source {

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -5,7 +5,7 @@
 use std::any::type_name;
 use std::convert::TryFrom;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -149,7 +149,7 @@ impl S3Downloader {
     pub async fn download_source(
         &self,
         file_source: S3RemoteDif,
-        destination: PathBuf,
+        destination: &Path,
     ) -> Result<DownloadStatus, DownloadError> {
         let key = file_source.key();
         let bucket = file_source.bucket();
@@ -206,7 +206,7 @@ impl S3Downloader {
             .and_then(|cl| u32::try_from(cl).ok());
         let timeout = content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
 
-        super::download_stream(source, stream, destination, timeout).await
+        super::download_stream(&source, stream, destination, timeout).await
     }
 
     pub fn list_files(
@@ -410,7 +410,7 @@ mod tests {
         let file_source = S3RemoteDif::new(source, source_location);
 
         let download_status = downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .unwrap();
 
@@ -439,7 +439,7 @@ mod tests {
         let file_source = S3RemoteDif::new(source, source_location);
 
         let download_status = downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .unwrap();
 
@@ -467,7 +467,7 @@ mod tests {
         let file_source = S3RemoteDif::new(source, source_location);
 
         downloader
-            .download_source(file_source, target_path.clone())
+            .download_source(file_source, &target_path)
             .await
             .expect_err("authentication should fail");
 

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -4,7 +4,7 @@
 //! to fetch files which were directly uploaded to Sentry itself.
 
 use std::fmt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -253,7 +253,7 @@ impl SentryDownloader {
     pub async fn download_source(
         &self,
         file_source: SentryRemoteDif,
-        destination: PathBuf,
+        destination: &Path,
     ) -> Result<DownloadStatus, DownloadError> {
         let request = self
             .client
@@ -282,7 +282,7 @@ impl SentryDownloader {
                         content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
                     let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
 
-                    super::download_stream(source, stream, destination, timeout).await
+                    super::download_stream(&source, stream, destination, timeout).await
                 } else if matches!(
                     response.status(),
                     StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -170,9 +170,7 @@ impl CacheItemRequest for FetchFileDataRequest {
                 .parent()
                 .ok_or(ObjectError::NoTempDir)?;
 
-            let status = downloader
-                .download(file_id, download_file.path().to_owned())
-                .await;
+            let status = downloader.download(file_id, download_file.path()).await;
 
             match status {
                 Ok(DownloadStatus::NotFound) => {


### PR DESCRIPTION
While seeing this, I became curious how much stuff we needlessly clone all the time.

#skip-changelog