### PR TITLE
Use debian:buster-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM debian:stretch-slim AS symbolicator-build
+FROM debian:buster-slim AS symbolicator-build
 
 WORKDIR /work
 
@@ -53,7 +53,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I have tested and this gets build fine, but I don't know how to test the functionality of docker images.

This was first brought up in https://github.com/getsentry/onpremise/issues/1128.