### PR TITLE
Use rust:bullseye-slim as base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0
+## Unreleased
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- Use `rust:bullseye-slim` as base image for docker container builder. ([#578](https://github.com/getsentry/symbolicator/pull/578))
+- Use `debian:bullseye-slim` as base image for docker container runner. ([#578](https://github.com/getsentry/symbolicator/pull/578))
+
 ## 0.4.0
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM debian:stretch-slim AS symbolicator-build
+FROM debian:buster-slim AS symbolicator-build
 
 WORKDIR /work
 
@@ -53,7 +53,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates gosu cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/symbolicator/build.rs crates/symbolicator/Cargo.toml crates/symbolicator/
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libssl-dev pkg-config \
+    && apt-get install -y --no-install-recommends libssl-dev pkg-config g++ \
     && rm -rf /var/lib/apt/lists/*
 # Build without --locked.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/symbolicator/build.rs crates/symbolicator/Cargo.toml crates/symbolicator/
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libssl-dev pkg-config g++ git \
+    && apt-get install -y --no-install-recommends libssl-dev pkg-config g++ git zip \
     && rm -rf /var/lib/apt/lists/*
 # Build without --locked.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/symbolicator/build.rs crates/symbolicator/Cargo.toml crates/symbolicator/
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libssl-dev pkg-config g++ \
+    && apt-get install -y --no-install-recommends libssl-dev pkg-config g++ git \
     && rm -rf /var/lib/apt/lists/*
 # Build without --locked.
 #


### PR DESCRIPTION
I have tested and this gets build fine, but I don't know how to test the functionality of docker images.

This was first brought up in getsentry/onpremise#1128.