### PR TITLE
fix(cache): Add back in the marker at the beginning of malformed cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Very basic shared-cache support, allowing multiple symbolicators to share one global cache and have faster warmup times. ([#581](https://github.com/getsentry/symbolicator/pull/581))
 
+### Fixes
+- Truncate Malformed and Cache-Specific entries in the cache to match the length of their contents, in case they overwrote some longer, existing entry. ([#586](https://github.com/getsentry/symbolicator/pull/586))
+
 ## 0.4.0
 
 ### Features

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -104,6 +104,7 @@ impl CacheStatus {
             }
             CacheStatus::Malformed(details) => {
                 file.rewind().await?;
+                file.write_all(MALFORMED_MARKER).await?;
                 file.write_all(details.as_bytes()).await?;
             }
             CacheStatus::CacheSpecificError(details) => {

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -93,7 +93,7 @@ impl CacheStatus {
     ///
     /// For a positive status this only seeks to the end.  For the other cases this seeks
     /// to the beginning, writes the appropriate marker and truncates the file.
-    pub async fn write_marker(&self, file: &mut File) -> Result<(), io::Error> {
+    pub async fn write(&self, file: &mut File) -> Result<(), io::Error> {
         match self {
             CacheStatus::Positive => {
                 file.seek(SeekFrom::End(0)).await?;

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -316,7 +316,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
         let status = if !shared_cache_hit {
             let status = request.compute(temp_file.path()).await?;
-            status.write_marker(&mut temp_fd).await?;
+            status.write(&mut temp_fd).await?;
             Some(status)
         } else {
             None


### PR DESCRIPTION
Primarily fixes a regression from the shared cache PR (https://github.com/getsentry/symbolicator/pull/581) which was no longer writing the sentinel/"header" for malformed entries in caches.

Also includes a minor fix that ensures that other non-positive entries in the cache are truncated in case they are overwriting some other content that is slightly longer than their new value. This is highly unlikely to occur, but this is added in as a safeguard if this _does_ ever occur.

This also renames the helper because there's no need for the user to know about the existence of markers at the abstraction level where that would be invoked.

Unit tests have been written because they would have caught this error assuming that they weren't deleted or commented out during the original function's refactor. Proper integration tests would most likely test `compute` itself, which is a pretty complicated function to test.