### PR TITLE
fix(gcs): Only request read-only access

### DIFF
--- a/crates/symbolicator/src/utils/gcs.rs
+++ b/crates/symbolicator/src/utils/gcs.rs
@@ -80,7 +80,7 @@ fn get_auth_jwt(source_key: &GcsSourceKey, expiration: i64) -> Result<String, Gc
 
     let jwt_claims = JwtClaims {
         issuer: source_key.client_email.clone(),
-        scope: "https://www.googleapis.com/auth/devstorage.read_write".into(),
+        scope: "https://www.googleapis.com/auth/devstorage.read_only".into(),
         audience: "https://www.googleapis.com/oauth2/v4/token".into(),
         expiration,
         issued_at: Utc::now().timestamp(),


### PR DESCRIPTION
We accidentally switched to requesting a read-write scope for all
buckets symbolicator tries to access and customers might not have
given our tokens those permissions, resulting in us not being able to
use their symbol source.

Tests probably keep passing since the GCP tests are not configured to
run correctly in CI yet.  Something else to fix, but let's stop this
regression first.

#skip-changelog