### PR TITLE
fix: Remove dead stores of SharedCache in Cache

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -247,13 +247,6 @@ pub struct Cache {
 
     /// The maximum number of lazy refreshes of this cache.
     max_lazy_refreshes: Arc<AtomicIsize>,
-
-    /// A cache that may be shared between symbolicator instances.
-    ///
-    /// If it is present any missing cache item will first be looked up here before being
-    /// computed.  If it is still missing it will be computed and then uploaded to the
-    /// shared cache.
-    shared_cache: Option<SharedCacheConfig>,
 }
 
 impl Cache {
@@ -263,7 +256,6 @@ impl Cache {
         tmp_dir: Option<PathBuf>,
         cache_config: CacheConfig,
         max_lazy_refreshes: Arc<AtomicIsize>,
-        shared_cache: Option<SharedCacheConfig>,
     ) -> io::Result<Self> {
         if let Some(ref dir) = cache_dir {
             std::fs::create_dir_all(dir)?;
@@ -275,7 +267,6 @@ impl Cache {
             start_time: SystemTime::now(),
             cache_config,
             max_lazy_refreshes,
-            shared_cache,
         })
     }
 
@@ -531,7 +522,6 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
                     max_lazy_redownloads.clone(),
-                    config.shared_cache.clone(),
                 )?
             },
             object_meta: {
@@ -542,7 +532,6 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
-                    config.shared_cache.clone(),
                 )?
             },
             auxdifs: {
@@ -553,7 +542,6 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
                     max_lazy_redownloads,
-                    config.shared_cache.clone(),
                 )?
             },
             symcaches: {
@@ -564,7 +552,6 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
-                    config.shared_cache.clone(),
                 )?
             },
             cficaches: {
@@ -575,7 +562,6 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations,
-                    config.shared_cache.clone(),
                 )?
             },
             diagnostics: {
@@ -586,7 +572,6 @@ impl Caches {
                     tmp_dir,
                     config.caches.diagnostics.into(),
                     Default::default(),
-                    config.shared_cache.clone(),
                 )?
             },
         })
@@ -679,7 +664,6 @@ mod tests {
             None,
             CacheConfig::Downloaded(Default::default()),
             Default::default(),
-            None,
         );
         let fsinfo = fs::metadata(cachedir).unwrap();
         assert!(fsinfo.is_dir());
@@ -739,7 +723,6 @@ mod tests {
                 ..Default::default()
             }),
             Default::default(),
-            None,
         )?;
 
         File::create(tempdir.path().join("foo/killthis"))?.write_all(b"hi")?;
@@ -778,7 +761,6 @@ mod tests {
                 ..Default::default()
             }),
             Default::default(),
-            None,
         )?;
 
         File::create(tempdir.path().join("foo/keepthis"))?.write_all(b"hi")?;
@@ -829,7 +811,6 @@ mod tests {
                 ..Default::default()
             }),
             Default::default(),
-            None,
         )?;
 
         cache.cleanup()?;
@@ -876,7 +857,6 @@ mod tests {
                 ..Default::default()
             }),
             Default::default(),
-            None,
         )?;
 
         sleep(Duration::from_millis(30));
@@ -923,7 +903,6 @@ mod tests {
                 ..Default::default()
             }),
             Default::default(),
-            None,
         )?;
 
         sleep(Duration::from_millis(30));
@@ -1160,7 +1139,6 @@ mod tests {
             None,
             CacheConfig::Downloaded(Default::default()),
             Default::default(),
-            None,
         )?;
 
         // Create a file in the cache, with mtime of 1h 15s ago since it only gets touched

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -624,7 +624,6 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().derived),
             Arc::new(AtomicIsize::new(1)),
-            None,
         )
         .unwrap();
         let shared_cache = Arc::new(SharedCacheService::try_new(None).await.unwrap());
@@ -668,7 +667,6 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().derived),
             Arc::new(AtomicIsize::new(1)),
-            None,
         )
         .unwrap();
         let shared_cache = Arc::new(SharedCacheService::try_new(None).await.unwrap());

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -318,7 +318,6 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().derived),
             Default::default(),
-            None,
         )
         .unwrap();
 
@@ -328,7 +327,6 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().downloaded),
             Default::default(),
-            None,
         )
         .unwrap();
 

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -312,6 +312,7 @@ impl SharedCacheKey {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum SharedCacheBackend {
     Gcs(GcsState),
     Fs(FilesystemSharedCacheConfig),


### PR DESCRIPTION
The SharedCache now lives in the Cacher, and not the Cache.

#skip-changelog