### PR TITLE
fix(shared-cache): Measure and adjust timeouts

### DIFF
--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -315,7 +315,7 @@ enum MeasureState {
 ///
 /// If `bytes_transferred` is not set, then only the first metric (amount of time taken) is
 /// recorded.
-struct MeasureSourceDownloadGuard<'a> {
+pub struct MeasureSourceDownloadGuard<'a> {
     state: MeasureState,
     task_name: &'a str,
     source_name: &'a str,


### PR DESCRIPTION
We accidentally shipped with an upload timeout of 5 seconds, which
explains our relatively high upload failure ratio (vs a zero download
failre ratio).  This adjusts the upload timeout to 60s which should be
sufficient to upload 4GB according to
https://cloud.google.com/storage/docs/uploads-downloads.

It also tweaks the timeout reporting.  The fetch connect timeout was
accidentally reporting as a source downloader.  We still resuse some
of the downloader infrastructure so "gcs" is still reported as a
source tag.  We do not utilise the throughput measurements though, we
already have metrics for throughput with simple counters which is
sufficient for the shared cache.

#skip-changelog