### PR TITLE
ref(shared-cache): Bump default size of upload queue

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -178,7 +178,7 @@ pub struct SharedCacheConfig {
 }
 
 fn default_max_upload_queue_size() -> usize {
-    100
+    400
 }
 
 fn default_max_concurrent_uploads() -> usize {

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -1444,7 +1444,7 @@ mod tests {
         "#;
         let cfg: SharedCacheConfig = serde_yaml::from_reader(yaml.as_bytes()).unwrap();
 
-        assert_eq!(cfg.max_upload_queue_size, 100);
+        assert_eq!(cfg.max_upload_queue_size, 400);
         assert_eq!(cfg.max_concurrent_uploads, 20);
         match cfg.backend {
             SharedCacheBackendConfig::Gcs(_) => panic!("wrong backend"),


### PR DESCRIPTION
The items put on this queue are relatively small so we have no real
worry about memory.  This increases the ratio of concurrency to queue
size to 20:1 instead of 5:1, which is slightly more sensible.  If
anything it is still too concervative.

#skip-changelog