### PR TITLE
fix(shared-cache): Do not put bucket and key in error

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -172,11 +172,7 @@ impl GcsState {
                         "Insufficient permissions for bucket {}",
                         self.config.bucket
                     )),
-                    _ => Err(anyhow!(
-                        "Error response from GCS: {} {}",
-                        status,
-                        status.canonical_reason().unwrap_or("")
-                    )),
+                    _ => Err(anyhow!("Error response from GCS: {}", status)),
                 }
             }
             Ok(Err(err)) => {

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -173,9 +173,7 @@ impl GcsState {
                         self.config.bucket
                     )),
                     _ => Err(anyhow!(
-                        "Error response from GCS for bucket={}, key={}: {} {}",
-                        self.config.bucket,
-                        key.gcs_bucket_key(),
+                        "Error response from GCS: {} {}",
                         status,
                         status.canonical_reason().unwrap_or("")
                     )),


### PR DESCRIPTION
This is bad for sentry grouping.

#skip-changelog