### PR TITLE
fix(shared-cache): Ensure startup with broken shared cache

### DIFF
--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -644,7 +644,7 @@ mod tests {
             Arc::new(AtomicIsize::new(1)),
         )
         .unwrap();
-        let shared_cache = Arc::new(SharedCacheService::try_new(None).await.unwrap());
+        let shared_cache = Arc::new(SharedCacheService::new(None).await);
         let cacher = Cacher::new(cache, shared_cache);
 
         let request = TestCacheItem::new("some_cache_key");
@@ -687,7 +687,7 @@ mod tests {
             Arc::new(AtomicIsize::new(1)),
         )
         .unwrap();
-        let shared_cache = Arc::new(SharedCacheService::try_new(None).await.unwrap());
+        let shared_cache = Arc::new(SharedCacheService::new(None).await);
         let cacher = Cacher::new(cache, shared_cache);
 
         let request = TestCacheItem::new("0");

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -77,8 +77,7 @@ impl Service {
             .context("failed to create process pool")?;
 
         let downloader = DownloadService::new(config.clone());
-        let shared_cache =
-            Arc::new(SharedCacheService::try_new(config.shared_cache.clone()).await?);
+        let shared_cache = Arc::new(SharedCacheService::new(config.shared_cache.clone()).await);
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches
             .clear_tmp(&config)

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -337,7 +337,7 @@ mod tests {
         });
 
         let download_svc = DownloadService::new(config);
-        let shared_cache_svc = Arc::new(SharedCacheService::try_new(None).await.unwrap());
+        let shared_cache_svc = Arc::new(SharedCacheService::new(None).await);
         ObjectsActor::new(meta_cache, data_cache, shared_cache_svc, download_svc)
     }
 

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -440,7 +440,7 @@ mod tests {
         let caches = Caches::from_config(&config).unwrap();
         caches.clear_tmp(&config).unwrap();
         let downloader = DownloadService::new(config);
-        let shared_cache = Arc::new(SharedCacheService::try_new(None).await.unwrap());
+        let shared_cache = Arc::new(SharedCacheService::new(None).await);
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,


### PR DESCRIPTION
If the shared cache is not working for some reason we still want to
ensure symbolicator starts up so that it does not affect the normal
operation.

NATIVE-424

#skip-changelog