### PR TITLE
ref: Remove LogError struct

### DIFF
--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -17,7 +17,6 @@ use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
 use crate::config::{CacheConfig, Config};
-use crate::logging::LogError;
 
 /// Starting content of cache items whose writing failed.
 ///
@@ -617,7 +616,7 @@ impl Caches {
         for result in results {
             if let Err(err) = result {
                 let stderr: &dyn std::error::Error = &*err;
-                log::error!("Failed to cleanup cache: {}", LogError(stderr));
+                log::error!("Failed to cleanup cache: {:?}", stderr);
                 if first_error.is_none() {
                     first_error = Some(err);
                 }

--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::fmt;
 use std::io::{self, Write};
 
 use chrono::{DateTime, Utc};
@@ -154,22 +153,6 @@ pub fn init_logging(config: &Config) {
 
     let breadcrumb_logger = Box::new(BreadcrumbLogger::new(logger));
     log::set_boxed_logger(breadcrumb_logger).unwrap();
-}
-
-/// A wrapper around an [`Error`](std::error::Error) that prints its causes.
-pub struct LogError<'a>(pub &'a dyn std::error::Error);
-
-impl<'a> fmt::Display for LogError<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut error = self.0;
-        write!(f, "{}", error)?;
-        while let Some(cause) = error.source() {
-            write!(f, "\n  caused by: {}", cause)?;
-            error = cause;
-        }
-
-        Ok(())
-    }
 }
 
 /// Logs an error to the configured logger or `stderr` if not yet configured.

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -18,7 +18,6 @@ use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use tempfile::tempfile_in;
 
 use crate::cache::{Cache, CacheStatus};
-use crate::logging::LogError;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
 use crate::sources::{FileType, SourceConfig};
@@ -106,7 +105,7 @@ impl FetchFileRequest {
                 return Ok(CacheStatus::Negative);
             }
             Err(e) => {
-                log::debug!("Error while downloading file: {}", LogError(&e));
+                log::debug!("Error while downloading file: {:?}", e);
                 return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
             }
             Ok(DownloadStatus::Completed) => {

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -20,7 +20,6 @@ use symbolic::debuginfo::{Archive, Object};
 use tempfile::tempfile_in;
 
 use crate::cache::CacheStatus;
-use crate::logging::LogError;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath};
 use crate::services::download::{DownloadError, DownloadStatus};
 use crate::types::{ObjectId, Scope};
@@ -185,9 +184,9 @@ impl CacheItemRequest for FetchFileDataRequest {
                     // hit `CachedError`, but listing it for completeness is not a bad idea either.
                     match e {
                         DownloadError::Permissions | DownloadError::CachedError(_) => {
-                            log::debug!("Error while downloading file: {}", LogError(&e))
+                            log::debug!("Error while downloading file: {:?}", e)
                         }
-                        _ => log::error!("Error while downloading file: {}", LogError(&e)),
+                        _ => log::error!("Error while downloading file: {:?}", e),
                     }
 
                     return Ok(CacheStatus::CacheSpecificError(e.for_cache()));

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -10,7 +10,6 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::debuginfo;
 
 use crate::cache::{Cache, CacheStatus};
-use crate::logging::LogError;
 use crate::services::cacher::Cacher;
 use crate::services::download::{DownloadError, DownloadService, RemoteDif, RemoteDifUri};
 use crate::sources::{FileType, SourceConfig, SourceId};
@@ -260,11 +259,7 @@ impl ObjectsActor {
                         // the search by debug/code id. We do not surface those errors to the
                         // user (instead we default to an empty search result) and only report
                         // them internally.
-                        log::error!(
-                            "Failed to fetch file list from {}: {}",
-                            type_name,
-                            LogError(&err)
-                        );
+                        log::error!("Failed to fetch file list from {}: {:?}", type_name, err);
                         Vec::new()
                     })
             }

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -26,7 +26,6 @@ use crate::cache::{
     CacheName, FilesystemSharedCacheConfig, GcsSharedCacheConfig, SharedCacheBackendConfig,
     SharedCacheConfig,
 };
-use crate::logging::LogError;
 use crate::services::download::MeasureSourceDownloadGuard;
 use crate::utils::gcs::GcsError;
 

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -449,9 +449,9 @@ impl SharedCacheService {
             }
             Err(err) => {
                 log::error!(
-                    "Error storing file on {} shared cache: {}",
+                    "Error storing file on {} shared cache: {:?}",
                     backend.name(),
-                    LogError(&*err),
+                    err,
                 );
                 metric!(
                     counter("services.shared_cache.store") += 1,
@@ -464,8 +464,8 @@ impl SharedCacheService {
         // Tell the work coordinator we're done.
         done_tx.send(()).await.unwrap_or_else(|err| {
             log::error!(
-                "Shared cache single_uploader failed to send done message: {}",
-                LogError(&err)
+                "Shared cache single_uploader failed to send done message: {:?}",
+                err
             );
         });
 
@@ -527,9 +527,9 @@ impl SharedCacheService {
             }
             Err(err) => {
                 log::error!(
-                    "Error fetching from {} shared cache: {}",
+                    "Error fetching from {} shared cache: {:?}",
                     self.backend_name(),
-                    LogError(&*err)
+                    err,
                 );
                 metric!(
                     counter("services.shared_cache.fetch") += 1,


### PR DESCRIPTION
The point of the `LogError` struct is that its `Display` impl prints a chain of causes. But `anyhow::Error` can already do that (in one line with `{:#}`, over multiple lines with `{:?}`, see https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations).

Edited to add: I would like to see if by some happy accident this by itself resolves NATIVE-427.

#skip-changelog