### PR TITLE
fix(shared cache): Improve reporting of auth errors [NATIVE-427]

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -93,7 +93,8 @@ impl GcsState {
         let token = self
             .auth_manager
             .get_token(&["https://www.googleapis.com/auth/devstorage.read_write"])
-            .await?;
+            .await
+            .context("Failed to get authentication token")?;
 
         let mut url = Url::parse("https://www.googleapis.com/download/storage/v1/b?alt=media")
             .map_err(|_| GcsError::InvalidUrl)?;


### PR DESCRIPTION
This should replace the error reported in NATIVE-427 with

```
"Error fetching from GCS shared cache: Failed to get authentication token,\n caused by: Could not establish connection with server"
```
#skip-changelog