### PR TITLE
build: Switch back to released gcp_auth version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,8 +951,9 @@ dependencies = [
 
 [[package]]
 name = "gcp_auth"
-version = "0.6.0"
-source = "git+https://github.com/getsentry/gcp_auth?branch=sentry-main#70b3df783e3943650b0cc0fe1d8592a74d7c49e9"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41af881b65785e78b2b01437cbb01a125c06a7655c91383299970ade8280a5"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.7.1"
 filetime = "0.2.14"
 flate2 = "1.0.0"
 futures = "0.3.12"
+gcp_auth = "0.6.1"
 glob = "0.3.0"
 hostname = "0.3.1"
 humantime-serde = "1.0.1"
@@ -54,7 +55,6 @@ tower-service = "0.3"
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.9.0"
-gcp_auth = { git = "https://github.com/getsentry/gcp_auth", branch = "sentry-main" }
 
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }


### PR DESCRIPTION
The required fixes and features have been merged and released.

#skip-changelog