### PR TITLE
fix: Discard minidumps with multipart form data [NATIVE-431]

### DIFF
--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -59,9 +59,11 @@ pub async fn handle_minidump_request(
     let minidump = ByteView::open(minidump_path).unwrap_or_else(|_| ByteView::from_slice(b""));
     if minidump.starts_with(b"--") {
         metric!(counter("symbolication.minidump.multipart_form_data") += 1);
-        return Ok(Json(SymbolicationResponse::Failed {
-            message: "minidump file contains multipart form data".to_string(),
-        }));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "minidump contains multipart form data",
+        )
+            .into());
     }
     let symbolication = state.symbolication();
     let request_id =

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -1,6 +1,7 @@
 use axum::extract;
 use axum::http::StatusCode;
 use axum::response::Json;
+use symbolic::common::ByteView;
 use tokio::fs::File;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -53,6 +54,15 @@ pub async fn handle_minidump_request(
 
     let minidump_file = minidump.ok_or((StatusCode::BAD_REQUEST, "missing minidump"))?;
 
+    // check if the minidump starts with multipart form data and discard it if so
+    let minidump_path = minidump_file.to_path_buf();
+    let minidump = ByteView::open(minidump_path).unwrap_or_else(|_| ByteView::from_slice(b""));
+    if minidump.starts_with(b"--") {
+        metric!(counter("symbolication.minidump.multipart_form_data") += 1);
+        return Ok(Json(SymbolicationResponse::Failed {
+            message: "minidump file contains multipart form data".to_string(),
+        }));
+    }
     let symbolication = state.symbolication();
     let request_id =
         symbolication.process_minidump(params.scope, minidump_file, sources, options)?;

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2118,12 +2118,6 @@ impl SymbolicationActor {
         sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
-        // check if the minidump starts with multipart form data and discard it if so
-        let minidump_path = minidump_file.to_path_buf();
-        let minidump = ByteView::open(minidump_path).unwrap_or_else(|_| ByteView::from_slice(b""));
-        if minidump.starts_with(b"--") {
-            return Err(anyhow::anyhow!("Minidump contains multipart form data").into());
-        }
         let (request, state) = self
             .clone()
             .do_stackwalk_minidump(scope, minidump_file, sources, options)

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2118,6 +2118,12 @@ impl SymbolicationActor {
         sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
+        // check if the minidump starts with multipart form data and discard it if so
+        let minidump_path = minidump_file.to_path_buf();
+        let minidump = ByteView::open(minidump_path).unwrap_or_else(|_| ByteView::from_slice(b""));
+        if minidump.starts_with(b"--") {
+            return Err(anyhow::anyhow!("Minidump contains multipart form data").into());
+        }
         let (request, state) = self
             .clone()
             .do_stackwalk_minidump(scope, minidump_file, sources, options)


### PR DESCRIPTION
I'm not entirely clear if the error we return here would be reported to sentry.

#skip-changelog