### PR TITLE
feat(wasm-split): --external-dwarf-url option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Very basic shared-cache support, allowing multiple symbolicators to share one global cache and have faster warmup times. ([#581](https://github.com/getsentry/symbolicator/pull/581))
 - Support concurrency control and backpressure on uploading to shared cache. ([#584](https://github.com/getsentry/symbolicator/pull/584))
 - Use Google Application Credentials to authenticate to GCS in the shared cache. ([#591](https://github.com/getsentry/symbolicator/pull/591))
+- Support for `external_debug_info` section in wasm-split for external dwarf files. ([#619](https://github.com/getsentry/symbolicator/pull/619))
 
 ### Fixes
 - Truncate Malformed and Cache-Specific entries in the cache to match the length of their contents, in case they overwrote some longer, existing entry. ([#586](https://github.com/getsentry/symbolicator/pull/586))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,6 +3836,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",
+ "integer-encoding",
  "structopt",
  "uuid",
  "wasmbin",

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -12,3 +12,4 @@ structopt = "0.3.21"
 hex = "0.4.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 wasmbin = "0.3.1"
+integer-encoding = "3.0.2"

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use wasmbin::builtins::Blob;
 use wasmbin::sections::{CustomSection, RawCustomSection, Section};
 use wasmbin::Module;
+use integer_encoding::VarInt;
 
 /// Adds build IDs to wasm files.
 ///
@@ -53,6 +54,9 @@ pub struct Cli {
     /// explicit build id to provide
     #[structopt(long)]
     build_id: Option<Uuid>,
+    /// URL for browsers to fetch the separate dwarf debug symbol file
+    #[structopt(long)]
+    external_dwarf_url: Option<String>,
 }
 
 fn load_custom_section(section: &Section) -> Option<(&str, &[u8])> {
@@ -121,7 +125,7 @@ fn main() -> Result<(), anyhow::Error> {
     });
 
     // split dwarf data out if needed into a separate file.
-    if let Some(debug_output) = cli.debug_out {
+    if let Some(debug_output) = cli.debug_out.as_ref() {
         // note that this actually copies the entire original file over after
         // adding the build ID.  The reason for this is that we can only deal
         // with WASM files if the code section offset can be calculated.  This
@@ -140,6 +144,40 @@ fn main() -> Result<(), anyhow::Error> {
             .sections
             .retain(|section| !is_strippable_section(section, strip_names));
         should_write_main_module = true;
+    }
+
+    // If the debug file path is set, resolve the filename (ie. /some/path/to/foo.debug.wasm -> foo.debug.wasm)
+    let debug_file_name = cli.debug_out
+        .as_ref()
+        .and_then(|name| name.file_name())
+        .and_then(|name| name.to_str())
+        .and_then(|name| Some(name.to_string()));
+
+
+    // Use the command line flag if set, but fallback to the debug file name if that is set.
+    // This is a reasonable default, as the filename on its own will resolve as a path relative to the main wasm file.
+    // Emscripten falls back in the same way: https://github.com/emscripten-core/emscripten/pull/12549
+    let resolved_external_dwarf_url = cli.external_dwarf_url.or(debug_file_name);
+
+    if let Some(external_dwarf_url) = resolved_external_dwarf_url {
+        should_write_main_module = true;
+
+        // From the wasm spec, the URL is encoded as bytes, and prefixed with a varint encoding of a u32 size
+        // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
+        // Emscripten: https://github.com/emscripten-core/emscripten/blob/4eefe273/tools/building.py#L1200
+        let contents_vec = external_dwarf_url.to_string().as_bytes().to_vec();
+        let debug_url_len = external_dwarf_url.len() as u32;
+        let mut encoded_byte_vec = debug_url_len.encode_var_vec();
+        encoded_byte_vec.extend(contents_vec);
+
+        module
+            .sections
+            .push(Section::Custom(Blob::from(CustomSection::Other(
+                RawCustomSection {
+                    name: "external_debug_info".to_string(),
+                    data: encoded_byte_vec,
+                },
+            ))));
     }
 
     // main module

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -165,7 +165,7 @@ fn main() -> Result<(), anyhow::Error> {
         // From the wasm spec, the URL is encoded as bytes, and prefixed with a varint encoding of a u32 size
         // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
         // Emscripten: https://github.com/emscripten-core/emscripten/blob/4eefe273/tools/building.py#L1200
-        let contents_vec = external_dwarf_url.as_bytes().to_vec();
+        let contents_vec = external_dwarf_url.as_bytes();
         let debug_url_len = external_dwarf_url.len() as u32;
         let mut encoded_byte_vec = debug_url_len.encode_var_vec();
         encoded_byte_vec.extend(contents_vec);

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> Result<(), anyhow::Error> {
         .as_ref()
         .and_then(|name| name.file_name())
         .and_then(|name| name.to_str())
-        .and_then(|name| Some(name.to_string()));
+        .map(|name| name.to_string());
 
     // Use the command line flag if set, but fallback to the debug file name if that is set.
     // This is a reasonable default, as the filename on its own will resolve as a path relative to the main wasm file.
@@ -165,7 +165,7 @@ fn main() -> Result<(), anyhow::Error> {
         // From the wasm spec, the URL is encoded as bytes, and prefixed with a varint encoding of a u32 size
         // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
         // Emscripten: https://github.com/emscripten-core/emscripten/blob/4eefe273/tools/building.py#L1200
-        let contents_vec = external_dwarf_url.to_string().as_bytes().to_vec();
+        let contents_vec = external_dwarf_url.as_bytes().to_vec();
         let debug_url_len = external_dwarf_url.len() as u32;
         let mut encoded_byte_vec = debug_url_len.encode_var_vec();
         encoded_byte_vec.extend(contents_vec);

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -11,12 +11,12 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
 
+use integer_encoding::VarInt;
 use structopt::StructOpt;
 use uuid::Uuid;
 use wasmbin::builtins::Blob;
 use wasmbin::sections::{CustomSection, RawCustomSection, Section};
 use wasmbin::Module;
-use integer_encoding::VarInt;
 
 /// Adds build IDs to wasm files.
 ///
@@ -147,12 +147,12 @@ fn main() -> Result<(), anyhow::Error> {
     }
 
     // If the debug file path is set, resolve the filename (ie. /some/path/to/foo.debug.wasm -> foo.debug.wasm)
-    let debug_file_name = cli.debug_out
+    let debug_file_name = cli
+        .debug_out
         .as_ref()
         .and_then(|name| name.file_name())
         .and_then(|name| name.to_str())
         .and_then(|name| Some(name.to_string()));
-
 
     // Use the command line flag if set, but fallback to the debug file name if that is set.
     // This is a reasonable default, as the filename on its own will resolve as a path relative to the main wasm file.


### PR DESCRIPTION
**Background**

Closes https://github.com/getsentry/symbolicator/issues/614

Note that I brought in a new library to implement the variable-int encoding of the size prefix for the custom section payload. I noticed that the wasmbin library already has an implementation of this [here](https://github.com/GoogleChromeLabs/wasmbin/blob/77f8d736219b5129188c7a6a355c74151bfdc67d/src/builtins/integers.rs#L89). I've filed a ticket on that repo [here](https://github.com/GoogleChromeLabs/wasmbin/issues/6) asking for help.

In the meantime though, this implementation seems to work from my testing. I'm new to rust so please let me know what can improve.

PTAL @Swatinem 

**Testing**

Using a sample wasm binary with debug symbols
```
% wasm-objdump -h main.wasm          

main.wasm:      file format wasm 0x1

Sections:

...
   Custom start=0x009579fb end=0x0af8e3f3 (size=0x0a6369f8) "name"
   Custom start=0x0af8e3f8 end=0x0f78df7a (size=0x047ffb82) ".debug_info"
   Custom start=0x0f78df7f end=0x0fff1866 (size=0x008638e7) ".debug_loc"
   Custom start=0x0fff186b end=0x1034d7e9 (size=0x0035bf7e) ".debug_ranges"
   Custom start=0x1034d7ed end=0x10502f61 (size=0x001b5774) ".debug_abbrev"
   Custom start=0x10502f66 end=0x1202e813 (size=0x01b2b8ad) ".debug_line"
   Custom start=0x1202e818 end=0x18701a0b (size=0x066d31f3) ".debug_str"
```

Without a debug file, and no option specified, no change:
```
% ./target/release/wasm-split --strip-names --strip main.wasm -o stripped.wasm
e966d2ec508f45038a05c396aecc2e29
% wasm-objdump -j external_debug_info -s stripped.wasm   
stripped.wasm:  file format wasm 0x1
Section not found: external_debug_info
```

Without a debug file, option specified, url is present:
```
% ./target/release/wasm-split --strip-names --strip main.wasm -o stripped.wasm --external-dwarf-url https://my-site.com/foo.debug.wasm
649fad5124584411912e58c9ee8d7dd6
% wasm-objdump -j external_debug_info -s stripped.wasm

stripped.wasm:  file format wasm 0x1

Contents of section Custom:
0957a13: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0957a23: 696e 666f 2268 7474 7073 3a2f 2f6d 792d  info"https://my-
0957a33: 7369 7465 2e63 6f6d 2f66 6f6f 2e64 6562  site.com/foo.deb
0957a43: 7567 2e77 6173 6d                        ug.wasm
```

With debug file, defaults to name:
```
% ./target/release/wasm-split --strip-names --strip main.wasm -o stripped.wasm -d ../symbolicator/symbols.wasm                                          
b1cf15942f7d40a6b7136aa8598cb7f3
% wasm-objdump -j external_debug_info -s stripped.wasm

stripped.wasm:  file format wasm 0x1

Contents of section Custom:
0957a13: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0957a23: 696e 666f 0c73 796d 626f 6c73 2e77 6173  info.symbols.was
0957a33: 6d                                       m
```

With debug file, and url specified, cli takes precedence
```
% ./target/release/wasm-split --strip-names --strip main.wasm -o stripped.wasm -d ../symbolicator/symbols.wasm --external-dwarf-url foo.com
8823cd8564374d5bb1cc6996480131d4
% wasm-objdump -j external_debug_info -s stripped.wasm

stripped.wasm:  file format wasm 0x1

Contents of section Custom:
0957a13: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0957a23: 696e 666f 0766 6f6f 2e63 6f6d            info.foo.com
```