### PR TITLE
ref(wasm-split): Simplify varint encoding prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,12 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,7 +3830,6 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "hex",
- "integer-encoding",
  "structopt",
  "uuid",
  "wasmbin",
@@ -3845,8 +3838,6 @@ dependencies = [
 [[package]]
 name = "wasmbin"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20fcb9fd22f03e03721440fc53e05d6d65fedb5cf8bac3dcbf750d5f2d6858f"
 dependencies = [
  "arbitrary",
  "custom_debug",
@@ -3859,8 +3850,6 @@ dependencies = [
 [[package]]
 name = "wasmbin-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62532b8d65dcb46bc02469aac67580e35f216a09fbe6724202023a99e4120f1f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,6 +3838,8 @@ dependencies = [
 [[package]]
 name = "wasmbin"
 version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20fcb9fd22f03e03721440fc53e05d6d65fedb5cf8bac3dcbf750d5f2d6858f"
 dependencies = [
  "arbitrary",
  "custom_debug",
@@ -3850,6 +3852,8 @@ dependencies = [
 [[package]]
 name = "wasmbin-derive"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62532b8d65dcb46bc02469aac67580e35f216a09fbe6724202023a99e4120f1f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -11,5 +11,4 @@ anyhow = "1.0.38"
 structopt = "0.3.21"
 hex = "0.4.2"
 uuid = { version = "0.8.2", features = ["v4"] }
-wasmbin = "0.3.1"
-integer-encoding = "3.0.2"
+wasmbin = { path = "../../../wasmbin" }

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -11,4 +11,4 @@ anyhow = "1.0.38"
 structopt = "0.3.21"
 hex = "0.4.2"
 uuid = { version = "0.8.2", features = ["v4"] }
-wasmbin = { path = "../../../wasmbin" }
+wasmbin = "0.3.1"

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -161,6 +161,11 @@ fn main() -> Result<(), anyhow::Error> {
     if let Some(external_dwarf_url) = resolved_external_dwarf_url {
         should_write_main_module = true;
 
+        // From the wasm spec, the URL is encoded as bytes, and prefixed with a varint encoding of a u32 size
+        // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
+        // Emscripten: https://github.com/emscripten-core/emscripten/blob/4eefe273/tools/building.py#L1200
+        // We use the `wasmbin::io::Encode` trait, as it will handle serializing a string as a Vec<u8> with
+        // an LEB128 prefix.
         let data_vec = &mut Vec::new();
         external_dwarf_url.encode(data_vec).unwrap();
 

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -12,10 +12,10 @@ use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
 use structopt::StructOpt;
 use uuid::Uuid;
-use wasmbin::builtins::{Blob};
+use wasmbin::builtins::Blob;
+use wasmbin::io::Encode;
 use wasmbin::sections::{CustomSection, RawCustomSection, Section};
 use wasmbin::Module;
-use wasmbin::io::Encode;
 
 /// Adds build IDs to wasm files.
 ///

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -10,13 +10,12 @@
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
-
-use integer_encoding::VarInt;
 use structopt::StructOpt;
 use uuid::Uuid;
-use wasmbin::builtins::Blob;
+use wasmbin::builtins::{Blob};
 use wasmbin::sections::{CustomSection, RawCustomSection, Section};
 use wasmbin::Module;
+use wasmbin::io::Encode;
 
 /// Adds build IDs to wasm files.
 ///
@@ -75,6 +74,8 @@ fn is_strippable_section(section: &Section, strip_names: bool) -> bool {
         Some(match section.try_as()?.try_contents().ok()? {
             CustomSection::Name(_) => "name",
             CustomSection::Producers(_) => "producers",
+            CustomSection::ExternalDebugInfo(_) => "external_debug_info",
+            CustomSection::SourceMappingUrl(_) => "sourceMappingURL",
             CustomSection::Other(s) => &s.name,
         })
     }
@@ -162,20 +163,15 @@ fn main() -> Result<(), anyhow::Error> {
     if let Some(external_dwarf_url) = resolved_external_dwarf_url {
         should_write_main_module = true;
 
-        // From the wasm spec, the URL is encoded as bytes, and prefixed with a varint encoding of a u32 size
-        // https://github.com/WebAssembly/tool-conventions/blob/08bacbed/Debugging.md#external-dwarf
-        // Emscripten: https://github.com/emscripten-core/emscripten/blob/4eefe273/tools/building.py#L1200
-        let contents_vec = external_dwarf_url.as_bytes();
-        let debug_url_len = external_dwarf_url.len() as u32;
-        let mut encoded_byte_vec = debug_url_len.encode_var_vec();
-        encoded_byte_vec.extend(contents_vec);
+        let data_vec = &mut Vec::new();
+        external_dwarf_url.encode(data_vec).unwrap();
 
         module
             .sections
             .push(Section::Custom(Blob::from(CustomSection::Other(
                 RawCustomSection {
                     name: "external_debug_info".to_string(),
-                    data: encoded_byte_vec,
+                    data: data_vec.to_vec(),
                 },
             ))));
     }

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -74,8 +74,6 @@ fn is_strippable_section(section: &Section, strip_names: bool) -> bool {
         Some(match section.try_as()?.try_contents().ok()? {
             CustomSection::Name(_) => "name",
             CustomSection::Producers(_) => "producers",
-            CustomSection::ExternalDebugInfo(_) => "external_debug_info",
-            CustomSection::SourceMappingUrl(_) => "sourceMappingURL",
             CustomSection::Other(s) => &s.name,
         })
     }


### PR DESCRIPTION
#skip-changelog

Follow-up to https://github.com/getsentry/symbolicator/pull/619.

I wasn't quite sure at the time how to reuse the LEB128 / varint encoding prefix from the `wasmbin` library. It turns out that it is easy to do with the Encode trait.

The library has some basic encoding support for builtin types. Strings get encoded as binary contents, and binary contents (RawBlob) automatically get encoded with the length before the contents, and the length integer gets encoded as a LEB128 / varint. 

Tested by comparing the emscripten output with the wasm-split flag.

```
% emcc -gseparate-dwarf=foobar bazel/hello-world/hello-world.cc -o test.wasm
% wasm-objdump -j external_debug_info -s test.wasm

test.wasm:	file format wasm 0x1

Contents of section Custom:
0050c3c: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0050c4c: 696e 666f 0666 6f6f 6261 72              info.foobar
```

```
% cargo build --release --package wasm-split 
% ./target/release/wasm-split --strip-names --strip test.debug.wasm -o test.wasm -d test.symbols.wasm --external-dwarf-url=foobar
% wasm-objdump -j external_debug_info -s test.wasm

test.wasm:	file format wasm 0x1

Contents of section Custom:
0957a13: 1365 7874 6572 6e61 6c5f 6465 6275 675f  .external_debug_
0957a23: 696e 666f 0666 6f6f 6261 72              info.foobar
```

PTAL @Swatinem 