### PR TITLE
feat: Hook up the new sentry-tower Http Layer (NATIVE-327)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "axum"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8757fdd8f5b3ef2838f0e83fff84c4b89c12c93ff95b8448686d10a82ac86a53"
+checksum = "310a147401c66e79fc78636e4db63ac68cd6acb9ece056de806ea173a15bce32"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -2144,7 +2144,7 @@ name = "process-event"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "reqwest 0.11.8",
+ "reqwest 0.11.9",
  "serde",
  "serde_json",
  "structopt",
@@ -2380,15 +2380,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -2674,10 +2675,10 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 [[package]]
 name = "sentry"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "httpdate",
- "reqwest 0.11.8",
+ "reqwest 0.11.9",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -2685,14 +2686,14 @@ dependencies = [
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
- "sentry-tower",
+ "sentry-tracing",
  "tokio",
 ]
 
 [[package]]
 name = "sentry-anyhow"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2702,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "sentry-backtrace"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2713,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "hostname",
  "libc",
@@ -2725,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -2738,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "findshlibs 0.10.2",
  "lazy_static",
@@ -2748,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "sentry-log"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "log",
  "sentry-core",
@@ -2757,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "sentry-panic"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2766,17 +2767,29 @@ dependencies = [
 [[package]]
 name = "sentry-tower"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
+ "http",
+ "pin-project",
  "sentry-core",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
+name = "sentry-tracing"
+version = "0.23.0"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
+dependencies = [
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "sentry-types"
 version = "0.23.0"
-source = "git+https://github.com/getsentry/sentry-rust#281f3ffff6a037c3e20a69dbba9f5bbd4cec7b74"
+source = "git+https://github.com/getsentry/sentry-rust#b907d6f4cf750118a097b35aef3ea98c9c19af37"
 dependencies = [
  "chrono",
  "debugid",
@@ -2891,6 +2904,15 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3172,6 +3194,7 @@ dependencies = [
  "rusoto_credential",
  "rusoto_s3",
  "sentry",
+ "sentry-tower",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3186,6 +3209,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "warp",
@@ -3309,6 +3334,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3513,6 +3547,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -37,7 +37,8 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.47.0"
 rusoto_credential = "0.47.0"
 rusoto_s3 = "0.47.0"
-sentry = { git = "https://github.com/getsentry/sentry-rust", version = "0.23.0", features = ["anyhow", "debug-images", "log", "tower"] }
+sentry = { git = "https://github.com/getsentry/sentry-rust", version = "0.23.0", features = ["anyhow", "debug-images", "log", "tracing"] }
+sentry-tower = { git = "https://github.com/getsentry/sentry-rust", version = "0.23.0", features = ["http"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
@@ -47,6 +48,8 @@ symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demang
 # symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.26"
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3.5", default-features = false, features = ["std", "registry"] }
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }
 tokio-util = "0.6"
 tower = "0.4"

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -67,7 +67,6 @@ pub fn execute() -> Result<()> {
     let sentry = sentry::init(sentry::ClientOptions {
         dsn: config.sentry_dsn.clone(),
         release: Some(env!("SYMBOLICATOR_RELEASE").into()),
-        traces_sample_rate: 1.0, // TODO: dont merge this ;-)
         session_mode: sentry::SessionMode::Request,
         auto_session_tracking: false,
         ..Default::default()

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use structopt::StructOpt;
+use tracing_subscriber::prelude::*;
 
 use crate::cache;
 use crate::config::Config;
@@ -66,10 +67,15 @@ pub fn execute() -> Result<()> {
     let sentry = sentry::init(sentry::ClientOptions {
         dsn: config.sentry_dsn.clone(),
         release: Some(env!("SYMBOLICATOR_RELEASE").into()),
+        traces_sample_rate: 1.0, // TODO: dont merge this ;-)
         session_mode: sentry::SessionMode::Request,
         auto_session_tracking: false,
         ..Default::default()
     });
+
+    tracing_subscriber::Registry::default()
+        .with(sentry::integrations::tracing::layer())
+        .init();
 
     logging::init_logging(&config);
     if let Some(ref statsd) = config.metrics.statsd {

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -1,11 +1,10 @@
 use axum::routing::{get, post};
 use axum::Router;
-use sentry::integrations::tower::NewSentryLayer;
+use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use tower::ServiceBuilder;
 
 use crate::metrics::MetricsLayer;
 use crate::services::Service;
-use crate::utils::sentry::SentryRequestLayer;
 
 mod applecrashreport;
 mod error;
@@ -31,7 +30,7 @@ pub async fn healthcheck() -> &'static str {
 pub fn create_app(service: Service) -> Router {
     let layer = ServiceBuilder::new()
         .layer(axum::AddExtensionLayer::new(service))
-        .layer(SentryRequestLayer)
+        .layer(SentryHttpLayer::with_transaction())
         .layer(NewSentryLayer::new_from_top())
         .layer(MetricsLayer);
     Router::new()

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -137,6 +137,11 @@ struct FetchCfiCacheInternal {
     threadpool: tokio::runtime::Handle,
 }
 
+/// Extracts the Call Frame Information (CFI) from an object file.
+///
+/// The extracted CFI is written to `path` in symbolic's
+/// [`CfiCache`](symbolic::minidump::cfi::CfiCache) format.
+#[tracing::instrument(skip_all)]
 async fn compute_cficache(
     threadpool: tokio::runtime::Handle,
     objects_actor: ObjectsActor,
@@ -184,10 +189,6 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         self.meta_handle.cache_key()
     }
 
-    /// Extracts the Call Frame Information (CFI) from an object file.
-    ///
-    /// The extracted CFI is written to `path` in symbolic's
-    /// [`CfiCache`](symbolic::minidump::cfi::CfiCache) format.
     fn compute(&self, path: &Path) -> BoxFuture<'static, Result<CacheStatus, Self::Error>> {
         let future = compute_cficache(
             self.threadpool.clone(),
@@ -295,6 +296,7 @@ impl CfiCacheActor {
 ///
 /// The source file is probably an executable or so, the resulting file is in the format of
 /// [symbolic::minidump::cfi::CfiCache].
+#[tracing::instrument(skip_all)]
 fn write_cficache(path: &Path, object_handle: &ObjectHandle) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_cficache"));

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -147,6 +147,7 @@ impl fmt::Display for ObjectHandle {
 /// This is the actual implementation of [`CacheItemRequest::compute`] for
 /// [`FetchFileDataRequest`] but outside of the trait so it can be written as async/await
 /// code.
+#[tracing::instrument(skip_all)]
 async fn fetch_file(
     path: PathBuf,
     cache_key: CacheKey,

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -180,6 +180,7 @@ struct FetchSymCacheInternal {
 /// This is the actual implementation of [`CacheItemRequest::compute`] for
 /// [`FetchSymCacheInternal`] but outside of the trait so it can be written as async/await
 /// code.
+#[tracing::instrument(name = "compute_symcache", skip_all)]
 async fn fetch_difs_and_compute_symcache(
     path: PathBuf,
     object_meta: Arc<ObjectMetaHandle>,
@@ -358,6 +359,7 @@ impl SymCacheActor {
 ///
 /// It is assumed both the `object_handle` contains a positive cache.  The
 /// `bcsymbolmap_handle` can only exist for a positive cache so does not have this issue.
+#[tracing::instrument(skip_all)]
 fn write_symcache(
     path: &Path,
     object_handle: &ObjectHandle,

--- a/crates/symbolicator/src/utils/sentry.rs
+++ b/crates/symbolicator/src/utils/sentry.rs
@@ -1,11 +1,3 @@
-use std::collections::BTreeMap;
-use std::task::{Context, Poll};
-
-use axum::body::Body;
-use axum::http::Request;
-use tower_layer::Layer;
-use tower_service::Service;
-
 /// Write own data to [`sentry::Scope`], only the subset that is considered useful for debugging.
 pub trait ConfigureScope {
     /// Writes information to the given scope.
@@ -14,51 +6,5 @@ pub trait ConfigureScope {
     /// Configures the current scope.
     fn configure_scope(&self) {
         sentry::configure_scope(|scope| self.to_scope(scope));
-    }
-}
-
-#[derive(Clone)]
-pub struct SentryRequestLayer;
-
-#[derive(Clone)]
-pub struct SentryRequestService<S> {
-    service: S,
-}
-
-impl<S> Layer<S> for SentryRequestLayer {
-    type Service = SentryRequestService<S>;
-
-    fn layer(&self, service: S) -> Self::Service {
-        Self::Service { service }
-    }
-}
-
-impl<S> Service<Request<Body>> for SentryRequestService<S>
-where
-    S: Service<Request<Body>>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
-    }
-
-    fn call(&mut self, request: Request<Body>) -> Self::Future {
-        sentry::configure_scope(|scope| {
-            let mut headers = BTreeMap::new();
-            for (header, value) in request.headers() {
-                headers.insert(
-                    header.to_string(),
-                    value.to_str().unwrap_or("<Opaque header value>").into(),
-                );
-            }
-            scope.set_context(
-                "HTTP Request Headers",
-                sentry::protocol::Context::Other(headers),
-            );
-        });
-        self.service.call(request)
     }
 }


### PR DESCRIPTION
This hooks up the new sentry-tower Http layer to capture request properties, and also start a new transaction.

It also pulls in `tracing` and sprinkles a few `instrument` attrs around, and does explicit trace/transaction forwarding in a couple of places. (so this supercedes #515)

The result is this:

![Bildschirmfoto 2022-01-13 um 15 18 14](https://user-images.githubusercontent.com/580492/149347130-eab8e275-9b9a-497b-b1c4-9dd84ef23c29.png)

#skip-changelog ffs