### PR TITLE
ref: Forward CacheItemRequest::compute to async fns

### DIFF
--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::fs;
 use std::io::{self, Seek, SeekFrom};
 use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
@@ -18,10 +20,13 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use tempfile::tempfile_in;
+use tempfile::NamedTempFile;
 
 use crate::cache::CacheStatus;
 use crate::logging::LogError;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath};
+use crate::services::download::DownloadService;
+use crate::services::download::RemoteDif;
 use crate::services::download::{DownloadError, DownloadStatus};
 use crate::types::{ObjectId, Scope};
 use crate::utils::compression::decompress_object_file;
@@ -119,6 +124,130 @@ impl fmt::Display for ObjectHandle {
     }
 }
 
+/// Downloads the object file, processes it and returns whether the file is in the cache.
+///
+/// If the object file was successfully downloaded it is first decompressed.  If it is
+/// an archive containing multiple objects, then next the object matching the code or
+/// debug ID of our request is extracted first.  Finally the object is parsed with
+/// symbolic to ensure it is not malformed.
+///
+/// If there is an error decompression then an `Err` of [`ObjectError`] is returned.  If the
+/// parsing the final object file failed, or there is an error downloading the file an `Ok` with
+/// [`CacheStatus::Malformed`] is returned.
+///
+/// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
+/// returned.
+///
+/// If there was an error downloading the object file, an `Ok` with
+/// [`CacheStatus::CacheSpecificError`] is returned.
+///
+/// If the object file did not exist on the source an `Ok` with [`CacheStatus::Negative`] will
+/// be returned.
+///
+/// This is the actual implementation of [`CacheItemRequest::compute`] for
+/// [`FetchFileDataRequest`] but outside of the trait so it can be written as async/await
+/// code.
+async fn fetch_file(
+    path: PathBuf,
+    cache_key: CacheKey,
+    object_id: ObjectId,
+    file_id: RemoteDif,
+    downloader: Arc<DownloadService>,
+    tempfile: std::io::Result<NamedTempFile>,
+) -> Result<CacheStatus, ObjectError> {
+    log::trace!("Fetching file data for {}", cache_key);
+    sentry::configure_scope(|scope| {
+        scope.set_transaction(Some("download_file"));
+        file_id.to_scope(scope);
+        object_id.to_scope(scope);
+    });
+
+    let download_file = tempfile?;
+    let download_dir = download_file
+        .path()
+        .parent()
+        .ok_or(ObjectError::NoTempDir)?;
+
+    let status = downloader.download(file_id, download_file.path()).await;
+
+    match status {
+        Ok(DownloadStatus::NotFound) => {
+            log::debug!("No debug file found for {}", cache_key);
+            return Ok(CacheStatus::Negative);
+        }
+
+        Err(e) => {
+            // We want to error-log "interesting" download errors so we can look them up
+            // in our internal sentry. We downgrade to debug-log for unactionable
+            // permissions errors. Since this function does a fresh download, it will never
+            // hit `CachedError`, but listing it for completeness is not a bad idea either.
+            match e {
+                DownloadError::Permissions | DownloadError::CachedError(_) => {
+                    log::debug!("Error while downloading file: {}", LogError(&e))
+                }
+                _ => log::error!("Error while downloading file: {}", LogError(&e)),
+            }
+
+            return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
+        }
+
+        Ok(DownloadStatus::Completed) => {
+            // fall-through
+        }
+    }
+
+    log::trace!("Finished download of {}", cache_key);
+    let decompress_result = decompress_object_file(&download_file, tempfile_in(download_dir)?);
+
+    // Treat decompression errors as malformed files. It is more likely that
+    // the error comes from a corrupt file than a local file system error.
+    let mut decompressed = match decompress_result {
+        Ok(decompressed) => decompressed,
+        Err(e) => return Ok(CacheStatus::Malformed(e.to_string())),
+    };
+
+    // Seek back to the start and parse this object so we can deal with it.
+    // Since objects in Sentry (and potentially also other sources) might be
+    // multi-arch files (e.g. FatMach), we parse as Archive and try to
+    // extract the wanted file.
+    decompressed.seek(SeekFrom::Start(0))?;
+    let view = ByteView::map_file(decompressed)?;
+    let archive = match Archive::parse(&view) {
+        Ok(archive) => archive,
+        Err(e) => return Ok(CacheStatus::Malformed(e.to_string())),
+    };
+    let mut persist_file = fs::File::create(&path)?;
+    if archive.is_multi() {
+        let object_opt = archive
+            .objects()
+            .filter_map(Result::ok)
+            .find(|object| object_id.match_object(object));
+
+        let object = match object_opt {
+            Some(object) => object,
+            None => {
+                if let Some(Err(err)) = archive.objects().find(|r| r.is_err()) {
+                    return Ok(CacheStatus::Malformed(err.to_string()));
+                } else {
+                    return Ok(CacheStatus::Negative);
+                }
+            }
+        };
+
+        io::copy(&mut object.data(), &mut persist_file)?;
+    } else {
+        // Attempt to parse the object to capture errors. The result can be
+        // discarded as the object's data is the entire ByteView.
+        if let Err(err) = archive.object_by_index(0) {
+            return Ok(CacheStatus::Malformed(err.to_string()));
+        }
+
+        io::copy(&mut view.as_ref(), &mut persist_file)?;
+    }
+
+    Ok(CacheStatus::Positive)
+}
+
 impl CacheItemRequest for FetchFileDataRequest {
     type Item = ObjectHandle;
     type Error = ObjectError;
@@ -127,129 +256,15 @@ impl CacheItemRequest for FetchFileDataRequest {
         self.0.get_cache_key()
     }
 
-    /// Downloads the object file, processes it and returns whether the file is in the cache.
-    ///
-    /// If the object file was successfully downloaded it is first decompressed.  If it is
-    /// an archive containing multiple objects, then next the object matching the code or
-    /// debug ID of our request is extracted first.  Finally the object is parsed with
-    /// symbolic to ensure it is not malformed.
-    ///
-    /// If there is an error decompression then an `Err` of [`ObjectError`] is returned.  If the
-    /// parsing the final object file failed, or there is an error downloading the file an `Ok` with
-    /// [`CacheStatus::Malformed`] is returned.
-    ///
-    /// If the object file did not exist on the source a [`CacheStatus::Negative`] will be
-    /// returned.
-    ///
-    /// If there was an error downloading the object file, an `Ok` with
-    /// [`CacheStatus::CacheSpecificError`] is returned.
-    ///
-    /// If the object file did not exist on the source an `Ok` with [`CacheStatus::Negative`] will
-    /// be returned.
     fn compute(&self, path: &Path) -> BoxFuture<'static, Result<CacheStatus, Self::Error>> {
-        let cache_key = self.get_cache_key();
-        log::trace!("Fetching file data for {}", cache_key);
-
-        let path = path.to_owned();
-        let object_id = self.0.object_id.clone();
-
-        sentry::configure_scope(|scope| {
-            scope.set_transaction(Some("download_file"));
-            self.0.file_source.to_scope(scope);
-            self.0.object_id.to_scope(scope);
-        });
-
-        let file_id = self.0.file_source.clone();
-        let downloader = self.0.download_svc.clone();
-        let tempfile = self.0.data_cache.tempfile();
-
-        let future = async move {
-            let download_file = tempfile?;
-            let download_dir = download_file
-                .path()
-                .parent()
-                .ok_or(ObjectError::NoTempDir)?;
-
-            let status = downloader.download(file_id, download_file.path()).await;
-
-            match status {
-                Ok(DownloadStatus::NotFound) => {
-                    log::debug!("No debug file found for {}", cache_key);
-                    return Ok(CacheStatus::Negative);
-                }
-
-                Err(e) => {
-                    // We want to error-log "interesting" download errors so we can look them up
-                    // in our internal sentry. We downgrade to debug-log for unactionable
-                    // permissions errors. Since this function does a fresh download, it will never
-                    // hit `CachedError`, but listing it for completeness is not a bad idea either.
-                    match e {
-                        DownloadError::Permissions | DownloadError::CachedError(_) => {
-                            log::debug!("Error while downloading file: {}", LogError(&e))
-                        }
-                        _ => log::error!("Error while downloading file: {}", LogError(&e)),
-                    }
-
-                    return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
-                }
-
-                Ok(DownloadStatus::Completed) => {
-                    // fall-through
-                }
-            }
-
-            log::trace!("Finished download of {}", cache_key);
-            let decompress_result =
-                decompress_object_file(&download_file, tempfile_in(download_dir)?);
-
-            // Treat decompression errors as malformed files. It is more likely that
-            // the error comes from a corrupt file than a local file system error.
-            let mut decompressed = match decompress_result {
-                Ok(decompressed) => decompressed,
-                Err(e) => return Ok(CacheStatus::Malformed(e.to_string())),
-            };
-
-            // Seek back to the start and parse this object so we can deal with it.
-            // Since objects in Sentry (and potentially also other sources) might be
-            // multi-arch files (e.g. FatMach), we parse as Archive and try to
-            // extract the wanted file.
-            decompressed.seek(SeekFrom::Start(0))?;
-            let view = ByteView::map_file(decompressed)?;
-            let archive = match Archive::parse(&view) {
-                Ok(archive) => archive,
-                Err(e) => return Ok(CacheStatus::Malformed(e.to_string())),
-            };
-            let mut persist_file = fs::File::create(&path)?;
-            if archive.is_multi() {
-                let object_opt = archive
-                    .objects()
-                    .filter_map(Result::ok)
-                    .find(|object| object_id.match_object(object));
-
-                let object = match object_opt {
-                    Some(object) => object,
-                    None => {
-                        if let Some(Err(err)) = archive.objects().find(|r| r.is_err()) {
-                            return Ok(CacheStatus::Malformed(err.to_string()));
-                        } else {
-                            return Ok(CacheStatus::Negative);
-                        }
-                    }
-                };
-
-                io::copy(&mut object.data(), &mut persist_file)?;
-            } else {
-                // Attempt to parse the object to capture errors. The result can be
-                // discarded as the object's data is the entire ByteView.
-                if let Err(err) = archive.object_by_index(0) {
-                    return Ok(CacheStatus::Malformed(err.to_string()));
-                }
-
-                io::copy(&mut view.as_ref(), &mut persist_file)?;
-            }
-
-            Ok(CacheStatus::Positive)
-        };
+        let future = fetch_file(
+            path.to_owned(),
+            self.get_cache_key(),
+            self.0.object_id.clone(),
+            self.0.file_source.clone(),
+            self.0.download_svc.clone(),
+            self.0.data_cache.tempfile(),
+        );
 
         let future = async move {
             future.await.map_err(|e| {

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -8,7 +8,7 @@
 //! consistency.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -22,7 +22,7 @@ use crate::services::download::{RemoteDif, RemoteDifUri};
 use crate::sources::SourceId;
 use crate::types::{ObjectFeatures, ObjectId, Scope};
 
-use super::{FetchFileDataRequest, ObjectError, ObjectHandle};
+use super::{FetchFileDataRequest, ObjectError};
 
 /// This requests metadata of a single file at a specific path/url.
 #[derive(Clone, Debug)]
@@ -84,14 +84,7 @@ impl ObjectMetaHandle {
     }
 }
 
-impl CacheItemRequest for FetchFileMetaRequest {
-    type Item = ObjectMetaHandle;
-    type Error = ObjectError;
-
-    fn get_cache_key(&self) -> CacheKey {
-        self.file_source.cache_key(self.scope.clone())
-    }
-
+impl FetchFileMetaRequest {
     /// Fetches object file and derives metadata from it, storing this in the cache.
     ///
     /// This uses the data cache to fetch the requested file before parsing it and writing
@@ -103,47 +96,57 @@ impl CacheItemRequest for FetchFileMetaRequest {
     /// This returns [`CacheStatus::CacheSpecificError`] if the download failed.  If the
     /// data cache is [`CacheStatus::Negative`] or [`CacheStatus::Malformed`] then the same
     /// status is returned.
-    fn compute(&self, path: &Path) -> BoxFuture<'static, Result<CacheStatus, Self::Error>> {
+    ///
+    /// This is the actual implementation of [`CacheItemRequest::compute`] for
+    /// [`FetchFileMetaRequest`] but outside of the trait so it can be written as async/await
+    /// code.
+    async fn compute_file_meta(self, path: PathBuf) -> Result<CacheStatus, ObjectError> {
         let cache_key = self.get_cache_key();
         log::trace!("Fetching file meta for {}", cache_key);
 
-        let path = path.to_owned();
         let data_cache = self.data_cache.clone();
-        let slf = self.clone();
-        let result = async move {
-            data_cache
-                .compute_memoized(FetchFileDataRequest(slf))
-                .await
-                .map_err(ObjectError::Caching)
-                .and_then(move |object_handle: Arc<ObjectHandle>| {
-                    if object_handle.status == CacheStatus::Positive {
-                        if let Ok(object) = Object::parse(&object_handle.data) {
-                            let mut new_cache = fs::File::create(path)?;
+        let object_handle = data_cache
+            .compute_memoized(FetchFileDataRequest(self))
+            .await
+            .map_err(ObjectError::Caching)?;
+        if object_handle.status == CacheStatus::Positive {
+            if let Ok(object) = Object::parse(&object_handle.data) {
+                let mut new_cache = fs::File::create(path)?;
 
-                            let meta = ObjectFeatures {
-                                has_debug_info: object.has_debug_info(),
-                                has_unwind_info: object.has_unwind_info(),
-                                has_symbols: object.has_symbols(),
-                                has_sources: object.has_sources(),
-                            };
+                let meta = ObjectFeatures {
+                    has_debug_info: object.has_debug_info(),
+                    has_unwind_info: object.has_unwind_info(),
+                    has_symbols: object.has_symbols(),
+                    has_sources: object.has_sources(),
+                };
 
-                            log::trace!("Persisting object meta for {}: {:?}", cache_key, meta);
-                            serde_json::to_writer(&mut new_cache, &meta)?;
-                        }
-                    }
+                log::trace!("Persisting object meta for {}: {:?}", cache_key, meta);
+                serde_json::to_writer(&mut new_cache, &meta)?;
+            }
+        }
 
-                    // Unlike compute for other caches, this does not convert `CacheSpecificError`s
-                    // into `Negative` entries. This is because `create_candidate_info` populates
-                    // info about the original cache entry using the meta cache's data. If this
-                    // were to be converted to `Negative` when the original cache is a
-                    // `CacheSpecificError` then the user would never see what caused a download
-                    // failure, as what's visible to them is sourced from the output of
-                    //  `create_candidate_info`.
-                    Ok(object_handle.status.clone())
-                })
-        };
+        // Unlike compute for other caches, this does not convert `CacheSpecificError`s
+        // into `Negative` entries. This is because `create_candidate_info` populates
+        // info about the original cache entry using the meta cache's data. If this
+        // were to be converted to `Negative` when the original cache is a
+        // `CacheSpecificError` then the user would never see what caused a download
+        // failure, as what's visible to them is sourced from the output of
+        //  `create_candidate_info`.
+        Ok(object_handle.status.clone())
+    }
+}
 
-        Box::pin(result)
+impl CacheItemRequest for FetchFileMetaRequest {
+    type Item = ObjectMetaHandle;
+    type Error = ObjectError;
+
+    fn get_cache_key(&self) -> CacheKey {
+        self.file_source.cache_key(self.scope.clone())
+    }
+
+    fn compute(&self, path: &Path) -> BoxFuture<'static, Result<CacheStatus, Self::Error>> {
+        let future = self.clone().compute_file_meta(path.to_owned());
+        Box::pin(future)
     }
 
     fn should_load(&self, data: &[u8]) -> bool {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1963,11 +1963,10 @@ impl SymbolicationActor {
             )
         };
 
-        Ok(self
-            .cpu_pool
+        self.cpu_pool
             .spawn(lazy.bind_hub(sentry::Hub::current()))
             .await?
-            .context("Minidump stackwalk future cancelled")?)
+            .context("Minidump stackwalk future cancelled")
     }
 
     /// Saves the given `minidump_file` in the diagnostics cache if configured to do so.


### PR DESCRIPTION
This refactors the code, pulling as much of the actual computation out into an async fn.

Moves some refactors out of #628 and this should in the end help with https://github.com/tokio-rs/tracing/issues/1831

#skip-changelog ffs