### PR TITLE
ref(shared-cache): Do not block at process startup

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -400,7 +400,7 @@ impl SharedCacheBackend {
     }
 }
 
-/// Message to send upload tasks across the [`SharedCacheService::upload_queue_tx`].
+/// Message to send upload tasks across the [`InnerSharedCacheService::upload_queue_tx`].
 struct UploadMessage {
     /// The cache key to store the data at.
     key: SharedCacheKey,

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -94,7 +94,22 @@ impl GcsState {
                         Err(err) if start.elapsed() > MAX_DELAY => return Err(err),
                         Err(err) => {
                             let remaining = MAX_DELAY - start.elapsed();
-                            log::warn!("Error initialising GCS authentication token: {}", err);
+                            log::warn!("Error initialising GCS authentication token: {}", &err);
+                            match err.downcast_ref::<gcp_auth::Error>() {
+                                Some(gcp_auth::Error::NoAuthMethod(custom, gcloud, svc, user)) => {
+                                    log::error!(
+                                        "No GCP auth: custom: {}, gcloud: {}, svc: {}, user: {}",
+                                        custom,
+                                        gcloud,
+                                        svc,
+                                        user,
+                                    );
+                                }
+                                _ => log::warn!(
+                                    "Error initialising GCS authentication token: {}",
+                                    &err
+                                ),
+                            }
                             log::info!(
                                 "Waiting for GKE metadata server, {}s remaining",
                                 remaining.as_secs(),

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -92,8 +92,9 @@ impl GcsState {
                         }) {
                         Ok(auth_manager) => break auth_manager,
                         Err(err) if start.elapsed() > MAX_DELAY => return Err(err),
-                        _ => {
+                        Err(err) => {
                             let remaining = MAX_DELAY - start.elapsed();
+                            log::warn!("Error initialising GCS authentication token: {}", err);
                             log::info!(
                                 "Waiting for GKE metadata server, {}s remaining",
                                 remaining.as_secs(),


### PR DESCRIPTION
Getting the first token may take a little while, this refactors
startup to do this is the background and not block during startup.
When the shared cache becomes available it will be used, it does not
matter much if there are a few cache uses before the shared cache is
available.

#skip-changelog