### PR TITLE
fix(shared-cache): Use a fixed version of gcp_auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,8 +987,7 @@ dependencies = [
 [[package]]
 name = "gcp_auth"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e41af881b65785e78b2b01437cbb01a125c06a7655c91383299970ade8280a5"
+source = "git+https://github.com/getsentry/gcp_auth?branch=sentry-main#29f625ad3b2eb5f36c7976998c73aa90d8541a18"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.7.1"
 filetime = "0.2.14"
 flate2 = "1.0.0"
 futures = "0.3.12"
-gcp_auth = "0.6.1"
+gcp_auth = { git = "https://github.com/getsentry/gcp_auth", branch = "sentry-main" }
 glob = "0.3.0"
 hostname = "0.3.1"
 humantime-serde = "1.0.1"


### PR DESCRIPTION
Seems upstream gcp_auth broke the default service account, while they
haven't fixed it yet switch back to our own version of gcp_auth.

#skip-changelog