### PR TITLE
ci: Switch to pinned cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,10 @@ jobs:
       - name: Build Docs
         run: mkdocs build
 
+  # Code coverage instrumentation is current broken in recent Rust nightlies,
+  # as they fail processing with the following error:
+  # `Failed to load coverage: Truncated coverage data`
+  # https://github.com/taiki-e/cargo-llvm-cov/issues/128
   codecov:
     name: Code Coverage
     runs-on: ubuntu-latest
@@ -223,16 +227,16 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-01-14
           components: llvm-tools-preview
           override: true
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: Swatinem/fucov@v1
-        with:
-          args: --workspace --all-features
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - run: cargo llvm-cov --all-features --workspace --doctests --lcov --output-path lcov.info
 
       - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
         with:
-          directory: coverage
+          files: lcov.info


### PR DESCRIPTION
Switches from `fucov` to `cargo-llvm-cov`, and pins the nightly Rust version as recent nightlies regressed coverage reports.

#skip-changelog