### PR TITLE
fix(bitcode): Do not error out for source errors

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -320,13 +320,6 @@ impl BitcodeService {
         scope: Scope,
         source: SourceConfig,
     ) -> Result<Option<Arc<CacheHandle>>, Error> {
-        let _guard = Hub::current().push_scope();
-        sentry::configure_scope(|scope| {
-            scope.set_tag("auxdif.debugid", uuid);
-            scope.set_extra("auxdif.kind", dif_kind.to_string().into());
-            scope.set_extra("auxdif.source", source.type_name().into());
-        });
-
         let file_type = match dif_kind {
             AuxDifKind::BcSymbolMap => &[FileType::BcSymbolMap],
             AuxDifKind::UuidMap => &[FileType::UuidMap],

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -241,10 +241,10 @@ impl BitcodeService {
 
         let uuid_mapping = UuidMapping::parse_plist(uuid, &plist_handle.data)
             .context("Failed to parse plist")
-            .or_else(|err| {
+            .map_err(|err| {
                 log::warn!("{}: {:?}", err, err.source());
                 sentry::capture_error(&*err);
-                Err(())
+                err
             })
             .ok()?;
 

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -231,13 +231,9 @@ impl BitcodeService {
         sources: Arc<[SourceConfig]>,
     ) -> Option<BcSymbolMapHandle> {
         // First find the PList.
-        let find_plist = self
+        let plist_handle = self
             .fetch_file_from_all_sources(uuid, AuxDifKind::UuidMap, scope.clone(), sources.clone())
-            .await;
-        let plist_handle = match find_plist {
-            Some(handle) => handle,
-            None => return None,
-        };
+            .await?;
 
         let uuid_mapping = UuidMapping::parse_plist(uuid, &plist_handle.data)
             .context("Failed to parse plist")
@@ -249,18 +245,14 @@ impl BitcodeService {
             .ok()?;
 
         // Next find the BCSymbolMap.
-        let find_symbolmap = self
+        let symbolmap_handle = self
             .fetch_file_from_all_sources(
                 uuid_mapping.original_uuid(),
                 AuxDifKind::BcSymbolMap,
                 scope,
                 sources,
             )
-            .await;
-        let symbolmap_handle = match find_symbolmap {
-            Some(handle) => handle,
-            None => return None,
-        };
+            .await?;
 
         Some(BcSymbolMapHandle {
             uuid: symbolmap_handle.uuid,

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -243,11 +243,11 @@ impl ObjectsActor {
     // TODO(flub): this function should inline already fetch the meta (what
     // `fetch_file_metas()` does now) for each file.  Currently we synchronise all the
     // futures at the end of the listing for no good reason.
-    async fn list_files<'a>(
-        &'a self,
-        sources: &'a [SourceConfig],
-        filetypes: &'static [FileType],
-        identifier: &'a ObjectId,
+    async fn list_files(
+        &self,
+        sources: &[SourceConfig],
+        filetypes: &[FileType],
+        identifier: &ObjectId,
     ) -> Vec<RemoteDif> {
         let queries = sources.iter().map(|source| {
             async move {

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -321,15 +321,15 @@ impl SymCacheActor {
                 // TODO: while there is some caching *internally* in the bitcode_svc, the *complete*
                 // fetch request is not cached
                 let bcsymbolmap_handle = match handle.object_id().debug_id {
-                    Some(debug_id) => self
-                        .bitcode_svc
-                        .fetch_bcsymbolmap(
-                            debug_id,
-                            handle.scope().clone(),
-                            request.sources.clone(),
-                        )
-                        .await
-                        .map_err(SymCacheError::BcSymbolMapError)?,
+                    Some(debug_id) => {
+                        self.bitcode_svc
+                            .fetch_bcsymbolmap(
+                                debug_id,
+                                handle.scope().clone(),
+                                request.sources.clone(),
+                            )
+                            .await
+                    }
                     None => None,
                 };
 


### PR DESCRIPTION
The bitcode service incorrectly errored out for errors from sources
instead of not providing a result.  This in turn results in any source
errors during bitcode lookups killing the entire symcache lookup, even
if no bitcode could be needed.

Fixes #640

#skip-changelog