### PR TITLE
feat(shared-cache): Upload files on cache extensions as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 - Support for `external_debug_info` section in wasm-split for external dwarf files. ([#619](https://github.com/getsentry/symbolicator/pull/619))
 - Added windows binaries for `wasm-split` and `symsorter` to releases ([#624](https://github.com/getsentry/symbolicator/pull/624))
-- Also populate the shared cache from exiting items in the local cache, not only new ones. ([#648](https://github.com/getsentry/symbolicator/pull/648))
+- Also populate the shared cache from existing items in the local cache, not only new ones. ([#648](https://github.com/getsentry/symbolicator/pull/648))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Support for `external_debug_info` section in wasm-split for external dwarf files. ([#619](https://github.com/getsentry/symbolicator/pull/619))
 - Added windows binaries for `wasm-split` and `symsorter` to releases ([#624](https://github.com/getsentry/symbolicator/pull/624))
+- Also populate the shared cache from exiting items in the local cache, not only new ones. ([#648](https://github.com/getsentry/symbolicator/pull/648))
 
 ### Fixes
 

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -14,7 +14,7 @@ use tempfile::NamedTempFile;
 use tokio::fs;
 
 use crate::cache::{Cache, CacheStatus};
-use crate::services::shared_cache::{SharedCacheKey, SharedCacheService};
+use crate::services::shared_cache::{CacheStoreReason, SharedCacheKey, SharedCacheService};
 use crate::types::Scope;
 use crate::utils::futures::CallOnDrop;
 
@@ -226,7 +226,7 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// # Errors
     ///
     /// If there is an I/O error reading the cache [`CacheItemRequest::Error`] is returned.
-    fn lookup_local_cache(
+    async fn lookup_local_cache(
         &self,
         request: &T,
         key: &CacheKey,
@@ -237,42 +237,51 @@ impl<T: CacheItemRequest> Cacher<T> {
                 let name = self.config.name();
                 let item_path = key.cache_path(cache_dir, version);
                 log::trace!("Trying {} cache at path {}", name, item_path.display());
-                sentry::with_scope(
-                    |scope| {
-                        scope.set_extra(
-                            &format!("cache.{}.cache_path", name),
-                            item_path.to_string_lossy().into(),
-                        );
-                    },
-                    || {
-                        let byteview = match self.config.open_cachefile(&item_path)? {
-                            Some(bv) => bv,
-                            None => return Ok(None),
-                        };
-                        let status = CacheStatus::from_content(&byteview);
-                        if status == CacheStatus::Positive && !request.should_load(&byteview) {
-                            log::trace!("Discarding {} at path {}", name, item_path.display());
-                            metric!(counter(&format!("caches.{}.file.discarded", name)) += 1);
-                            return Ok(None);
-                        }
-                        // This is also reported for "negative cache hits": When we cached
-                        // the 404 response from a server as empty file.
-                        metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
-                        metric!(
-                            time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
-                            "hit" => "true"
-                        );
+                let _scope = Hub::current().push_scope();
+                sentry::configure_scope(|scope| {
+                    scope.set_extra(
+                        &format!("cache.{}.cache_path", name),
+                        item_path.to_string_lossy().into(),
+                    );
+                });
+                let (byteview, mtime_bumped) = match self.config.open_cachefile(&item_path)? {
+                    Some(bv) => bv,
+                    None => return Ok(None),
+                };
+                let status = CacheStatus::from_content(&byteview);
+                if status == CacheStatus::Positive && mtime_bumped {
+                    let shared_cache_key = SharedCacheKey {
+                        name: self.config.name(),
+                        version: T::VERSIONS.current,
+                        local_key: key.clone(),
+                    };
+                    if let Ok(fd) = fs::File::open(&item_path).await {
+                        self.shared_cache_service
+                            .store(shared_cache_key, fd, CacheStoreReason::Refresh)
+                            .await;
+                    }
+                }
+                if status == CacheStatus::Positive && !request.should_load(&byteview) {
+                    log::trace!("Discarding {} at path {}", name, item_path.display());
+                    metric!(counter(&format!("caches.{}.file.discarded", name)) += 1);
+                    return Ok(None);
+                }
+                // This is also reported for "negative cache hits": When we cached
+                // the 404 response from a server as empty file.
+                metric!(counter(&format!("caches.{}.file.hit", name)) += 1);
+                metric!(
+                    time_raw(&format!("caches.{}.file.size", name)) = byteview.len() as u64,
+                    "hit" => "true"
+                );
 
-                        log::trace!("Loading {} at path {}", name, item_path.display());
-                        let item = request.load(
-                            key.scope.clone(),
-                            status,
-                            byteview,
-                            CachePath::Cached(item_path.clone()),
-                        );
-                        Ok(Some(item))
-                    },
-                )
+                log::trace!("Loading {} at path {}", name, item_path.display());
+                let item = request.load(
+                    key.scope.clone(),
+                    status,
+                    byteview,
+                    CachePath::Cached(item_path.clone()),
+                );
+                Ok(Some(item))
             }
             None => Ok(None),
         }
@@ -295,7 +304,10 @@ impl<T: CacheItemRequest> Cacher<T> {
         // lookup without going through the deduplication/channel creation logic. This creates a
         // small opportunity of invoking compute another time after a fresh cache has just been
         // computed. To avoid duplicated work in that case, we will check the cache here again.
-        if let Some(item) = self.lookup_local_cache(&request, &key, T::VERSIONS.current)? {
+        if let Some(item) = self
+            .lookup_local_cache(&request, &key, T::VERSIONS.current)
+            .await?
+        {
             return Ok(item);
         }
 
@@ -388,7 +400,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         // persisted the file.
         if !shared_cache_hit && status == CacheStatus::Positive {
             self.shared_cache_service
-                .store(shared_cache_key, temp_fd)
+                .store(shared_cache_key, temp_fd, CacheStoreReason::New)
                 .await;
         }
 
@@ -540,13 +552,16 @@ impl<T: CacheItemRequest> Cacher<T> {
 
         // cache_path is None when caching is disabled.
         if let Some(cache_dir) = self.config.cache_dir() {
-            if let Some(item) = self.lookup_local_cache(&request, &key, T::VERSIONS.current)? {
+            if let Some(item) = self
+                .lookup_local_cache(&request, &key, T::VERSIONS.current)
+                .await?
+            {
                 return Ok(Arc::new(item));
             }
 
             // try fallback cache paths next
             for version in T::VERSIONS.fallbacks.iter() {
-                if let Ok(Some(item)) = self.lookup_local_cache(&request, &key, *version) {
+                if let Ok(Some(item)) = self.lookup_local_cache(&request, &key, *version).await {
                     // we have found an outdated cache that we will use right away,
                     // and we will kick off a recomputation for the `current` cache version
                     // in a deduplicated background task, which we will not await


### PR DESCRIPTION
The local cache extends the lifetime of files by bumping the mtime at
most once an hour for files which keep being used.  There are a
surprisingly large number of cache entries which seem to never expire
and always stay in the local cache.

This is not ideal for the shared cache: its entries expire at some
point regardless of whether they are used or not.  And thus the really
common files can expire out, meaning it would be upon a new
symbolicator to repopulate these.

Instead this hooks up the shared cache to also attemp to upload every
time the local cache lifetime was extended.  This will normally only
result in requests but not in actual transfers of data because the
shared cache does not upload when a file already exists.  Only when a
file finally expires out of the shared cache will it be re-uploaded.


There are kind of two code-smells here:

- The `open_cachefile()` function now returns a tuple.  This is always
  ugly.
  
- We need to re-open the path of the local cache in order to upload
  it.

Both are kind of a consequence the fact that the layer in cache.rs
tries to only deal with files rather than a more generic notion of
cache items.  This is all not ideal but refactoring this now is well
out of scope.  The increased complexity is not too bad.

This will increase the number of requests to store items in the shared cache, but that is pretty low currently anyway.