### PR TITLE
ref(shared-cache): tweak error reporting

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -240,7 +240,7 @@ impl GcsState {
             match self
                 .exists(&key)
                 .await
-                .context("Failed fetching object metadata")
+                .context("Failed fetching object metadata from shared cache")
             {
                 Ok(true) => return Ok(SharedCacheStoreResult::Skipped),
                 Ok(false) => (),


### PR DESCRIPTION
This gives better context when capturing errors, otherwise you're a
bit lost as to why this is.

#skip-changelog