### PR TITLE
feat(symbolication): Compare stackwalking methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha-1 0.10.0",
+ "similar",
  "structopt",
  "symbolic",
  "tempfile",

--- a/crates/process-event/src/main.rs
+++ b/crates/process-event/src/main.rs
@@ -23,6 +23,10 @@ struct Cli {
     /// Whether to include DIF candidate information.
     #[structopt(short, long)]
     dif_candidates: bool,
+
+    /// Whether to compare the old and new stackwalking methods.
+    #[structopt(short, long)]
+    compare_stackwalking_methods: bool,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -30,6 +34,7 @@ fn main() -> Result<(), anyhow::Error> {
         input,
         symbolicator,
         dif_candidates,
+        compare_stackwalking_methods,
     } = Cli::from_args();
 
     let client = reqwest::Client::new();
@@ -48,6 +53,11 @@ fn main() -> Result<(), anyhow::Error> {
         if dif_candidates {
             form = form.text("options", r#"{"dif_candidates":true}"#);
         }
+
+        if compare_stackwalking_methods {
+            form = form.text("options", r#"{"compare_stackwalking_methods":true}"#);
+        }
+
         form = form.file("upload_file_minidump", input)?;
 
         req.multipart(form).send()

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -55,6 +55,7 @@ tower-service = "0.3"
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.10.0"
+similar = "2.1.0"
 
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2566,6 +2566,7 @@ mod tests {
             })],
             options: RequestOptions {
                 dif_candidates: true,
+                ..Default::default()
             },
         }
     }
@@ -2709,6 +2710,7 @@ mod tests {
                     Arc::new([source]),
                     RequestOptions {
                         dif_candidates: true,
+                        ..Default::default()
                     },
                 );
                 let response = symbolication.get_response(request_id.unwrap(), None).await;
@@ -2757,6 +2759,7 @@ mod tests {
                 Arc::new([source]),
                 RequestOptions {
                     dif_candidates: true,
+                    ..Default::default()
                 },
             )
             .unwrap();

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -155,6 +155,10 @@ pub struct RequestOptions {
     /// [`ObjectCandidate`] struct for which extra information is returned for DIF objects.
     #[serde(default)]
     pub dif_candidates: bool,
+
+    /// Whether to run the new stackwalking method in addition to the old one and compare their results.
+    #[serde(default)]
+    pub compare_stackwalking_methods: bool,
 }
 
 /// A map of register values.

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -169,7 +169,7 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 }
 
 /// An unsymbolicated frame from a symbolication request.
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
 pub struct RawFrame {
     /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
     /// [`sym_addr`](Self::sym_addr).
@@ -237,7 +237,7 @@ pub struct RawFrame {
 }
 
 /// A stack trace containing unsymbolicated stack frames.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct RawStacktrace {
     /// The OS-dependent identifier of the thread.
     #[serde(default)]


### PR DESCRIPTION
This adds functionality for comparing breakpad-based and rust-minidump-based stackwalking.

1. The giant closure in `stackwalk_minidump(_with_cfi)` is extracted into its own function `stackwalk_with_breakpad`.
2. It gets a little sibling `stackwalk_with_rust_minidump` that is `unimplemented!()` right now.
3. `StackWalkMinidumpResult` gains a `duration` field for the time it took to stackwalk. It also gains a `PartialEq` impl that ignores this duration—when we look for diffs, different durations are not interesting. I'm on the fence about doing it this way; alternatives include
      1. keeping the duration separate from the struct and
      2. not going via `PartialEq`, but comparing "manually".
4. The code that checks whether there was a stackwalking problem (diff or new method being slow) is split from the code that saves the minidump in such a case. This is due to issues with `TempPath`: saving the minidump takes ownership of `TempPath`, but we still need the path for further processing. My solution was to move the saving code after said processing.

#skip-changelog