### PR TITLE
ref(shared-cache): Shorten the connect timeout

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -36,7 +36,7 @@ use crate::utils::gcs::{self, GcsError};
 use super::cacher::CacheKey;
 
 // TODO: get timeouts from global config?
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
 const STORE_TIMEOUT: Duration = Duration::from_secs(60);
 
 struct GcsState {


### PR DESCRIPTION
The metrics indicate that waiting for 3s is pointless, making a cutoff
at 500ms will make a few more requests timeout but that's a reasonable
tradeoff to not wait for 2.5s to get a timeout anyway on most slow
requests.

Some other time we could do some retries with circuit breaking maybe.
Fow now this is fine because the local cache exists as well.

#skip-changelog