### PR TITLE
ref: Try to optimize stackwalking procspawn usage

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1807,7 +1807,7 @@ fn stackwalk_with_breakpad(
     cfi_caches: BTreeMap<DebugId, PathBuf>,
     minidump_path: PathBuf,
     spawn_time: SystemTime,
-) -> Result<procspawn::serde::Json<StackWalkMinidumpResult>, ProcError> {
+) -> Result<StackWalkMinidumpResult, ProcError> {
     if let Ok(duration) = spawn_time.elapsed() {
         metric!(timer("minidump.stackwalk.spawn.duration") = duration);
     }
@@ -1892,20 +1892,20 @@ fn stackwalk_with_breakpad(
         });
     }
 
-    Ok(procspawn::serde::Json(StackWalkMinidumpResult {
+    Ok(StackWalkMinidumpResult {
         modules,
         missing_modules,
         stacktraces,
         minidump_state,
         duration,
-    }))
+    })
 }
 
 fn stackwalk_with_rust_minidump(
     _cfi_caches: BTreeMap<DebugId, PathBuf>,
     _minidump_path: PathBuf,
     _spawn_time: SystemTime,
-) -> Result<procspawn::serde::Json<StackWalkMinidumpResult>, ProcError> {
+) -> Result<StackWalkMinidumpResult, ProcError> {
     unimplemented!()
 }
 
@@ -2037,6 +2037,7 @@ impl SymbolicationActor {
                 |(cfi_caches, minidump_path, spawn_time)| -> Result<_, ProcError> {
                     let procspawn::serde::Json(cfi_caches) = cfi_caches;
                     stackwalk_with_breakpad(cfi_caches, minidump_path, spawn_time)
+                        .map(procspawn::serde::Json)
                 },
             );
 
@@ -2057,6 +2058,7 @@ impl SymbolicationActor {
                     |(cfi_caches, minidump_path, spawn_time)| {
                         let procspawn::serde::Json(cfi_caches) = cfi_caches;
                         stackwalk_with_rust_minidump(cfi_caches, minidump_path, spawn_time)
+                            .map(procspawn::serde::Json)
                     },
                 );
 

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::fs::File;
 use std::future::Future;


### PR DESCRIPTION
This does a couple of things:
- Switches from `BTreeMap` back to `Vec`, keeping the types that are being serialized over procspawn simpler.
  - This is: all modules, missing modules, and cfi caches
- Converting modules to `HashMap`, as lookups should ideally be `O(1)` vs `O(log n)`, though not sure that matters too much.
- Avoid serializing/sending Object Infos for missing modules, the mapping happens *after* procspawn now.
- Only pass the complete module list on the first run, since that should be idempotent.
- Comparison mode will only compare `stacktraces`, as Vec/HashMap have unpredictable sorting order, and the previous optimization makes sure we only get the complete module list once anyway.

The effect is probably hard to quantify. It went from `Requests/sec:    189.40` to `Requests/sec:    216.52`, though I have a bunch of other stuff running in the background now so numbers are not quite stable anyway :-D

Another data point: profiling with Instruments showed 20% time spent in ipc-channel before vs 6% now. So a lot better than before. And an interesting data point in itself, as this quantifies the potential savings by cutting out procspawn completely.

#skip-changelog