### PR TITLE
fix: Use wildcard matcher for symstore proxy

### DIFF
--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -35,11 +35,11 @@ pub fn create_app(service: Service) -> Router {
         .layer(SentryHttpLayer::with_transaction())
         .layer(MetricsLayer);
     Router::new()
-        .route("/proxy/:path", get(proxy).head(proxy))
+        .route("/proxy/*path", get(proxy).head(proxy))
         .route("/requests/:request_id", get(requests))
-        .route("/symbolicate", post(symbolicate))
-        .route("/minidump", post(minidump))
         .route("/applecrashreport", post(applecrashreport))
+        .route("/minidump", post(minidump))
+        .route("/symbolicate", post(symbolicate))
         .layer(layer)
         // the healthcheck is last, as it will bypass all the middlewares
         .route("/healthcheck", get(healthcheck))


### PR DESCRIPTION
This should fix #654, though hard to tell since we don’t have any tests for this at the moment.