### PR TITLE
ref: Target upstream rust-minidump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,9 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
 dependencies = [
+ "async-trait",
  "circular",
  "log",
  "minidump-common",
@@ -1599,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
 dependencies = [
  "encoding",
  "log",
@@ -1615,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
@@ -1629,8 +1630,9 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
 dependencies = [
+ "async-trait",
  "breakpad-symbols",
  "clap",
  "log",
@@ -3193,6 +3195,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "apple-crash-report-parser",
+ "async-trait",
  "axum",
  "backtrace",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,10 +266,11 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
+source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
 dependencies = [
  "async-trait",
  "circular",
+ "debugid",
  "log",
  "minidump-common",
  "nom 1.2.4",
@@ -1565,9 +1566,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
 dependencies = [
  "libc",
 ]
@@ -1600,8 +1601,9 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
+source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
 dependencies = [
+ "debugid",
  "encoding",
  "log",
  "memmap2",
@@ -1611,14 +1613,16 @@ dependencies = [
  "scroll",
  "thiserror",
  "time 0.3.6",
+ "uuid",
 ]
 
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
+source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
 dependencies = [
  "bitflags",
+ "debugid",
  "enum-primitive-derive",
  "log",
  "num-traits 0.2.14",
@@ -1630,11 +1634,12 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#8e1f9a8f9fb67d25a817b48fdee7b9870e1cb321"
+source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
  "clap",
+ "debugid",
  "log",
  "memmap2",
  "minidump",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
+source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
 dependencies = [
  "async-trait",
  "circular",
@@ -588,9 +588,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debugid"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "serde",
  "uuid",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
+source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
 dependencies = [
  "debugid",
  "encoding",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
+source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
 dependencies = [
  "bitflags",
  "debugid",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#7f5adf743560705fa3d46a784c874655e6681432"
+source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
 dependencies = [
  "async-trait",
  "breakpad-symbols",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,13 +1061,13 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
+checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
 dependencies = [
  "log",
  "plain",
- "scroll",
+ "scroll 0.11.0",
 ]
 
 [[package]]
@@ -1474,9 +1474,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1610,7 +1610,7 @@ dependencies = [
  "minidump-common",
  "num-traits 0.2.14",
  "range-map",
- "scroll",
+ "scroll 0.10.2",
  "thiserror",
  "time 0.3.6",
  "uuid",
@@ -1627,7 +1627,7 @@ dependencies = [
  "log",
  "num-traits 0.2.14",
  "range-map",
- "scroll",
+ "scroll 0.10.2",
  "smart-default",
 ]
 
@@ -1643,7 +1643,7 @@ dependencies = [
  "log",
  "memmap2",
  "minidump",
- "scroll",
+ "scroll 0.10.2",
  "serde",
  "serde_json",
  "thiserror",
@@ -1963,7 +1963,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1981,13 +1991,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "pdb"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
 dependencies = [
  "fallible-iterator",
- "scroll",
+ "scroll 0.10.2",
  "uuid",
 ]
 
@@ -2646,7 +2669,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 dependencies = [
- "scroll_derive",
+ "scroll_derive 0.10.5",
+]
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive 0.11.0",
 ]
 
 [[package]]
@@ -2654,6 +2686,17 @@ name = "scroll_derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3060,7 +3103,7 @@ checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.2",
  "phf_shared",
  "precomputed-hash",
  "serde",
@@ -3104,8 +3147,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3116,8 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3128,8 +3171,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3142,10 +3185,10 @@ dependencies = [
  "lazycell",
  "nom 7.1.0",
  "nom-supreme",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pdb",
  "regex",
- "scroll",
+ "scroll 0.11.0",
  "serde",
  "serde_json",
  "smallvec",
@@ -3157,8 +3200,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3169,8 +3212,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-minidump"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3183,8 +3226,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#9afb94fcc453197b2780f5e64a13d4c8b2daa4fd"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3222,7 +3265,7 @@ dependencies = [
  "minidump",
  "minidump-processor",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.11.2",
  "procspawn",
  "regex",
  "reqwest 0.11.0",
@@ -3665,7 +3708,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -4077,6 +4120,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 similar = "2.1.0"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.5.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.26"
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-axum = { version = "0.4.3", features = ["multipart"] }
 anyhow = "1.0.38"
 apple-crash-report-parser = "0.4.2"
+async-trait = "0.1.52"
+axum = { version = "0.4.3", features = ["multipart"] }
 backtrace = "0.3.55"
 base64 = "0.13.0"
 cadence = "0.27.0"
@@ -25,9 +26,9 @@ ipnetwork = "0.18.0"
 jsonwebtoken = "7.2.0"
 lazy_static = "1.4.0"
 lru = "0.7.0"
+minidump = { git = "https://github.com/luser/rust-minidump", branch = "master" }
+minidump-processor = { git = "https://github.com/luser/rust-minidump", branch = "master", features = ["symbolic-syms"] }
 num_cpus = "1.13.0"
-minidump = { git = "https://github.com/getsentry/rust-minidump", branch = "feat/symbolicator-integration" }
-minidump-processor = { git = "https://github.com/getsentry/rust-minidump", branch = "feat/symbolicator-integration" }
 parking_lot = "0.11.1"
 procspawn = { version = "0.10.0", features = ["backtrace", "json"] }
 regex = "1.4.3"
@@ -40,28 +41,26 @@ sentry-tower = { version = "0.24.2", features = ["http"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
+similar = "2.1.0"
 structopt = "0.3.21"
 symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.5.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
-# Uncomment the line below for local development
-# symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.26"
-tracing = "0.1.29"
-tracing-subscriber = { version = "0.3.6", features = ["tracing-log", "local-time", "env-filter", "json"] }
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }
 tokio-util = "0.6"
 tower = "0.4"
 tower-layer = "0.3"
 tower-service = "0.3"
+tracing = "0.1.29"
+tracing-subscriber = { version = "0.3.6", features = ["tracing-log", "local-time", "env-filter", "json"] }
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.10.0"
-similar = "2.1.0"
 
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }
 procspawn = { version = "0.10.0", features = ["test-support"] }
 reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["multipart"] }
 sha-1 = "0.10.0"
-warp = "0.3.0"
 test-assembler = "0.1.5"
+warp = "0.3.0"

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -96,10 +96,9 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use minidump_processor::FrameTrust;
 use thiserror::Error;
 
-use crate::types;
+use crate::types::{self, FrameTrust};
 use crate::utils::hex;
 
 const MINIDUMP_EXTENSION_TYPE: u32 = u32::from_be_bytes([b'S', b'y', 0, 1]);

--- a/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux_rust_minidump.snap
+++ b/crates/symbolicator/src/services/snapshots/symbolicator__services__symbolication__tests__minidump_linux_rust_minidump.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator/src/services/symbolication.rs
-assertion_line: 2880
+assertion_line: 2932
 expression: response.unwrap()
 
 ---
@@ -8,8 +8,8 @@ status: completed
 timestamp: 1522061032
 system_info:
   os_name: Linux
-  os_version: 0.0.0
-  os_build: "Linux 4.9.60-linuxkit-aufs #1 SMP Mon Nov 6 16:00:12 UTC 2017 x86_64"
+  os_version: 4.9.60-linuxkit-aufs
+  os_build: "#1 SMP Mon Nov 6 16:00:12 UTC 2017"
   cpu_arch: x86_64
   device_model: ""
 crashed: true

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2585,9 +2585,11 @@ fn map_symbolic_registers_breakpad(x: BTreeMap<&'_ str, RegVal>) -> BTreeMap<Str
         .collect()
 }
 
-fn map_symbolic_registers_rust_minidump(_context: &MinidumpContext) -> BTreeMap<String, HexValue> {
-    // TODO: not this!  See https://github.com/luser/rust-minidump/pull/414
-    BTreeMap::new()
+fn map_symbolic_registers_rust_minidump(context: &MinidumpContext) -> BTreeMap<String, HexValue> {
+    context
+        .valid_registers()
+        .map(|(reg, val)| (reg.to_owned(), HexValue(val)))
+        .collect()
 }
 
 impl From<&CfiCacheError> for ObjectFileStatus {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1753,7 +1753,7 @@ async fn stackwalk_with_rust_minidump(
         let mut frames = Vec::with_capacity(frame_count);
         for frame in thread.frames.iter().take(frame_count) {
             frames.push(RawFrame {
-                instruction_addr: HexValue(frame.return_address()),
+                instruction_addr: HexValue(frame.resume_address),
                 package: frame.module.as_ref().map(|m| m.code_file().into_owned()),
                 trust: frame.trust.into(),
                 ..RawFrame::default()

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2600,11 +2600,9 @@ fn map_symbolic_registers_breakpad(x: BTreeMap<&'_ str, RegVal>) -> BTreeMap<Str
         .collect()
 }
 
-fn map_symbolic_registers_rust_minidump(context: &MinidumpContext) -> BTreeMap<String, HexValue> {
-    context
-        .valid_registers()
-        .map(|(reg, val)| (reg.to_owned(), HexValue(val)))
-        .collect()
+fn map_symbolic_registers_rust_minidump(_context: &MinidumpContext) -> BTreeMap<String, HexValue> {
+    // TODO: not this!  See https://github.com/luser/rust-minidump/pull/414
+    BTreeMap::new()
 }
 
 impl From<&CfiCacheError> for ObjectFileStatus {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -977,7 +977,7 @@ fn symbolicate_stacktrace(
     while let Some((index, mut frame)) = unsymbolicated_frames_iter.next() {
         match symbolicate_frame(caches, &thread.registers, signal, &mut frame, index) {
             Ok(frames) => {
-                if matches!(frame.trust, crate::types::FrameTrust::Scan) {
+                if matches!(frame.trust, FrameTrust::Scan) {
                     metrics.scanned_frames += 1;
                 }
                 symbolicated_frames.extend(frames)

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1493,8 +1493,8 @@ impl TempSymbolProvider {
             .ok()
     }
 
-    fn missing_ids(&self) -> Vec<DebugId> {
-        self.missing_ids.read().iter().copied().collect()
+    fn missing_ids(self) -> Vec<DebugId> {
+        self.missing_ids.into_inner().into_iter().collect()
     }
 }
 

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -239,7 +239,7 @@ pub struct RawFrame {
     pub trust: FrameTrust,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FrameTrust {
     None,

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -239,15 +239,31 @@ pub struct RawFrame {
     pub trust: FrameTrust,
 }
 
+/// How trustworth the instruction pointer of the frame is.
+///
+/// During stack walking it is not always possible to exactly be sure of the instruction
+/// pointer and thus detected frame, especially if there was not enough Call Frame
+/// Information available.  Frames that were detected by scanning may contain dubious
+/// information.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FrameTrust {
+    /// Unknown.
     None,
+    /// Found by scanning the stack.
     Scan,
+    /// Found by scanning the stack using Call Frame Info.
     CfiScan,
+    /// Derived from the Frame Pointer.
     Fp,
+    /// Derived from the Call Frame Info rules.
     Cfi,
+    /// Explicitly provided by an external stack walker (probably on crashing device).
     PreWalked,
+    /// Provided by the CPU context (i.e. the registers).
+    ///
+    /// This is only possible for the topmost, i.e. the crashing, frame as for the other
+    /// frames the registers need to be reconstructed when unwinding the stack.
     Context,
 }
 

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -235,7 +235,7 @@ pub struct RawFrame {
     pub post_context: Vec<String>,
 
     /// Information about how the raw frame was created.
-    #[serde(skip_serializing_if = "is_default_value")]
+    #[serde(default, skip_serializing_if = "is_default_value")]
     pub trust: FrameTrust,
 }
 


### PR DESCRIPTION
This adapts to the async API of rust-minidump but also does a few other things:

* Changes the FrameTrust mapping to our own struct so we can impl Default etc we need for it.
* Completely ignores registers for now, this is a regression

Apart from the obvious there are still a few test failures that I haven't gotten to the bottom off.

#skip-changelog