### PR TITLE
build: Switch to getsentry fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#fc0f82fbcdcdecdf56996e7603c2d01f47d0469b"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
 dependencies = [
  "circular",
  "log",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#fc0f82fbcdcdecdf56996e7603c2d01f47d0469b"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
 dependencies = [
  "encoding",
  "log",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#fc0f82fbcdcdecdf56996e7603c2d01f47d0469b"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#fc0f82fbcdcdecdf56996e7603c2d01f47d0469b"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
 dependencies = [
  "breakpad-symbols",
  "clap",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -26,8 +26,8 @@ jsonwebtoken = "7.2.0"
 lazy_static = "1.4.0"
 lru = "0.7.0"
 num_cpus = "1.13.0"
-minidump = { git = "https://github.com/jan-auer/rust-minidump", branch = "tmp/symbolicator-integration" }
-minidump-processor = { git = "https://github.com/jan-auer/rust-minidump", branch = "tmp/symbolicator-integration" }
+minidump = { git = "https://github.com/getsentry/rust-minidump", branch = "feat/symbolicator-integration" }
+minidump-processor = { git = "https://github.com/getsentry/rust-minidump", branch = "feat/symbolicator-integration" }
 parking_lot = "0.11.1"
 procspawn = { version = "0.10.0", features = ["backtrace", "json"] }
 regex = "1.4.3"


### PR DESCRIPTION
This switches the branch's `rust-minidump` dependency to a branch in Sentry's fork. That branch's state is that of @jan-auer's `tmp/symbolicator-integration` branch plus [this fix](https://github.com/luser/rust-minidump/pull/446).