### PR TITLE
fix: Skip the leading slash for the symstore path

### DIFF
--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -442,7 +442,9 @@ pub fn get_directory_paths(
 }
 
 pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)> {
-    let mut split = path.splitn(3, '/');
+    let mut split = path.splitn(4, '/');
+    // Skip the leading / that the path contains
+    split.next()?;
     let leading_fn = split.next()?;
     let signature = split.next()?;
     let trailing_fn = split.next()?;


### PR DESCRIPTION
For #654. Now it does actually work, at least from my testing on an actual S3 bucket.
Would be nice to have a new release published after this, so people who use tagged versions can actually benefit from this.

#skip-changelog