### PR TITLE
ref(symbolication): Return symbolicator to a state of grace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,21 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "breakpad-symbols"
-version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#75e59fd84a47ff8e82e981c2da6ece54322817c9"
-dependencies = [
- "circular",
- "failure",
- "log",
- "minidump-common",
- "nom 1.2.4",
- "range-map",
- "reqwest 0.11.9",
- "tempfile",
-]
-
-[[package]]
 name = "brownstone"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,12 +370,6 @@ dependencies = [
  "time 0.1.44",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "circular"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clap"
@@ -1631,7 +1610,8 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#75e59fd84a47ff8e82e981c2da6ece54322817c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0f06e24debf89a5ed527f0c06422c0c6c112aa28e78c20ac3ed626823c3bc"
 dependencies = [
  "chrono",
  "encoding",
@@ -1647,7 +1627,8 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#75e59fd84a47ff8e82e981c2da6ece54322817c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e0e0bb43d6a2a4fe9ab129bc8a5107df5e0f2c2869279983932dd222ca03fb"
 dependencies = [
  "bitflags",
  "enum-primitive-derive",
@@ -1656,24 +1637,6 @@ dependencies = [
  "range-map",
  "scroll",
  "smart-default",
-]
-
-[[package]]
-name = "minidump-processor"
-version = "0.9.6"
-source = "git+https://github.com/jan-auer/rust-minidump?branch=tmp/symbolicator-integration#75e59fd84a47ff8e82e981c2da6ece54322817c9"
-dependencies = [
- "breakpad-symbols",
- "chrono",
- "clap",
- "failure",
- "log",
- "memmap",
- "minidump",
- "scroll",
- "serde",
- "serde_json",
- "simplelog",
 ]
 
 [[package]]
@@ -1827,12 +1790,6 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
-
-[[package]]
-name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
@@ -1852,7 +1809,7 @@ dependencies = [
  "indent_write",
  "joinery",
  "memchr",
- "nom 7.1.0",
+ "nom",
 ]
 
 [[package]]
@@ -2436,7 +2393,6 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
- "async-compression",
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
@@ -2461,7 +2417,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3012,17 +2967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1348164456f72ca0116e4538bdaabb0ddb622c7d9f16387c725af3e96d6001c"
-dependencies = [
- "chrono",
- "log",
- "termcolor",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +3122,7 @@ dependencies = [
  "goblin",
  "lazy_static",
  "lazycell",
- "nom 7.1.0",
+ "nom",
  "nom-supreme",
  "parking_lot",
  "pdb",
@@ -3257,7 +3201,6 @@ dependencies = [
  "lazy_static",
  "lru",
  "minidump",
- "minidump-processor",
  "num_cpus",
  "parking_lot",
  "procspawn",
@@ -3357,15 +3300,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha-1 0.10.0",
- "similar",
  "structopt",
  "symbolic",
  "tempfile",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -26,8 +26,7 @@ jsonwebtoken = "7.2.0"
 lazy_static = "1.4.0"
 lru = "0.7.0"
 num_cpus = "1.13.0"
-minidump = { git = "https://github.com/jan-auer/rust-minidump", branch = "tmp/symbolicator-integration" }
-minidump-processor = { git = "https://github.com/jan-auer/rust-minidump", branch = "tmp/symbolicator-integration" }
+minidump = "0.9.4"
 parking_lot = "0.11.1"
 procspawn = { version = "0.10.0", features = ["backtrace", "json"] }
 regex = "1.4.3"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -55,7 +55,6 @@ tower-service = "0.3"
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.10.0"
-similar = "2.1.0"
 
 [dev-dependencies]
 insta = { version = "1.5.2", features = ["redactions"] }

--- a/crates/symbolicator/src/services/minidump.rs
+++ b/crates/symbolicator/src/services/minidump.rs
@@ -96,7 +96,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use minidump_processor::FrameTrust;
+use symbolic::minidump::processor::FrameTrust;
 use thiserror::Error;
 
 use crate::types;
@@ -120,7 +120,7 @@ pub fn parse_stacktraces_from_minidump(
     let stacktraces = parsed
         .threads()
         .map(types::RawStacktrace::try_from)
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(Some(stacktraces))
 }
@@ -156,7 +156,7 @@ impl TryFrom<format::Frame<'_>> for types::RawFrame {
         Ok(types::RawFrame {
             instruction_addr: hex::HexValue(frame.instruction_addr()),
             function: Some(String::from_utf8_lossy(symbol).into_owned()),
-            trust: FrameTrust::PreWalked,
+            trust: FrameTrust::Prewalked,
             ..Default::default()
         })
     }

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1998,18 +1998,15 @@ impl SymbolicationActor {
                             }).unwrap_or_else(|| String::from("diff unrecoverable"))
                     });
 
-                    let module_diff = {
-                        let modules_old: HashMap<DebugId,  RawObjectInfo> = result_old.modules.clone().unwrap_or_default().into_iter().collect();
-                        let modules_new: HashMap<DebugId,  RawObjectInfo> = result_new.modules.clone().unwrap_or_default().into_iter().collect();
-                        (modules_new != modules_old).then(|| {
-                        serde_json::to_string_pretty(&modules_old)
+                    let module_diff = (result_new.modules != result_old.modules ).then(|| {
+                        serde_json::to_string_pretty(&result_old.modules)
                             .map_err(|e| {
                                 let stderr: &dyn std::error::Error = &e;
                                 tracing::error!(stderr,"Failed to convert old modules to json")
                             })
                             .ok()
                             .and_then(|old| {
-                                serde_json::to_string_pretty(&modules_new)
+                                serde_json::to_string_pretty(&result_new.modules)
                                     .map_err(|e| {
                                         let stderr: &dyn std::error::Error = &e;
                                         tracing::error!(
@@ -2028,7 +2025,7 @@ impl SymbolicationActor {
                                         )
                                     })
                             }).unwrap_or_else(|| String::from("diff unrecoverable"))
-                    })};
+                    });
 
                     if stacktrace_diff.is_some() || module_diff.is_some() {
                         Some(NewStackwalkingProblem::Diff {stacktraces: stacktrace_diff.unwrap_or_default(), modules: module_diff.unwrap_or_default()})

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::fs::File;
 use std::future::Future;
@@ -13,11 +12,6 @@ use anyhow::Context;
 use apple_crash_report_parser::AppleCrashReport;
 use chrono::{DateTime, TimeZone, Utc};
 use futures::{channel::oneshot, future, FutureExt as _};
-use minidump::system_info::Os;
-use minidump::{MinidumpContext, MinidumpModule, Module};
-use minidump_processor::{
-    FrameTrust, ProcessState as MinidumpProcessState, SymbolFile, SymbolProvider, SymbolStats,
-};
 use parking_lot::Mutex;
 use regex::Regex;
 use sentry::protocol::SessionStatus;
@@ -30,7 +24,7 @@ use symbolic::common::{Arch, ByteView, CodeId, DebugId, InstructionInfo, Languag
 use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::minidump::cfi::CfiCache;
 use symbolic::minidump::processor::{
-    CodeModule, ProcessMinidumpError, ProcessState as BreakpadProcessState, RegVal,
+    CodeModule, FrameTrust, ProcessMinidumpError, ProcessState, RegVal,
 };
 use tempfile::TempPath;
 use thiserror::Error;
@@ -54,8 +48,6 @@ use crate::utils::hex::HexValue;
 mod module_lookup;
 
 use module_lookup::{SourceLookup, SymCacheLookup};
-
-type Minidump = minidump::Minidump<'static, ByteView<'static>>;
 
 /// Options for demangling all symbols.
 const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
@@ -302,7 +294,7 @@ impl ModuleListBuilder {
         for trace in stacktraces {
             for frame in &trace.frames {
                 let addr = frame.instruction_addr.0;
-                let is_prewalked = frame.trust == FrameTrust::PreWalked;
+                let is_prewalked = frame.trust == FrameTrust::Prewalked;
                 self.mark_referenced(addr, is_prewalked);
             }
         }
@@ -520,7 +512,7 @@ fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
     }
 }
 
-fn normalize_minidump_os_name_breakpad(minidump_os_name: &str) -> &str {
+fn normalize_minidump_os_name(minidump_os_name: &str) -> &str {
     // Be aware that MinidumpState::object_type matches on names produced here.
     match minidump_os_name {
         "Windows NT" => "Windows",
@@ -529,22 +521,7 @@ fn normalize_minidump_os_name_breakpad(minidump_os_name: &str) -> &str {
     }
 }
 
-fn normalize_minidump_os_name_rust_minidump(os: Os) -> &'static str {
-    // Be aware that MinidumpState::object_type matches on names produced here.
-    match os {
-        Os::Windows => "Windows",
-        Os::MacOs => "macOS",
-        Os::Ios => "iOS",
-        Os::Linux => "Linux",
-        Os::Solaris => "Solaris",
-        Os::Android => "Android",
-        Os::Ps3 => "PS3",
-        Os::NaCl => "NaCl",
-        Os::Unknown(_) => "", // TODO(ja): What was the breakpad value?
-    }
-}
-
-fn object_info_from_minidump_module_breakpad(ty: ObjectType, module: &CodeModule) -> RawObjectInfo {
+fn object_info_from_minidump_module(ty: ObjectType, module: &CodeModule) -> RawObjectInfo {
     let mut code_id = module.code_identifier();
 
     // The processor reports an empty string as code id for MachO files
@@ -559,35 +536,6 @@ fn object_info_from_minidump_module_breakpad(ty: ObjectType, module: &CodeModule
         code_file: Some(module.code_file()),
         debug_id: Some(module.debug_identifier()), // TODO: This should use module.id().map(_)
         debug_file: Some(module.debug_file()),
-        image_addr: HexValue(module.base_address()),
-        image_size: match module.size() {
-            0 => None,
-            size => Some(size),
-        },
-    }
-}
-
-fn object_info_from_minidump_module_rust_minidump(
-    ty: ObjectType,
-    module: &MinidumpModule,
-) -> RawObjectInfo {
-    let mut code_id = module.code_identifier().into_owned();
-
-    // The processor reports an empty string as code id for MachO files
-    // TODO(ja): Fix MinidumpModule::code_identifier for MachO
-    if ty == ObjectType::Macho {
-        code_id = module.debug_identifier().unwrap_or_default().into_owned();
-        code_id.truncate(32); // MachO code_id is the debug_id without `0` age.
-    }
-
-    RawObjectInfo {
-        ty,
-        code_id: Some(code_id),
-        code_file: Some(module.code_file().into_owned()),
-        // TODO(ja): Old TODO: This should use module.id().map(_)
-        // TODO(ja): This is optional now, wasn't before, check why
-        debug_id: module.debug_identifier().map(|c| c.into_owned()),
-        debug_file: module.debug_file().map(|c| c.into_owned()),
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {
             0 => None,
@@ -1050,7 +998,7 @@ fn symbolicate_stacktrace(
                         metrics.scanned_frames += 1;
                         metrics.unsymbolicated_scanned_frames += 1;
                     }
-                    FrameTrust::CallFrameInfo => metrics.unsymbolicated_cfi_frames += 1,
+                    FrameTrust::CFI => metrics.unsymbolicated_cfi_frames += 1,
                     FrameTrust::Context => metrics.unsymbolicated_context_frames += 1,
                     _ => {}
                 }
@@ -1321,7 +1269,7 @@ struct MinidumpState {
 
 impl MinidumpState {
     /// Creates a new [`MinidumpState`] from a breakpad symbolication result.
-    fn from_breakpad(process_state: &BreakpadProcessState<'_>) -> Self {
+    fn new(process_state: &ProcessState<'_>) -> Self {
         let minidump_system_info = process_state.system_info();
         let os_name = minidump_system_info.os_name();
         let os_version = minidump_system_info.os_version();
@@ -1341,7 +1289,7 @@ impl MinidumpState {
         MinidumpState {
             timestamp: Utc.timestamp(process_state.timestamp().try_into().unwrap_or_default(), 0),
             system_info: SystemInfo {
-                os_name: normalize_minidump_os_name_breakpad(&os_name).to_owned(),
+                os_name: normalize_minidump_os_name(&os_name).to_owned(),
                 os_version,
                 os_build,
                 cpu_arch,
@@ -1350,45 +1298,6 @@ impl MinidumpState {
             crashed: process_state.crashed(),
             crash_reason: process_state.crash_reason(),
             assertion: process_state.assertion(),
-        }
-    }
-
-    fn from_rust_minidump(process_state: &MinidumpProcessState) -> Self {
-        let info = &process_state.system_info;
-
-        let cpu_arch = match info.cpu {
-            minidump::system_info::Cpu::X86 => Arch::X86,
-            minidump::system_info::Cpu::X86_64 => Arch::Amd64,
-            minidump::system_info::Cpu::Ppc => Arch::Ppc,
-            minidump::system_info::Cpu::Ppc64 => Arch::Ppc64,
-            minidump::system_info::Cpu::Arm => Arch::Arm,
-            minidump::system_info::Cpu::Arm64 => Arch::Arm64,
-            minidump::system_info::Cpu::Unknown(val) => {
-                let msg = format!("Unknown minidump arch: {}", val);
-                sentry::capture_message(&msg, sentry::Level::Error);
-                Arch::Unknown
-            }
-            minidump::system_info::Cpu::Sparc => {
-                sentry::capture_message("Unknown minidump arch: sparc", sentry::Level::Error);
-                Arch::Unknown
-            }
-        };
-
-        MinidumpState {
-            timestamp: process_state.time,
-            system_info: SystemInfo {
-                os_name: normalize_minidump_os_name_rust_minidump(info.os).to_owned(),
-                os_version: info.os_version.clone().unwrap_or_default(),
-                os_build: info.os_build.clone().unwrap_or_default(),
-                cpu_arch,
-                device_model: String::default(),
-            },
-            crashed: process_state.crashed(),
-            crash_reason: process_state
-                .crash_reason
-                .map(|r| r.to_string())
-                .unwrap_or_default(),
-            assertion: process_state.assertion.clone().unwrap_or_default(),
         }
     }
 
@@ -1453,113 +1362,6 @@ fn load_cfi_for_processor(cfi: Vec<(DebugId, PathBuf)>) -> BTreeMap<DebugId, Cfi
         .collect()
 }
 
-struct TempSymbolProvider {
-    files: BTreeMap<DebugId, SymbolFile>,
-    missing_ids: RefCell<BTreeSet<DebugId>>,
-}
-
-impl TempSymbolProvider {
-    /// Load the CFI information from the cache.
-    ///
-    /// This reads the CFI caches from disk and returns them in a format suitable for the
-    /// breakpad processor to stackwalk.
-    pub fn new<'a, M: Iterator<Item = &'a (DebugId, PathBuf)>>(modules: M) -> Self {
-        // TODO(ja): Make TempSymbolProvider the thing serialized to procspawn (prepares for moving in-process)
-        Self {
-            files: modules
-                .filter_map(|(id, path)| Some((*id, Self::load(path)?)))
-                .collect(),
-
-            missing_ids: RefCell::new(BTreeSet::new()),
-        }
-    }
-
-    fn load(cfi_path: &Path) -> Option<SymbolFile> {
-        let bytes = ByteView::open(cfi_path)
-            .map_err(|err| {
-                let stderr: &dyn std::error::Error = &err;
-                tracing::error!(stderr, "Error while reading cficache");
-            })
-            .ok()?;
-
-        let cfi_cache = CfiCache::from_bytes(bytes)
-            // This mostly never happens since we already checked the files
-            // after downloading and they would have been tagged with
-            // CacheStatus::Malformed.
-            .map_err(|err| {
-                let stderr: &dyn std::error::Error = &err;
-                tracing::error!(stderr, "Error while loading cficache");
-            })
-            .ok()?;
-
-        SymbolFile::from_bytes(cfi_cache.as_slice())
-            .map_err(|err| {
-                let stderr: &dyn std::error::Error = &err;
-                tracing::error!(stderr, "Error while procecssing cficache");
-            })
-            .ok()
-    }
-
-    fn into_missing_ids(self) -> BTreeSet<DebugId> {
-        self.missing_ids.into_inner()
-    }
-}
-
-impl SymbolProvider for TempSymbolProvider {
-    fn fill_symbol(
-        &self,
-        module: &dyn Module,
-        _frame: &mut dyn minidump_processor::FrameSymbolizer,
-    ) -> Result<(), minidump_processor::FillSymbolError> {
-        // TODO(ja): Deduplicate this. Probably should use a different map key, ...
-        let debug_id = module
-            .debug_identifier()
-            .and_then(|id| DebugId::from_str(&id).ok())
-            .unwrap_or_default();
-
-        // Symbolicator's CFI caches never store symbolication information. However, we could hook
-        // up symbolic here to fill frame info right away. This requires a larger refactor of
-        // minidump processing and the types, however.
-        // TODO(ja): Check if this is OK. Shouldn't trigger skip heuristics
-        if self.files.contains_key(&debug_id) {
-            Ok(())
-        } else {
-            Err(minidump_processor::FillSymbolError {})
-        }
-    }
-
-    fn walk_frame(
-        &self,
-        module: &dyn Module,
-        walker: &mut dyn minidump_processor::FrameWalker,
-    ) -> Option<()> {
-        // TODO(ja): Deduplicate this. Probably should use a different map key, ...
-        let debug_id = DebugId::from_str(&module.debug_identifier()?).ok()?;
-        match self.files.get(&debug_id) {
-            Some(file) => file.walk_frame(module, walker),
-            None => {
-                self.missing_ids.borrow_mut().insert(debug_id);
-                None
-            }
-        }
-    }
-
-    fn stats(&self) -> HashMap<String, minidump_processor::SymbolStats> {
-        self.files
-            .iter()
-            .map(|(debug_id, sym)| {
-                let stats = SymbolStats {
-                    symbol_url: sym.url.clone(), // TODO(ja): We could put our candidate URI here
-                    loaded_symbols: true, // TODO(ja): Should we return `false` for not found?
-                    corrupt_symbols: false,
-                };
-
-                (debug_id.to_string(), stats)
-            })
-            .collect()
-    }
-}
-
 /// Generic error serialized over procspawn.
 #[derive(Debug, Serialize, Deserialize)]
 struct ProcError(String);
@@ -1581,12 +1383,6 @@ impl From<minidump::Error> for ProcError {
     }
 }
 
-impl From<minidump_processor::ProcessError> for ProcError {
-    fn from(e: minidump_processor::ProcessError) -> Self {
-        Self::new(e)
-    }
-}
-
 impl From<ProcessMinidumpError> for ProcError {
     fn from(e: ProcessMinidumpError) -> Self {
         Self::new(e)
@@ -1600,18 +1396,6 @@ impl std::fmt::Display for ProcError {
 }
 
 impl std::error::Error for ProcError {}
-
-fn convert_frame_trust(trust: symbolic::minidump::processor::FrameTrust) -> FrameTrust {
-    match trust {
-        symbolic::minidump::processor::FrameTrust::None => FrameTrust::None,
-        symbolic::minidump::processor::FrameTrust::Scan => FrameTrust::Scan,
-        symbolic::minidump::processor::FrameTrust::CFIScan => FrameTrust::CfiScan,
-        symbolic::minidump::processor::FrameTrust::FP => FrameTrust::FramePointer,
-        symbolic::minidump::processor::FrameTrust::CFI => FrameTrust::CallFrameInfo,
-        symbolic::minidump::processor::FrameTrust::Prewalked => FrameTrust::PreWalked,
-        symbolic::minidump::processor::FrameTrust::Context => FrameTrust::Context,
-    }
-}
 
 fn stackwalk_with_breakpad(
     cfi_caches: Vec<(DebugId, PathBuf)>,
@@ -1634,9 +1418,9 @@ fn stackwalk_with_breakpad(
     // the same error though.
     let minidump = ByteView::open(minidump_path).unwrap_or_else(|_| ByteView::from_slice(b""));
     let duration = Instant::now();
-    let process_state = BreakpadProcessState::from_minidump(&minidump, Some(&cfi))?;
+    let process_state = ProcessState::from_minidump(&minidump, Some(&cfi))?;
     let duration = duration.elapsed();
-    let minidump_state = MinidumpState::from_breakpad(&process_state);
+    let minidump_state = MinidumpState::new(&process_state);
     let object_type = minidump_state.object_type();
 
     let missing_modules = process_state
@@ -1659,7 +1443,7 @@ fn stackwalk_with_breakpad(
                     // TODO(ja): Check how this can be empty and how we shim.
                     //           Probably needs explicit conversion from raw
                     DebugId::from_str(&module.debug_identifier()).unwrap_or_default(),
-                    object_info_from_minidump_module_breakpad(object_type, module),
+                    object_info_from_minidump_module(object_type, module),
                 )
             })
             .collect()
@@ -1672,9 +1456,9 @@ fn stackwalk_with_breakpad(
     let mut stacktraces = Vec::with_capacity(threads.len());
     for (index, thread) in threads.iter().enumerate() {
         let registers = match thread.frames().get(0) {
-            Some(frame) => map_symbolic_registers_breakpad(
-                frame.registers(minidump_state.system_info.cpu_arch),
-            ),
+            Some(frame) => {
+                map_symbolic_registers(frame.registers(minidump_state.system_info.cpu_arch))
+            }
             None => Registers::new(),
         };
 
@@ -1690,7 +1474,7 @@ fn stackwalk_with_breakpad(
             frames.push(RawFrame {
                 instruction_addr: HexValue(return_address),
                 package: frame.module().map(CodeModule::code_file),
-                trust: convert_frame_trust(frame.trust()),
+                trust: frame.trust(),
                 ..RawFrame::default()
             });
         }
@@ -1713,83 +1497,11 @@ fn stackwalk_with_breakpad(
 }
 
 fn stackwalk_with_rust_minidump(
-    cfi_caches: Vec<(DebugId, PathBuf)>,
-    minidump_path: PathBuf,
-    spawn_time: SystemTime,
-    return_modules: bool,
+    _cfi_caches: Vec<(DebugId, PathBuf)>,
+    _minidump_path: PathBuf,
+    _spawn_time: SystemTime,
 ) -> Result<StackWalkMinidumpResult, ProcError> {
-    if let Ok(duration) = spawn_time.elapsed() {
-        metric!(timer("minidump.stackwalk.spawn.duration") = duration);
-    }
-
-    // Stackwalk the minidump.
-    let minidump = Minidump::read(ByteView::open(minidump_path)?)?;
-    let provider = TempSymbolProvider::new(cfi_caches.iter());
-    let duration = Instant::now();
-    let process_state = minidump_processor::process_minidump(&minidump, &provider)?;
-    let duration = duration.elapsed();
-
-    let minidump_state = MinidumpState::from_rust_minidump(&process_state);
-    let object_type = minidump_state.object_type();
-
-    let missing_modules = provider.into_missing_ids().into_iter().collect();
-    let modules = return_modules.then(|| {
-        process_state
-            .modules
-            .iter()
-            .map(|module| {
-                (
-                    // TODO(ja): Check how this can be empty and how we shim.
-                    //           Probably needs explicit conversion from raw
-                    DebugId::from_str(&module.debug_identifier().unwrap_or_default())
-                        .unwrap_or_default(),
-                    object_info_from_minidump_module_rust_minidump(object_type, module),
-                )
-            })
-            .collect()
-    });
-
-    // Finally iterate through the threads and build the stacktraces to
-    // return, marking modules as used when they are referenced by a frame.
-    let requesting_thread_index: Option<usize> = process_state.requesting_thread;
-    let threads = process_state.threads;
-    let mut stacktraces = Vec::with_capacity(threads.len());
-    for (index, thread) in threads.iter().enumerate() {
-        let registers = match thread.frames.get(0) {
-            Some(frame) => map_symbolic_registers_rust_minidump(&frame.context),
-            None => Registers::new(),
-        };
-
-        // Trim infinite recursions explicitly because those do not
-        // correlate to minidump size. Every other kind of bloated
-        // input data we know is already trimmed/rejected by raw
-        // byte size alone.
-        let frame_count = thread.frames.len().min(20000);
-        let mut frames = Vec::with_capacity(frame_count);
-        for frame in thread.frames.iter().take(frame_count) {
-            frames.push(RawFrame {
-                instruction_addr: HexValue(frame.return_address),
-                package: frame.module.as_ref().map(|m| m.code_file().into_owned()),
-                trust: frame.trust,
-                ..RawFrame::default()
-            });
-        }
-
-        stacktraces.push(RawStacktrace {
-            is_requesting: requesting_thread_index.map(|r| r == index),
-            thread_id: Some(thread.thread_id.into()),
-            registers,
-            frames,
-        });
-    }
-
-    Ok(StackWalkMinidumpResult {
-        modules,
-        missing_modules,
-        stacktraces,
-        minidump_state,
-        duration,
-    })
+    unimplemented!()
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1933,17 +1645,11 @@ impl SymbolicationActor {
                         procspawn::serde::Json(cfi_caches),
                         minidump_path,
                         spawn_time,
-                        return_modules,
                     ),
-                    |(cfi_caches, minidump_path, spawn_time, return_modules)| {
+                    |(cfi_caches, minidump_path, spawn_time)| {
                         let procspawn::serde::Json(cfi_caches) = cfi_caches;
-                        stackwalk_with_rust_minidump(
-                            cfi_caches,
-                            minidump_path,
-                            spawn_time,
-                            return_modules,
-                        )
-                        .map(procspawn::serde::Json)
+                        stackwalk_with_rust_minidump(cfi_caches, minidump_path, spawn_time)
+                            .map(procspawn::serde::Json)
                     },
                 );
 
@@ -2201,19 +1907,6 @@ impl SymbolicationActor {
                     NewStackwalkingProblem::Diff { .. } => "Different stackwalking results",
                     NewStackwalkingProblem::Slow => "Slow stackwalking run",
                 };
-
-                if let NewStackwalkingProblem::Diff {
-                    ref stacktraces,
-                    ref modules,
-                } = problem
-                {
-                    tracing::debug!(
-                        %stacktraces,
-                        %modules,
-                        "Stackwalking difference"
-                    );
-                }
-
                 sentry::with_scope(
                     |scope| {
                         if let NewStackwalkingProblem::Diff {
@@ -2505,7 +2198,7 @@ impl SymbolicationActor {
     }
 }
 
-fn map_symbolic_registers_breakpad(x: BTreeMap<&'_ str, RegVal>) -> BTreeMap<String, HexValue> {
+fn map_symbolic_registers(x: BTreeMap<&'_ str, RegVal>) -> BTreeMap<String, HexValue> {
     x.into_iter()
         .map(|(register, value)| {
             (
@@ -2516,13 +2209,6 @@ fn map_symbolic_registers_breakpad(x: BTreeMap<&'_ str, RegVal>) -> BTreeMap<Str
                 }),
             )
         })
-        .collect()
-}
-
-fn map_symbolic_registers_rust_minidump(context: &MinidumpContext) -> BTreeMap<String, HexValue> {
-    context
-        .valid_registers()
-        .map(|(reg, val)| (reg.to_owned(), HexValue(val)))
         .collect()
 }
 

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use minidump_processor::FrameTrust;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use symbolic::common::{split_path, Arch, CodeId, DebugId, Language};
 use symbolic::debuginfo::Object;
+use symbolic::minidump::processor::FrameTrust;
 use uuid::Uuid;
 
 use crate::utils::addr::AddrMode;
@@ -232,50 +232,8 @@ pub struct RawFrame {
     pub post_context: Vec<String>,
 
     /// Information about how the raw frame was created.
-    #[serde(
-        default,
-        with = "frame_trust",
-        skip_serializing_if = "is_default_value"
-    )]
+    #[serde(default, skip_serializing_if = "is_default_value")]
     pub trust: FrameTrust,
-}
-
-mod frame_trust {
-    use super::*;
-    use serde::{Deserializer, Serializer};
-
-    pub fn serialize<S>(trust: &FrameTrust, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(match *trust {
-            FrameTrust::None => "none",
-            FrameTrust::Scan => "scan",
-            FrameTrust::CfiScan => "cfiscan",
-            FrameTrust::FramePointer => "fp",
-            FrameTrust::CallFrameInfo => "cfi",
-            FrameTrust::PreWalked => "prewalked",
-            FrameTrust::Context => "context",
-        })
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<FrameTrust, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let string = <Cow<str>>::deserialize(deserializer)?;
-
-        match string.as_ref() {
-            "none" => Ok(FrameTrust::None),
-            "scan" => Ok(FrameTrust::Scan),
-            "cfiscan" => Ok(FrameTrust::CfiScan),
-            "fp" => Ok(FrameTrust::FramePointer),
-            "cfi" => Ok(FrameTrust::CallFrameInfo),
-            "prewalked" => Ok(FrameTrust::PreWalked),
-            "context" => Ok(FrameTrust::Context),
-            _ => Err(serde::de::Error::custom("failed to parse frame trust")),
-        }
-    }
 }
 
 /// A stack trace containing unsymbolicated stack frames.


### PR DESCRIPTION
This reverts commits that introduced stackwalking comparison code and also does some manual cleanup. We are now doing this work in [the release/rust-minidump branch](https://github.com/getsentry/symbolicator/tree/release/rust-minidump); this functionality shouldn't have been in master.

#skip-changelog