### PR TITLE
ref(symbolication): Do module comparison by sorting

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1810,6 +1810,36 @@ enum NewStackwalkingProblem {
     Slow,
 }
 
+fn fixup_modules(modules: &mut [(DebugId, RawObjectInfo)]) {
+    modules.sort_by_key(|module| module.0);
+
+    for (_, info) in modules.iter_mut() {
+        if let Some(ref mut code_id) = info.code_id {
+            if code_id.is_empty() {
+                info.code_id = None;
+            }
+        }
+
+        if let Some(ref mut code_file) = info.code_file {
+            if code_file.is_empty() {
+                info.code_file = None;
+            }
+        }
+
+        if let Some(ref mut debug_id) = info.debug_id {
+            if debug_id.is_empty() {
+                info.debug_id = None;
+            }
+        }
+
+        if let Some(ref mut debug_file) = info.debug_file {
+            if debug_file.is_empty() {
+                info.debug_file = None;
+            }
+        }
+    }
+}
+
 /// Determines whether there was a problem with the rust-minidump based stackwalking method.
 ///
 /// A problem is either
@@ -1862,9 +1892,9 @@ fn find_stackwalking_problem(
 
     let module_diff = {
         let mut modules_breakpad = result_breakpad.modules.clone().unwrap_or_default();
-        modules_breakpad.sort_by_key(|module| module.0);
         let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
-        modules_rust_minidump.sort_by_key(|module| module.0);
+        fixup_modules(&mut modules_breakpad);
+        fixup_modules(&mut modules_rust_minidump);
         (modules_rust_minidump != modules_breakpad).then(|| {
             serde_json::to_string_pretty(&modules_breakpad)
                 .map_err(|e| {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1861,18 +1861,10 @@ fn find_stackwalking_problem(
     });
 
     let module_diff = {
-        let modules_breakpad: HashMap<DebugId, RawObjectInfo> = result_breakpad
-            .modules
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
-        let modules_rust_minidump: HashMap<DebugId, RawObjectInfo> = result_rust_minidump
-            .modules
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+        let mut modules_breakpad = result_breakpad.modules.clone().unwrap_or_default();
+        modules_breakpad.sort_by_key(|module| module.0);
+        let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
+        modules_rust_minidump.sort_by_key(|module| module.0);
         (modules_rust_minidump != modules_breakpad).then(|| {
             serde_json::to_string_pretty(&modules_breakpad)
                 .map_err(|e| {


### PR DESCRIPTION
This sorts the lists of modules instead of converting them to maps. Turns out that the latter is a stupid idea for multiple reasons:
1. what if there are multiple modules with the same (trivial) id
2. serializing a map to json apparently has no defined order

#skip-changelog