### PR TITLE
build: Bump rust-minidump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#4853cf8d81029a387b0dc50a5cb84afcd0538adc"
 dependencies = [
  "circular",
  "debugid",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#4853cf8d81029a387b0dc50a5cb84afcd0538adc"
 dependencies = [
  "debugid",
  "encoding",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#4853cf8d81029a387b0dc50a5cb84afcd0538adc"
 dependencies = [
  "bitflags",
  "debugid",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#4853cf8d81029a387b0dc50a5cb84afcd0538adc"
 dependencies = [
  "breakpad-symbols",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,10 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
 dependencies = [
  "circular",
+ "debugid",
  "log",
  "minidump-common",
  "nom 1.2.4",
@@ -1599,8 +1600,9 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
 dependencies = [
+ "debugid",
  "encoding",
  "log",
  "memmap2",
@@ -1610,14 +1612,16 @@ dependencies = [
  "scroll",
  "thiserror",
  "time 0.3.6",
+ "uuid",
 ]
 
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
 dependencies = [
  "bitflags",
+ "debugid",
  "enum-primitive-derive",
  "log",
  "num-traits 0.2.14",
@@ -1629,10 +1633,11 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#64d62899c931dec6404630a52c8d607e3a0a89f7"
+source = "git+https://github.com/getsentry/rust-minidump?branch=feat/symbolicator-integration#a06a1b60a7391cbc45a70e5ef5ac395149a34597"
 dependencies = [
  "breakpad-symbols",
  "clap",
+ "debugid",
  "log",
  "memmap2",
  "minidump",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.5.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 # Uncomment the line below for local development
 # symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -557,7 +557,7 @@ fn object_info_from_minidump_module_breakpad(ty: ObjectType, module: &CodeModule
         ty,
         code_id: Some(code_id),
         code_file: Some(module.code_file()),
-        debug_id: module.id().map(|id| id.as_object_id().to_string()),
+        debug_id: module.id().map(|id| id.to_string()),
         debug_file: Some(module.debug_file()),
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {
@@ -579,7 +579,9 @@ fn object_info_from_minidump_module_rust_minidump(
         code_id: Some(code_id),
         code_file: Some(module.code_file().into_owned()),
         // TODO(ja): This is optional now, wasn't before, check why
-        debug_id: module.debug_identifier().map(|id| id.to_string()),
+        debug_id: module
+            .debug_identifier()
+            .map(|id| id.breakpad().to_string()),
         debug_file: module.debug_file().map(|c| c.into_owned()),
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -571,16 +571,7 @@ fn object_info_from_minidump_module_rust_minidump(
     ty: ObjectType,
     module: &MinidumpModule,
 ) -> RawObjectInfo {
-    let mut code_id = module.code_identifier().to_string();
-
-    // The processor reports an empty string as code id for MachO files
-    // TODO(ja): Fix MinidumpModule::code_identifier for MachO
-    if ty == ObjectType::Macho {
-        code_id = module
-            .debug_identifier()
-            .map(|id| id.to_string())
-            .unwrap_or_default();
-    }
+    let code_id = module.code_identifier().to_string();
 
     RawObjectInfo {
         ty,

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -578,9 +578,8 @@ fn object_info_from_minidump_module_rust_minidump(
     if ty == ObjectType::Macho {
         code_id = module
             .debug_identifier()
-            .map(|id| id.breakpad().to_string())
+            .map(|id| id.to_string())
             .unwrap_or_default();
-        code_id.truncate(32); // MachO code_id is the debug_id without `0` age.
     }
 
     RawObjectInfo {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -578,7 +578,7 @@ fn object_info_from_minidump_module_rust_minidump(
     if ty == ObjectType::Macho {
         code_id = module
             .debug_identifier()
-            .map(|id| id.to_string())
+            .map(|id| id.breakpad().to_string())
             .unwrap_or_default();
         code_id.truncate(32); // MachO code_id is the debug_id without `0` age.
     }

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -584,9 +584,9 @@ fn object_info_from_minidump_module_rust_minidump(
 
     RawObjectInfo {
         ty,
+        // TODO: shouldn't this be None if code_id is empty?
         code_id: Some(code_id),
         code_file: Some(module.code_file().into_owned()),
-        // TODO(ja): Old TODO: This should use module.id().map(_)
         // TODO(ja): This is optional now, wasn't before, check why
         debug_id: module.debug_identifier().map(|id| id.to_string()),
         debug_file: module.debug_file().map(|c| c.into_owned()),

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -557,7 +557,7 @@ fn object_info_from_minidump_module_breakpad(ty: ObjectType, module: &CodeModule
         ty,
         code_id: Some(code_id),
         code_file: Some(module.code_file()),
-        debug_id: Some(module.debug_identifier()), // TODO: This should use module.id().map(_)
+        debug_id: module.id().map(|id| id.as_object_id().to_string()),
         debug_file: Some(module.debug_file()),
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {
@@ -571,12 +571,15 @@ fn object_info_from_minidump_module_rust_minidump(
     ty: ObjectType,
     module: &MinidumpModule,
 ) -> RawObjectInfo {
-    let mut code_id = module.code_identifier().into_owned();
+    let mut code_id = module.code_identifier().to_string();
 
     // The processor reports an empty string as code id for MachO files
     // TODO(ja): Fix MinidumpModule::code_identifier for MachO
     if ty == ObjectType::Macho {
-        code_id = module.debug_identifier().unwrap_or_default().into_owned();
+        code_id = module
+            .debug_identifier()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
         code_id.truncate(32); // MachO code_id is the debug_id without `0` age.
     }
 
@@ -586,7 +589,7 @@ fn object_info_from_minidump_module_rust_minidump(
         code_file: Some(module.code_file().into_owned()),
         // TODO(ja): Old TODO: This should use module.id().map(_)
         // TODO(ja): This is optional now, wasn't before, check why
-        debug_id: module.debug_identifier().map(|c| c.into_owned()),
+        debug_id: module.debug_identifier().map(|id| id.to_string()),
         debug_file: module.debug_file().map(|c| c.into_owned()),
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {
@@ -1512,10 +1515,7 @@ impl SymbolProvider for TempSymbolProvider {
         _frame: &mut dyn minidump_processor::FrameSymbolizer,
     ) -> Result<(), minidump_processor::FillSymbolError> {
         // TODO(ja): Deduplicate this. Probably should use a different map key, ...
-        let debug_id = module
-            .debug_identifier()
-            .and_then(|id| DebugId::from_str(&id).ok())
-            .unwrap_or_default();
+        let debug_id = module.debug_identifier().unwrap_or_default();
 
         // Symbolicator's CFI caches never store symbolication information. However, we could hook
         // up symbolic here to fill frame info right away. This requires a larger refactor of
@@ -1534,7 +1534,7 @@ impl SymbolProvider for TempSymbolProvider {
         walker: &mut dyn minidump_processor::FrameWalker,
     ) -> Option<()> {
         // TODO(ja): Deduplicate this. Probably should use a different map key, ...
-        let debug_id = DebugId::from_str(&module.debug_identifier()?).ok()?;
+        let debug_id = module.debug_identifier().unwrap_or_default();
         match self.files.get(&debug_id) {
             Some(file) => file.walk_frame(module, walker),
             None => {
@@ -1741,8 +1741,7 @@ fn stackwalk_with_rust_minidump(
                 (
                     // TODO(ja): Check how this can be empty and how we shim.
                     //           Probably needs explicit conversion from raw
-                    DebugId::from_str(&module.debug_identifier().unwrap_or_default())
-                        .unwrap_or_default(),
+                    module.debug_identifier().unwrap_or_default(),
                     object_info_from_minidump_module_rust_minidump(object_type, module),
                 )
             })


### PR DESCRIPTION
Our rust-minidump branch now contains [this commit](https://github.com/getsentry/rust-minidump/commit/a06a1b60a7391cbc45a70e5ef5ac395149a34597), cherry-picked from upstream. Consequently we need to update the dependency in this branch to make everything work with `DebugId`.

#skip-changelog