### PR TITLE
ref: Remove some self-cloning methods

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1150,7 +1150,7 @@ pub struct SymbolicateStacktraces {
 impl SymbolicationActor {
     #[tracing::instrument(skip_all)]
     async fn do_symbolicate(
-        self,
+        &self,
         request: SymbolicateStacktraces,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
         let serialize_dif_candidates = request.options.dif_candidates;
@@ -1172,7 +1172,7 @@ impl SymbolicationActor {
     }
 
     async fn do_symbolicate_impl(
-        self,
+        &self,
         request: SymbolicateStacktraces,
     ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
         let SymbolicateStacktraces {
@@ -1187,7 +1187,12 @@ impl SymbolicationActor {
 
         let mut symcache_lookup: SymCacheLookup = modules.iter().cloned().collect();
         symcache_lookup
-            .fetch_symcaches(self.symcaches, scope.clone(), sources.clone(), &stacktraces)
+            .fetch_symcaches(
+                self.symcaches.clone(),
+                scope.clone(),
+                sources.clone(),
+                &stacktraces,
+            )
             .await;
 
         let future = async move {
@@ -1217,7 +1222,7 @@ impl SymbolicationActor {
 
         let mut source_lookup: SourceLookup = modules.into_iter().collect();
         source_lookup
-            .fetch_sources(self.objects, scope, sources, &response.stacktraces)
+            .fetch_sources(self.objects.clone(), scope, sources, &response.stacktraces)
             .await;
 
         let future = async move {
@@ -2138,7 +2143,7 @@ impl SymbolicationActor {
 
     #[tracing::instrument(skip_all)]
     async fn do_stackwalk_minidump(
-        self,
+        &self,
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
@@ -2251,14 +2256,13 @@ impl SymbolicationActor {
     }
 
     async fn do_process_minidump(
-        self,
+        &self,
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
         let (request, state) = self
-            .clone()
             .do_stackwalk_minidump(scope, minidump_file, sources, options)
             .await?;
 


### PR DESCRIPTION
This converts some more methods to simply pass self by reference,
these were left overs from a time when not everything was async-fn.

#skip-changelog