### PR TITLE
ref(symbolication): Triage stackwalking comparisons

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -24,8 +24,6 @@ use sentry::protocol::SessionStatus;
 use sentry::{Hub, SentryFutureExt};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use similar::udiff::unified_diff;
-use similar::Algorithm;
 use symbolic::common::{Arch, ByteView, CodeId, DebugId, InstructionInfo, Language, Name};
 use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::minidump::cfi::CfiCache;
@@ -51,8 +49,10 @@ use crate::types::{
 use crate::utils::futures::{m, measure, CallOnDrop, CancelOnDrop};
 use crate::utils::hex::HexValue;
 
+mod comparisons;
 mod module_lookup;
 
+use comparisons::{find_stackwalking_problem, NewStackwalkingProblem};
 use module_lookup::{SourceLookup, SymCacheLookup};
 
 type Minidump = minidump::Minidump<'static, ByteView<'static>>;
@@ -1790,154 +1790,6 @@ struct StackWalkMinidumpResult {
     stacktraces: Vec<RawStacktrace>,
     minidump_state: MinidumpState,
     duration: Duration,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-enum NewStackwalkingProblem {
-    StacktraceDiff { diff: String, scan: bool },
-    ModuleDiff { diff: String },
-    Slow,
-}
-
-fn fixup_modules(modules: &mut [(DebugId, RawObjectInfo)]) {
-    modules.sort_by_key(|module| module.0);
-
-    for (_, info) in modules.iter_mut() {
-        if let Some(ref mut code_id) = info.code_id {
-            if code_id.is_empty() {
-                info.code_id = None;
-            }
-        }
-
-        if let Some(ref mut code_file) = info.code_file {
-            if code_file.is_empty() {
-                info.code_file = None;
-            }
-        }
-
-        if let Some(ref mut debug_id) = info.debug_id {
-            if debug_id.is_empty() {
-                info.debug_id = None;
-            }
-        }
-
-        if let Some(ref mut debug_file) = info.debug_file {
-            if debug_file.is_empty() {
-                info.debug_file = None;
-            }
-        }
-    }
-}
-
-fn raw_object_info_equal(this: &RawObjectInfo, that: &RawObjectInfo) -> bool {
-    this.ty == that.ty
-        && this.code_id.as_ref().map(|id| id.parse::<CodeId>())
-            == that.code_id.as_ref().map(|id| id.parse())
-        && this.code_file == that.code_file
-        && this.debug_id.as_ref().map(|id| id.parse::<DebugId>())
-            == that.debug_id.as_ref().map(|id| id.parse())
-        && this.debug_file == that.debug_file
-        && this.image_addr == that.image_addr
-        && this.image_size == that.image_size
-}
-
-/// Determines whether there was a problem with the rust-minidump based stackwalking method.
-///
-/// A problem is either
-/// 1. a difference in the returned modules or stacktraces, modulo reordering and trivial renaming of registers, or
-/// 2. rust-minidump taking more than 50% longer than breakpad.
-fn find_stackwalking_problem(
-    result_breakpad: &StackWalkMinidumpResult,
-    result_rust_minidump: &StackWalkMinidumpResult,
-) -> Option<NewStackwalkingProblem> {
-    metric!(timer("minidump.stackwalk.duration") = result_rust_minidump.duration, "method" => "rust-minidump");
-
-    // Normalize the name of the `eflags` register (returned by breakpad) to `efl` (returned by rust-minidump).
-    // Not doing this leads to tons of spurious diffs.
-    let mut stacktraces_breakpad = result_breakpad.stacktraces.clone();
-    let scan = stacktraces_breakpad
-        .iter()
-        .flat_map(|st| st.frames.iter())
-        .any(|f| f.trust == FrameTrust::Scan);
-    for stacktrace in stacktraces_breakpad.iter_mut() {
-        if let Some(val) = stacktrace.registers.remove("eflags") {
-            stacktrace.registers.insert("efl".to_string(), val);
-        }
-    }
-
-    if result_rust_minidump.stacktraces != stacktraces_breakpad {
-        let diff = serde_json::to_string_pretty(&result_breakpad.stacktraces)
-            .map_err(|e| {
-                let stderr: &dyn std::error::Error = &e;
-                tracing::error!(stderr, "Failed to convert breakpad stacktraces to json")
-            })
-            .ok()
-            .and_then(|breakpad| {
-                serde_json::to_string_pretty(&result_rust_minidump.stacktraces)
-                    .map_err(|e| {
-                        let stderr: &dyn std::error::Error = &e;
-                        tracing::error!(
-                            stderr,
-                            "Failed to convert rust-minidump stacktraces to json",
-                        )
-                    })
-                    .ok()
-                    .map(|rust_minidump| {
-                        unified_diff(
-                            Algorithm::Myers,
-                            &breakpad,
-                            &rust_minidump,
-                            3,
-                            Some(("breakpad", "rust-minidump")),
-                        )
-                    })
-            })
-            .unwrap_or_else(|| String::from("diff unrecoverable"));
-        return Some(NewStackwalkingProblem::StacktraceDiff { diff, scan });
-    }
-
-    let mut modules_breakpad = result_breakpad.modules.clone().unwrap_or_default();
-    let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
-    fixup_modules(&mut modules_breakpad);
-    fixup_modules(&mut modules_rust_minidump);
-    if modules_rust_minidump.len() != modules_breakpad.len()
-        || !modules_rust_minidump
-            .iter()
-            .zip(modules_breakpad.iter())
-            .all(|(md, bp)| md.0 == bp.0 && raw_object_info_equal(&md.1, &bp.1))
-    {
-        let diff = serde_json::to_string_pretty(&modules_breakpad)
-            .map_err(|e| {
-                let stderr: &dyn std::error::Error = &e;
-                tracing::error!(stderr, "Failed to convert breakpad modules to json")
-            })
-            .ok()
-            .and_then(|breakpad| {
-                serde_json::to_string_pretty(&modules_rust_minidump)
-                    .map_err(|e| {
-                        let stderr: &dyn std::error::Error = &e;
-                        tracing::error!(stderr, "Failed to convert rust-minidump modules to json",)
-                    })
-                    .ok()
-                    .map(|rust_minidump| {
-                        unified_diff(
-                            Algorithm::Myers,
-                            &breakpad,
-                            &rust_minidump,
-                            3,
-                            Some(("breakpad", "rust-minidump")),
-                        )
-                    })
-            })
-            .unwrap_or_else(|| String::from("diff unrecoverable"));
-        return Some(NewStackwalkingProblem::ModuleDiff { diff });
-    }
-
-    if 2 * result_rust_minidump.duration >= 3 * result_breakpad.duration {
-        Some(NewStackwalkingProblem::Slow)
-    } else {
-        None
-    }
 }
 
 impl SymbolicationActor {

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2096,6 +2096,26 @@ impl SymbolicationActor {
                     find_stackwalking_problem(&result_breakpad, result_rust_minidump)
                 });
 
+            if compare_stackwalking_methods {
+                match problem {
+                    Some(NewStackwalkingProblem::StacktraceDiff { scan: true, .. }) => {
+                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "stacktrace-diff-scan" )
+                    }
+                    Some(NewStackwalkingProblem::StacktraceDiff { scan: false, .. }) => {
+                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "stacktrace-diff-noscan" )
+                    }
+                    Some(NewStackwalkingProblem::ModuleDiff { .. }) => {
+                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "module-diff" )
+                    }
+                    Some(NewStackwalkingProblem::Slow) => {
+                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "slow" )
+                    }
+                    None => {
+                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "none" )
+                    }
+                }
+            }
+
             Ok::<_, anyhow::Error>((result_breakpad, problem))
         };
 

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -1843,19 +1843,13 @@ fn find_stackwalking_problem(
     // Normalize the name of the `eflags` register (returned by breakpad) to `efl` (returned by rust-minidump).
     // Not doing this leads to tons of spurious diffs.
     let mut stacktraces_breakpad = result_breakpad.stacktraces.clone();
-    let mut scan = false;
+    let scan = stacktraces_breakpad
+        .iter()
+        .flat_map(|st| st.frames.iter())
+        .any(|f| f.trust == FrameTrust::Scan);
     for stacktrace in stacktraces_breakpad.iter_mut() {
         if let Some(val) = stacktrace.registers.remove("eflags") {
             stacktrace.registers.insert("efl".to_string(), val);
-        }
-
-        if !scan {
-            for frame in stacktrace.frames.iter() {
-                if frame.trust == FrameTrust::Scan {
-                    scan = true;
-                    break;
-                }
-            }
         }
     }
 

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2097,23 +2097,18 @@ impl SymbolicationActor {
                 });
 
             if compare_stackwalking_methods {
-                match problem {
+                let problem_str = match problem {
                     Some(NewStackwalkingProblem::StacktraceDiff { scan: true, .. }) => {
-                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "stacktrace-diff-scan" )
+                        "stacktrace-diff-scan"
                     }
                     Some(NewStackwalkingProblem::StacktraceDiff { scan: false, .. }) => {
-                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "stacktrace-diff-noscan" )
+                        "stacktrace-diff-noscan"
                     }
-                    Some(NewStackwalkingProblem::ModuleDiff { .. }) => {
-                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "module-diff" )
-                    }
-                    Some(NewStackwalkingProblem::Slow) => {
-                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "slow" )
-                    }
-                    None => {
-                        metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => "none" )
-                    }
-                }
+                    Some(NewStackwalkingProblem::ModuleDiff { .. }) => "module-diff",
+                    Some(NewStackwalkingProblem::Slow) => "slow",
+                    None => "none",
+                };
+                metric!(counter("minidump.stackwalk.comparisons") += 1, "problem" => problem_str);
             }
 
             Ok::<_, anyhow::Error>((result_breakpad, problem))

--- a/crates/symbolicator/src/services/symbolication/comparisons.rs
+++ b/crates/symbolicator/src/services/symbolication/comparisons.rs
@@ -1,0 +1,156 @@
+use minidump_processor::FrameTrust;
+use sentry::types::{CodeId, DebugId};
+use serde::{Deserialize, Serialize};
+use similar::{udiff::unified_diff, Algorithm};
+
+use crate::types::RawObjectInfo;
+
+use super::StackWalkMinidumpResult;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) enum NewStackwalkingProblem {
+    StacktraceDiff { diff: String, scan: bool },
+    ModuleDiff { diff: String },
+    Slow,
+}
+
+fn fixup_modules(modules: &mut [(DebugId, RawObjectInfo)]) {
+    modules.sort_by_key(|module| module.0);
+
+    for (_, info) in modules.iter_mut() {
+        if let Some(ref mut code_id) = info.code_id {
+            if code_id.is_empty() {
+                info.code_id = None;
+            }
+        }
+
+        if let Some(ref mut code_file) = info.code_file {
+            if code_file.is_empty() {
+                info.code_file = None;
+            }
+        }
+
+        if let Some(ref mut debug_id) = info.debug_id {
+            if debug_id.is_empty() {
+                info.debug_id = None;
+            }
+        }
+
+        if let Some(ref mut debug_file) = info.debug_file {
+            if debug_file.is_empty() {
+                info.debug_file = None;
+            }
+        }
+    }
+}
+
+fn raw_object_info_equal(this: &RawObjectInfo, that: &RawObjectInfo) -> bool {
+    this.ty == that.ty
+        && this.code_id.as_ref().map(|id| id.parse::<CodeId>())
+            == that.code_id.as_ref().map(|id| id.parse())
+        && this.code_file == that.code_file
+        && this.debug_id.as_ref().map(|id| id.parse::<DebugId>())
+            == that.debug_id.as_ref().map(|id| id.parse())
+        && this.debug_file == that.debug_file
+        && this.image_addr == that.image_addr
+        && this.image_size == that.image_size
+}
+
+/// Determines whether there was a problem with the rust-minidump based stackwalking method.
+///
+/// A problem is either
+/// 1. a difference in the returned modules or stacktraces, modulo reordering and trivial renaming of registers, or
+/// 2. rust-minidump taking more than 50% longer than breakpad.
+pub(super) fn find_stackwalking_problem(
+    result_breakpad: &StackWalkMinidumpResult,
+    result_rust_minidump: &StackWalkMinidumpResult,
+) -> Option<NewStackwalkingProblem> {
+    metric!(timer("minidump.stackwalk.duration") = result_rust_minidump.duration, "method" => "rust-minidump");
+
+    // Normalize the name of the `eflags` register (returned by breakpad) to `efl` (returned by rust-minidump).
+    // Not doing this leads to tons of spurious diffs.
+    let mut stacktraces_breakpad = result_breakpad.stacktraces.clone();
+    let scan = stacktraces_breakpad
+        .iter()
+        .flat_map(|st| st.frames.iter())
+        .any(|f| f.trust == FrameTrust::Scan);
+    for stacktrace in stacktraces_breakpad.iter_mut() {
+        if let Some(val) = stacktrace.registers.remove("eflags") {
+            stacktrace.registers.insert("efl".to_string(), val);
+        }
+    }
+
+    if result_rust_minidump.stacktraces != stacktraces_breakpad {
+        let diff = serde_json::to_string_pretty(&result_breakpad.stacktraces)
+            .map_err(|e| {
+                let stderr: &dyn std::error::Error = &e;
+                tracing::error!(stderr, "Failed to convert breakpad stacktraces to json")
+            })
+            .ok()
+            .and_then(|breakpad| {
+                serde_json::to_string_pretty(&result_rust_minidump.stacktraces)
+                    .map_err(|e| {
+                        let stderr: &dyn std::error::Error = &e;
+                        tracing::error!(
+                            stderr,
+                            "Failed to convert rust-minidump stacktraces to json",
+                        )
+                    })
+                    .ok()
+                    .map(|rust_minidump| {
+                        unified_diff(
+                            Algorithm::Myers,
+                            &breakpad,
+                            &rust_minidump,
+                            3,
+                            Some(("breakpad", "rust-minidump")),
+                        )
+                    })
+            })
+            .unwrap_or_else(|| String::from("diff unrecoverable"));
+        return Some(NewStackwalkingProblem::StacktraceDiff { diff, scan });
+    }
+
+    let mut modules_breakpad = result_breakpad.modules.clone().unwrap_or_default();
+    let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
+    fixup_modules(&mut modules_breakpad);
+    fixup_modules(&mut modules_rust_minidump);
+    if modules_rust_minidump.len() != modules_breakpad.len()
+        || !modules_rust_minidump
+            .iter()
+            .zip(modules_breakpad.iter())
+            .all(|(md, bp)| md.0 == bp.0 && raw_object_info_equal(&md.1, &bp.1))
+    {
+        let diff = serde_json::to_string_pretty(&modules_breakpad)
+            .map_err(|e| {
+                let stderr: &dyn std::error::Error = &e;
+                tracing::error!(stderr, "Failed to convert breakpad modules to json")
+            })
+            .ok()
+            .and_then(|breakpad| {
+                serde_json::to_string_pretty(&modules_rust_minidump)
+                    .map_err(|e| {
+                        let stderr: &dyn std::error::Error = &e;
+                        tracing::error!(stderr, "Failed to convert rust-minidump modules to json",)
+                    })
+                    .ok()
+                    .map(|rust_minidump| {
+                        unified_diff(
+                            Algorithm::Myers,
+                            &breakpad,
+                            &rust_minidump,
+                            3,
+                            Some(("breakpad", "rust-minidump")),
+                        )
+                    })
+            })
+            .unwrap_or_else(|| String::from("diff unrecoverable"));
+        return Some(NewStackwalkingProblem::ModuleDiff { diff });
+    }
+
+    if 2 * result_rust_minidump.duration >= 3 * result_breakpad.duration {
+        Some(NewStackwalkingProblem::Slow)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
After discussion with @Swatinem and @flub I propose sorting stackwalking differences like this, from most to least interesting:

1. difference in stacktraces, no scanning involved
2. difference in stacktraces, scanning involved
3. difference in modules
4. rust-minidump ran slowly

The reason for separating stacktrace and module differences and treating the latter as less interesting is that we so far all module differences we've seen have been due to fairly benign differences in IDs.

The logic for separating stacktrace differences with and without scanning may be overly simplistic. It just checks whether any frames in the stacktrace returned by breakpad were found by stack scanning.

#skip-changelog