### PR TITLE
ref: Merge SymCacheLookup and SourceLookup (ISSUE-1365)

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -2448,7 +2448,7 @@ mod tests {
             image_size: Some(0),
         });
 
-        let lookup = ModuleLookup::from_iter(vec![info.clone()]);
+        let lookup = ModuleLookup::new(Scope::Global, Arc::new([]), std::iter::once(info.clone()));
 
         let lookup_result = lookup.lookup_symcache(43, AddrMode::Abs).unwrap();
         assert_eq!(lookup_result.module_index, 0);

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -45,7 +45,7 @@ use crate::utils::hex::HexValue;
 
 mod module_lookup;
 
-use module_lookup::{SourceLookup, SymCacheLookup};
+use module_lookup::ModuleLookup;
 
 /// Options for demangling all symbols.
 const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
@@ -543,7 +543,7 @@ fn object_info_from_minidump_module(ty: ObjectType, module: &CodeModule) -> RawO
 }
 
 fn symbolicate_frame(
-    caches: &SymCacheLookup,
+    caches: &ModuleLookup,
     registers: &Registers,
     signal: Option<Signal>,
     frame: &mut RawFrame,
@@ -922,7 +922,7 @@ fn record_symbolication_metrics(
 
 fn symbolicate_stacktrace(
     thread: RawStacktrace,
-    caches: &SymCacheLookup,
+    caches: &ModuleLookup,
     metrics: &mut StacktraceMetrics,
     signal: Option<Signal>,
 ) -> CompleteStacktrace {
@@ -1131,57 +1131,41 @@ impl SymbolicationActor {
             ..
         } = request;
 
-        let mut symcache_lookup: SymCacheLookup = modules.iter().cloned().collect();
-        symcache_lookup
-            .fetch_symcaches(
-                self.symcaches.clone(),
-                scope.clone(),
-                sources.clone(),
-                &stacktraces,
-            )
+        let mut module_lookup = ModuleLookup::new(scope, sources, modules.into_iter());
+        module_lookup
+            .fetch_symcaches(self.symcaches.clone(), &stacktraces)
             .await;
 
         let future = async move {
             let mut metrics = StacktraceMetrics::default();
             let stacktraces: Vec<_> = stacktraces
                 .into_iter()
-                .map(|trace| symbolicate_stacktrace(trace, &symcache_lookup, &mut metrics, signal))
+                .map(|trace| symbolicate_stacktrace(trace, &module_lookup, &mut metrics, signal))
                 .collect();
 
-            // bring modules back into the original order
-            let modules = symcache_lookup.into_inner();
-
-            record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
-
-            CompletedSymbolicationResponse {
-                signal,
-                stacktraces,
-                modules,
-                ..Default::default()
-            }
+            (module_lookup, stacktraces, metrics)
         };
 
-        let mut response =
+        let (mut module_lookup, mut stacktraces, metrics) =
             CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
                 .await
                 .context("Symbolication future cancelled")?;
 
-        let mut source_lookup: SourceLookup = modules.into_iter().collect();
-        source_lookup
-            .fetch_sources(self.objects.clone(), scope, sources, &response.stacktraces)
+        module_lookup
+            .fetch_sources(self.objects.clone(), &stacktraces)
             .await;
 
         let future = async move {
-            let debug_sessions = source_lookup.prepare_debug_sessions();
+            let debug_sessions = module_lookup.prepare_debug_sessions();
 
-            for trace in &mut response.stacktraces {
+            for trace in &mut stacktraces {
                 for frame in &mut trace.frames {
                     let (abs_path, lineno) = match (&frame.raw.abs_path, frame.raw.lineno) {
                         (&Some(ref abs_path), Some(lineno)) => (abs_path, lineno),
                         _ => continue,
                     };
 
-                    let result = source_lookup.get_context_lines(
+                    let result = module_lookup.get_context_lines(
                         &debug_sessions,
                         frame.raw.instruction_addr.0,
                         frame.raw.addr_mode,
@@ -1197,7 +1181,20 @@ impl SymbolicationActor {
                     }
                 }
             }
-            response
+            // explicitly drop this, so it does not borrow `module_lookup` anymore.
+            drop(debug_sessions);
+
+            // bring modules back into the original order
+            let modules = module_lookup.into_inner();
+
+            record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
+
+            CompletedSymbolicationResponse {
+                signal,
+                stacktraces,
+                modules,
+                ..Default::default()
+            }
         };
 
         CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
@@ -2451,7 +2448,7 @@ mod tests {
             image_size: Some(0),
         });
 
-        let lookup = SymCacheLookup::from_iter(vec![info.clone()]);
+        let lookup = ModuleLookup::from_iter(vec![info.clone()]);
 
         let lookup_result = lookup.lookup_symcache(43, AddrMode::Abs).unwrap();
         assert_eq!(lookup_result.module_index, 0);

--- a/crates/symbolicator/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator/src/services/symbolication/module_lookup.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use futures::future;
@@ -51,23 +50,142 @@ impl<'a> SymCacheLookupResult<'a> {
 
 pub struct SourceObject(SelfCell<ByteView<'static>, Object<'static>>);
 
-struct SourceObjectEntry {
+struct ModuleEntry {
     module_index: usize,
     object_info: CompleteObjectInfo,
+    symcache: Option<Arc<SymCacheFile>>,
     source_object: Option<SourceObject>,
 }
 
-pub struct SourceLookup {
-    inner: Vec<SourceObjectEntry>,
+pub struct ModuleLookup {
+    modules: Vec<ModuleEntry>,
+    scope: Scope,
+    sources: Arc<[SourceConfig]>,
 }
 
-impl SourceLookup {
+impl ModuleLookup {
+    /// Creates a new [`ModuleLookup`] out of the given module iterator.
+    pub fn new<Iter>(scope: Scope, sources: Arc<[SourceConfig]>, iter: Iter) -> Self
+    where
+        Iter: IntoIterator<Item = CompleteObjectInfo>,
+    {
+        let mut modules: Vec<_> = iter
+            .into_iter()
+            .enumerate()
+            .map(|(module_index, object_info)| ModuleEntry {
+                module_index,
+                object_info,
+                symcache: None,
+                source_object: None,
+            })
+            .collect();
+
+        modules.sort_by_key(|entry| entry.object_info.raw.image_addr.0);
+
+        // Ignore the name `dedup_by`, I just want to iterate over consecutive items and update
+        // some.
+        modules.dedup_by(|entry2, entry1| {
+            // If this underflows we didn't sort properly.
+            let size = entry2.object_info.raw.image_addr.0 - entry1.object_info.raw.image_addr.0;
+            if entry1.object_info.raw.image_size.unwrap_or(0) == 0 {
+                entry1.object_info.raw.image_size = Some(size);
+            }
+
+            false
+        });
+
+        Self {
+            modules,
+            scope,
+            sources,
+        }
+    }
+
+    /// Returns the original `CompleteObjectInfo` list in its original sorting order.
+    pub fn into_inner(mut self) -> Vec<CompleteObjectInfo> {
+        self.modules.sort_by_key(|entry| entry.module_index);
+        self.modules
+            .into_iter()
+            .map(|entry| entry.object_info)
+            .collect()
+    }
+
+    /// Fetches all the SymCaches for the modules referenced by the `stacktraces`.
+    #[tracing::instrument(skip_all)]
+    pub async fn fetch_symcaches(
+        &mut self,
+        symcache_actor: SymCacheActor,
+        stacktraces: &[RawStacktrace],
+    ) {
+        let mut referenced_objects = HashSet::new();
+        for stacktrace in stacktraces {
+            for frame in &stacktrace.frames {
+                if let Some(SymCacheLookupResult { module_index, .. }) =
+                    self.lookup_symcache(frame.instruction_addr.0, frame.addr_mode)
+                {
+                    referenced_objects.insert(module_index);
+                }
+            }
+        }
+
+        let futures = self
+            .modules
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, entry)| {
+                let is_used = referenced_objects.contains(&entry.module_index);
+                if !is_used {
+                    entry.object_info.debug_status = ObjectFileStatus::Unused;
+                    return None;
+                }
+
+                let symcache_actor = symcache_actor.clone();
+                let request = FetchSymCache {
+                    object_type: entry.object_info.raw.ty,
+                    identifier: object_id_from_object_info(&entry.object_info.raw),
+                    sources: self.sources.clone(),
+                    scope: self.scope.clone(),
+                };
+
+                Some(
+                    async move {
+                        let symcache_result = symcache_actor.fetch(request).await;
+                        (idx, symcache_result)
+                    }
+                    .bind_hub(Hub::new_from_top(Hub::current())),
+                )
+            });
+
+        for (idx, symcache_result) in future::join_all(futures).await {
+            if let Some(entry) = self.modules.get_mut(idx) {
+                let (symcache, status) = match symcache_result {
+                    Ok(symcache) => match symcache.parse() {
+                        Ok(Some(_)) => (Some(symcache), ObjectFileStatus::Found),
+                        Ok(None) => (Some(symcache), ObjectFileStatus::Missing),
+                        Err(e) => (None, (&e).into()),
+                    },
+                    Err(e) => (None, (&*e).into()),
+                };
+
+                entry.object_info.arch = Default::default();
+
+                if let Some(ref symcache) = symcache {
+                    entry.object_info.arch = symcache.arch();
+                    entry.object_info.features.merge(symcache.features());
+                    entry.object_info.candidates.merge(symcache.candidates());
+                }
+
+                entry.symcache = symcache;
+                entry.object_info.debug_status = status;
+            }
+        }
+    }
+
+    /// Fetches all the sources for the modules referenced by the `stacktraces`.
     #[tracing::instrument(skip_all)]
     pub async fn fetch_sources(
         &mut self,
         objects: ObjectsActor,
-        scope: Scope,
-        sources: Arc<[SourceConfig]>,
         stacktraces: &[CompleteStacktrace],
     ) {
         let mut referenced_objects = HashSet::new();
@@ -82,7 +200,7 @@ impl SourceLookup {
         }
 
         let futures = self
-            .inner
+            .modules
             .iter_mut()
             .enumerate()
             .filter_map(|(idx, entry)| {
@@ -97,9 +215,9 @@ impl SourceLookup {
                 let find_request = FindObject {
                     filetypes: FileType::sources(),
                     purpose: ObjectPurpose::Source,
-                    scope: scope.clone(),
+                    scope: self.scope.clone(),
                     identifier: object_id_from_object_info(&entry.object_info.raw),
-                    sources: sources.clone(),
+                    sources: self.sources.clone(),
                 };
 
                 Some(
@@ -125,7 +243,7 @@ impl SourceLookup {
             });
 
         for (idx, source_object) in future::join_all(futures).await {
-            if let Some(entry) = self.inner.get_mut(idx) {
+            if let Some(entry) = self.modules.get_mut(idx) {
                 entry.source_object = source_object;
 
                 if entry.source_object.is_some() {
@@ -135,8 +253,13 @@ impl SourceLookup {
         }
     }
 
+    /// Creates a [`ObjectDebugSession`] for each module that has a [`SourceObject`].
+    ///
+    /// This returns a separate HashMap purely to avoid self-referential borrowing issues.
+    /// The [`ObjectDebugSession`] borrows from the [`SourceObject`] and thus they can't live within
+    /// the same mutable [`ModuleLookup`].
     pub fn prepare_debug_sessions(&self) -> HashMap<usize, Option<ObjectDebugSession<'_>>> {
-        self.inner
+        self.modules
             .iter()
             .map(|entry| {
                 (
@@ -150,6 +273,54 @@ impl SourceLookup {
             .collect()
     }
 
+    /// Look up the corresponding SymCache based on the instruction `addr`.
+    pub fn lookup_symcache(
+        &self,
+        addr: u64,
+        addr_mode: AddrMode,
+    ) -> Option<SymCacheLookupResult<'_>> {
+        match addr_mode {
+            AddrMode::Abs => {
+                for entry in self.modules.iter() {
+                    let start_addr = entry.object_info.raw.image_addr.0;
+
+                    if start_addr > addr {
+                        // The debug image starts at a too high address
+                        continue;
+                    }
+
+                    let size = entry.object_info.raw.image_size.unwrap_or(0);
+                    if let Some(end_addr) = start_addr.checked_add(size) {
+                        if end_addr < addr && size != 0 {
+                            // The debug image ends at a too low address and we're also confident that
+                            // end_addr is accurate (size != 0)
+                            continue;
+                        }
+                    }
+
+                    return Some(SymCacheLookupResult {
+                        module_index: entry.module_index,
+                        object_info: &entry.object_info,
+                        symcache: entry.symcache.as_deref(),
+                        relative_addr: entry.object_info.abs_to_rel_addr(addr),
+                    });
+                }
+                None
+            }
+            AddrMode::Rel(this_module_index) => self
+                .modules
+                .iter()
+                .find(|x| x.module_index == this_module_index)
+                .map(|entry| SymCacheLookupResult {
+                    module_index: entry.module_index,
+                    object_info: &entry.object_info,
+                    symcache: entry.symcache.as_deref(),
+                    relative_addr: Some(addr),
+                }),
+        }
+    }
+
+    /// This looks up the source of the given line, plus `n` lines above/below.
     pub fn get_context_lines(
         &self,
         debug_sessions: &HashMap<usize, Option<ObjectDebugSession<'_>>>,
@@ -178,10 +349,14 @@ impl SourceLookup {
         Some((pre_context, context, post_context))
     }
 
+    // TODO:
+    // * The lookup logic is mostly duplicated with `lookup_symcache`, unify the two in a followup.
+    // * The lookup performs a linear scan, even though we have a sorted list (by addr), switch this
+    //   to a binary search in a followup.
     fn get_module_index_by_addr(&self, addr: u64, addr_mode: AddrMode) -> Option<usize> {
         match addr_mode {
             AddrMode::Abs => {
-                for entry in self.inner.iter() {
+                for entry in self.modules.iter() {
                     let start_addr = entry.object_info.raw.image_addr.0;
 
                     if start_addr > addr {
@@ -203,225 +378,10 @@ impl SourceLookup {
                 None
             }
             AddrMode::Rel(this_module_index) => self
-                .inner
+                .modules
                 .iter()
                 .find(|x| x.module_index == this_module_index)
                 .map(|x| x.module_index),
-        }
-    }
-
-    fn sort(&mut self) {
-        self.inner
-            .sort_by_key(|entry| entry.object_info.raw.image_addr.0);
-
-        // Ignore the name `dedup_by`, I just want to iterate over consecutive items and update
-        // some.
-        self.inner.dedup_by(|entry2, entry1| {
-            // If this underflows we didn't sort properly.
-            let size = entry2.object_info.raw.image_addr.0 - entry1.object_info.raw.image_addr.0;
-            if entry1.object_info.raw.image_size.unwrap_or(0) == 0 {
-                entry1.object_info.raw.image_size = Some(size);
-            }
-
-            false
-        });
-    }
-}
-
-impl FromIterator<CompleteObjectInfo> for SourceLookup {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = CompleteObjectInfo>,
-    {
-        let mut rv = SourceLookup {
-            inner: iter
-                .into_iter()
-                .enumerate()
-                .map(|(module_index, object_info)| SourceObjectEntry {
-                    module_index,
-                    object_info,
-                    source_object: None,
-                })
-                .collect(),
-        };
-        rv.sort();
-        rv
-    }
-}
-
-struct SymCacheEntry {
-    module_index: usize,
-    object_info: CompleteObjectInfo,
-    symcache: Option<Arc<SymCacheFile>>,
-}
-
-pub struct SymCacheLookup {
-    inner: Vec<SymCacheEntry>,
-}
-
-impl FromIterator<CompleteObjectInfo> for SymCacheLookup {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = CompleteObjectInfo>,
-    {
-        let mut rv = SymCacheLookup {
-            inner: iter
-                .into_iter()
-                .enumerate()
-                .map(|(module_index, object_info)| SymCacheEntry {
-                    module_index,
-                    object_info,
-                    symcache: None,
-                })
-                .collect(),
-        };
-        rv.sort();
-        rv
-    }
-}
-
-impl SymCacheLookup {
-    fn sort(&mut self) {
-        self.inner
-            .sort_by_key(|entry| entry.object_info.raw.image_addr.0);
-
-        // Ignore the name `dedup_by`, I just want to iterate over consecutive items and update
-        // some.
-        self.inner.dedup_by(|entry2, entry1| {
-            // If this underflows we didn't sort properly.
-            let size = entry2.object_info.raw.image_addr.0 - entry1.object_info.raw.image_addr.0;
-            if entry1.object_info.raw.image_size.unwrap_or(0) == 0 {
-                entry1.object_info.raw.image_size = Some(size);
-            }
-
-            false
-        });
-    }
-
-    /// Returns the original `CompleteObjectInfo` list in its original sorting order.
-    pub fn into_inner(mut self) -> Vec<CompleteObjectInfo> {
-        self.inner.sort_by_key(|entry| entry.module_index);
-        self.inner
-            .into_iter()
-            .map(|entry| entry.object_info)
-            .collect()
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub async fn fetch_symcaches(
-        &mut self,
-        symcache_actor: SymCacheActor,
-        scope: Scope,
-        sources: Arc<[SourceConfig]>,
-        stacktraces: &[RawStacktrace],
-    ) {
-        let mut referenced_objects = HashSet::new();
-        for stacktrace in stacktraces {
-            for frame in &stacktrace.frames {
-                if let Some(SymCacheLookupResult { module_index, .. }) =
-                    self.lookup_symcache(frame.instruction_addr.0, frame.addr_mode)
-                {
-                    referenced_objects.insert(module_index);
-                }
-            }
-        }
-
-        let futures = self
-            .inner
-            .iter_mut()
-            .enumerate()
-            .filter_map(|(idx, entry)| {
-                let is_used = referenced_objects.contains(&entry.module_index);
-                if !is_used {
-                    entry.object_info.debug_status = ObjectFileStatus::Unused;
-                    return None;
-                }
-
-                let symcache_actor = symcache_actor.clone();
-                let request = FetchSymCache {
-                    object_type: entry.object_info.raw.ty,
-                    identifier: object_id_from_object_info(&entry.object_info.raw),
-                    sources: sources.clone(),
-                    scope: scope.clone(),
-                };
-
-                Some(
-                    async move {
-                        let symcache_result = symcache_actor.fetch(request).await;
-                        (idx, symcache_result)
-                    }
-                    .bind_hub(Hub::new_from_top(Hub::current())),
-                )
-            });
-
-        for (idx, symcache_result) in future::join_all(futures).await {
-            if let Some(entry) = self.inner.get_mut(idx) {
-                let (symcache, status) = match symcache_result {
-                    Ok(symcache) => match symcache.parse() {
-                        Ok(Some(_)) => (Some(symcache), ObjectFileStatus::Found),
-                        Ok(None) => (Some(symcache), ObjectFileStatus::Missing),
-                        Err(e) => (None, (&e).into()),
-                    },
-                    Err(e) => (None, (&*e).into()),
-                };
-
-                entry.object_info.arch = Default::default();
-
-                if let Some(ref symcache) = symcache {
-                    entry.object_info.arch = symcache.arch();
-                    entry.object_info.features.merge(symcache.features());
-                    entry.object_info.candidates.merge(symcache.candidates());
-                }
-
-                entry.symcache = symcache;
-                entry.object_info.debug_status = status;
-            }
-        }
-    }
-
-    pub fn lookup_symcache(
-        &self,
-        addr: u64,
-        addr_mode: AddrMode,
-    ) -> Option<SymCacheLookupResult<'_>> {
-        match addr_mode {
-            AddrMode::Abs => {
-                for entry in self.inner.iter() {
-                    let start_addr = entry.object_info.raw.image_addr.0;
-
-                    if start_addr > addr {
-                        // The debug image starts at a too high address
-                        continue;
-                    }
-
-                    let size = entry.object_info.raw.image_size.unwrap_or(0);
-                    if let Some(end_addr) = start_addr.checked_add(size) {
-                        if end_addr < addr && size != 0 {
-                            // The debug image ends at a too low address and we're also confident that
-                            // end_addr is accurate (size != 0)
-                            continue;
-                        }
-                    }
-
-                    return Some(SymCacheLookupResult {
-                        module_index: entry.module_index,
-                        object_info: &entry.object_info,
-                        symcache: entry.symcache.as_deref(),
-                        relative_addr: entry.object_info.abs_to_rel_addr(addr),
-                    });
-                }
-                None
-            }
-            AddrMode::Rel(this_module_index) => self
-                .inner
-                .iter()
-                .find(|x| x.module_index == this_module_index)
-                .map(|entry| SymCacheLookupResult {
-                    module_index: entry.module_index,
-                    object_info: &entry.object_info,
-                    symcache: entry.symcache.as_deref(),
-                    relative_addr: Some(addr),
-                }),
         }
     }
 }


### PR DESCRIPTION
This avoids an unnecessary copy (and subsequent sorting) of the module list,
and fixes the "sources" feature being set on a transient throw-away copy of the module metadata.

#skip-changelog