### PR TITLE
ref: Give http transactions better names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,9 +2726,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "sentry"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476c496f4b112059d58ba2871dd7bd0fb3743511975b3331e24af983628498a2"
+checksum = "f2d23af89cf3e40dffb53f974e9a21653353b3e21cf51633aa58006f2a0caf8a"
 dependencies = [
  "httpdate",
  "reqwest 0.11.9",
@@ -2745,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2892cd1aad861405aa3966e6b7088d982e9105f2d3900561f3634ca4c8ff3b6"
+checksum = "de88cf0967eb3d7247071a7e6753b06c0939d509f9db44607ec00aa4b4aefd04"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062d19e114079c0ac209c1d05c77ae0de709e1c9c1965cc43168f916b9691ad9"
+checksum = "8158a446429420acdf6a4f75192ee8929da16a0c41c89a1c34b2e0f1eaebcc02"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7ffe5e38b3fe50e1f92db30cbf9f17318a1261aa74b779737e5d6940244e23"
+checksum = "5a3bda8a1e3213f1944da2d42f3081ea9f3717105bb2a6b0a8fe4f5e603010a3"
 dependencies = [
  "hostname",
  "libc",
@@ -2781,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bbccac5904deebfd44f1bdedac78c73b606140904d8e7a60e74310ffe0a923"
+checksum = "56333f11be3a78131c67637f7611339df8af7ad9af831226585a457df75f9e3b"
 dependencies = [
  "lazy_static",
  "rand 0.8.4",
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea36c7a590134c080ca678729c0898a5d9b97f62abd4c0b63113010d3e0466ac"
+checksum = "b4c700f97918705167bde634fd33fa407d392cdf573da5362d1a55d6655ceb7d"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -2805,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a2a81f0e69b5f3e81dc5150b4a34c3efcbf5d51852ecca15e1800ed6ee6aaf"
+checksum = "91b56c287a5295358bd4a3481a32add1f3fb7131102e300f561f788e33b79efe"
 dependencies = [
  "log",
  "sentry-core",
@@ -2815,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37e172d427216eb45ada4cae81d29ab1cc10f73e0b9c531a4a902c321f6eb43"
+checksum = "b957b1965c450acd220a27806fe1f2dec998d393973ebae797936b12df1c7416"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2825,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc994af8e7ff70ecad0923ca958f92b04413140c8c6e29c4077b3a4f6adb6162"
+checksum = "dd49ee3ab5156738ae19c89c87e5516bd56a7f7fa93d7b05cefba88dc7bbd262"
 dependencies = [
  "http",
  "pin-project",
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9bbaa12aaf9bca94be6e4be421a62b0695e4b94acadb5c37d155f815ac71d3"
+checksum = "8a1b281efe225a8750e2011a325a5455b29a3e5cd40762337ef647a253e3213f"
 dependencies = [
  "sentry-core",
  "tracing-core",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd82ef59ae000f8502e3095508eb3e9606f1716f15394e539d6a5c24fd38484d"
+checksum = "825fd3382e2397007499a910e0184e55f7837cb0df4af30ae62bd2123e2ebcd6"
 dependencies = [
  "debugid",
  "getrandom 0.2.4",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -34,8 +34,8 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.47.0"
 rusoto_credential = "0.47.0"
 rusoto_s3 = "0.47.0"
-sentry = { version = "0.24.3", features = ["anyhow", "debug-images", "log", "tracing"] }
-sentry-tower = { version = "0.24.2", features = ["http"] }
+sentry = { version = "0.25.0", features = ["anyhow", "debug-images", "log", "tracing"] }
+sentry-tower = { version = "0.25.0", features = ["http"] }
 serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"

--- a/crates/symbolicator/src/endpoints/proxy.rs
+++ b/crates/symbolicator/src/endpoints/proxy.rs
@@ -61,6 +61,10 @@ pub async fn proxy_symstore_request(
     extract::Path(path): extract::Path<String>,
     request: Request<Body>,
 ) -> Result<Response<Body>, ResponseError> {
+    sentry::configure_scope(|scope| {
+        scope.set_transaction(Some("GET /proxy"));
+    });
+
     let object_handle = match load_object(state, path).await? {
         Some(handle) => handle,
         None => {

--- a/crates/symbolicator/src/endpoints/requests.rs
+++ b/crates/symbolicator/src/endpoints/requests.rs
@@ -18,6 +18,10 @@ pub async fn poll_request(
     extract::Path(request_id): extract::Path<RequestId>,
     extract::Query(query): extract::Query<PollSymbolicationRequestQueryParams>,
 ) -> Result<Json<SymbolicationResponse>, StatusCode> {
+    sentry::configure_scope(|scope| {
+        scope.set_transaction(Some("GET /requests"));
+    });
+
     let response_opt = state
         .symbolication()
         .get_response(request_id, query.timeout)

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -299,7 +299,6 @@ impl CfiCacheActor {
 #[tracing::instrument(skip_all)]
 fn write_cficache(path: &Path, object_handle: &ObjectHandle) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {
-        scope.set_transaction(Some("compute_cficache"));
         object_handle.to_scope(scope);
     });
 

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -157,7 +157,6 @@ async fn fetch_file(
 ) -> Result<CacheStatus, ObjectError> {
     tracing::trace!("Fetching file data for {}", cache_key);
     sentry::configure_scope(|scope| {
-        scope.set_transaction(Some("download_file"));
         file_id.to_scope(scope);
         object_id.to_scope(scope);
     });

--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -366,7 +366,6 @@ fn write_symcache(
     bcsymbolmap_handle: Option<BcSymbolMapHandle>,
 ) -> Result<(), SymCacheError> {
     configure_scope(|scope| {
-        scope.set_transaction(Some("compute_symcache"));
         object_handle.to_scope(scope);
     });
 


### PR DESCRIPTION
This solves the problem of having a ton of unique `GET /requests/UUID` performance monitoring transactions.

Also updates the Sentry SDK for newly introduced API.

#skip-changelog