### PR TITLE
build: Update symbolic to 8.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Avoid errors from symbol source in bcsymbolmap lookups from cancelling the entire symcache lookup. ([#643](https://github.com/getsentry/symbolicator/pull/643))
 - Use wildcard matcher for symstore proxy. ([#671](https://github.com/getsentry/symbolicator/pull/671))
+- Detect unwind and debug information in ELF files that contain sections with offset `0`. They were previously skipped in some cases. ([#688](https://github.com/getsentry/symbolicator/pull/688))
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Avoid errors from symbol source in bcsymbolmap lookups from cancelling the entire symcache lookup. ([#643](https://github.com/getsentry/symbolicator/pull/643))
 - Use wildcard matcher for symstore proxy. ([#671](https://github.com/getsentry/symbolicator/pull/671))
 - Detect unwind and debug information in ELF files that contain sections with offset `0`. They were previously skipped in some cases. ([#688](https://github.com/getsentry/symbolicator/pull/688))
+- Support processing unwind information in ELF files linked with `gold`. ([#688](https://github.com/getsentry/symbolicator/pull/688))
 
 ## 0.4.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,13 +1060,13 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
+checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
 dependencies = [
  "log",
  "plain",
- "scroll",
+ "scroll 0.11.0",
 ]
 
 [[package]]
@@ -1473,9 +1473,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1621,7 +1621,7 @@ dependencies = [
  "minidump-common",
  "num-traits 0.2.14",
  "range-map",
- "scroll",
+ "scroll 0.10.2",
 ]
 
 [[package]]
@@ -1635,7 +1635,7 @@ dependencies = [
  "log",
  "num-traits 0.2.14",
  "range-map",
- "scroll",
+ "scroll 0.10.2",
  "smart-default",
 ]
 
@@ -1947,7 +1947,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1965,13 +1975,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "pdb"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
 dependencies = [
  "fallible-iterator",
- "scroll",
+ "scroll 0.10.2",
  "uuid",
 ]
 
@@ -2628,7 +2651,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 dependencies = [
- "scroll_derive",
+ "scroll_derive 0.10.5",
+]
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive 0.11.0",
 ]
 
 [[package]]
@@ -2636,6 +2668,17 @@ name = "scroll_derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3042,7 +3085,7 @@ checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.2",
  "phf_shared",
  "precomputed-hash",
  "serde",
@@ -3086,8 +3129,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3098,8 +3141,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3110,8 +3153,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3124,10 +3167,10 @@ dependencies = [
  "lazycell",
  "nom",
  "nom-supreme",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pdb",
  "regex",
- "scroll",
+ "scroll 0.11.0",
  "serde",
  "serde_json",
  "smallvec",
@@ -3139,8 +3182,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3151,8 +3194,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-minidump"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3165,8 +3208,8 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "8.5.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#4472c974b6497a786267506d472f61502d3336f0"
+version = "8.6.1"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#410812893989e6d7b02086340421c1f70f9d9961"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3202,7 +3245,7 @@ dependencies = [
  "lru",
  "minidump",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.11.2",
  "procspawn",
  "regex",
  "reqwest 0.11.0",
@@ -3644,7 +3687,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot",
+ "parking_lot 0.11.2",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -4056,6 +4099,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 # NOTE: Keep symbolic in sync with symsorter
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.6.1", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 # Uncomment the line below for local development
 # symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -40,7 +40,8 @@ serde = { version = "1.0.119", features = ["derive", "rc"] }
 serde_json = "1.0.61"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.5.0", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+# NOTE: Keep symbolic in sync with symsorter
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.6.1", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 # Uncomment the line below for local development
 # symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 tempfile = "3.2.0"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.6.1", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.10.0"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.4.3"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.3.0", features = ["debuginfo-serde"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", version = "8.6.1", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
 zstd = "0.10.0"


### PR DESCRIPTION
In fact, this pulls in https://github.com/getsentry/symbolic/commit/410812893989e6d7b02086340421c1f70f9d9961, which includes:

- getsentry/symbolic#505
- internal changes
