### PR TITLE
ref(symbolication): Write code_ids in lowercase

### DIFF
--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -555,7 +555,7 @@ fn object_info_from_minidump_module_breakpad(ty: ObjectType, module: &CodeModule
 
     RawObjectInfo {
         ty,
-        code_id: Some(code_id),
+        code_id: Some(code_id.to_lowercase()),
         code_file: Some(module.code_file()),
         debug_id: module.id().map(|id| id.to_string()),
         debug_file: Some(module.debug_file()),
@@ -577,7 +577,7 @@ fn object_info_from_minidump_module_rust_minidump(
     let code_id = module.code_identifier();
     let code_id = match code_id.is_nil() {
         true => None,
-        false => Some(code_id.to_string()),
+        false => Some(code_id.to_string().to_lowercase()),
     };
     let code_file = module.code_file();
     let code_file = match code_file.is_empty() {


### PR DESCRIPTION
This eliminates some erroneous diffs. Parsing the strings to `CodeId`s before comparison doesn't help because `CodeId` just wraps a string and compares like a string, i.e., case-sensitively.

#skip-changelog