### PR TITLE
fix(symbolication): Sort by image_addr as well

### DIFF
--- a/crates/symbolicator/src/services/symbolication/comparisons.rs
+++ b/crates/symbolicator/src/services/symbolication/comparisons.rs
@@ -15,6 +15,7 @@ pub(super) enum NewStackwalkingProblem {
 
 fn fixup_modules(modules: &mut [(DebugId, RawObjectInfo)]) {
     modules.sort_by_key(|module| module.0);
+    modules.sort_by_key(|module| module.1.image_addr);
 
     for (_, info) in modules.iter_mut() {
         if let Some(ref mut code_id) = info.code_id {
@@ -114,6 +115,7 @@ pub(super) fn find_stackwalking_problem(
     fixup_modules(&mut modules_breakpad);
     let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
     modules_rust_minidump.sort_by_key(|module| module.0);
+    modules_rust_minidump.sort_by_key(|module| module.1.image_addr);
 
     if modules_rust_minidump.len() != modules_breakpad.len()
         || !modules_rust_minidump

--- a/crates/symbolicator/src/services/symbolication/comparisons.rs
+++ b/crates/symbolicator/src/services/symbolication/comparisons.rs
@@ -14,8 +14,7 @@ pub(super) enum NewStackwalkingProblem {
 }
 
 fn fixup_modules(modules: &mut [(DebugId, RawObjectInfo)]) {
-    modules.sort_by_key(|module| module.0);
-    modules.sort_by_key(|module| module.1.image_addr);
+    modules.sort_by_key(|module| (module.0, module.1.image_addr));
 
     for (_, info) in modules.iter_mut() {
         if let Some(ref mut code_id) = info.code_id {
@@ -114,8 +113,7 @@ pub(super) fn find_stackwalking_problem(
     let mut modules_breakpad = result_breakpad.modules.clone().unwrap_or_default();
     fixup_modules(&mut modules_breakpad);
     let mut modules_rust_minidump = result_rust_minidump.modules.clone().unwrap_or_default();
-    modules_rust_minidump.sort_by_key(|module| module.0);
-    modules_rust_minidump.sort_by_key(|module| module.1.image_addr);
+    modules_rust_minidump.sort_by_key(|module| (module.0, module.1.image_addr));
 
     if modules_rust_minidump.len() != modules_breakpad.len()
         || !modules_rust_minidump


### PR DESCRIPTION
Sorting by `debug_id` is apparently not enough.

#skip-changelog