### PR TITLE
ref: Re-design transformed SymCache Markers (NATIVE-499)

### DIFF
--- a/crates/symbolicator/src/services/symcaches.rs
+++ b/crates/symbolicator/src/services/symcaches.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, BufWriter, Seek, SeekFrom, Write};
+use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,7 +13,7 @@ use symbolic::symcache::{self, SymCache, SymCacheWriter};
 use thiserror::Error;
 
 use crate::cache::{Cache, CacheStatus};
-use crate::services::bitcode::{BcSymbolMapHandle, BitcodeService};
+use crate::services::bitcode::BitcodeService;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, CacheVersions, Cacher};
 use crate::services::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
@@ -26,10 +26,11 @@ use crate::types::{
 use crate::utils::futures::{m, measure, CancelOnDrop};
 use crate::utils::sentry::ConfigureScope;
 
+use self::markers::{SecondarySymCacheSources, SymCacheMarkers};
+
 use super::shared_cache::SharedCacheService;
 
-/// This marker string is appended to symcaches to indicate that they were created using a `BcSymbolMap`.
-const SYMBOLMAP_MARKER: &[u8] = b"WITH_SYMBOLMAP";
+mod markers;
 
 /// The supported symcache versions.
 ///
@@ -155,8 +156,8 @@ struct FetchSymCacheInternal {
     /// The objects actor, used to fetch original DIF objects from.
     objects_actor: ObjectsActor,
 
-    /// The result of fetching the BcSymbolMap
-    bcsymbolmap_handle: Option<BcSymbolMapHandle>,
+    /// Secondary sources to use when creating a SymCache.
+    secondary_sources: SecondarySymCacheSources,
 
     /// ObjectMeta handle of the original DIF object to fetch.
     object_meta: Arc<ObjectMetaHandle>,
@@ -185,7 +186,7 @@ async fn fetch_difs_and_compute_symcache(
     path: PathBuf,
     object_meta: Arc<ObjectMetaHandle>,
     objects_actor: ObjectsActor,
-    bcsymbolmap_handle: Option<BcSymbolMapHandle>,
+    secondary_sources: SecondarySymCacheSources,
     threadpool: tokio::runtime::Handle,
 ) -> Result<CacheStatus, SymCacheError> {
     let object_handle = objects_actor
@@ -203,7 +204,7 @@ async fn fetch_difs_and_compute_symcache(
     }
 
     let compute_future = async move {
-        let status = match write_symcache(&path, &*object_handle, bcsymbolmap_handle) {
+        let status = match write_symcache(&path, &*object_handle, secondary_sources) {
             Ok(_) => CacheStatus::Positive,
             Err(err) => {
                 tracing::warn!("Failed to write symcache: {}", err);
@@ -234,7 +235,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
             path.to_owned(),
             self.object_meta.clone(),
             self.objects_actor.clone(),
-            self.bcsymbolmap_handle.clone(),
+            self.secondary_sources.clone(),
             self.threadpool.clone(),
         );
 
@@ -251,12 +252,13 @@ impl CacheItemRequest for FetchSymCacheInternal {
     }
 
     fn should_load(&self, data: &[u8]) -> bool {
-        let had_symbolmap = data.ends_with(SYMBOLMAP_MARKER);
         SymCache::parse(data)
             .map(|_symcache| {
                 // NOTE: we do *not* check for the `is_latest` version here.
                 // If the symcache is parsable, we want to use even outdated versions.
-                had_symbolmap == self.bcsymbolmap_handle.is_some()
+
+                let symcache_markers = SymCacheMarkers::parse(data);
+                SymCacheMarkers::from_sources(&self.secondary_sources) == symcache_markers
             })
             .unwrap_or(false)
     }
@@ -333,11 +335,13 @@ impl SymCacheActor {
                     None => None,
                 };
 
+                let secondary_sources = SecondarySymCacheSources { bcsymbolmap_handle };
+
                 self.symcaches
                     .compute_memoized(FetchSymCacheInternal {
                         request,
                         objects_actor: self.objects.clone(),
-                        bcsymbolmap_handle,
+                        secondary_sources,
                         object_meta: handle,
                         threadpool: self.threadpool.clone(),
                         candidates,
@@ -357,13 +361,13 @@ impl SymCacheActor {
 
 /// Computes and writes the symcache.
 ///
-/// It is assumed both the `object_handle` contains a positive cache.  The
-/// `bcsymbolmap_handle` can only exist for a positive cache so does not have this issue.
+/// It is assumed that the `object_handle` contains a positive cache.
+/// Any secondary source can only exist for a positive cache so does not have this issue.
 #[tracing::instrument(skip_all)]
 fn write_symcache(
     path: &Path,
     object_handle: &ObjectHandle,
-    bcsymbolmap_handle: Option<BcSymbolMapHandle>,
+    secondary_sources: SecondarySymCacheSources,
 ) -> Result<(), SymCacheError> {
     configure_scope(|scope| {
         scope.set_transaction(Some("compute_symcache"));
@@ -374,8 +378,11 @@ fn write_symcache(
         .parse()
         .map_err(SymCacheError::ObjectParsing)?
         .unwrap();
+
+    let markers = SymCacheMarkers::from_sources(&secondary_sources);
+
     if let Object::MachO(ref mut macho) = symbolic_object {
-        if let Some(ref handle) = bcsymbolmap_handle {
+        if let Some(ref handle) = secondary_sources.bcsymbolmap_handle {
             let bcsymbolmap = handle
                 .bc_symbol_map()
                 .map_err(SymCacheError::BcSymbolMapError)?;
@@ -397,11 +404,8 @@ fn write_symcache(
 
     let mut file = writer.into_inner().map_err(io::Error::from)?;
 
-    if bcsymbolmap_handle.is_some() {
-        file.flush()?;
-        file.seek(SeekFrom::End(0))?;
-        file.write_all(SYMBOLMAP_MARKER)?;
-    }
+    markers.write_to(&mut file)?;
+
     file.sync_all()?;
 
     Ok(())

--- a/crates/symbolicator/src/services/symcaches/markers.rs
+++ b/crates/symbolicator/src/services/symcaches/markers.rs
@@ -1,0 +1,140 @@
+use std::io::SeekFrom;
+
+use crate::services::bitcode::BcSymbolMapHandle;
+
+/// This is the legacy marker that was used previously to flag a SymCache that was created
+/// using a`BcSymbolMap`.
+const LEGACY_SYMBOLMAP_MARKER: &[u8] = b"WITH_SYMBOLMAP";
+
+/// This marker denotes that a SymCache has appended markers.
+const MARKERS32_MARKER: &[u8] = b"WITH_MARKERS32";
+
+/// Encapsulation of all the source artifacts that are being used to create SymCaches.
+#[derive(Clone, Debug, Default)]
+pub struct SecondarySymCacheSources {
+    pub bcsymbolmap_handle: Option<BcSymbolMapHandle>,
+}
+
+const MARKER_BCSYMBOLMAP: u32 = 1 << 0;
+
+/// This is the markers that are being embedded into, and read from, a SymCache file.
+#[derive(Debug, Default, PartialEq)]
+pub struct SymCacheMarkers {
+    markers: u32,
+}
+
+impl SymCacheMarkers {
+    /// Gets all the markers for the given `sources`.
+    pub fn from_sources(sources: &SecondarySymCacheSources) -> Self {
+        let mut markers = 0;
+        if sources.bcsymbolmap_handle.is_some() {
+            markers |= MARKER_BCSYMBOLMAP;
+        }
+        Self { markers }
+    }
+
+    /// Extracts the markers embedded in the given `data`.
+    ///
+    /// This is lenient and will return an empty set of markers if there is a parse error.
+    pub fn parse(data: &[u8]) -> Self {
+        if data.ends_with(LEGACY_SYMBOLMAP_MARKER) {
+            let markers = MARKER_BCSYMBOLMAP;
+            return Self { markers };
+        }
+
+        fn parse_marker(data: &[u8]) -> Option<SymCacheMarkers> {
+            let data = data.strip_suffix(MARKERS32_MARKER)?;
+
+            let marker_offset = data.len().checked_sub(std::mem::size_of::<u32>())?;
+            let marker_bytes = data.get(marker_offset..)?.try_into().ok()?;
+
+            let markers = u32::from_le_bytes(marker_bytes);
+
+            Some(SymCacheMarkers { markers })
+        }
+        parse_marker(data).unwrap_or_default()
+    }
+
+    /// Writes the markers to the end of `file`.
+    pub fn write_to<F>(&self, mut file: F) -> std::io::Result<()>
+    where
+        F: std::io::Seek + std::io::Write,
+    {
+        if self.markers == 0 {
+            return Ok(());
+        }
+
+        file.flush()?;
+        file.seek(SeekFrom::End(0))?;
+
+        file.write_all(&self.markers.to_le_bytes())?;
+
+        file.write_all(MARKERS32_MARKER)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use symbolic::common::ByteView;
+
+    use super::*;
+
+    #[test]
+    fn test_legacy_marker() {
+        let data = b"foobarWITH_SYMBOLMAP";
+        let markers = SymCacheMarkers::parse(data);
+
+        assert_eq!(markers.markers, MARKER_BCSYMBOLMAP);
+    }
+
+    #[test]
+    fn test_marker_roundtrip() {
+        let bcsymbolmap = BcSymbolMapHandle {
+            uuid: Default::default(),
+            data: ByteView::from_vec(vec![]),
+        };
+        let sources = SecondarySymCacheSources {
+            bcsymbolmap_handle: Some(bcsymbolmap),
+        };
+        let markers = SymCacheMarkers::from_sources(&sources);
+
+        let mut buf = Cursor::new(Vec::new());
+        markers.write_to(&mut buf).unwrap();
+
+        let buf = buf.into_inner();
+        let parsed_markers = SymCacheMarkers::parse(&buf);
+
+        assert_eq!(parsed_markers, markers);
+    }
+
+    #[test]
+    fn test_empty_marker() {
+        let data = b"\0\0\0\0WITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+    }
+
+    #[test]
+    fn test_corrupted_marker() {
+        let data = b"ITH_SYMBOLMAP";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+
+        let data = b"ITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+
+        let data = b"WITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+
+        let data = b"\x01\0WITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+
+        let data = b"\x01\0WITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+
+        let data = b"\0\0\0WITH_MARKERS32";
+        assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+    }
+}

--- a/crates/symbolicator/src/services/symcaches/markers.rs
+++ b/crates/symbolicator/src/services/symcaches/markers.rs
@@ -118,6 +118,12 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_but_unknown_marker() {
+        let data = b"\0\x01\x01\0WITH_MARKERS32";
+        assert_ne!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
+    }
+
+    #[test]
     fn test_corrupted_marker() {
         let data = b"ITH_SYMBOLMAP";
         assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
@@ -134,7 +140,7 @@ mod tests {
         let data = b"\x01\0WITH_MARKERS32";
         assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
 
-        let data = b"\0\0\0WITH_MARKERS32";
+        let data = b"\0\x01\0WITH_MARKERS32";
         assert_eq!(SymCacheMarkers::parse(data), SymCacheMarkers::default());
     }
 }


### PR DESCRIPTION
We want to attach arbitrary markers to symcaches to cater to multiple source files that are used in SymCache creation, and to react to changes to availability of those files.

So far we have used a marker specific to bcsymbolmaps, and this PR keeps backwards compatibility to that marker.
After an initial idea about using JSON, I rather went with just using a u32 bitfield, which will give us enough bits to have 32 markers, and is trivial to parse/compare, instead of JSON which would need to be parsed and potentially allocate.

#skip-changelog