### PR TITLE
ref(shared-cache): Distinguish forbidden from unauthorised

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -296,10 +296,11 @@ impl GcsState {
                         Ok(SharedCacheStoreResult::Written(total_bytes))
                     }
                     StatusCode::PRECONDITION_FAILED => Ok(SharedCacheStoreResult::Skipped),
-                    StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => Err(anyhow!(
+                    StatusCode::FORBIDDEN => Err(anyhow!(
                         "Insufficient permissions for bucket {}",
                         self.config.bucket
                     )),
+                    StatusCode::UNAUTHORIZED => Err(anyhow!("Invalid credentials",)),
                     _ => Err(anyhow!("Error response from GCS: {}", status)),
                 }
             }


### PR DESCRIPTION
These are not the same, having them logged at the same could be
confusing.

#skip-changelog