### PR TITLE
build: Bump rust-minidump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
+source = "git+https://github.com/luser/rust-minidump?branch=master#3bc49b07a094bad2e8c130a82b86fad017952689"
 dependencies = [
  "async-trait",
  "circular",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
+source = "git+https://github.com/luser/rust-minidump?branch=master#3bc49b07a094bad2e8c130a82b86fad017952689"
 dependencies = [
  "debugid",
  "encoding",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
+source = "git+https://github.com/luser/rust-minidump?branch=master#3bc49b07a094bad2e8c130a82b86fad017952689"
 dependencies = [
  "bitflags",
  "debugid",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "minidump-processor"
 version = "0.9.6"
-source = "git+https://github.com/luser/rust-minidump?branch=master#d77b26b2e0d10e8f8fe5f8b944c0f142cde3a705"
+source = "git+https://github.com/luser/rust-minidump?branch=master#3bc49b07a094bad2e8c130a82b86fad017952689"
 dependencies = [
  "async-trait",
  "breakpad-symbols",

--- a/crates/symbolicator/src/services/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication.rs
@@ -576,11 +576,10 @@ fn object_info_from_minidump_module_rust_minidump(
     // Some modules are not objects but rather fonts or JIT areas or other mmapped files
     // which we don't care about.  These may not have complete information so map these to
     // our schema by converting to None when needed.
-    let code_id = module.code_identifier();
-    let code_id = match code_id.is_nil() {
-        true => None,
-        false => Some(code_id.to_string()),
-    };
+    let code_id = module
+        .code_identifier()
+        .filter(|code_id| !code_id.is_nil())
+        .map(|code_id| code_id.to_string().to_lowercase());
     let code_file = module.code_file();
     let code_file = match code_file.is_empty() {
         true => None,


### PR DESCRIPTION
This gives us optional `code_id`s, which eliminates some stackwalking discrepancies between rust-minidump and breakpad.

#skip-changelog