### PR TITLE
ref: Metrics around symbolication task spawning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,7 @@ dependencies = [
  "test-assembler",
  "thiserror",
  "tokio",
+ "tokio-metrics",
  "tokio-util",
  "tower",
  "tower-layer",
@@ -3466,6 +3467,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -49,6 +49,7 @@ thiserror = "1.0.26"
 tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.6", features = ["tracing-log", "local-time", "env-filter", "json"] }
 tokio = { version = "1.0.2", features = ["rt", "macros", "fs"] }
+tokio-metrics = "0.1.0"
 tokio-util = "0.6"
 tower = "0.4"
 tower-layer = "0.3"

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -234,3 +234,28 @@ where
         }
     }
 }
+
+trait ToMaxingI64: TryInto<i64> + Copy {
+    fn to_maxing_i64(self) -> i64 {
+        self.try_into().unwrap_or(i64::MAX)
+    }
+}
+
+impl<T: TryInto<i64> + Copy> ToMaxingI64 for T {}
+
+pub fn record_task_metrics(name: &str, metrics: &tokio_metrics::TaskMetrics) {
+    metric!(counter("tasks.instrumented_count") += metrics.instrumented_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.dropped_count") += metrics.dropped_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.first_poll_count") += metrics.first_poll_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_first_poll_delay") += metrics.total_first_poll_delay.as_millis().to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_idled_count") += metrics.total_idled_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_idle_duration") += metrics.total_idle_duration.as_millis().to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_scheduled_count") += metrics.total_scheduled_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_scheduled_duration") += metrics.total_scheduled_duration.as_millis().to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_poll_count") += metrics.total_poll_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_poll_duration") += metrics.total_poll_duration.as_millis().to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_fast_poll_count") += metrics.total_fast_poll_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_fast_poll_durations") += metrics.total_fast_poll_duration.as_millis().to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_slow_poll_count") += metrics.total_slow_poll_count.to_maxing_i64(), "name" => name);
+    metric!(counter("tasks.total_slow_poll_duration") += metrics.total_slow_poll_duration.as_millis().to_maxing_i64(), "name" => name);
+}


### PR DESCRIPTION
This experiments with metrics targetted around the symbolication task
spawning.  This matters because these spawning times starting to
increase is a precursor to things going south and our backpressure not
working correctly.  Until recently we had our healthchecks failing in
these cases but now they should be more isolated and not provide that
incredibly crude form of backpressure (kill symbolicator).

It does a manual histogram-timer first spawn duration as we have been
using in various places before.  It also experiments with adding
tokio-metrics to measure the same thing in more detail.  The reason to
do both is to be able to compare and evaluate tokio-metrics a bit.

#skip-changelog