### PR TITLE
fix(symbolication): Remove dead enum

### DIFF
--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -1534,12 +1534,6 @@ struct StackWalkMinidumpResult {
     duration: Duration,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-enum NewStackwalkingProblem {
-    Diff(String),
-    Slow,
-}
-
 impl SymbolicationActor {
     /// Join a procspawn handle with a timeout.
     ///


### PR DESCRIPTION
This enum is left over from when stackwalking comparison code briefly existed in master. Not sure why this wasn't flagged as dead code.

#skip-changelog