### PR TITLE
ci(danger): Do not require changelogs from dependabot

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     name: Changelogs

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -42,7 +42,9 @@ function skipChangelog() {
     return true;
   }
   for (let review of danger.github.reviews) {
-    if (review.body && review.body.includes("#skip-changelog")) {
+      if (review.body
+          && review.body.includes("#skip-changelog")
+          && review.body.includes("@dependabot")) {
       return true;
     }
   }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -34,13 +34,23 @@ async function containsChangelog(path) {
   return contents.includes(PR_LINK);
 }
 
-async function checkChangelog() {
-  const skipChangelog =
-    danger.github
-      && ((danger.github.pr.body + "").includes("#skip-changelog")
-          || danger.github.pr.user.href === "https://github.com/apps/dependabot");
+function skipChangelog() {
+  if (!danger.github) {
+    return false;
+  }
+  if ((danger.github.pr.body + "").includes("#skip-changelog")) {
+    return true;
+  }
+  for (let review of danger.github.reviews) {
+    if (review.body && review.body.includes("#skip-changelog")) {
+      return true;
+    }
+  }
+  return false;
+}
 
-  if (skipChangelog) {
+async function checkChangelog() {
+  if (skipChangelog()) {
     return;
   }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,7 +36,9 @@ async function containsChangelog(path) {
 
 async function checkChangelog() {
   const skipChangelog =
-    danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
+    danger.github
+      && ((danger.github.pr.body + "").includes("#skip-changelog")
+          || danger.github.pr.user.href === "https://github.com/apps/dependabot");
 
   if (skipChangelog) {
     return;

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -39,13 +39,14 @@ function skipChangelog() {
     return false;
   }
   if ((danger.github.pr.body + "").includes("#skip-changelog")) {
+    // The PR description can always contain skip-changelog
     return true;
   }
-  for (let review of danger.github.reviews) {
-      if (review.body
-          && review.body.includes("#skip-changelog")
-          && review.body.includes("@dependabot")) {
-      return true;
+  for (let comment of danger.github.api.getPullRequestComments) {
+    // If a comment in a command to dependabot we also accept a #skip-changelog marker there
+    if (comment.body.includes("@dependabot")
+        && comment.body.includes("#skip-changelog")) {
+        return true;
     }
   }
   return false;


### PR DESCRIPTION
For plain dependency upgrades that require not changes we normally do
not need any changelog entries.  But not having them fails CI which
renders every dependabot PR a huge hassle.

Sadly we can not customise the dependabot PRs to add a #skip-changelog
marker (see e.g.
https://github.com/dependabot/dependabot-core/issues/2091), so lets
resort to changing the check instead.

There is a risk that someone pushes some changes to such a PR that
does require a changelog.  Hopefully we'll recognise this and do the
right thing anyway.

#skip-changelog