### PR TITLE
CI: Skip tests when credentials are not available.

### DIFF
--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -759,6 +759,7 @@ impl SharedCacheService {
         src: File,
         reason: CacheStoreReason,
     ) -> Option<oneshot::Receiver<()>> {
+        println!("a dummy change");
         let inner_guard = self.inner.read().await;
         match inner_guard.as_ref() {
             Some(inner) => {

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -759,7 +759,6 @@ impl SharedCacheService {
         src: File,
         reason: CacheStoreReason,
     ) -> Option<oneshot::Receiver<()>> {
-        println!("a dummy change");
         let inner_guard = self.inner.read().await;
         match inner_guard.as_ref() {
             Some(inner) => {

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -446,12 +446,10 @@ macro_rules! gcs_credentials {
             },
             Ok(None) => {
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
-                    Ok(path) => {
-                        $crate::test::TestGcsCredentials {
-                            bucket: "sentryio-symbolicator-cache-test".to_string(),
-                            credentials_file: Some(path.into()),
-                        }
-                    }
+                    Ok(path) => $crate::test::TestGcsCredentials {
+                        bucket: "sentryio-symbolicator-cache-test".to_string(),
+                        credentials_file: Some(path.into()),
+                    },
                     Err(_) => {
                         println!("Skipping due to missing GOOGLE_APPLICATION_CREDENTIALS or gcs-service-account.json");
                         return;

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -410,7 +410,7 @@ pub fn gcs_credentials_file() -> Result<Option<PathBuf>, std::io::Error> {
             std::io::ErrorKind::NotFound => {
                 // Special case, see if we can create it from a env var, our CI sets this.
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON") {
-                    Ok(data) => {
+                    Ok(data) if !data.is_empty() => {
                         println!("HELLO YES, what is this?? {:?}", data);
                         std::fs::write(&path, data).unwrap();
                         path

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -411,6 +411,7 @@ pub fn gcs_credentials_file() -> Result<Option<PathBuf>, std::io::Error> {
                 // Special case, see if we can create it from a env var, our CI sets this.
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON") {
                     Ok(data) => {
+                        println!("HELLO YES, what is this?? {:?}", data);
                         std::fs::write(&path, data).unwrap();
                         path
                     }
@@ -446,10 +447,13 @@ macro_rules! gcs_credentials {
             },
             Ok(None) => {
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
-                    Ok(path) => $crate::test::TestGcsCredentials {
-                        bucket: "sentryio-symbolicator-cache-test".to_string(),
-                        credentials_file: Some(path.into()),
-                    },
+                    Ok(path) => {
+                        println!("WELL, seems like we have a credentials file??? {:?}", path);
+                        $crate::test::TestGcsCredentials {
+                            bucket: "sentryio-symbolicator-cache-test".to_string(),
+                            credentials_file: Some(path.into()),
+                        }
+                    }
                     Err(_) => {
                         println!("Skipping due to missing GOOGLE_APPLICATION_CREDENTIALS or gcs-service-account.json");
                         return;

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -415,7 +415,7 @@ pub fn gcs_credentials_file() -> Result<Option<PathBuf>, std::io::Error> {
                         std::fs::write(&path, data).unwrap();
                         path
                     }
-                    Err(_) => return Ok(None),
+                    _ => return Ok(None),
                 }
             }
             _ => return Err(err),

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -411,7 +411,6 @@ pub fn gcs_credentials_file() -> Result<Option<PathBuf>, std::io::Error> {
                 // Special case, see if we can create it from a env var, our CI sets this.
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON") {
                     Ok(data) if !data.is_empty() => {
-                        println!("HELLO YES, what is this?? {:?}", data);
                         std::fs::write(&path, data).unwrap();
                         path
                     }
@@ -448,7 +447,6 @@ macro_rules! gcs_credentials {
             Ok(None) => {
                 match std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
                     Ok(path) => {
-                        println!("WELL, seems like we have a credentials file??? {:?}", path);
                         $crate::test::TestGcsCredentials {
                             bucket: "sentryio-symbolicator-cache-test".to_string(),
                             credentials_file: Some(path.into()),


### PR DESCRIPTION
This makes sure that tests from forks which do not have access to the secrets will work seamlessly, just like those tests work seamlessly when you run in local development without the secrets.

The risk of regressing on the GCS functionality is mitigated by the fact CI also runs on master after merging.

#skip-changelog