### PR TITLE
fix: Measure the correct minidump processing time

### DIFF
--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -1741,9 +1741,9 @@ async fn stackwalk_with_rust_minidump(
     }
 
     // Stackwalk the minidump.
+    let duration = Instant::now();
     let minidump = Minidump::read(ByteView::open(minidump_path)?)?;
     let provider = TempSymbolProvider::new(cfi_caches.iter());
-    let duration = Instant::now();
     let process_state = minidump_processor::process_minidump(&minidump, &provider).await?;
     let duration = duration.elapsed();
 


### PR DESCRIPTION
The duration was only measuring the stackwalking itself, not the minidump and symbolfile parsing.

#skip-changelog