### PR TITLE
fix(TempSymbolProvider): don't parse empty symbol files

### DIFF
--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -1535,6 +1535,10 @@ impl TempSymbolProvider {
                     })
                     .ok()?;
 
+                if cfi_cache.as_slice().is_empty() {
+                    return None;
+                }
+
                 SymbolFile::from_bytes(cfi_cache.as_slice())
                     .map_err(|err| {
                         let stderr: &dyn std::error::Error = &err;


### PR DESCRIPTION
Empty cfi caches likely occur in practice and `rust-minidump`'s parser (quite reasonably) rejects them. Therefore we bail early in such cases.

#skip-changelog