### PR TITLE
ref: Remove duplicate configure sentry scope

### DIFF
--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -214,9 +214,6 @@ impl S3Downloader {
                             }
                         });
                         if let Some(code) = code {
-                            sentry::configure_scope(|scope| {
-                                scope.set_extra("AWS code", code.into());
-                            });
                             return Err(DownloadError::S3WithCode(
                                 response.status,
                                 code.to_string(),


### PR DESCRIPTION
This set_extra() call already happens just a few lines above, no need
to do this twice.

#skip-changelog