### PR TITLE
fix(symbolication): Attach context to the right error

### DIFF
--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -1998,8 +1998,8 @@ impl SymbolicationActor {
 
         self.cpu_pool
             .spawn(lazy.bind_hub(sentry::Hub::current()))
-            .await?
-            .context("Minidump stackwalk future cancelled")
+            .await
+            .context("Minidump stackwalk future cancelled")?
     }
 
     /// Saves the given `minidump_file` in the diagnostics cache if configured to do so.


### PR DESCRIPTION
The type of `self.cpu_pool.spawn(lazy.bind_hub(sentry::Hub::current())).await` is `Result<Result<StackwalkMinidumpResult, Error>, JoinError>`. Currently the `?` after the `.await` means that we bail in case of a `JoinError` and attach the "Minidump stackwalk future cancelled" context to the inner `Error`. I think this is exactly backwards; the context should be attached to the `JoinError`.

#skip-changelog