### PR TITLE
fix: Remove metrics tagging

### DIFF
--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -859,7 +859,6 @@ fn record_symbolication_metrics(
     metrics: StacktraceMetrics,
     modules: &[CompleteObjectInfo],
     stacktraces: &[CompleteStacktrace],
-    method: &'static str,
 ) {
     let origin = origin.to_string();
 
@@ -883,7 +882,7 @@ fn record_symbolication_metrics(
     for m in modules {
         metric!(
             counter("symbolication.debug_status") += 1,
-            "status" => m.debug_status.name(), "method" => method,
+            "status" => m.debug_status.name()
         );
 
         // FIXME: `object_id_from_object_info` allocates and is kind-of expensive
@@ -899,65 +898,65 @@ fn record_symbolication_metrics(
 
     metric!(
         time_raw("symbolication.num_modules") = modules.len() as u64,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unusable_modules") = unusable_modules,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unparsable_modules") = unparsable_modules,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
 
     metric!(
         time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.short_stacktraces") = metrics.short_traces,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.truncated_stacktraces") = metrics.truncated_traces,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.bad_stacktraces") = metrics.bad_traces,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
 
     metric!(
         time_raw("symbolication.num_frames") =
             stacktraces.iter().map(|s| s.frames.len() as u64).sum::<u64>(),
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.scanned_frames") = metrics.scanned_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unsymbolicated_frames") = metrics.unsymbolicated_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unsymbolicated_context_frames") =
             metrics.unsymbolicated_context_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unsymbolicated_cfi_frames") =
             metrics.unsymbolicated_cfi_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unsymbolicated_scanned_frames") =
             metrics.unsymbolicated_scanned_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
     metric!(
         time_raw("symbolication.unmapped_frames") = metrics.unmapped_frames,
-        "platform" => &platform, "origin" => &origin, "method" => method,
+        "platform" => &platform, "origin" => &origin
     );
 }
 
@@ -1169,7 +1168,6 @@ impl SymbolicationActor {
             signal,
             origin,
             modules,
-            options,
             ..
         } = request;
 
@@ -1228,18 +1226,7 @@ impl SymbolicationActor {
 
             // bring modules back into the original order
             let modules = module_lookup.into_inner();
-            let stackwalking_method = if options.rust_minidump {
-                "rust-minidump"
-            } else {
-                "breakpad"
-            };
-            record_symbolication_metrics(
-                origin,
-                metrics,
-                &modules,
-                &stacktraces,
-                stackwalking_method,
-            );
+            record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
 
             CompletedSymbolicationResponse {
                 signal,
@@ -1761,7 +1748,7 @@ impl SymbolicationActor {
                 "minidump.stackwalk.spawn.error",
             )?;
 
-            metric!(timer("minidump.stackwalk.duration") = result.duration, "method" => if rust_minidump { "rust-minidump" } else { "breakpad" });
+            metric!(timer("minidump.stackwalk.duration") = result.duration);
 
             Ok::<_, anyhow::Error>(result)
         };
@@ -1843,7 +1830,7 @@ impl SymbolicationActor {
         };
 
         result.modules = modules.map(|modules| modules.into_iter().collect());
-        metric!(time_raw("minidump.stackwalk.iterations") = iterations, "method" => if rust_minidump { "rust-minidump" } else { "breakpad" });
+        metric!(time_raw("minidump.stackwalk.iterations") = iterations);
         Ok(result)
     }
 


### PR DESCRIPTION
Since the previous commit removed the choice between stackwalking methods, this metrics tagging no longer works. Not sure why CI didn't catch that. An alternative would be to just statically tag with `"rust-minidump"`.

#skip-changelog