### PR TITLE
feat: Add Usym variant to FileType

### DIFF
--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -224,6 +224,7 @@ impl SentryDownloader {
                     FileType::WasmDebug | FileType::WasmCode => "wasm",
                     FileType::Breakpad => "breakpad",
                     FileType::SourceBundle => "sourcebundle",
+                    FileType::Usym => "usym",
                 })
                 .map(|val| ("file_formats", val)),
         );

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -214,17 +214,17 @@ impl SentryDownloader {
         index_url.query_pairs_mut().extend_pairs(
             file_types
                 .iter()
-                .map(|file_type| match file_type {
-                    FileType::UuidMap => "uuidmap",
-                    FileType::BcSymbolMap => "bcsymbolmap",
-                    FileType::Pe => "pe",
-                    FileType::Pdb => "pdb",
-                    FileType::MachDebug | FileType::MachCode => "macho",
-                    FileType::ElfDebug | FileType::ElfCode => "elf",
-                    FileType::WasmDebug | FileType::WasmCode => "wasm",
-                    FileType::Breakpad => "breakpad",
-                    FileType::SourceBundle => "sourcebundle",
-                    FileType::Usym => "usym",
+                .filter_map(|file_type| match file_type {
+                    FileType::UuidMap => Some("uuidmap"),
+                    FileType::BcSymbolMap => Some("bcsymbolmap"),
+                    FileType::Pe => Some("pe"),
+                    FileType::Pdb => Some("pdb"),
+                    FileType::MachDebug | FileType::MachCode => Some("macho"),
+                    FileType::ElfDebug | FileType::ElfCode => Some("elf"),
+                    FileType::WasmDebug | FileType::WasmCode => Some("wasm"),
+                    FileType::Breakpad => Some("breakpad"),
+                    FileType::SourceBundle => Some("sourcebundle"),
+                    FileType::Usym => None,
                 })
                 .map(|val| ("file_formats", val)),
         );

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -448,6 +448,7 @@ impl FileType {
             SourceBundle,
             UuidMap,
             BcSymbolMap,
+            Usym,
         ]
     }
 

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -425,6 +425,9 @@ pub enum FileType {
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
     #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
+    /// A .usym file that maps source information between generated C++ code and managed
+    /// C# code.
+    Usym,
 }
 
 impl FileType {
@@ -504,6 +507,7 @@ impl AsRef<str> for FileType {
             FileType::SourceBundle => "sourcebundle",
             FileType::UuidMap => "uuidmap",
             FileType::BcSymbolMap => "bcsymbolmap",
+            FileType::Usym => "usym",
         }
     }
 }

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -331,7 +331,6 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
         FileType::SourceBundle => None,
         FileType::UuidMap => None,
         FileType::BcSymbolMap => None,
-        // TODO(sebastian): is this correct?
         FileType::Usym => None,
     }
 }
@@ -350,7 +349,6 @@ fn get_search_target_object_type(filetype: FileType, identifier: &ObjectId) -> O
         }
         FileType::ElfCode | FileType::ElfDebug => ObjectType::Elf,
         FileType::WasmDebug | FileType::WasmCode => ObjectType::Wasm,
-        // TODO(sebastian): is this correct? do we have to fall back to the identifier for usym?
         FileType::SourceBundle | FileType::Breakpad | FileType::Usym => identifier.object_type,
     }
 }

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -121,7 +121,7 @@ fn get_breakpad_path(identifier: &ObjectId) -> Option<String> {
 
 /// Returns the relative locations on a native symbols server for the requested DIF.
 ///
-/// Some filetypes can not be stored on a native symbol server so return an emtpy vector.
+/// Some filetypes can not be stored on a native symbol server so return an empty vector.
 fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
     match filetype {
         // ELF follows GDB "Build ID Method" conventions.
@@ -198,6 +198,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
         }
         FileType::UuidMap => Vec::new(),
         FileType::BcSymbolMap => Vec::new(),
+        FileType::Usym => Vec::new(),
     }
 }
 
@@ -280,8 +281,11 @@ fn get_symstore_path(
         // Microsoft SymbolServer does not specify PropertyList.
         FileType::UuidMap => None,
 
-        // Microsoft SymbolServer does not speicfy BCSymbolMap.
+        // Microsoft SymbolServer does not specify BCSymbolMap.
         FileType::BcSymbolMap => None,
+
+        // Microsoft SymbolServer does not specify Usym.
+        FileType::Usym => None,
     }
 }
 
@@ -327,6 +331,8 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
         FileType::SourceBundle => None,
         FileType::UuidMap => None,
         FileType::BcSymbolMap => None,
+        // TODO(sebastian): is this correct?
+        FileType::Usym => None,
     }
 }
 
@@ -344,7 +350,8 @@ fn get_search_target_object_type(filetype: FileType, identifier: &ObjectId) -> O
         }
         FileType::ElfCode | FileType::ElfDebug => ObjectType::Elf,
         FileType::WasmDebug | FileType::WasmCode => ObjectType::Wasm,
-        FileType::SourceBundle | FileType::Breakpad => identifier.object_type,
+        // TODO(sebastian): is this correct? do we have to fall back to the identifier for usym?
+        FileType::SourceBundle | FileType::Breakpad | FileType::Usym => identifier.object_type,
     }
 }
 
@@ -359,6 +366,7 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
         FileType::SourceBundle => "sourcebundle",
         FileType::UuidMap => "uuidmap",
         FileType::BcSymbolMap => "bcsymbolmap",
+        FileType::Usym => "usym",
     };
 
     // determine the ID we use for the path


### PR DESCRIPTION
This is modeled on https://github.com/getsentry/symbolicator/pull/695.

Some questions I'm still unsure about:
* Is it correct that Usym should not be supported for `debuginfod` and `SymStore`?
* Is it correct that in `get_search_target_object_type` we have to fall back to the identifier to determine the object type or can we do better for Usym?

#skip-changelog