### PR TITLE
Don't emit ANSI escape codes with auto=false or simplified logging formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use wildcard matcher for symstore proxy. ([#671](https://github.com/getsentry/symbolicator/pull/671))
 - Detect unwind and debug information in ELF files that contain sections with offset `0`. They were previously skipped in some cases. ([#688](https://github.com/getsentry/symbolicator/pull/688))
 - Support processing unwind information in ELF files linked with `gold`. ([#688](https://github.com/getsentry/symbolicator/pull/688))
+- Don't emit ANSI escape sequences with `auto=false` and `simplified` logging formats. ([#755](https://github.com/getsentry/symbolicator/pull/755))
 
 ## 0.4.1
 

--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -60,6 +60,7 @@ pub fn init_logging(config: &Config) {
             .init(),
         (LogFormat::Auto, false) | (LogFormat::Simplified, _) => subscriber
             .compact()
+            .with_ansi(false)
             .finish()
             .with(sentry::integrations::tracing::layer())
             .init(),


### PR DESCRIPTION
Fixes [#753].