### PR TITLE
fix(minidump): fill_symbol always returns an error

### DIFF
--- a/crates/symbolicator/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator/src/services/symbolication/process_minidump.rs
@@ -250,18 +250,16 @@ impl SymbolicatorSymbolProvider {
 impl SymbolProvider for SymbolicatorSymbolProvider {
     async fn fill_symbol(
         &self,
-        module: &(dyn Module + Sync),
+        _module: &(dyn Module + Sync),
         _frame: &mut (dyn FrameSymbolizer + Send),
     ) -> Result<(), FillSymbolError> {
-        let debug_id = module.debug_identifier().ok_or(FillSymbolError {})?;
-
-        // Symbolicator's CFI caches never store symbolication information. However, we could hook
-        // up symbolic here to fill frame info right away. This requires a larger refactor of
-        // minidump processing and the types, however.
-        match self.files.contains_key(&debug_id) {
-            true => Ok(()),
-            false => Err(FillSymbolError {}),
-        }
+        // Always return an error here to signal that we have no useful symbol information to
+        // contribute. Doing nothing and reporting Ok trips a check in rust_minidump's
+        // instruction_seems_valid_by_symbols function that leads stack scanning to stop prematurely.
+        // See https://github.com/rust-minidump/rust-minidump/blob/7eed71e4075e0a81696ccc307d6ac68920de5db5/minidump-processor/src/stackwalker/mod.rs#L295.
+        //
+        // TODO: implement this properly, i.e., use symbolic to actually fill in information.
+        Err(FillSymbolError {})
     }
 
     async fn walk_frame(


### PR DESCRIPTION
The current behavior of the `fill_symbol` method on `SymbolicatorSymbolProvider` trips [a check](https://github.com/rust-minidump/rust-minidump/blob/7eed71e4075e0a81696ccc307d6ac68920de5db5/minidump-processor/src/stackwalker/mod.rs#L295) in the `instruction_seems_valid_by_symbols` method in `rust_minidump`. This results in stack scanning ending prematurely. Always returning an error instead fixes this.

#skip-changelog

NATIVE-549