### PR TITLE
ci(dependabot): auto-merge approved PRs

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     name: Changelogs

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,8 +1,9 @@
-name: Dependabot auto-approve
+name: Dependabot auto-merge
 on: pull_request
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   dependabot:
@@ -14,8 +15,9 @@ jobs:
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Flip the automation around: auto-merge instead of auto-approve.
Auto-approve doesn't work since the approver is not in owners-ingest.

#skip-changelog