### PR TITLE
meta: Add patch section to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ inherits = "release"
 incremental = true
 codegen-units = 256
 
-# For local development: uncomment the following two lines (and adjust the path if necessary)
+# For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.
 # See also https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 # [patch."https://github.com/getsentry/symbolic"]
 # symbolic = { path = "../symbolic/symbolic" }
+# symbolic-minidump = { path = "../symbolic/symbolic-minidump" }


### PR DESCRIPTION
This adds a commented-out patch section to Cargo.toml that easily allows one to use a local symbolic checkout throughout the entire project.

#skip-changelog