### PR TITLE
ref: Increase CFI cache version

### DIFF
--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -39,9 +39,13 @@ use super::shared_cache::SharedCacheService;
 ///
 /// In case a symbolic update increased its own internal format version, bump the
 /// cficache file version as described above, and update the static assertion.
+///
+/// # Version History
+///
+/// - `1`: Generate higher fidelity CFI for Win-x64 binaries.
 const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 0,
-    fallbacks: &[],
+    current: 1,
+    fallbacks: &[0],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -46,6 +46,10 @@ mod markers;
 ///
 /// In case a symbolic update increased its own internal format version, bump the
 /// symcache file version as described above, and update the static assertion.
+///
+/// # Version History
+///
+/// - `1`: New binary format based on instruction addr lookup.
 const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 1,
     fallbacks: &[0],


### PR DESCRIPTION
This will trigger lazy re-generation of all the CFI caches, to take advantage of higher fidelity CFI generation for Win-x64 binaries.

This is a separate PR from #822 which actually introduces the CFI changes.

#skip-changelog