### PR TITLE
Add support for serving web requests using HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Added an internal option to capture minidumps for hard crashes. This has to be enabled via the `_crash_db` config parameter. ([#795](https://github.com/getsentry/symbolicator/pull/795))
+- Add support for serving web requests using HTTPS ([#829](https://github.com/getsentry/symbolicator/pull/829))
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -167,6 +173,26 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf18303ef7e23b045301555bf8a0dfbc1444ea1a37b3c81757a32680ace4d7d"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 1.0.0",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -309,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byte-tools"
@@ -1046,9 +1072,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
+checksum = "cfeb764aa29a0774d290c2df134a37ab2e3c1ba59009162626658aabefda321a"
 dependencies = [
  "log",
  "plain",
@@ -1070,7 +1096,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
@@ -1518,9 +1544,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
 dependencies = [
  "libc",
 ]
@@ -1848,9 +1874,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
  "autocfg",
  "cc",
@@ -2096,15 +2122,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "quote"
@@ -2870,9 +2887,9 @@ checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.15",
@@ -3094,6 +3111,7 @@ dependencies = [
  "apple-crash-report-parser",
  "async-trait",
  "axum",
+ "axum-server",
  "backtrace",
  "base64",
  "cadence",
@@ -3135,7 +3153,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-metrics",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.3",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3176,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3309,7 +3327,6 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "quickcheck",
  "serde",
  "time-macros",
 ]
@@ -3337,9 +3354,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes",
  "libc",
@@ -3356,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3399,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3437,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3460,7 +3477,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.3",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.57"
 apple-crash-report-parser = "0.4.2"
 async-trait = "0.1.53"
 axum = { version = "0.5.4", features = ["multipart"] }
-axum-server = { version = "0.4.0", features = [ "tls-rustls"] }
+axum-server = { version = "0.4.0" }
 backtrace = "0.3.65"
 base64 = "0.13.0"
 cadence = "0.29.0"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.57"
 apple-crash-report-parser = "0.4.2"
 async-trait = "0.1.53"
 axum = { version = "0.5.4", features = ["multipart"] }
+axum-server = { version = "0.4.0", features = [ "tls-rustls"] }
 backtrace = "0.3.65"
 base64 = "0.13.0"
 cadence = "0.29.0"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -65,3 +65,6 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 sha-1 = "0.10.0"
 test-assembler = "0.1.5"
 warp = "0.3.0"
+
+[features]
+https = ["axum-server/tls-rustls"]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -67,5 +67,4 @@ test-assembler = "0.1.5"
 warp = "0.3.0"
 
 [features]
-default = ["https"]
 https = ["axum-server/tls-rustls"]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -67,4 +67,5 @@ test-assembler = "0.1.5"
 warp = "0.3.0"
 
 [features]
+default = ["https"]
 https = ["axum-server/tls-rustls"]

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -28,6 +28,7 @@ pub enum LogFormat {
     Json,
 }
 
+#[cfg(feature = "https")]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub struct HTTPSConfig {
@@ -35,6 +36,7 @@ pub struct HTTPSConfig {
     pub key_path: PathBuf,
 }
 
+#[cfg(feature = "https")]
 impl Default for HTTPSConfig {
     fn default() -> Self {
         HTTPSConfig {
@@ -44,7 +46,8 @@ impl Default for HTTPSConfig {
     }
 }
 
-/// Controls the HTTP server setup
+/// Controls the HTTPS server setup
+#[cfg(feature = "https")]
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct ServerConfig {
@@ -267,6 +270,7 @@ pub struct Config {
     pub bind: String,
 
     /// Host and port to bind the HTTPS webserver to.
+    #[cfg(feature = "https")]
     pub bind_https: Option<String>,
 
     /// Configuration for internal logging.
@@ -275,6 +279,7 @@ pub struct Config {
     /// Configuration for reporting metrics to a statsd instance.
     pub metrics: Metrics,
 
+    #[cfg(feature = "https")]
     pub server_config: ServerConfig,
 
     /// DSN to report internal errors to
@@ -394,8 +399,10 @@ impl Default for Config {
         Config {
             cache_dir: default_cache_dir(),
             bind: default_bind(),
+            #[cfg(feature = "https")]
             bind_https: None,
             logging: Logging::default(),
+            #[cfg(feature = "https")]
             server_config: ServerConfig::default(),
             metrics: Metrics::default(),
             sentry_dsn: None,

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -28,6 +28,36 @@ pub enum LogFormat {
     Json,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct HTTPSConfig {
+    pub certificate_path: PathBuf,
+    pub key_path: PathBuf,
+}
+
+impl Default for HTTPSConfig {
+    fn default() -> Self {
+        HTTPSConfig {
+            certificate_path: PathBuf::from("cert.pem"),
+            key_path: PathBuf::from("cert.pem"),
+        }
+    }
+}
+
+/// Controls the HTTP server setup
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    /// The log level for the relay.
+    pub https: Option<HTTPSConfig>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig { https: None }
+    }
+}
+
 /// Controls the logging system.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
@@ -242,11 +272,16 @@ pub struct Config {
     /// Host and port to bind the HTTP webserver to.
     pub bind: String,
 
+    /// Host and port to bind the HTTPS webserver to.
+    pub bind_https: Option<String>,
+
     /// Configuration for internal logging.
     pub logging: Logging,
 
     /// Configuration for reporting metrics to a statsd instance.
     pub metrics: Metrics,
+
+    pub server_config: ServerConfig,
 
     /// DSN to report internal errors to
     pub sentry_dsn: Option<Dsn>,
@@ -365,7 +400,9 @@ impl Default for Config {
         Config {
             cache_dir: default_cache_dir(),
             bind: default_bind(),
+            bind_https: None,
             logging: Logging::default(),
+            server_config: ServerConfig::default(),
             metrics: Metrics::default(),
             sentry_dsn: None,
             caches: CacheConfigs::default(),

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -48,7 +48,7 @@ impl Default for HTTPSConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct ServerConfig {
-    /// The log level for the relay.
+    /// HTTPS configuration
     pub https: Option<HTTPSConfig>,
 }
 

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -45,17 +45,11 @@ impl Default for HTTPSConfig {
 }
 
 /// Controls the HTTP server setup
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct ServerConfig {
     /// The log level for the relay.
     pub https: Option<HTTPSConfig>,
-}
-
-impl Default for ServerConfig {
-    fn default() -> Self {
-        ServerConfig { https: None }
-    }
 }
 
 /// Controls the logging system.

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -52,7 +52,7 @@ pub fn run(config: Config) -> Result<()> {
     let server_http = axum_server::bind(socket_http)
         .serve(endpoints::create_app(service_http).into_make_service());
     servers.push(Box::pin(server_http));
-    tracing::info!("Starting HTTP server");
+    tracing::info!("Starting HTTP server on {}", socket_http);
 
     if let Some(ref bind_str) = config.bind_https {
         let https_conf = match config.server_config.https {
@@ -74,7 +74,7 @@ pub fn run(config: Config) -> Result<()> {
         let server_https = axum_server::bind_rustls(socket_https, tls_config)
             .serve(endpoints::create_app(service_https).into_make_service());
         servers.push(Box::pin(server_https));
-        tracing::info!("Starting HTTPS server");
+        tracing::info!("Starting HTTPS server on {}", socket_https);
     }
 
     let _guard = web_pool.enter();

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -1,3 +1,4 @@
+use axum_server::Handle;
 #[cfg(feature = "https")]
 use std::fs::read;
 use std::net::SocketAddr;
@@ -55,13 +56,26 @@ pub fn run(config: Config) -> Result<()> {
 
     let svc = endpoints::create_app(service).into_make_service();
 
+    let handle_http = Handle::new();
     let socket_http = config.bind.parse::<SocketAddr>()?;
-    let server_http = axum_server::bind(socket_http).serve(svc.clone());
+    let server_http = axum_server::bind(socket_http)
+        .handle(handle_http.clone())
+        .serve(svc.clone());
     servers.push(Box::pin(server_http));
-    tracing::info!("Starting HTTP server on {}", socket_http);
+
+    let listening_http = async move {
+        if let Some(local_addr) = handle_http.listening().await {
+            tracing::info!("Starting HTTP server on {}", local_addr);
+        } else {
+            panic!("Unable to listen on HTTP port");
+        }
+        Ok(())
+    };
+    servers.push(Box::pin(listening_http));
 
     #[cfg(feature = "https")]
     if let Some(ref bind_str) = config.bind_https {
+        let handle_https = Handle::new();
         let https_conf = match config.server_config.https {
             None => panic!("Need HTTPS config"),
             Some(ref conf) => conf,
@@ -71,9 +85,20 @@ pub fn run(config: Config) -> Result<()> {
         let key = read_pem_file(&https_conf.key_path)?;
         let tls_config =
             web_pool.block_on(async { RustlsConfig::from_pem(certificate, key).await })?;
-        let server_https = axum_server::bind_rustls(socket_https, tls_config).serve(svc);
+        let server_https = axum_server::bind_rustls(socket_https, tls_config)
+            .handle(handle_https.clone())
+            .serve(svc);
         servers.push(Box::pin(server_https));
-        tracing::info!("Starting HTTPS server on {}", socket_https);
+
+        let listening_https = async move {
+            if let Some(local_addr) = handle_https.listening().await {
+                tracing::info!("Starting HTTPS server on {}", local_addr);
+            } else {
+                panic!("Unable to listen on HTTPS port");
+            }
+            Ok(())
+        };
+        servers.push(Box::pin(listening_https));
     }
 
     web_pool.block_on(try_join_all(servers))?;

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use axum_server;
 #[cfg(feature = "https")]
 use axum_server::tls_rustls::RustlsConfig;
 use futures::future::try_join_all;

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -1,12 +1,22 @@
+use std::fs::read;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+
+use axum_server::tls_rustls::RustlsConfig;
+use futures::future::try_join_all;
+use futures::future::BoxFuture;
 
 use crate::config::Config;
 use crate::endpoints;
 use crate::services::Service;
 
-/// Starts all actors and HTTP server based on loaded config.
+fn read_pem_file(path: &PathBuf) -> Result<Vec<u8>> {
+    read(path).context(format!("unable to read file: {}", path.display()))
+}
+
+/// Starts all actors and HTTP (and optionally HTTPS) server based on loaded config.
 pub fn run(config: Config) -> Result<()> {
     // Log this metric before actually starting the server. This allows to see restarts even if
     // service creation fails.
@@ -29,24 +39,46 @@ pub fn run(config: Config) -> Result<()> {
         .thread_stack_size(8 * megs)
         .build()?;
 
-    let socket = config.bind.parse::<SocketAddr>()?;
+    let mut servers: Vec<BoxFuture<_>> = vec![];
 
-    let service = web_pool
+    let service_http = web_pool
         .block_on(Service::create(
-            config,
+            config.clone(),
             io_pool.handle().to_owned(),
             cpu_pool.handle().to_owned(),
         ))
-        .context("failed to create service state")?;
+        .context("failed to create HTTP service state")?;
+    let socket_http = config.bind.parse::<SocketAddr>()?;
+    let server_http = axum_server::bind(socket_http)
+        .serve(endpoints::create_app(service_http).into_make_service());
+    servers.push(Box::pin(server_http));
+    tracing::info!("Starting HTTP server");
+
+    if let Some(ref bind_str) = config.bind_https {
+        let https_conf = match config.server_config.https {
+            None => panic!("Need HTTPS config"),
+            Some(ref conf) => conf,
+        };
+        let service_https = web_pool
+            .block_on(Service::create(
+                config.clone(),
+                io_pool.handle().to_owned(),
+                cpu_pool.handle().to_owned(),
+            ))
+            .context("failed to create HTTPS service state")?;
+        let socket_https = bind_str.parse::<SocketAddr>()?;
+        let certificate = read_pem_file(&https_conf.certificate_path)?;
+        let key = read_pem_file(&https_conf.key_path)?;
+        let tls_config =
+            web_pool.block_on(async { RustlsConfig::from_pem(certificate, key).await })?;
+        let server_https = axum_server::bind_rustls(socket_https, tls_config)
+            .serve(endpoints::create_app(service_https).into_make_service());
+        servers.push(Box::pin(server_https));
+        tracing::info!("Starting HTTPS server");
+    }
 
     let _guard = web_pool.enter();
-    let server =
-        axum::Server::try_bind(&socket)?.serve(endpoints::create_app(service).into_make_service());
-
-    tracing::info!("Starting server on {}", server.local_addr());
-
-    web_pool.block_on(server)?;
-
+    web_pool.block_on(try_join_all(servers))?;
     tracing::info!("System shutdown complete");
 
     Ok(())

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -1,9 +1,13 @@
+#[cfg(feature = "https")]
 use std::fs::read;
 use std::net::SocketAddr;
+#[cfg(feature = "https")]
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+use axum_server;
+#[cfg(feature = "https")]
 use axum_server::tls_rustls::RustlsConfig;
 use futures::future::try_join_all;
 use futures::future::BoxFuture;
@@ -12,6 +16,7 @@ use crate::config::Config;
 use crate::endpoints;
 use crate::services::Service;
 
+#[cfg(feature = "https")]
 fn read_pem_file(path: &PathBuf) -> Result<Vec<u8>> {
     read(path).context(format!("unable to read file: {}", path.display()))
 }
@@ -56,6 +61,7 @@ pub fn run(config: Config) -> Result<()> {
     servers.push(Box::pin(server_http));
     tracing::info!("Starting HTTP server on {}", socket_http);
 
+    #[cfg(feature = "https")]
     if let Some(ref bind_str) = config.bind_https {
         let https_conf = match config.server_config.https {
             None => panic!("Need HTTPS config"),

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -77,7 +77,6 @@ pub fn run(config: Config) -> Result<()> {
         tracing::info!("Starting HTTPS server on {}", socket_https);
     }
 
-    let _guard = web_pool.enter();
     web_pool.block_on(try_join_all(servers))?;
     tracing::info!("System shutdown complete");
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,16 @@ metrics:
   persistent volume, and `null` otherwise, which disables caching. **It is
   strictly recommended to configure caches in production!**
 - `bind`: Host and port for HTTP interface.
+- `bind_https`: Host and port for optional HTTPS interface.
+
+  Notes:
+  - HTTPS support is a Cargo feature, and needs to be enabled before the application is built:
+    - Edit `crates/symbolicator/Cargo.toml` and add `default = ["https"]` under `[features]`, then build the software.
+  - For HTTPS support, additionally paths to TLS certificate and key files need to be specified:
+    - `server_config`: web server configuration needed for serving over HTTPS.
+      - `https`: HTTPS configuration.
+        - `certificate_path`: Path to a TLS certificate file in PEM format.
+        - `key_path`: Path to a TLS key file in PEM format.
 - `logging`: Command line logging behavior.
     - `level`: Log level, defaults to `info`. Can be one of `off`, `error`,
       `warn`, `info`, `debug`, or `trace`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,9 +48,11 @@ metrics:
 - `bind_https`: Host and port for optional HTTPS interface.
 
   Notes:
-  - HTTPS support is a Cargo feature, and needs to be enabled before the application is built:
-    - Edit `crates/symbolicator/Cargo.toml` and add `default = ["https"]` under `[features]`, then build the software.
-  - For HTTPS support, additionally paths to TLS certificate and key files need to be specified:
+  - HTTPS support is a Cargo feature, and needs to be enabled during building:
+    ```shell
+    cargo build --features https <other build options>
+    ```
+  - Additionally for HTTPS support, paths to TLS certificate and key files need to be specified in the configuration file:
     - `server_config`: web server configuration needed for serving over HTTPS.
       - `https`: HTTPS configuration.
         - `certificate_path`: Path to a TLS certificate file in PEM format.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,7 +94,7 @@ class SymbolicatorRunner(threading.Thread):
         self._proc.kill()
 
     def run(self):
-        port_re = re.compile(r"Starting server on [0-9.]+:([0-9]+)")
+        port_re = re.compile(r"Starting HTTP server on [0-9.]+:([0-9]+)")
         line = self._proc.stdout.readline()
         while line:
             print(line, end="", file=sys.stderr)


### PR DESCRIPTION
The config file format has been extended with a bind_https keyword,
as well as

    server_config:
      https:
        certificate_path: cert.pem
        key_path: key.pem