### PR TITLE
feat: Use il2cpp line mappings in symcache creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Use Unity il2cpp line mapping files in symcache creation ([#831](https://github.com/getsentry/symbolicator/pull/831))
+
 ## 0.5.1
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "symbolic"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3018,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "symbolic-il2cpp"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "anyhow",
  "gimli",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "symbolic-minidump"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "cc",
  "symbolic-common",
@@ -3086,13 +3086,14 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
 dependencies = [
  "dmsort",
  "fnv",
  "indexmap",
  "symbolic-common",
  "symbolic-debuginfo",
+ "symbolic-il2cpp",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -1793,6 +1794,7 @@ version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
+ "flate2",
  "memchr",
 ]
 
@@ -2997,6 +2999,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
  "symbolic-demangle",
+ "symbolic-il2cpp",
  "symbolic-symcache",
 ]
 
@@ -3051,6 +3054,22 @@ dependencies = [
  "msvc-demangler",
  "rustc-demangle",
  "symbolic-common",
+]
+
+[[package]]
+name = "symbolic-il2cpp"
+version = "8.7.3"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#024f78e7b75007df614dcad1154783c204f9e221"
+dependencies = [
+ "anyhow",
+ "gimli",
+ "indexmap",
+ "object",
+ "scroll 0.11.0",
+ "serde_json",
+ "symbolic-common",
+ "symbolic-debuginfo",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "symcache"] }
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
 symbolic-minidump = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", default-features = false}
 tempfile = "3.2.0"
 thiserror = "1.0.31"

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -190,6 +190,7 @@ pub enum CacheName {
     Objects,
     ObjectMeta,
     Auxdifs,
+    Il2cpp,
     Symcaches,
     Cficaches,
     Diagnostics,
@@ -201,6 +202,7 @@ impl AsRef<str> for CacheName {
             Self::Objects => "objects",
             Self::ObjectMeta => "object_meta",
             Self::Auxdifs => "auxdifs",
+            Self::Il2cpp => "il2cpp",
             Self::Symcaches => "symcaches",
             Self::Cficaches => "cficaches",
             Self::Diagnostics => "diagnostics",
@@ -492,6 +494,8 @@ pub struct Caches {
     pub object_meta: Cache,
     /// Caches for auxiliary DIF files, used by [`crate::services::bitcode::BitcodeService`].
     pub auxdifs: Cache,
+    /// Caches for il2cpp line mapping files, used by [`crate::services::il2cpp::Il2cppService`].
+    pub il2cpp: Cache,
     /// Caches for [`symbolic::symcache::SymCache`], used by
     /// [`crate::services::symcaches::SymCacheActor`].
     pub symcaches: Cache,
@@ -540,6 +544,16 @@ impl Caches {
                 let path = config.cache_dir("auxdifs");
                 Cache::from_config(
                     CacheName::Auxdifs,
+                    path,
+                    tmp_dir.clone(),
+                    config.caches.downloaded.into(),
+                    max_lazy_redownloads.clone(),
+                )?
+            },
+            il2cpp: {
+                let path = config.cache_dir("il2cpp");
+                Cache::from_config(
+                    CacheName::Il2cpp,
                     path,
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
@@ -599,6 +613,7 @@ impl Caches {
             objects,
             object_meta,
             auxdifs,
+            il2cpp,
             symcaches,
             cficaches,
             diagnostics,
@@ -613,6 +628,7 @@ impl Caches {
             cficaches.cleanup(),
             diagnostics.cleanup(),
             auxdifs.cleanup(),
+            il2cpp.cleanup(),
         ];
 
         let mut first_error = None;

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -214,17 +214,17 @@ impl SentryDownloader {
         index_url.query_pairs_mut().extend_pairs(
             file_types
                 .iter()
-                .filter_map(|file_type| match file_type {
-                    FileType::UuidMap => Some("uuidmap"),
-                    FileType::BcSymbolMap => Some("bcsymbolmap"),
-                    FileType::Pe => Some("pe"),
-                    FileType::Pdb => Some("pdb"),
-                    FileType::MachDebug | FileType::MachCode => Some("macho"),
-                    FileType::ElfDebug | FileType::ElfCode => Some("elf"),
-                    FileType::WasmDebug | FileType::WasmCode => Some("wasm"),
-                    FileType::Breakpad => Some("breakpad"),
-                    FileType::SourceBundle => Some("sourcebundle"),
-                    FileType::Usym => None,
+                .map(|file_type| match file_type {
+                    FileType::UuidMap => "uuidmap",
+                    FileType::BcSymbolMap => "bcsymbolmap",
+                    FileType::Pe => "pe",
+                    FileType::Pdb => "pdb",
+                    FileType::MachDebug | FileType::MachCode => "macho",
+                    FileType::ElfDebug | FileType::ElfCode => "elf",
+                    FileType::WasmDebug | FileType::WasmCode => "wasm",
+                    FileType::Breakpad => "breakpad",
+                    FileType::SourceBundle => "sourcebundle",
+                    FileType::Il2cpp => "il2cpp",
                 })
                 .map(|val| ("file_formats", val)),
         );

--- a/crates/symbolicator/src/services/il2cpp.rs
+++ b/crates/symbolicator/src/services/il2cpp.rs
@@ -1,0 +1,293 @@
+//! Service for retrieving Unity il2cpp line mapping files.
+//!
+//! This service downloads and caches the [`LineMapping`] used to map
+//! generated C++ source files back to the original C# sources.
+
+use std::fs::File;
+use std::io::{self, Cursor, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Error};
+use futures::future::{self, BoxFuture};
+use sentry::{Hub, SentryFutureExt};
+use symbolic::common::{ByteView, DebugId};
+use symbolic::il2cpp::LineMapping;
+use tempfile::tempfile_in;
+
+use crate::cache::{Cache, CacheStatus};
+use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
+use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
+use crate::sources::{FileType, SourceConfig};
+use crate::types::Scope;
+use crate::utils::compression::decompress_object_file;
+use crate::utils::futures::{m, measure};
+
+use super::shared_cache::SharedCacheService;
+
+/// Handle to a valid [`LineMapping`].
+///
+/// While this handle points to the raw data, this data is guaranteed to be valid, you can
+/// only have this handle if a positive cache existed.
+#[derive(Debug, Clone)]
+pub struct Il2cppHandle {
+    pub debug_id: DebugId,
+    pub data: ByteView<'static>,
+}
+
+impl Il2cppHandle {
+    /// Parses the line mapping from the handle.
+    pub fn line_mapping(&self) -> Result<LineMapping, Error> {
+        LineMapping::parse(&self.data).ok_or_else(|| anyhow::anyhow!("Failed to parse LineMapping"))
+    }
+}
+
+/// The handle to be returned by [`CacheItemRequest`].
+///
+/// This trait requires us to return a handle regardless of its cache status.
+/// This is this handle but we do not expose it outside of this module, see
+/// [`Il2cppHandle`] for that.
+#[derive(Debug, Clone)]
+struct CacheHandle {
+    status: CacheStatus,
+    debug_id: DebugId,
+    data: ByteView<'static>,
+}
+
+/// The interface to the [`Cacher`] service.
+///
+/// The main work is done by the [`CacheItemRequest`] impl.
+#[derive(Debug, Clone)]
+struct FetchFileRequest {
+    scope: Scope,
+    file_source: RemoteDif,
+    debug_id: DebugId,
+    download_svc: Arc<DownloadService>,
+    cache: Arc<Cacher<FetchFileRequest>>,
+}
+
+impl FetchFileRequest {
+    /// Downloads the file and saves it to `path`.
+    ///
+    /// Actual implementation of [`FetchFileRequest::compute`].
+    // XXX: We use a `PathBuf` here because the resulting future needs to be `'static`
+    async fn fetch_file(self, path: PathBuf) -> Result<CacheStatus, Error> {
+        let download_file = self.cache.tempfile()?;
+        let cache_key = self.get_cache_key();
+
+        let result = self
+            .download_svc
+            .download(self.file_source, download_file.path())
+            .await;
+
+        match result {
+            Ok(DownloadStatus::NotFound) => {
+                tracing::debug!("No il2cpp linemapping file found for {}", cache_key);
+                return Ok(CacheStatus::Negative);
+            }
+            Err(e) => {
+                let stderr: &dyn std::error::Error = &e;
+                tracing::debug!(stderr, "Error while downloading file");
+                return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
+            }
+            Ok(DownloadStatus::Completed) => {
+                // fall through
+            }
+        }
+        let download_dir = download_file
+            .path()
+            .parent()
+            .ok_or_else(|| Error::msg("Parent of download dir not found"))?;
+        let decompressed_path = tempfile_in(download_dir)?;
+        let mut decompressed = match decompress_object_file(&download_file, decompressed_path) {
+            Ok(file) => file,
+            Err(err) => {
+                return Ok(CacheStatus::Malformed(err.to_string()));
+            }
+        };
+
+        // Seek back to the start and parse this DIF.
+        decompressed.seek(SeekFrom::Start(0))?;
+        let view = ByteView::map_file(decompressed)?;
+
+        if LineMapping::parse(&view).is_none() {
+            metric!(counter("services.il2cpp.loaderrror") += 1);
+            tracing::debug!("Failed to parse il2cpp");
+            return Ok(CacheStatus::Malformed("Failed to parse il2cpp".to_string()));
+        }
+        // The file is valid, lets save it.
+        let mut destination = File::create(path)?;
+        let mut cursor = Cursor::new(&view);
+        io::copy(&mut cursor, &mut destination)?;
+
+        Ok(CacheStatus::Positive)
+    }
+}
+
+impl CacheItemRequest for FetchFileRequest {
+    type Item = CacheHandle;
+    type Error = Error;
+
+    fn get_cache_key(&self) -> CacheKey {
+        self.file_source.cache_key(self.scope.clone())
+    }
+
+    /// Downloads a file, writing it to `path`.
+    ///
+    /// Only when [`CacheStatus::Positive`] is returned is the data written to `path` used.
+    fn compute(&self, path: &Path) -> BoxFuture<'static, Result<CacheStatus, Self::Error>> {
+        let fut = self
+            .clone()
+            .fetch_file(path.to_path_buf())
+            .bind_hub(Hub::current());
+
+        let source_name = self.file_source.source_type_name().into();
+
+        let future = tokio::time::timeout(Duration::from_secs(1200), fut);
+        let future = measure(
+            "il2cpp",
+            m::timed_result,
+            Some(("source_type", source_name)),
+            future,
+        );
+        Box::pin(async move {
+            future
+                .await
+                .map_err(|_| Error::msg("Timeout fetching il2cpp"))?
+        })
+    }
+
+    fn load(
+        &self,
+        _scope: Scope,
+        status: CacheStatus,
+        data: ByteView<'static>,
+        _path: CachePath,
+    ) -> Self::Item {
+        CacheHandle {
+            status,
+            debug_id: self.debug_id,
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Il2cppService {
+    cache: Arc<Cacher<FetchFileRequest>>,
+    download_svc: Arc<DownloadService>,
+}
+
+impl Il2cppService {
+    pub fn new(
+        difs_cache: Cache,
+        shared_cache_svc: Arc<SharedCacheService>,
+        download_svc: Arc<DownloadService>,
+    ) -> Self {
+        Self {
+            cache: Arc::new(Cacher::new(difs_cache, shared_cache_svc)),
+            download_svc,
+        }
+    }
+
+    /// Returns a `LineMapping` if one is found for the `debug_id`.
+    pub async fn fetch_line_mapping(
+        &self,
+        debug_id: DebugId,
+        scope: Scope,
+        sources: Arc<[SourceConfig]>,
+    ) -> Option<Il2cppHandle> {
+        let jobs = sources.iter().map(|source| {
+            self.fetch_file_from_source_with_error(debug_id, scope.clone(), source.clone())
+                .bind_hub(Hub::new_from_top(Hub::current()))
+        });
+        let results = future::join_all(jobs).await;
+        let mut line_mapping_handle = None;
+        for result in results {
+            if result.is_some() {
+                line_mapping_handle = result;
+            }
+        }
+
+        let line_mapping_handle = line_mapping_handle?;
+
+        Some(Il2cppHandle {
+            debug_id: line_mapping_handle.debug_id,
+            data: line_mapping_handle.data.clone(),
+        })
+    }
+
+    /// Wraps `fetch_file_from_source` in sentry error handling.
+    async fn fetch_file_from_source_with_error(
+        &self,
+        debug_id: DebugId,
+        scope: Scope,
+        source: SourceConfig,
+    ) -> Option<Arc<CacheHandle>> {
+        let _guard = Hub::current().push_scope();
+        sentry::configure_scope(|scope| {
+            scope.set_tag("il2cpp.debugid", debug_id);
+            scope.set_extra("il2cpp.source", source.type_name().into());
+        });
+        match self
+            .fetch_file_from_source(debug_id, scope, source)
+            .await
+            .context("il2cpp svc failed for single source")
+        {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::warn!("{}: {:?}", err, err.source());
+                sentry::capture_error(&*err);
+                None
+            }
+        }
+    }
+
+    /// Fetches a file and returns the [`CacheHandle`] if found.
+    async fn fetch_file_from_source(
+        &self,
+        debug_id: DebugId,
+        scope: Scope,
+        source: SourceConfig,
+    ) -> Result<Option<Arc<CacheHandle>>, Error> {
+        let file_sources = self
+            .download_svc
+            .list_files(source, &[FileType::Il2cpp], debug_id.into())
+            .await?;
+
+        let fetch_jobs = file_sources.into_iter().map(|file_source| {
+            let scope = if file_source.is_public() {
+                Scope::Global
+            } else {
+                scope.clone()
+            };
+            let request = FetchFileRequest {
+                scope,
+                file_source,
+                debug_id,
+                download_svc: self.download_svc.clone(),
+                cache: self.cache.clone(),
+            };
+            self.cache
+                .compute_memoized(request)
+                .bind_hub(Hub::new_from_top(Hub::current()))
+        });
+
+        let all_results = future::join_all(fetch_jobs).await;
+        let mut ret = None;
+        for result in all_results {
+            match result {
+                Ok(handle) if handle.status == CacheStatus::Positive => ret = Some(handle),
+                Ok(_) => (),
+                Err(err) => {
+                    let stderr: &dyn std::error::Error = (*err).as_ref();
+                    let mut event = sentry::event_from_error(stderr);
+                    event.message = Some("Failure fetching il2cpp file from source".into());
+                    sentry::capture_event(event);
+                }
+            }
+        }
+        Ok(ret)
+    }
+}

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -42,6 +42,7 @@ pub mod bitcode;
 pub mod cacher;
 pub mod cficaches;
 pub mod download;
+pub mod il2cpp;
 mod minidump;
 pub mod objects;
 pub mod shared_cache;
@@ -51,6 +52,7 @@ pub mod symcaches;
 use self::bitcode::BitcodeService;
 use self::cficaches::CfiCacheActor;
 use self::download::DownloadService;
+use self::il2cpp::Il2cppService;
 use self::objects::ObjectsActor;
 use self::shared_cache::SharedCacheService;
 use self::symbolication::SymbolicationActor;
@@ -87,12 +89,14 @@ impl Service {
             shared_cache.clone(),
             downloader.clone(),
         );
-        let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader);
+        let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader.clone());
+        let il2cpp = Il2cppService::new(caches.il2cpp, shared_cache.clone(), downloader);
         let symcaches = SymCacheActor::new(
             caches.symcaches,
             shared_cache.clone(),
             objects.clone(),
             bitcode,
+            il2cpp,
             cpu_pool.clone(),
         );
         let cficaches = CfiCacheActor::new(

--- a/crates/symbolicator/src/services/symcaches/markers.rs
+++ b/crates/symbolicator/src/services/symcaches/markers.rs
@@ -1,6 +1,6 @@
 use std::io::SeekFrom;
 
-use crate::services::bitcode::BcSymbolMapHandle;
+use crate::services::{bitcode::BcSymbolMapHandle, il2cpp::Il2cppHandle};
 
 /// This is the legacy marker that was used previously to flag a SymCache that was created
 /// using a`BcSymbolMap`.
@@ -13,9 +13,11 @@ const MARKERS32_MARKER: &[u8] = b"WITH_MARKERS32";
 #[derive(Clone, Debug, Default)]
 pub struct SecondarySymCacheSources {
     pub bcsymbolmap_handle: Option<BcSymbolMapHandle>,
+    pub il2cpp_handle: Option<Il2cppHandle>,
 }
 
 const MARKER_BCSYMBOLMAP: u32 = 1 << 0;
+const MARKER_IL2CPP: u32 = 1 << 1;
 
 /// This is the markers that are being embedded into, and read from, a SymCache file.
 #[derive(Debug, Default, PartialEq)]
@@ -29,6 +31,9 @@ impl SymCacheMarkers {
         let mut markers = 0;
         if sources.bcsymbolmap_handle.is_some() {
             markers |= MARKER_BCSYMBOLMAP;
+        }
+        if sources.il2cpp_handle.is_some() {
+            markers |= MARKER_IL2CPP;
         }
         Self { markers }
     }
@@ -81,6 +86,8 @@ mod tests {
 
     use symbolic::common::ByteView;
 
+    use crate::services::il2cpp::Il2cppHandle;
+
     use super::*;
 
     #[test]
@@ -97,8 +104,13 @@ mod tests {
             uuid: Default::default(),
             data: ByteView::from_vec(vec![]),
         };
+        let il2cpp = Il2cppHandle {
+            debug_id: Default::default(),
+            data: ByteView::from_vec(vec![]),
+        };
         let sources = SecondarySymCacheSources {
             bcsymbolmap_handle: Some(bcsymbolmap),
+            il2cpp_handle: Some(il2cpp),
         };
         let markers = SymCacheMarkers::from_sources(&sources);
 

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -28,6 +28,7 @@ use crate::utils::sentry::ConfigureScope;
 
 use self::markers::{SecondarySymCacheSources, SymCacheMarkers};
 
+use super::il2cpp::Il2cppService;
 use super::shared_cache::SharedCacheService;
 
 mod markers;
@@ -77,6 +78,9 @@ pub enum SymCacheError {
     #[error("failed to handle auxiliary BCSymbolMap file")]
     BcSymbolMapError(#[source] Error),
 
+    #[error("failed to handle auxiliary il2cpp line mapping file")]
+    Il2cppError(#[source] Error),
+
     #[error("symcache building took too long")]
     Timeout,
 
@@ -89,6 +93,7 @@ pub struct SymCacheActor {
     symcaches: Arc<Cacher<FetchSymCacheInternal>>,
     objects: ObjectsActor,
     bitcode_svc: BitcodeService,
+    il2cpp_svc: Il2cppService,
     threadpool: tokio::runtime::Handle,
 }
 
@@ -98,12 +103,14 @@ impl SymCacheActor {
         shared_cache_svc: Arc<SharedCacheService>,
         objects: ObjectsActor,
         bitcode_svc: BitcodeService,
+        il2cpp_svc: Il2cppService,
         threadpool: tokio::runtime::Handle,
     ) -> Self {
         SymCacheActor {
             symcaches: Arc::new(Cacher::new(cache, shared_cache_svc)),
             objects,
             bitcode_svc,
+            il2cpp_svc,
             threadpool,
         }
     }
@@ -322,20 +329,44 @@ impl SymCacheActor {
             Some(handle) => {
                 // TODO: while there is some caching *internally* in the bitcode_svc, the *complete*
                 // fetch request is not cached
-                let bcsymbolmap_handle = match handle.object_id().debug_id {
-                    Some(debug_id) => {
-                        self.bitcode_svc
-                            .fetch_bcsymbolmap(
-                                debug_id,
-                                handle.scope().clone(),
-                                request.sources.clone(),
-                            )
-                            .await
+                let fetch_bcsymbolmap = async {
+                    match handle.object_id().debug_id {
+                        Some(debug_id) => {
+                            self.bitcode_svc
+                                .fetch_bcsymbolmap(
+                                    debug_id,
+                                    handle.scope().clone(),
+                                    request.sources.clone(),
+                                )
+                                .await
+                        }
+                        None => None,
                     }
-                    None => None,
                 };
 
-                let secondary_sources = SecondarySymCacheSources { bcsymbolmap_handle };
+                let fetch_il2cpp = async {
+                    match handle.object_id().debug_id {
+                        Some(debug_id) => {
+                            tracing::trace!("Fetching line mapping");
+                            self.il2cpp_svc
+                                .fetch_line_mapping(
+                                    debug_id,
+                                    handle.scope().clone(),
+                                    request.sources.clone(),
+                                )
+                                .await
+                        }
+                        None => None,
+                    }
+                };
+
+                let (bcsymbolmap_handle, il2cpp_handle) =
+                    futures::future::join(fetch_bcsymbolmap, fetch_il2cpp).await;
+
+                let secondary_sources = SecondarySymCacheSources {
+                    bcsymbolmap_handle,
+                    il2cpp_handle,
+                };
 
                 self.symcaches
                     .compute_memoized(FetchSymCacheInternal {
@@ -380,6 +411,10 @@ fn write_symcache(
 
     let markers = SymCacheMarkers::from_sources(&secondary_sources);
 
+    let file = File::create(&path)?;
+    let mut writer = BufWriter::new(file);
+    let mut symcache_writer = SymCacheWriter::new(&mut writer).unwrap();
+
     if let Object::MachO(ref mut macho) = symbolic_object {
         if let Some(ref handle) = secondary_sources.bcsymbolmap_handle {
             let bcsymbolmap = handle
@@ -395,12 +430,22 @@ fn write_symcache(
         }
     }
 
-    let file = File::create(&path)?;
-    let mut writer = BufWriter::new(file);
+    if let Some(ref handle) = secondary_sources.il2cpp_handle {
+        let il2cpp = handle.line_mapping().map_err(SymCacheError::Il2cppError)?;
+        tracing::debug!(
+            "Adding il2cpp line mapping {} to object {}",
+            handle.debug_id,
+            object_handle
+        );
+        symcache_writer.add_transformer(il2cpp);
+    }
 
     tracing::debug!("Converting symcache for {}", object_handle.cache_key());
 
-    SymCacheWriter::write_object(&symbolic_object, &mut writer).map_err(SymCacheError::Writing)?;
+    symcache_writer
+        .process_object(&symbolic_object)
+        .map_err(SymCacheError::Writing)?;
+    symcache_writer.finish().map_err(SymCacheError::Writing)?;
 
     let mut file = writer.into_inner().map_err(io::Error::from)?;
 
@@ -452,9 +497,17 @@ mod tests {
             shared_cache.clone(),
             downloader.clone(),
         );
-        let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader);
+        let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader.clone());
+        let il2cpp = Il2cppService::new(caches.il2cpp, shared_cache.clone(), downloader);
 
-        SymCacheActor::new(caches.symcaches, shared_cache, objects, bitcode, cpu_pool)
+        SymCacheActor::new(
+            caches.symcaches,
+            shared_cache,
+            objects,
+            bitcode,
+            il2cpp,
+            cpu_pool,
+        )
     }
 
     /// Tests that a symcache is regenerated when it was created without a BcSymbolMap

--- a/crates/symbolicator/src/sources.rs
+++ b/crates/symbolicator/src/sources.rs
@@ -425,9 +425,11 @@ pub enum FileType {
     /// BCSymbolMap, de-obfuscates symbol names for MachO.
     #[serde(rename = "bcsymbolmap")]
     BcSymbolMap,
-    /// A .usym file that maps source information between generated C++ code and managed
-    /// C# code.
-    Usym,
+    /// The il2cpp `LineNumberMapping.json` file.
+    ///
+    /// This file maps from C++ source locations to the original C# source location it was transpiled from.
+    #[serde(rename = "il2cpp")]
+    Il2cpp,
 }
 
 impl FileType {
@@ -448,7 +450,6 @@ impl FileType {
             SourceBundle,
             UuidMap,
             BcSymbolMap,
-            Usym,
         ]
     }
 
@@ -508,7 +509,7 @@ impl AsRef<str> for FileType {
             FileType::SourceBundle => "sourcebundle",
             FileType::UuidMap => "uuidmap",
             FileType::BcSymbolMap => "bcsymbolmap",
-            FileType::Usym => "usym",
+            FileType::Il2cpp => "il2cpp",
         }
     }
 }

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -198,7 +198,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
         }
         FileType::UuidMap => Vec::new(),
         FileType::BcSymbolMap => Vec::new(),
-        FileType::Usym => Vec::new(),
+        FileType::Il2cpp => Vec::new(),
     }
 }
 
@@ -258,12 +258,6 @@ fn get_symstore_path(
         FileType::Pdb => get_pdb_symstore_path(identifier, ssqp_casing),
         FileType::Pe => get_pe_symstore_path(identifier, ssqp_casing),
 
-        // Microsoft SymbolServer does not specify Breakpad.
-        FileType::Breakpad => None,
-
-        // Microsoft SymbolServer does not specify WASM.
-        FileType::WasmDebug | FileType::WasmCode => None,
-
         // source bundles are available through an extension for PE/PDB only.
         FileType::SourceBundle => {
             let original_file_type = match identifier.object_type {
@@ -278,14 +272,12 @@ fn get_symstore_path(
             Some(base_path)
         }
 
-        // Microsoft SymbolServer does not specify PropertyList.
+        // Microsoft SymbolServer does not specify the following file types:
+        FileType::Breakpad => None,
+        FileType::WasmDebug | FileType::WasmCode => None,
         FileType::UuidMap => None,
-
-        // Microsoft SymbolServer does not specify BCSymbolMap.
         FileType::BcSymbolMap => None,
-
-        // Microsoft SymbolServer does not specify Usym.
-        FileType::Usym => None,
+        FileType::Il2cpp => None,
     }
 }
 
@@ -331,25 +323,61 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
         FileType::SourceBundle => None,
         FileType::UuidMap => None,
         FileType::BcSymbolMap => None,
-        FileType::Usym => None,
+        FileType::Il2cpp => None,
     }
 }
 
-/// Returns the object type used to determine how to construct the ID for the unified symbol
-/// server.
+/// Constructs the ID for the unified symbol server.
 ///
 /// We prefer to use the file type as indicator for going back to the object
 /// type. If that is not possible, we use the object type that is stored on the
 /// identifier which might be unreliable.
-fn get_search_target_object_type(filetype: FileType, identifier: &ObjectId) -> ObjectType {
+fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow<str>> {
     match filetype {
-        FileType::Pe | FileType::Pdb => ObjectType::Pe,
-        FileType::MachCode | FileType::MachDebug | FileType::UuidMap | FileType::BcSymbolMap => {
-            ObjectType::Macho
+        // For these we fall back to the identifier's object type.
+        FileType::SourceBundle | FileType::Breakpad => {
+            let filetype = match identifier.object_type {
+                ObjectType::Elf => FileType::ElfCode,
+                ObjectType::Macho => FileType::MachCode,
+                ObjectType::Pe => FileType::Pe,
+                ObjectType::Wasm => FileType::WasmCode,
+                // guess we're out of luck.
+                ObjectType::Unknown => return None,
+            };
+            get_search_target_id(filetype, identifier)
         }
-        FileType::ElfCode | FileType::ElfDebug => ObjectType::Elf,
-        FileType::WasmDebug | FileType::WasmCode => ObjectType::Wasm,
-        FileType::SourceBundle | FileType::Breakpad | FileType::Usym => identifier.object_type,
+        // PEs and PDBs are indexed by the debug id in lowercase breakpad format
+        // always.  This is done because code IDs by themselves are not reliable
+        // enough for PEs and are only useful together with the file name which
+        // we do not want to encode.
+        FileType::Pe | FileType::Pdb => Some(Cow::Owned(
+            identifier.debug_id?.breakpad().to_string().to_lowercase(),
+        )),
+        // On mach we can always determine the code ID from the debug ID if the
+        // code ID is unavailable.  We apply the same rule to WASM files as well as
+        // auxiliary DIFs, as we
+        // suggest Uuids to be used as build ids.
+        FileType::MachCode
+        | FileType::MachDebug
+        | FileType::WasmDebug
+        | FileType::WasmCode
+        | FileType::UuidMap
+        | FileType::BcSymbolMap
+        | FileType::Il2cpp => {
+            if identifier.code_id.is_none() {
+                Some(Cow::Owned(
+                    identifier.debug_id?.uuid().to_simple_ref().to_string(),
+                ))
+            } else {
+                Some(Cow::Borrowed(identifier.code_id.as_ref()?.as_str()))
+            }
+        }
+        // For ELF we always use the code ID.  If it's not available we can't actually
+        // find this file at all.  See symsorter which will never use the debug ID for
+        // such files.
+        FileType::ElfCode | FileType::ElfDebug => {
+            Some(Cow::Borrowed(identifier.code_id.as_ref()?.as_str()))
+        }
     }
 }
 
@@ -364,33 +392,11 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
         FileType::SourceBundle => "sourcebundle",
         FileType::UuidMap => "uuidmap",
         FileType::BcSymbolMap => "bcsymbolmap",
-        FileType::Usym => "usym",
+        FileType::Il2cpp => "il2cpp",
     };
 
     // determine the ID we use for the path
-    let id = match get_search_target_object_type(filetype, identifier) {
-        // PEs and PDBs are indexed by the debug id in lowercase breakpad format
-        // always.  This is done because code IDs by themselves are not reliable
-        // enough for PEs and are only useful together with the file name which
-        // we do not want to encode.
-        ObjectType::Pe => Cow::Owned(identifier.debug_id?.breakpad().to_string().to_lowercase()),
-        // On mach we can always determine the code ID from the debug ID if the
-        // code ID is unavailable.  We apply the same rule to WASM files as we
-        // suggest Uuids to be used as build ids.
-        ObjectType::Macho | ObjectType::Wasm => {
-            if identifier.code_id.is_none() {
-                Cow::Owned(identifier.debug_id?.uuid().to_simple_ref().to_string())
-            } else {
-                Cow::Borrowed(identifier.code_id.as_ref()?.as_str())
-            }
-        }
-        // For ELF we always use the code ID.  If it's not available we can't actually
-        // find this file at all.  See symsorter which will never use the debug ID for
-        // such files.
-        ObjectType::Elf => Cow::Borrowed(identifier.code_id.as_ref()?.as_str()),
-        // Guess we're out of luck.
-        ObjectType::Unknown => return None,
-    };
+    let id = get_search_target_id(filetype, identifier)?;
 
     Some(format!("{}/{}/{}", id.get(..2)?, id.get(2..)?, suffix))
 }


### PR DESCRIPTION
This adds a new `Il2cppService`, modeled after `BitcodeService`, that is responsible for downloading il2cpp line mapping files. `SymCacheActor` can then use these files when generating symcaches.

This PR also contains a drive-by refactoring of path handling logic. The function `get_search_target_object_type` computed an object type from a file type and identifier, which was then used to compute an ID. I removed the indirection in favor of computing the ID from the given
file type and identifier directly.

ETA: This depends upon https://github.com/getsentry/symbolic/pull/592.