### PR TITLE
ref: Avoid an explicit push_scope

### DIFF
--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -289,7 +289,6 @@ impl BitcodeService {
         scope: Scope,
         source: SourceConfig,
     ) -> Option<Arc<CacheHandle>> {
-        let _guard = Hub::current().push_scope();
         sentry::configure_scope(|scope| {
             scope.set_tag("auxdif.debugid", uuid);
             scope.set_extra("auxdif.kind", dif_kind.to_string().into());

--- a/crates/symbolicator/src/services/shared_cache.rs
+++ b/crates/symbolicator/src/services/shared_cache.rs
@@ -645,7 +645,6 @@ impl SharedCacheService {
             reason,
         } = message;
 
-        let _guard = Hub::current().push_scope();
         sentry::configure_scope(|scope| {
             let mut map = BTreeMap::new();
             map.insert("backend".to_string(), backend.name().into());
@@ -785,7 +784,6 @@ impl SharedCacheService {
                     CacheError::Other(_) => "other",
                 };
                 if let CacheError::Other(err) = outer_err {
-                    let backend_name = self.backend_name().await;
                     let stderr: &dyn std::error::Error = &*err;
                     tracing::error!(stderr, "Error fetching from {} shared cache", backend_name);
                 }


### PR DESCRIPTION
The functions here are directly being called with a new fresh Hub, so
immediately pushing a scope is not necessary.