### PR TITLE
ref: Change types of fields on RawObjectInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "regex",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -595,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "serde",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1567,7 +1567,7 @@ dependencies = [
  "scroll 0.11.0",
  "thiserror",
  "time 0.3.9",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1917,7 +1917,7 @@ checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
 dependencies = [
  "fallible-iterator",
  "scroll 0.10.2",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ dependencies = [
  "thiserror",
  "time 0.3.9",
  "url",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -3012,7 +3012,7 @@ dependencies = [
  "memmap2",
  "serde",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -3153,7 +3153,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid 1.1.1",
+ "uuid",
  "warp",
  "zstd",
 ]
@@ -3768,16 +3768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
-dependencies = [
- "getrandom",
- "serde",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,7 +3929,7 @@ dependencies = [
  "anyhow",
  "hex",
  "structopt",
- "uuid 1.1.1",
+ "uuid",
  "wasmbin",
 ]
 

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -55,7 +55,7 @@ tower-service = "0.3"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "local-time", "env-filter", "json"] }
 url = { version = "2.2.0", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["v4", "serde"] }
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
 zstd = "0.11.1"
 
 [dev-dependencies]

--- a/crates/symbolicator/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator/src/services/symbolication/module_lookup.rs
@@ -436,15 +436,42 @@ mod tests {
         );
 
         let entry = modules.get_module_by_addr(0x1234, AddrMode::Abs);
-        assert_eq!(entry.unwrap().object_info.raw.code_id.as_deref(), Some("a"));
+        assert_eq!(
+            entry
+                .unwrap()
+                .object_info
+                .raw
+                .code_id
+                .as_ref()
+                .map(|id| id.as_str()),
+            Some("a")
+        );
 
         let entry = modules.get_module_by_addr(0x3456, AddrMode::Abs);
         assert!(entry.is_none());
 
         let entry = modules.get_module_by_addr(0x3456, AddrMode::Rel(0));
-        assert_eq!(entry.unwrap().object_info.raw.code_id.as_deref(), Some("b"));
+        assert_eq!(
+            entry
+                .unwrap()
+                .object_info
+                .raw
+                .code_id
+                .as_ref()
+                .map(|id| id.as_str()),
+            Some("b")
+        );
 
         let entry = modules.get_module_by_addr(0x4567, AddrMode::Abs);
-        assert_eq!(entry.unwrap().object_info.raw.code_id.as_deref(), Some("c"));
+        assert_eq!(
+            entry
+                .unwrap()
+                .object_info
+                .raw
+                .code_id
+                .as_ref()
+                .map(|id| id.as_str()),
+            Some("c")
+        );
     }
 }

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -313,7 +313,7 @@ pub struct RawObjectInfo {
 
     /// Identifier of the code file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub code_id: Option<String>,
+    pub code_id: Option<CodeId>,
 
     /// Name of the code file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -321,7 +321,7 @@ pub struct RawObjectInfo {
 
     /// Identifier of the debug file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub debug_id: Option<String>,
+    pub debug_id: Option<DebugId>,
 
     /// Name of the debug file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -602,19 +602,7 @@ impl CompleteObjectInfo {
 }
 
 impl From<RawObjectInfo> for CompleteObjectInfo {
-    fn from(mut raw: RawObjectInfo) -> Self {
-        raw.debug_id = raw
-            .debug_id
-            .filter(|id| !id.is_empty())
-            .and_then(|id| id.parse::<DebugId>().ok())
-            .map(|id| id.to_string());
-
-        raw.code_id = raw
-            .code_id
-            .filter(|id| !id.is_empty())
-            .and_then(|id| id.parse::<CodeId>().ok())
-            .map(|id| id.to_string());
-
+    fn from(raw: RawObjectInfo) -> Self {
         CompleteObjectInfo {
             debug_status: ObjectFileStatus::Unused,
             unwind_status: None,

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 anyhow = "1.0.57"
 structopt = "0.3.21"
 hex = "0.4.2"
-uuid = { version = "1.0.0", features = ["v4"] }
+uuid = { version = "0.8.2", features = ["v4"] }
 wasmbin = "0.3.1"


### PR DESCRIPTION
This turns the `debug_id` and `code_id` fields on `RawObjectInfo` from `Option<String>` to `Option<DebugId>` and `Option<CodeId>`, respectively.

Note: the downgrade of `uuid` is purely to make this compile; currently two different versions of `uuid` are used and this creates a conflict. The proper fix is to update `uuid` to `1.1.1` everywhere.