### PR TITLE
ref: Avoid spawning tasks for early-returns

### DIFF
--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -151,15 +151,15 @@ async fn compute_cficache(
         .await
         .map_err(CfiCacheError::Fetching)?;
 
-    let future = async move {
-        // The original has a download error so the cfi cache entry should just be negative.
-        if matches!(object.status(), &CacheStatus::CacheSpecificError(_)) {
-            return Ok(CacheStatus::Negative);
-        }
-        if object.status() != &CacheStatus::Positive {
-            return Ok(object.status().clone());
-        }
+    // The original has a download error so the cfi cache entry should just be negative.
+    if matches!(object.status(), &CacheStatus::CacheSpecificError(_)) {
+        return Ok(CacheStatus::Negative);
+    }
+    if object.status() != &CacheStatus::Positive {
+        return Ok(object.status().clone());
+    }
 
+    let future = async move {
         let status = if let Err(e) = write_cficache(&path, &*object) {
             tracing::warn!("Could not write cficache: {}", e);
             sentry::capture_error(&e);


### PR DESCRIPTION
This syncs up cfi computation to bring it in-line with symcache computation, as bot have pretty much the same code with very little variance between them. But this avoids spawning a task (which is not free) for some early-return conditions such as negative caches.

#skip-changelog