### PR TITLE
ref: Update deps & Symbolic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,30 +48,30 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "apple-crash-report-parser"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1614301c75a08d6715446fe38b0b7ee44873e74c07c76fc27d5025e285576a"
+checksum = "77a93af7a900a542a9c20da77e19dc81f374e8f42a2969d833c8766692d5f291"
 dependencies = [
  "chrono",
  "lazy_static",
  "regex",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "arbitrary"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
+checksum = "25e0a02cf12f1b1f48b14cb7f8217b876d09992b39c816ffb3b1ba64dd979a87"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -125,9 +125,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.6"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2504b827a8bef941ba3dd64bdffe9cf56ca182908a147edd6189c95fbcae7d"
+checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
+checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -192,14 +192,14 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 3.2.5",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46350020400cced01aed8f6a4054c9d31919f9dced320263cf8b4f681d9a73b4"
+checksum = "4bd91dbd8c9c4a9ae92b043390cb669f18f6c46e94323fc155c5830f40fe9aa4"
 dependencies = [
  "async-trait",
  "circular",
@@ -283,16 +283,14 @@ dependencies = [
  "minidump-common",
  "nom 1.2.4",
  "range-map",
- "reqwest 0.11.10",
- "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "brownstone"
-version = "1.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
  "arrayvec",
 ]
@@ -425,10 +423,34 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -499,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -520,26 +542,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -590,19 +612,19 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e23c06c035dac87bd802d98f368df73a7f2cb05a66ffbd1f377e821fac4af9"
+checksum = "8728db27dd9033a7456655aaeb35fde74425d0f130b4cb18a19171ef38a1b454"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -660,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "dmsort"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4699f5cb7678f099b747ffdc1e6ce6cdc42579e29d28315aa715b9fd10324fc"
+checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
 
 [[package]]
 name = "either"
@@ -992,7 +1014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.10",
  "tokio",
  "url",
  "which",
@@ -1019,13 +1041,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1053,7 +1075,7 @@ checksum = "cfeb764aa29a0774d290c2df134a37ab2e3c1ba59009162626658aabefda321a"
 dependencies = [
  "log",
  "plain",
- "scroll 0.11.0",
+ "scroll",
 ]
 
 [[package]]
@@ -1083,6 +1105,12 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "headers"
@@ -1286,19 +1314,19 @@ checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
 name = "insta"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc3e639bcba360d9237acabd22014c16f3df772db463b7446cd81b070714767"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
 dependencies = [
  "console",
  "once_cell",
@@ -1369,18 +1397,18 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.1.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9051c17f81bae79440afa041b3a278e1de71bfb96d32454b477fd4703ccb6f"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
 dependencies = [
  "base64",
  "pem",
@@ -1451,11 +1479,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
+checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1553,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccb06643400b8a48ebcaf69d5c4b6adf50cacaf3b5d6aa27bfbaf0da21156cc"
+checksum = "fe66b009ea76a4727d61e386f6e6e353d373a963954c8fe5b93da650eab7db5d"
 dependencies = [
  "debugid",
  "encoding",
@@ -1564,17 +1592,17 @@ dependencies = [
  "minidump-common",
  "num-traits 0.2.15",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "thiserror",
- "time 0.3.9",
- "uuid 0.8.2",
+ "time 0.3.10",
+ "uuid",
 ]
 
 [[package]]
 name = "minidump-common"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190480ae87a21dc26a115c4ef5ce8c05c10074d55ea2042c472be7bf6dc6e592"
+checksum = "a5f37f242baafb519413c7f12baa8e6854a176ea2f44910e2c434a428e27358d"
 dependencies = [
  "bitflags",
  "debugid",
@@ -1582,15 +1610,15 @@ dependencies = [
  "log",
  "num-traits 0.2.15",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "smart-default",
 ]
 
 [[package]]
 name = "minidump-processor"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d286bdf783be15a8677b971a8860d43f626823f757472a9e3c4d1d6f3e52b85d"
+checksum = "34b8fc0048d90e4d5e804f062e00ac2010c73b318434f2a13df08252346b5851"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -1599,7 +1627,7 @@ dependencies = [
  "memmap2",
  "minidump",
  "minidump-common",
- "scroll 0.11.0",
+ "scroll",
  "serde",
  "serde_json",
  "thiserror",
@@ -1622,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1719,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "nom-supreme"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
 dependencies = [
  "brownstone",
  "indent_write",
@@ -1862,6 +1890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,13 +1945,13 @@ dependencies = [
 
 [[package]]
 name = "pdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
  "fallible-iterator",
- "scroll 0.10.2",
- "uuid 0.8.2",
+ "scroll",
+ "uuid",
 ]
 
 [[package]]
@@ -2075,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2087,7 +2121,7 @@ name = "process-event"
 version = "0.5.1"
 dependencies = [
  "anyhow",
- "reqwest 0.11.10",
+ "reqwest 0.11.11",
  "serde",
  "serde_json",
  "structopt",
@@ -2101,9 +2135,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2272,11 +2306,10 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -2301,7 +2334,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.10",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2524,12 +2557,6 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
@@ -2583,18 +2610,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
 
 [[package]]
 name = "sentry"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d23af89cf3e40dffb53f974e9a21653353b3e21cf51633aa58006f2a0caf8a"
+checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
 dependencies = [
  "httpdate",
- "reqwest 0.11.10",
+ "reqwest 0.11.11",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -2608,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de88cf0967eb3d7247071a7e6753b06c0939d509f9db44607ec00aa4b4aefd04"
+checksum = "08d3479158a7396b4dfd346a1944d523427a225ff3c39102e8e985bc21cdfea8"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2619,21 +2646,21 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158a446429420acdf6a4f75192ee8929da16a0c41c89a1c34b2e0f1eaebcc02"
+checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
 dependencies = [
  "backtrace",
- "lazy_static",
+ "once_cell",
  "regex",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3bda8a1e3213f1944da2d42f3081ea9f3717105bb2a6b0a8fe4f5e603010a3"
+checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
 dependencies = [
  "hostname",
  "libc",
@@ -2644,11 +2671,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56333f11be3a78131c67637f7611339df8af7ad9af831226585a457df75f9e3b"
+checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "rand",
  "sentry-types",
  "serde",
@@ -2657,20 +2684,20 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c700f97918705167bde634fd33fa407d392cdf573da5362d1a55d6655ceb7d"
+checksum = "06fcbb7efe38d7c213218445952096be246c1f914ef9591dc2cdae9cb4e316d8"
 dependencies = [
  "findshlibs",
- "lazy_static",
+ "once_cell",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-log"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b56c287a5295358bd4a3481a32add1f3fb7131102e300f561f788e33b79efe"
+checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
 dependencies = [
  "log",
  "sentry-core",
@@ -2678,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b957b1965c450acd220a27806fe1f2dec998d393973ebae797936b12df1c7416"
+checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2688,22 +2715,23 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd49ee3ab5156738ae19c89c87e5516bd56a7f7fa93d7b05cefba88dc7bbd262"
+checksum = "359fdd1be4c5ecf03ffa7b21bc865836159590d0f6d114bbabd1e9c9be4c513e"
 dependencies = [
  "http",
  "pin-project",
  "sentry-core",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
 name = "sentry-tracing"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b281efe225a8750e2011a325a5455b29a3e5cd40762337ef647a253e3213f"
+checksum = "ea50bcf843510179a7ba41c9fe4d83a8958e9f8adf707ec731ff999297536344"
 dependencies = [
  "sentry-core",
  "tracing-core",
@@ -2712,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825fd3382e2397007499a910e0184e55f7837cb0df4af30ae62bd2123e2ebcd6"
+checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
  "debugid",
  "getrandom",
@@ -2722,9 +2750,9 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.10",
  "url",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2870,7 +2898,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.15",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.10",
 ]
 
 [[package]]
@@ -2962,12 +2990,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2993,9 +3027,10 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
+ "symbolic-cfi",
  "symbolic-common",
  "symbolic-debuginfo",
  "symbolic-demangle",
@@ -3004,21 +3039,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbolic-cfi"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
+dependencies = [
+ "symbolic-common",
+ "symbolic-debuginfo",
+ "thiserror",
+]
+
+[[package]]
 name = "symbolic-common"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
  "debugid",
  "memmap2",
  "serde",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3034,20 +3079,20 @@ dependencies = [
  "parking_lot 0.12.1",
  "pdb",
  "regex",
- "scroll 0.11.0",
+ "scroll",
  "serde",
  "serde_json",
  "smallvec",
  "symbolic-common",
  "thiserror",
  "wasmparser",
- "zip 0.5.13",
+ "zip",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3058,14 +3103,14 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
  "anyhow",
  "gimli",
  "indexmap",
  "object",
- "scroll 0.11.0",
+ "scroll",
  "serde_json",
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3073,20 +3118,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "symbolic-minidump"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
-dependencies = [
- "cc",
- "symbolic-common",
- "symbolic-debuginfo",
- "thiserror",
-]
-
-[[package]]
 name = "symbolic-symcache"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "8.8.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#eedf7004e51e7d14eb0199e22eb189c74498ba8d"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3139,7 +3173,6 @@ dependencies = [
  "sha-1 0.10.0",
  "structopt",
  "symbolic",
- "symbolic-minidump",
  "symbolicator-crash",
  "tempfile",
  "test-assembler",
@@ -3153,7 +3186,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid 1.1.1",
+ "uuid",
  "warp",
  "zstd",
 ]
@@ -3181,15 +3214,15 @@ dependencies = [
  "structopt",
  "symbolic",
  "walkdir",
- "zip 0.6.2",
+ "zip",
  "zstd",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3272,6 +3305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "82501a4c1c0330d640a6e176a3d6a204f5ec5237aca029029d21864a902e27b0"
 dependencies = [
  "itoa",
  "libc",
@@ -3461,16 +3500,15 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3503,15 +3541,15 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "log",
@@ -3533,11 +3571,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -3577,7 +3615,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.9",
+ "time 0.3.10",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -3701,9 +3739,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3759,19 +3797,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
-
-[[package]]
-name = "uuid"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
  "serde",
@@ -3866,9 +3894,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3878,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3893,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3905,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3915,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3928,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-split"
@@ -3939,7 +3967,7 @@ dependencies = [
  "anyhow",
  "hex",
  "structopt",
- "uuid 1.1.1",
+ "uuid",
  "wasmbin",
 ]
 
@@ -3972,15 +4000,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4143,18 +4174,6 @@ name = "zeroize"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
-
-[[package]]
-name = "zip"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
-dependencies = [
- "byteorder",
- "crc32fast",
- "flate2",
- "thiserror",
-]
 
 [[package]]
 name = "zip"

--- a/crates/symbolicator-crash/Cargo.toml
+++ b/crates/symbolicator-crash/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.60.1"
 cmake = { version = "0.1.46" }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.57"
-apple-crash-report-parser = "0.4.2"
+apple-crash-report-parser = "0.5.0"
 async-trait = "0.1.53"
 axum = { version = "0.5.4", features = ["multipart"] }
 backtrace = "0.3.65"
@@ -26,8 +26,8 @@ ipnetwork = "0.19.0"
 jsonwebtoken = "8.1.0"
 lazy_static = "1.4.0"
 lru = "0.7.5"
-minidump = "0.10.3"
-minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
+minidump = "0.11.0"
+minidump-processor = { version = "0.11.0", features = ["symbolic-syms"] }
 num_cpus = "1.13.0"
 parking_lot = "0.12.0"
 regex = "1.5.5"
@@ -35,15 +35,14 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.48.0"
 rusoto_credential = "0.48.0"
 rusoto_s3 = "0.48.0"
-sentry = { version = "0.25.0", features = ["anyhow", "debug-images", "log", "tracing"] }
-sentry-tower = { version = "0.25.0", features = ["http"] }
+sentry = { version = "0.27.0", features = ["anyhow", "debug-images", "log", "tracing"] }
+sentry-tower = { version = "0.27.0", features = ["http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
-symbolic-minidump = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", default-features = false}
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::prelude::*;
 use sentry::{configure_scope, Hub, SentryFutureExt};
+use symbolic::cfi::CfiCache;
 use symbolic::common::ByteView;
-use symbolic_minidump::cfi::CfiCache;
 use thiserror::Error;
 
 use crate::cache::{Cache, CacheStatus};
@@ -44,7 +44,7 @@ const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 0,
     fallbacks: &[],
 };
-static_assert!(symbolic_minidump::cfi::CFICACHE_LATEST_VERSION == 2);
+static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
 /// Errors happening while generating a cficache
 #[derive(Debug, Error)]
@@ -56,7 +56,7 @@ pub enum CfiCacheError {
     Fetching(#[source] ObjectError),
 
     #[error("failed to parse cficache")]
-    Parsing(#[from] symbolic_minidump::cfi::CfiError),
+    Parsing(#[from] symbolic::cfi::CfiError),
 
     #[error("failed to parse object")]
     ObjectParsing(#[source] ObjectError),
@@ -138,7 +138,7 @@ struct FetchCfiCacheInternal {
 /// Extracts the Call Frame Information (CFI) from an object file.
 ///
 /// The extracted CFI is written to `path` in symbolic's
-/// [`CfiCache`](symbolic_minidump::cfi::CfiCache) format.
+/// [`CfiCache`] format.
 #[tracing::instrument(skip_all)]
 async fn compute_cficache(
     threadpool: tokio::runtime::Handle,
@@ -293,7 +293,7 @@ impl CfiCacheActor {
 /// Extracts the CFI from an object file, writing it to a CFI file.
 ///
 /// The source file is probably an executable or so, the resulting file is in the format of
-/// [symbolic_minidump::cfi::CfiCache].
+/// [`CfiCache`].
 #[tracing::instrument(skip_all)]
 fn write_cficache(path: &Path, object_handle: &ObjectHandle) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {

--- a/crates/symbolicator/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator/src/services/symbolication/process_minidump.rs
@@ -18,8 +18,8 @@ use parking_lot::RwLock;
 use sentry::types::DebugId;
 use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
+use symbolic::cfi::CfiCache;
 use symbolic::common::{Arch, ByteView};
-use symbolic_minidump::cfi::CfiCache;
 use tempfile::TempPath;
 
 use crate::cache::CacheStatus;

--- a/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__source_candidates.snap
+++ b/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__source_candidates.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator/src/services/symbolication/mod.rs
-assertion_line: 1537
+assertion_line: 1524
 expression: response.unwrap()
 ---
 status: completed
@@ -14,7 +14,7 @@ stacktraces:
         symbol: trigger_crash
         sym_addr: "0x3860"
         function: trigger_crash
-        filename: examples/example.c
+        filename: example.c
         abs_path: /Users/swatinem/Coding/sentry-native/examples/example.c
         lineno: 60
         pre_context:

--- a/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__wasm_payload.snap
+++ b/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__wasm_payload.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/symbolicator/src/services/symbolication/mod.rs
-assertion_line: 2431
+assertion_line: 1474
 expression: response.unwrap()
-
 ---
 status: completed
 stacktraces:
@@ -15,7 +14,7 @@ stacktraces:
         symbol: internal_func
         sym_addr: "0x8b"
         function: internal_func
-        filename: src/lib.rs
+        filename: lib.rs
         abs_path: /Users/mitsuhiko/Development/wasm-example/simple/src/lib.rs
         lineno: 19
 modules:

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -55,17 +55,9 @@ fn get_pdb_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<Str
         Cow::Borrowed(debug_file)
     };
     let debug_id = if ssqp_casing {
-        format!(
-            "{:x}{:X}",
-            debug_id.uuid().to_simple_ref(),
-            debug_id.appendix()
-        )
+        format!("{:x}{:X}", debug_id.uuid().as_simple(), debug_id.appendix())
     } else {
-        format!(
-            "{:X}{:x}",
-            debug_id.uuid().to_simple_ref(),
-            debug_id.appendix()
-        )
+        format!("{:X}{:x}", debug_id.uuid().as_simple(), debug_id.appendix())
     };
 
     Some(format!("{}/{}/{}", debug_file, debug_id, debug_file))
@@ -243,7 +235,7 @@ fn get_symstore_path(
             Some(format!(
                 "{}/mach-uuid-{}/{}",
                 code_file,
-                uuid.to_simple_ref(),
+                uuid.as_simple(),
                 code_file
             ))
         }
@@ -251,7 +243,7 @@ fn get_symstore_path(
             let uuid = get_mach_uuid(identifier)?;
             Some(format!(
                 "_.dwarf/mach-uuid-sym-{}/_.dwarf",
-                uuid.to_simple_ref()
+                uuid.as_simple()
             ))
         }
 
@@ -366,7 +358,7 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
         | FileType::Il2cpp => {
             if identifier.code_id.is_none() {
                 Some(Cow::Owned(
-                    identifier.debug_id?.uuid().to_simple_ref().to_string(),
+                    identifier.debug_id?.uuid().as_simple().to_string(),
                 ))
             } else {
                 Some(Cow::Borrowed(identifier.code_id.as_ref()?.as_str()))


### PR DESCRIPTION
This updates dependencies, most notably symbolic & rust-minidump, which now depend on the updated uuid/debugid.

Also adapts the codebase to the breaking changes in symbolic. Those did result in some changes to test snapshots, most notably the changes to absolute / compdir-relative paths.

#skip-changelog