### PR TITLE
build: Update symbolic to 9.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,14 +57,14 @@ dependencies = [
 
 [[package]]
 name = "apple-crash-report-parser"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1614301c75a08d6715446fe38b0b7ee44873e74c07c76fc27d5025e285576a"
+checksum = "77a93af7a900a542a9c20da77e19dc81f374e8f42a2969d833c8766692d5f291"
 dependencies = [
  "chrono",
  "lazy_static",
  "regex",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46350020400cced01aed8f6a4054c9d31919f9dced320263cf8b4f681d9a73b4"
+checksum = "4bd91dbd8c9c4a9ae92b043390cb669f18f6c46e94323fc155c5830f40fe9aa4"
 dependencies = [
  "async-trait",
  "circular",
@@ -283,16 +283,14 @@ dependencies = [
  "minidump-common",
  "nom 1.2.4",
  "range-map",
- "reqwest 0.11.10",
- "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "brownstone"
-version = "1.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
  "arrayvec",
 ]
@@ -590,12 +588,12 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "debugid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1053,7 +1051,7 @@ checksum = "cfeb764aa29a0774d290c2df134a37ab2e3c1ba59009162626658aabefda321a"
 dependencies = [
  "log",
  "plain",
- "scroll 0.11.0",
+ "scroll",
 ]
 
 [[package]]
@@ -1553,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccb06643400b8a48ebcaf69d5c4b6adf50cacaf3b5d6aa27bfbaf0da21156cc"
+checksum = "fe66b009ea76a4727d61e386f6e6e353d373a963954c8fe5b93da650eab7db5d"
 dependencies = [
  "debugid",
  "encoding",
@@ -1564,17 +1562,17 @@ dependencies = [
  "minidump-common",
  "num-traits 0.2.15",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "thiserror",
  "time 0.3.9",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "minidump-common"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190480ae87a21dc26a115c4ef5ce8c05c10074d55ea2042c472be7bf6dc6e592"
+checksum = "a5f37f242baafb519413c7f12baa8e6854a176ea2f44910e2c434a428e27358d"
 dependencies = [
  "bitflags",
  "debugid",
@@ -1582,15 +1580,15 @@ dependencies = [
  "log",
  "num-traits 0.2.15",
  "range-map",
- "scroll 0.11.0",
+ "scroll",
  "smart-default",
 ]
 
 [[package]]
 name = "minidump-processor"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d286bdf783be15a8677b971a8860d43f626823f757472a9e3c4d1d6f3e52b85d"
+checksum = "34b8fc0048d90e4d5e804f062e00ac2010c73b318434f2a13df08252346b5851"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -1599,7 +1597,7 @@ dependencies = [
  "memmap2",
  "minidump",
  "minidump-common",
- "scroll 0.11.0",
+ "scroll",
  "serde",
  "serde_json",
  "thiserror",
@@ -1719,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "nom-supreme"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
 dependencies = [
  "brownstone",
  "indent_write",
@@ -1911,13 +1909,13 @@ dependencies = [
 
 [[package]]
 name = "pdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
  "fallible-iterator",
- "scroll 0.10.2",
- "uuid 0.8.2",
+ "scroll",
+ "uuid",
 ]
 
 [[package]]
@@ -2276,7 +2274,6 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -2301,7 +2298,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.10",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2524,12 +2520,6 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
@@ -2589,9 +2579,9 @@ checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "sentry"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d23af89cf3e40dffb53f974e9a21653353b3e21cf51633aa58006f2a0caf8a"
+checksum = "904eca4fb30c6112a1dae60c0a9e29cfb42f42129da4260f1ee20e94151b62e3"
 dependencies = [
  "httpdate",
  "reqwest 0.11.10",
@@ -2608,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de88cf0967eb3d7247071a7e6753b06c0939d509f9db44607ec00aa4b4aefd04"
+checksum = "40ec14f6bedc88480805096ee145afcc1e517a28db3f58f51b93e2899d932f56"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -2619,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158a446429420acdf6a4f75192ee8929da16a0c41c89a1c34b2e0f1eaebcc02"
+checksum = "1671189d1b759879fa4bdde46c50a499abb14332ed81f84fc6f60658f41b2fdb"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2631,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3bda8a1e3213f1944da2d42f3081ea9f3717105bb2a6b0a8fe4f5e603010a3"
+checksum = "db80ceff16bb1a4b2689b8758e5e61e405fc4d8ff9f2d1b5b845b76ce37fa34e"
 dependencies = [
  "hostname",
  "libc",
@@ -2644,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56333f11be3a78131c67637f7611339df8af7ad9af831226585a457df75f9e3b"
+checksum = "6c9f509d3959ed4dbbd80ca42572caad682aaa1cdd92c719e0815d0e87f82c96"
 dependencies = [
  "lazy_static",
  "rand",
@@ -2657,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c700f97918705167bde634fd33fa407d392cdf573da5362d1a55d6655ceb7d"
+checksum = "b0a28809378552c81392a6f0b80863bdeac137acb45124a44b0dbb2895a7c0d3"
 dependencies = [
  "findshlibs",
  "lazy_static",
@@ -2668,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b56c287a5295358bd4a3481a32add1f3fb7131102e300f561f788e33b79efe"
+checksum = "f4e00357035f6af5404870048167affaa551e15e0bee6efa2157e4b9bec6a453"
 dependencies = [
  "log",
  "sentry-core",
@@ -2678,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b957b1965c450acd220a27806fe1f2dec998d393973ebae797936b12df1c7416"
+checksum = "f8b442769cc34115f64393f7bfe4f863c3c38749e0c0b9613a7ae25b37c7ba53"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2688,22 +2678,23 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd49ee3ab5156738ae19c89c87e5516bd56a7f7fa93d7b05cefba88dc7bbd262"
+checksum = "b12c49abfd7adfbbfb68d46328bc4a7aad9be0880eb553ad05aeb7e6c703d88d"
 dependencies = [
  "http",
  "pin-project",
  "sentry-core",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
 name = "sentry-tracing"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b281efe225a8750e2011a325a5455b29a3e5cd40762337ef647a253e3213f"
+checksum = "d4e2796e40502893ed0d04646e507f91e74f1cbf09e370d42bb1cdbcaeeca9bb"
 dependencies = [
  "sentry-core",
  "tracing-core",
@@ -2712,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825fd3382e2397007499a910e0184e55f7837cb0df4af30ae62bd2123e2ebcd6"
+checksum = "254b600e93e9ef00a48382c9f1e86d27884bd9a5489efa4eb9210c20c72e88a6"
 dependencies = [
  "debugid",
  "getrandom",
@@ -2724,7 +2715,7 @@ dependencies = [
  "thiserror",
  "time 0.3.9",
  "url",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2993,9 +2984,10 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
+ "symbolic-cfi",
  "symbolic-common",
  "symbolic-debuginfo",
  "symbolic-demangle",
@@ -3004,21 +2996,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbolic-cfi"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
+dependencies = [
+ "symbolic-common",
+ "symbolic-debuginfo",
+ "thiserror",
+]
+
+[[package]]
 name = "symbolic-common"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
  "debugid",
  "memmap2",
  "serde",
  "stable_deref_trait",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3034,20 +3036,20 @@ dependencies = [
  "parking_lot 0.12.1",
  "pdb",
  "regex",
- "scroll 0.11.0",
+ "scroll",
  "serde",
  "serde_json",
  "smallvec",
  "symbolic-common",
  "thiserror",
  "wasmparser",
- "zip 0.5.13",
+ "zip",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3058,14 +3060,14 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
  "anyhow",
  "gimli",
  "indexmap",
  "object",
- "scroll 0.11.0",
+ "scroll",
  "serde_json",
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3073,20 +3075,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "symbolic-minidump"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
-dependencies = [
- "cc",
- "symbolic-common",
- "symbolic-debuginfo",
- "thiserror",
-]
-
-[[package]]
 name = "symbolic-symcache"
-version = "8.7.3"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#fefe8572e8f2b3e0be69d9fa259fff97adc5542d"
+version = "9.0.0"
+source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#b5fba17e54335c0ea6f5d5db9bfbe7b5ee234c61"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3139,7 +3130,6 @@ dependencies = [
  "sha-1 0.10.0",
  "structopt",
  "symbolic",
- "symbolic-minidump",
  "symbolicator-crash",
  "tempfile",
  "test-assembler",
@@ -3153,7 +3143,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid 1.1.1",
+ "uuid",
  "warp",
  "zstd",
 ]
@@ -3181,7 +3171,7 @@ dependencies = [
  "structopt",
  "symbolic",
  "walkdir",
- "zip 0.6.2",
+ "zip",
  "zstd",
 ]
 
@@ -3759,16 +3749,6 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
-
-[[package]]
-name = "uuid"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
@@ -3939,7 +3919,7 @@ dependencies = [
  "anyhow",
  "hex",
  "structopt",
- "uuid 1.1.1",
+ "uuid",
  "wasmbin",
 ]
 
@@ -3972,9 +3952,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "web-sys"
@@ -4143,18 +4126,6 @@ name = "zeroize"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
-
-[[package]]
-name = "zip"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
-dependencies = [
- "byteorder",
- "crc32fast",
- "flate2",
- "thiserror",
-]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,3 @@ codegen-units = 256
 # See also https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 # [patch."https://github.com/getsentry/symbolic"]
 # symbolic = { path = "../symbolic/symbolic" }
-# symbolic-minidump = { path = "../symbolic/symbolic-minidump" }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.57"
-apple-crash-report-parser = "0.4.2"
+apple-crash-report-parser = "0.5.0"
 async-trait = "0.1.53"
 axum = { version = "0.5.4", features = ["multipart"] }
 backtrace = "0.3.65"
@@ -26,8 +26,8 @@ ipnetwork = "0.19.0"
 jsonwebtoken = "8.1.0"
 lazy_static = "1.4.0"
 lru = "0.7.5"
-minidump = "0.10.3"
-minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
+minidump = "0.11.0"
+minidump-processor = { version = "0.11.0", features = ["symbolic-syms"] }
 num_cpus = "1.13.0"
 parking_lot = "0.12.0"
 regex = "1.5.5"
@@ -35,15 +35,14 @@ reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", featur
 rusoto_core = "0.48.0"
 rusoto_credential = "0.48.0"
 rusoto_s3 = "0.48.0"
-sentry = { version = "0.25.0", features = ["anyhow", "debug-images", "log", "tracing"] }
-sentry-tower = { version = "0.25.0", features = ["http"] }
+sentry = { version = "0.26.0", features = ["anyhow", "debug-images", "log", "tracing"] }
+sentry-tower = { version = "0.26.0", features = ["http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
-symbolic-minidump = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", default-features = false}
+symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["cfi", "common-serde", "debuginfo", "demangle", "il2cpp", "symcache"] }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }
@@ -59,7 +58,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 zstd = "0.11.1"
 
 [dev-dependencies]
-insta = { version = "1.14.0", features = ["redactions"] }
+insta = { version = "1.14.1", features = ["redactions"] }
 reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["multipart"] }
 sha-1 = "0.10.0"
 test-assembler = "0.1.5"

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::prelude::*;
 use sentry::{configure_scope, Hub, SentryFutureExt};
+use symbolic::cfi::CfiCache;
 use symbolic::common::ByteView;
-use symbolic_minidump::cfi::CfiCache;
 use thiserror::Error;
 
 use crate::cache::{Cache, CacheStatus};
@@ -44,7 +44,7 @@ const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 0,
     fallbacks: &[],
 };
-static_assert!(symbolic_minidump::cfi::CFICACHE_LATEST_VERSION == 2);
+static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
 /// Errors happening while generating a cficache
 #[derive(Debug, Error)]
@@ -56,7 +56,7 @@ pub enum CfiCacheError {
     Fetching(#[source] ObjectError),
 
     #[error("failed to parse cficache")]
-    Parsing(#[from] symbolic_minidump::cfi::CfiError),
+    Parsing(#[from] symbolic::cfi::CfiError),
 
     #[error("failed to parse object")]
     ObjectParsing(#[source] ObjectError),
@@ -138,7 +138,7 @@ struct FetchCfiCacheInternal {
 /// Extracts the Call Frame Information (CFI) from an object file.
 ///
 /// The extracted CFI is written to `path` in symbolic's
-/// [`CfiCache`](symbolic_minidump::cfi::CfiCache) format.
+/// [`CfiCache`](symbolic::cfi::CfiCache) format.
 #[tracing::instrument(skip_all)]
 async fn compute_cficache(
     threadpool: tokio::runtime::Handle,
@@ -293,7 +293,7 @@ impl CfiCacheActor {
 /// Extracts the CFI from an object file, writing it to a CFI file.
 ///
 /// The source file is probably an executable or so, the resulting file is in the format of
-/// [symbolic_minidump::cfi::CfiCache].
+/// [symbolic::cfi::CfiCache].
 #[tracing::instrument(skip_all)]
 fn write_cficache(path: &Path, object_handle: &ObjectHandle) -> Result<(), CfiCacheError> {
     configure_scope(|scope| {

--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -14,7 +14,7 @@ use parking_lot::Mutex;
 use regex::Regex;
 use sentry::protocol::SessionStatus;
 use sentry::SentryFutureExt;
-use symbolic::common::{Arch, CodeId, DebugId, InstructionInfo, Language, Name};
+use symbolic::common::{split_path, Arch, CodeId, DebugId, InstructionInfo, Language, Name};
 use symbolic::demangle::{Demangle, DemangleOptions};
 use thiserror::Error;
 
@@ -353,11 +353,6 @@ fn symbolicate_frame(
     };
 
     tracing::trace!("Symbolicating {:#x}", relative_addr);
-    let line_infos = match symcache.lookup(relative_addr) {
-        Ok(x) => x,
-        Err(_) => return Err(FrameStatus::Malformed),
-    };
-
     let mut rv = vec![];
 
     // The symbol addr only makes sense for the outermost top-level function, and not its inlinees.
@@ -366,37 +361,22 @@ fn symbolicate_frame(
     let mut sym_addr = None;
     let instruction_addr = HexValue(lookup_result.expose_preferred_addr(relative_addr));
 
-    for line_info in line_infos {
-        let line_info = match line_info {
-            Ok(x) => x,
-            Err(_) => return Err(FrameStatus::Malformed),
-        };
-
+    for source_location in symcache.lookup(relative_addr) {
+        let function = source_location.function();
+        let file = source_location.file();
         // The logic for filename and abs_path intentionally diverges from how symbolic is used
         // inside of Sentry right now.
-        let (filename, abs_path) = {
-            let rel_path = line_info.path();
-            let abs_path = line_info.abs_path();
+        let abs_path = file.map(|file| file.full_path()).unwrap_or_default();
+        let (_, filename) = split_path(&abs_path);
 
-            if abs_path == rel_path {
-                // rel_path is absolute and therefore not usable for `filename`. Use the
-                // basename as filename.
-                (line_info.filename().to_owned(), abs_path.to_owned())
-            } else {
-                // rel_path is relative (probably to the compilation dir) and therefore useful
-                // as filename for Sentry.
-                (rel_path.to_owned(), abs_path.to_owned())
-            }
-        };
-
-        let name = line_info.function_name();
+        let name = function.name_for_demangling();
 
         // Detect the language from the bare name, ignoring any pre-set language. There are a few
         // languages that we should always be able to demangle. Only complain about those that we
         // detect explicitly, but silently ignore the rest. For instance, there are C-identifiers
         // reported as C++, which are expected not to demangle.
         let detected_language = Name::from(name.as_str()).detect_language();
-        let should_demangle = match (line_info.language(), detected_language) {
+        let should_demangle = match (function.language(), detected_language) {
             (_, Language::Unknown) => false, // can't demangle what we cannot detect
             (Language::ObjCpp, Language::Cpp) => true, // C++ demangles even if it was in ObjC++
             (Language::Unknown, _) => true,  // if there was no language, then rely on detection
@@ -408,14 +388,14 @@ fn symbolicate_frame(
             sentry::with_scope(
                 |scope| scope.set_extra("identifier", name.to_string().into()),
                 || {
-                    let message = format!("Failed to demangle {} identifier", line_info.language());
+                    let message = format!("Failed to demangle {} identifier", function.language());
                     sentry::capture_message(&message, sentry::Level::Error);
                 },
             );
         }
 
         sym_addr = Some(HexValue(
-            lookup_result.expose_preferred_addr(line_info.function_address()),
+            lookup_result.expose_preferred_addr(function.entry_pc() as u64),
         ));
         rv.push(SymbolicatedFrame {
             status: FrameStatus::Symbolicated,
@@ -424,9 +404,9 @@ fn symbolicate_frame(
                 package: lookup_result.object_info.raw.code_file.clone(),
                 addr_mode: lookup_result.preferred_addr_mode(),
                 instruction_addr,
-                symbol: Some(line_info.symbol().to_string()),
+                symbol: Some(function.name().to_string()),
                 abs_path: if !abs_path.is_empty() {
-                    Some(abs_path)
+                    Some(abs_path.clone())
                 } else {
                     frame.abs_path.clone()
                 },
@@ -435,16 +415,16 @@ fn symbolicate_frame(
                     None => name.into_cow().into_owned(),
                 }),
                 filename: if !filename.is_empty() {
-                    Some(filename)
+                    Some(filename.to_string())
                 } else {
                     frame.filename.clone()
                 },
-                lineno: Some(line_info.line()),
+                lineno: Some(source_location.line()),
                 pre_context: vec![],
                 context_line: None,
                 post_context: vec![],
                 sym_addr: None,
-                lang: match line_info.language() {
+                lang: match function.language() {
                     Language::Unknown => None,
                     language => Some(language),
                 },

--- a/crates/symbolicator/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator/src/services/symbolication/process_minidump.rs
@@ -18,8 +18,8 @@ use parking_lot::RwLock;
 use sentry::types::DebugId;
 use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
+use symbolic::cfi::CfiCache;
 use symbolic::common::{Arch, ByteView};
-use symbolic_minidump::cfi::CfiCache;
 use tempfile::TempPath;
 
 use crate::cache::CacheStatus;

--- a/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__source_candidates.snap
+++ b/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__source_candidates.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator/src/services/symbolication/mod.rs
-assertion_line: 1537
+assertion_line: 1521
 expression: response.unwrap()
 ---
 status: completed
@@ -14,7 +14,7 @@ stacktraces:
         symbol: trigger_crash
         sym_addr: "0x3860"
         function: trigger_crash
-        filename: examples/example.c
+        filename: example.c
         abs_path: /Users/swatinem/Coding/sentry-native/examples/example.c
         lineno: 60
         pre_context:

--- a/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__wasm_payload.snap
+++ b/crates/symbolicator/src/services/symbolication/snapshots/symbolicator__services__symbolication__tests__wasm_payload.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/symbolicator/src/services/symbolication/mod.rs
-assertion_line: 2431
+assertion_line: 1471
 expression: response.unwrap()
-
 ---
 status: completed
 stacktraces:
@@ -15,7 +14,7 @@ stacktraces:
         symbol: internal_func
         sym_addr: "0x8b"
         function: internal_func
-        filename: src/lib.rs
+        filename: lib.rs
         abs_path: /Users/mitsuhiko/Development/wasm-example/simple/src/lib.rs
         lineno: 19
 modules:

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -55,17 +55,9 @@ fn get_pdb_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<Str
         Cow::Borrowed(debug_file)
     };
     let debug_id = if ssqp_casing {
-        format!(
-            "{:x}{:X}",
-            debug_id.uuid().to_simple_ref(),
-            debug_id.appendix()
-        )
+        format!("{:x}{:X}", debug_id.uuid().simple(), debug_id.appendix())
     } else {
-        format!(
-            "{:X}{:x}",
-            debug_id.uuid().to_simple_ref(),
-            debug_id.appendix()
-        )
+        format!("{:X}{:x}", debug_id.uuid().simple(), debug_id.appendix())
     };
 
     Some(format!("{}/{}/{}", debug_file, debug_id, debug_file))
@@ -243,16 +235,13 @@ fn get_symstore_path(
             Some(format!(
                 "{}/mach-uuid-{}/{}",
                 code_file,
-                uuid.to_simple_ref(),
+                uuid.simple(),
                 code_file
             ))
         }
         FileType::MachDebug => {
             let uuid = get_mach_uuid(identifier)?;
-            Some(format!(
-                "_.dwarf/mach-uuid-sym-{}/_.dwarf",
-                uuid.to_simple_ref()
-            ))
+            Some(format!("_.dwarf/mach-uuid-sym-{}/_.dwarf", uuid.simple()))
         }
 
         FileType::Pdb => get_pdb_symstore_path(identifier, ssqp_casing),
@@ -365,9 +354,7 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
         | FileType::BcSymbolMap
         | FileType::Il2cpp => {
             if identifier.code_id.is_none() {
-                Some(Cow::Owned(
-                    identifier.debug_id?.uuid().to_simple_ref().to_string(),
-                ))
+                Some(Cow::Owned(identifier.debug_id?.uuid().simple().to_string()))
             } else {
                 Some(Cow::Borrowed(identifier.code_id.as_ref()?.as_str()))
             }
@@ -397,7 +384,6 @@ fn get_unified_path(filetype: FileType, identifier: &ObjectId) -> Option<String>
 
     // determine the ID we use for the path
     let id = get_search_target_id(filetype, identifier)?;
-
     Some(format!("{}/{}/{}", id.get(..2)?, id.get(2..)?, suffix))
 }
 


### PR DESCRIPTION
This also includes the following dependency updates:
* `apple-crash-report-parser` 0.4.2 -> 0.5.0
* `insta` 1.14.0 -> 1.14.1
* `minidump` / `minidump-processor` 0.10.3 -> 0.11.0
* `sentry` / `sentry-tower` 0.25.0 -> 0.26.0

#skip-changelog