### PR TITLE
ref: Avoid holding a Config in the Downloader

### DIFF
--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -92,6 +92,7 @@ pub enum SentryError {
 pub struct SentryDownloader {
     client: reqwest::Client,
     index_cache: Mutex<SentryIndexCache>,
+    cache_duration: Duration,
     connect_timeout: Duration,
     streaming_timeout: Duration,
 }
@@ -106,16 +107,23 @@ impl fmt::Debug for SentryDownloader {
 }
 
 impl SentryDownloader {
-    pub fn new(
-        client: reqwest::Client,
-        connect_timeout: Duration,
-        streaming_timeout: Duration,
-    ) -> Self {
+    pub fn new(client: reqwest::Client, config: &Config) -> Self {
+        // The Sentry cache index should expire as soon as we attempt to retry negative caches.
+        let cache_duration = if config.cache_dir.is_some() {
+            config
+                .caches
+                .downloaded
+                .retry_misses_after
+                .unwrap_or_else(|| Duration::from_secs(0))
+        } else {
+            Duration::from_secs(0)
+        };
         Self {
             client,
             index_cache: Mutex::new(SentryIndexCache::new(100_000)),
-            connect_timeout,
-            streaming_timeout,
+            cache_duration,
+            connect_timeout: config.connect_timeout,
+            streaming_timeout: config.streaming_timeout,
         }
     }
 
@@ -153,21 +161,9 @@ impl SentryDownloader {
     async fn cached_sentry_search(
         &self,
         query: SearchQuery,
-        config: &Config,
     ) -> Result<Vec<SearchResult>, DownloadError> {
-        // The Sentry cache index should expire as soon as we attempt to retry negative caches.
-        let cache_duration = if config.cache_dir.is_some() {
-            config
-                .caches
-                .downloaded
-                .retry_misses_after
-                .unwrap_or_else(|| Duration::from_secs(0))
-        } else {
-            Duration::from_secs(0)
-        };
-
         if let Some((created, entries)) = self.index_cache.lock().get(&query) {
-            if created.elapsed() < cache_duration {
+            if created.elapsed() < self.cache_duration {
                 return Ok(entries.clone());
             }
         }
@@ -178,7 +174,7 @@ impl SentryDownloader {
         );
         let entries = future_utils::retry(|| self.fetch_sentry_json(&query)).await?;
 
-        if cache_duration > Duration::from_secs(0) {
+        if self.cache_duration > Duration::from_secs(0) {
             self.index_cache
                 .lock()
                 .put(query, (Instant::now(), entries.clone()));
@@ -192,7 +188,6 @@ impl SentryDownloader {
         source: Arc<SentrySourceConfig>,
         object_id: ObjectId,
         file_types: &[FileType],
-        config: &Config,
     ) -> Result<Vec<RemoteDif>, DownloadError> {
         // TODO(flub): These queries do not handle pagination.  But sentry only starts to
         // paginate at 20 results so we get away with this for now.
@@ -240,7 +235,7 @@ impl SentryDownloader {
             token: source.token.clone(),
         };
 
-        let search = self.cached_sentry_search(query, config).await?;
+        let search = self.cached_sentry_search(query).await?;
         let file_ids = search
             .into_iter()
             .map(|search_result| SentryRemoteDif::new(source.clone(), search_result.id).into())

--- a/crates/symbolicator/src/services/mod.rs
+++ b/crates/symbolicator/src/services/mod.rs
@@ -77,7 +77,7 @@ impl Service {
     ) -> Result<Self> {
         let config = Arc::new(config);
 
-        let downloader = DownloadService::new(config.clone());
+        let downloader = DownloadService::new(&config);
         let shared_cache = Arc::new(SharedCacheService::new(config.shared_cache.clone()).await);
         let caches = Caches::from_config(&config).context("failed to create local caches")?;
         caches

--- a/crates/symbolicator/src/services/objects/data_cache.rs
+++ b/crates/symbolicator/src/services/objects/data_cache.rs
@@ -345,13 +345,13 @@ mod tests {
         )
         .unwrap();
 
-        let config = Arc::new(Config {
+        let config = Config {
             connect_to_reserved_ips: true,
             max_download_timeout: Duration::from_millis(100),
             ..Config::default()
-        });
+        };
 
-        let download_svc = DownloadService::new(config);
+        let download_svc = DownloadService::new(&config);
         let shared_cache_svc = Arc::new(SharedCacheService::new(None).await);
         ObjectsActor::new(meta_cache, data_cache, shared_cache_svc, download_svc)
     }

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -490,17 +490,17 @@ mod tests {
         let mut cache_config = CacheConfigs::default();
         cache_config.downloaded.retry_misses_after = Some(timeout);
 
-        let config = Arc::new(Config {
+        let config = Config {
             cache_dir: Some(cache_dir),
             connect_to_reserved_ips: true,
             caches: cache_config,
             ..Default::default()
-        });
+        };
 
         let cpu_pool = tokio::runtime::Handle::current();
         let caches = Caches::from_config(&config).unwrap();
         caches.clear_tmp(&config).unwrap();
-        let downloader = DownloadService::new(config);
+        let downloader = DownloadService::new(&config);
         let shared_cache = Arc::new(SharedCacheService::new(None).await);
         let objects = ObjectsActor::new(
             caches.object_meta,


### PR DESCRIPTION
This also avoids passing the Config to the SentryDownloader which previously matched an immutable config flag on every single request. Better to do that ahead of time.

#skip-changelog