### PR TITLE
ref: Split symbolication module into smaller pieces

### DIFF
--- a/crates/symbolicator/src/services/symbolication/apple.rs
+++ b/crates/symbolicator/src/services/symbolication/apple.rs
@@ -1,0 +1,207 @@
+use std::fs::File;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use apple_crash_report_parser::AppleCrashReport;
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use sentry::SentryFutureExt;
+use symbolic::common::{Arch, CodeId, DebugId};
+
+use crate::sources::SourceConfig;
+use crate::types::{
+    CompleteObjectInfo, CompletedSymbolicationResponse, ObjectType, RawFrame, RawObjectInfo,
+    RawStacktrace, RequestOptions, Scope, SystemInfo,
+};
+use crate::utils::futures::{m, measure, CancelOnDrop};
+use crate::utils::hex::HexValue;
+
+use super::{StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor, SymbolicationError};
+
+impl SymbolicationActor {
+    async fn parse_apple_crash_report(
+        &self,
+        scope: Scope,
+        report: File,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), SymbolicationError> {
+        let parse_future = async {
+            let report = AppleCrashReport::from_reader(report)?;
+            let mut metadata = report.metadata;
+
+            let arch = report
+                .code_type
+                .as_ref()
+                .and_then(|code_type| code_type.split(' ').next())
+                .and_then(|word| word.parse().ok())
+                .unwrap_or_default();
+
+            let modules = report
+                .binary_images
+                .into_iter()
+                .map(map_apple_binary_image)
+                .collect();
+
+            let mut stacktraces = Vec::with_capacity(report.threads.len());
+
+            for thread in report.threads {
+                let registers = thread
+                    .registers
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(name, addr)| (name, HexValue(addr.0)))
+                    .collect();
+
+                let frames = thread
+                    .frames
+                    .into_iter()
+                    .map(|frame| RawFrame {
+                        instruction_addr: HexValue(frame.instruction_addr.0),
+                        package: frame.module,
+                        ..RawFrame::default()
+                    })
+                    .collect();
+
+                stacktraces.push(RawStacktrace {
+                    thread_id: Some(thread.id),
+                    thread_name: thread.name,
+                    is_requesting: Some(thread.crashed),
+                    registers,
+                    frames,
+                });
+            }
+
+            let request = SymbolicateStacktraces {
+                modules,
+                scope,
+                sources,
+                origin: StacktraceOrigin::AppleCrashReport,
+                signal: None,
+                stacktraces,
+                options,
+            };
+
+            let mut system_info = SystemInfo {
+                os_name: metadata.remove("OS Version").unwrap_or_default(),
+                device_model: metadata.remove("Hardware Model").unwrap_or_default(),
+                cpu_arch: arch,
+                ..SystemInfo::default()
+            };
+
+            if let Some(captures) = OS_MACOS_REGEX.captures(&system_info.os_name) {
+                system_info.os_version = captures
+                    .name("version")
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
+                system_info.os_build = captures
+                    .name("build")
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
+                system_info.os_name = "macOS".to_string();
+            }
+
+            // https://developer.apple.com/library/archive/technotes/tn2151/_index.html
+            let crash_reason = metadata.remove("Exception Type");
+            let crash_details = report
+                .application_specific_information
+                .or_else(|| metadata.remove("Exception Message"))
+                .or_else(|| metadata.remove("Exception Subtype"))
+                .or_else(|| metadata.remove("Exception Codes"));
+
+            let state = AppleCrashReportState {
+                timestamp: report.timestamp,
+                system_info,
+                crash_reason,
+                crash_details,
+            };
+
+            Ok((request, state))
+        };
+
+        let future = async move {
+            CancelOnDrop::new(
+                self.cpu_pool
+                    .spawn(parse_future.bind_hub(sentry::Hub::current())),
+            )
+            .await
+            .context("Parse applecrashreport future cancelled")
+        };
+
+        let future = tokio::time::timeout(Duration::from_secs(1200), future);
+        let future = measure("parse_apple_crash_report", m::timed_result, None, future);
+        future
+            .await
+            .map(|res| res.map_err(SymbolicationError::from))
+            .unwrap_or(Err(SymbolicationError::Timeout))?
+    }
+
+    pub(super) async fn do_process_apple_crash_report(
+        self,
+        scope: Scope,
+        report: File,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
+        let (request, state) = self
+            .parse_apple_crash_report(scope, report, sources, options)
+            .await?;
+        let mut response = self.do_symbolicate(request).await?;
+
+        state.merge_into(&mut response);
+        Ok(response)
+    }
+}
+
+lazy_static::lazy_static! {
+    /// Format sent by Unreal Engine on macOS
+    static ref OS_MACOS_REGEX: Regex = Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap();
+}
+
+#[derive(Debug)]
+struct AppleCrashReportState {
+    timestamp: Option<DateTime<Utc>>,
+    system_info: SystemInfo,
+    crash_reason: Option<String>,
+    crash_details: Option<String>,
+}
+
+impl AppleCrashReportState {
+    fn merge_into(mut self, response: &mut CompletedSymbolicationResponse) {
+        if self.system_info.cpu_arch == Arch::Unknown {
+            self.system_info.cpu_arch = response
+                .modules
+                .iter()
+                .map(|object| object.arch)
+                .find(|arch| *arch != Arch::Unknown)
+                .unwrap_or_default();
+        }
+
+        response.timestamp = self.timestamp;
+        response.system_info = Some(self.system_info);
+        response.crash_reason = self.crash_reason;
+        response.crash_details = self.crash_details;
+        response.crashed = Some(true);
+    }
+}
+
+fn map_apple_binary_image(image: apple_crash_report_parser::BinaryImage) -> CompleteObjectInfo {
+    let code_id = CodeId::from_binary(&image.uuid.as_bytes()[..]);
+    let debug_id = DebugId::from_uuid(image.uuid);
+
+    let raw_info = RawObjectInfo {
+        ty: ObjectType::Macho,
+        code_id: Some(code_id.to_string()),
+        code_file: Some(image.path.clone()),
+        debug_id: Some(debug_id.to_string()),
+        debug_file: Some(image.path),
+        image_addr: HexValue(image.addr.0),
+        image_size: match image.size {
+            0 => None,
+            size => Some(size),
+        },
+    };
+
+    raw_info.into()
+}

--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -26,6 +26,9 @@ use crate::utils::futures::CallOnDrop;
 mod apple;
 mod module_lookup;
 mod process_minidump;
+// we should really rename this here to the `SymbolicatorService`, as it does a lot more
+// than just symbolication ;-)
+#[allow(clippy::module_inception)]
 mod symbolication;
 
 pub use symbolication::{StacktraceOrigin, SymbolicateStacktraces};

--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -6,16 +6,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::Context;
-use apple_crash_report_parser::AppleCrashReport;
-use chrono::{DateTime, Utc};
 use futures::{channel::oneshot, future, FutureExt as _};
 use parking_lot::Mutex;
-use regex::Regex;
 use sentry::protocol::SessionStatus;
 use sentry::SentryFutureExt;
-use symbolic::common::{split_path, Arch, CodeId, DebugId, InstructionInfo, Language, Name};
-use symbolic::demangle::{Demangle, DemangleOptions};
+use tempfile::TempPath;
 use thiserror::Error;
 
 use crate::services::cficaches::{CfiCacheActor, CfiCacheError};
@@ -23,61 +18,17 @@ use crate::services::objects::ObjectsActor;
 use crate::services::symcaches::{SymCacheActor, SymCacheError};
 use crate::sources::SourceConfig;
 use crate::types::{
-    CompleteObjectInfo, CompleteStacktrace, CompletedSymbolicationResponse, FrameStatus,
-    FrameTrust, ObjectFileStatus, ObjectId, ObjectType, RawFrame, RawObjectInfo, RawStacktrace,
-    Registers, RequestId, RequestOptions, Scope, Signal, SymbolicatedFrame, SymbolicationResponse,
-    SystemInfo,
+    CompletedSymbolicationResponse, ObjectFileStatus, ObjectId, RawObjectInfo, RequestId,
+    RequestOptions, Scope, SymbolicationResponse,
 };
-use crate::utils::futures::{m, measure, CallOnDrop, CancelOnDrop};
-use crate::utils::hex::HexValue;
+use crate::utils::futures::CallOnDrop;
 
+mod apple;
 mod module_lookup;
 mod process_minidump;
+mod symbolication;
 
-use module_lookup::ModuleLookup;
-
-/// Options for demangling all symbols.
-const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
-
-/// The maximum delay we allow for polling a finished request before dropping it.
-const MAX_POLL_DELAY: Duration = Duration::from_secs(90);
-
-lazy_static::lazy_static! {
-    /// Format sent by Unreal Engine on macOS
-    static ref OS_MACOS_REGEX: Regex = Regex::new(r#"^Mac OS X (?P<version>\d+\.\d+\.\d+)( \((?P<build>[a-fA-F0-9]+)\))?$"#).unwrap();
-}
-
-/// Errors during symbolication.
-#[derive(Debug, Error)]
-pub enum SymbolicationError {
-    #[error("symbolication took too long")]
-    Timeout,
-
-    #[error(transparent)]
-    Failed(#[from] anyhow::Error),
-
-    #[error("failed to parse apple crash report")]
-    InvalidAppleCrashReport(#[from] apple_crash_report_parser::ParseError),
-}
-
-impl SymbolicationError {
-    fn to_symbolication_response(&self) -> SymbolicationResponse {
-        match self {
-            SymbolicationError::Timeout => SymbolicationResponse::Timeout,
-            SymbolicationError::Failed(_) | SymbolicationError::InvalidAppleCrashReport(_) => {
-                SymbolicationResponse::Failed {
-                    message: self.to_string(),
-                }
-            }
-        }
-    }
-}
-
-/// An error returned when symbolicator receives a request while already processing
-/// the maximum number of requests.
-#[derive(Debug, Clone, Error)]
-#[error("maximum number of concurrent requests reached")]
-pub struct MaxRequestsError;
+use symbolication::{StacktraceOrigin, SymbolicateStacktraces};
 
 // We want a shared future here because otherwise polling for a response would hold the global lock.
 type ComputationChannel = future::Shared<oneshot::Receiver<(Instant, SymbolicationResponse)>>;
@@ -96,23 +47,6 @@ pub struct SymbolicationActor {
     max_concurrent_requests: Option<usize>,
     current_requests: Arc<AtomicUsize>,
     symbolication_taskmon: tokio_metrics::TaskMonitor,
-}
-
-impl fmt::Debug for SymbolicationActor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("SymbolicationActor")
-            .field("objects", &self.objects)
-            .field("symcaches", &self.symcaches)
-            .field("cficaches", &self.cficaches)
-            .field("diagnostics_cache", &self.diagnostics_cache)
-            .field("io_pool", &self.io_pool)
-            .field("cpu_pool", &self.cpu_pool)
-            .field("requests", &self.requests)
-            .field("max_concurrent_requests", &self.max_concurrent_requests)
-            .field("current_requests", &self.current_requests)
-            .field("symbolication_taskmon", &"<TaskMonitor>")
-            .finish()
-    }
 }
 
 impl SymbolicationActor {
@@ -137,6 +71,110 @@ impl SymbolicationActor {
             max_concurrent_requests,
             current_requests: Arc::new(AtomicUsize::new(0)),
             symbolication_taskmon: tokio_metrics::TaskMonitor::new(),
+        }
+    }
+
+    /// Creates a new request to symbolicate stacktraces.
+    ///
+    /// Returns `None` if the `SymbolicationActor` is already processing the
+    /// maximum number of requests, as given by `max_concurrent_requests`.
+    pub fn symbolicate_stacktraces(
+        &self,
+        request: SymbolicateStacktraces,
+    ) -> Result<RequestId, MaxRequestsError> {
+        let slf = self.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "symbolicate_stacktraces",
+            "symbolicate_stacktraces",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf.do_symbolicate(request).await;
+            transaction.finish();
+            res
+        })
+    }
+
+    /// Creates a new request to process a minidump.
+    ///
+    /// Returns `None` if the `SymbolicationActor` is already processing the
+    /// maximum number of requests, as given by `max_concurrent_requests`.
+    pub fn process_minidump(
+        &self,
+        scope: Scope,
+        minidump_file: TempPath,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<RequestId, MaxRequestsError> {
+        let slf = self.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "process_minidump",
+            "process_minidump",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf
+                .do_process_minidump(scope, minidump_file, sources, options)
+                .await;
+            transaction.finish();
+            res
+        })
+    }
+
+    /// Creates a new request to process an Apple crash report.
+    ///
+    /// Returns `None` if the `SymbolicationActor` is already processing the
+    /// maximum number of requests, as given by `max_concurrent_requests`.
+    pub fn process_apple_crash_report(
+        &self,
+        scope: Scope,
+        apple_crash_report: File,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<RequestId, MaxRequestsError> {
+        let slf = self.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "process_apple_crash_report",
+            "process_apple_crash_report",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf
+                .do_process_apple_crash_report(scope, apple_crash_report, sources, options)
+                .await;
+            transaction.finish();
+            res
+        })
+    }
+
+    /// Polls the status for a started symbolication task.
+    ///
+    /// If the timeout is set and no result is ready within the given time,
+    /// [`SymbolicationResponse::Pending`] is returned.
+    pub async fn get_response(
+        &self,
+        request_id: RequestId,
+        timeout: Option<u64>,
+    ) -> Option<SymbolicationResponse> {
+        let channel_opt = self.requests.lock().get(&request_id).cloned();
+        match channel_opt {
+            Some(channel) => Some(wrap_response_channel(request_id, timeout, channel).await),
+            None => {
+                // This is okay to occur during deploys, but if it happens all the time we have a state
+                // bug somewhere. Could be a misconfigured load balancer (supposed to be pinned to
+                // scopes).
+                metric!(counter("symbolication.request_id_unknown") += 1);
+                None
+            }
         }
     }
 
@@ -229,6 +267,58 @@ impl SymbolicationActor {
     }
 }
 
+impl fmt::Debug for SymbolicationActor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("SymbolicationActor")
+            .field("objects", &self.objects)
+            .field("symcaches", &self.symcaches)
+            .field("cficaches", &self.cficaches)
+            .field("diagnostics_cache", &self.diagnostics_cache)
+            .field("io_pool", &self.io_pool)
+            .field("cpu_pool", &self.cpu_pool)
+            .field("requests", &self.requests)
+            .field("max_concurrent_requests", &self.max_concurrent_requests)
+            .field("current_requests", &self.current_requests)
+            .field("symbolication_taskmon", &"<TaskMonitor>")
+            .finish()
+    }
+}
+
+/// The maximum delay we allow for polling a finished request before dropping it.
+const MAX_POLL_DELAY: Duration = Duration::from_secs(90);
+
+/// Errors during symbolication.
+#[derive(Debug, Error)]
+pub enum SymbolicationError {
+    #[error("symbolication took too long")]
+    Timeout,
+
+    #[error(transparent)]
+    Failed(#[from] anyhow::Error),
+
+    #[error("failed to parse apple crash report")]
+    InvalidAppleCrashReport(#[from] apple_crash_report_parser::ParseError),
+}
+
+impl SymbolicationError {
+    fn to_symbolication_response(&self) -> SymbolicationResponse {
+        match self {
+            SymbolicationError::Timeout => SymbolicationResponse::Timeout,
+            SymbolicationError::Failed(_) | SymbolicationError::InvalidAppleCrashReport(_) => {
+                SymbolicationResponse::Failed {
+                    message: self.to_string(),
+                }
+            }
+        }
+    }
+}
+
+/// An error returned when symbolicator receives a request while already processing
+/// the maximum number of requests.
+#[derive(Debug, Clone, Error)]
+#[error("maximum number of concurrent requests reached")]
+pub struct MaxRequestsError;
+
 async fn wrap_response_channel(
     request_id: RequestId,
     timeout: Option<u64>,
@@ -260,928 +350,6 @@ async fn wrap_response_channel(
         // If the sender is dropped, this is likely due to a panic that is captured at the source.
         // Therefore, we do not need to capture an error at this point.
         Err(_canceled) => SymbolicationResponse::InternalError,
-    }
-}
-
-fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
-    ObjectId {
-        debug_id: match object_info.debug_id.as_deref() {
-            None | Some("") => None,
-            Some(string) => string.parse().ok(),
-        },
-        code_id: match object_info.code_id.as_deref() {
-            None | Some("") => None,
-            Some(string) => string.parse().ok(),
-        },
-        debug_file: object_info.debug_file.clone(),
-        code_file: object_info.code_file.clone(),
-        object_type: object_info.ty,
-    }
-}
-
-fn symbolicate_frame(
-    caches: &ModuleLookup,
-    registers: &Registers,
-    signal: Option<Signal>,
-    frame: &mut RawFrame,
-    index: usize,
-) -> Result<Vec<SymbolicatedFrame>, FrameStatus> {
-    let lookup_result = caches
-        .lookup_symcache(frame.instruction_addr.0, frame.addr_mode)
-        .ok_or(FrameStatus::UnknownImage)?;
-
-    frame.package = lookup_result.object_info.raw.code_file.clone();
-    if lookup_result.symcache.is_none() {
-        if lookup_result.object_info.debug_status == ObjectFileStatus::Malformed {
-            return Err(FrameStatus::Malformed);
-        } else {
-            return Err(FrameStatus::Missing);
-        }
-    }
-
-    tracing::trace!("Loading symcache");
-    let symcache = match lookup_result
-        .symcache
-        .as_ref()
-        .expect("symcache should always be available at this point")
-        .parse()
-    {
-        Ok(Some(x)) => x,
-        Ok(None) => return Err(FrameStatus::Missing),
-        Err(_) => return Err(FrameStatus::Malformed),
-    };
-
-    // get the relative caller address
-    let relative_addr = if let Some(addr) = lookup_result.relative_addr {
-        // heuristics currently are only supported when we can work with absolute addresses.
-        // In cases where this is not possible we skip this part entirely and use the relative
-        // address calculated by the lookup result as lookup address in the module.
-        if let Some(absolute_addr) = lookup_result.object_info.rel_to_abs_addr(addr) {
-            let is_crashing_frame = index == 0;
-            let ip_register_value = if is_crashing_frame {
-                symcache
-                    .arch()
-                    .cpu_family()
-                    .ip_register_name()
-                    .and_then(|ip_reg_name| registers.get(ip_reg_name))
-                    .map(|x| x.0)
-            } else {
-                None
-            };
-            let absolute_caller_addr = InstructionInfo::new(symcache.arch(), absolute_addr)
-                .is_crashing_frame(is_crashing_frame)
-                .signal(signal.map(|signal| signal.0))
-                .ip_register_value(ip_register_value)
-                .caller_address();
-            lookup_result
-                .object_info
-                .abs_to_rel_addr(absolute_caller_addr)
-                .ok_or_else(|| {
-                    tracing::warn!(
-                            "Underflow when trying to subtract image start addr from caller address after heuristics"
-                        );
-                    metric!(counter("relative_addr.underflow") += 1);
-                    FrameStatus::MissingSymbol
-                })?
-        } else {
-            addr
-        }
-    } else {
-        tracing::warn!("Underflow when trying to subtract image start addr from caller address before heuristics");
-        metric!(counter("relative_addr.underflow") += 1);
-        return Err(FrameStatus::MissingSymbol);
-    };
-
-    tracing::trace!("Symbolicating {:#x}", relative_addr);
-    let mut rv = vec![];
-
-    // The symbol addr only makes sense for the outermost top-level function, and not its inlinees.
-    // We keep track of it while iterating and only set it for the last frame,
-    // which is the top-level function.
-    let mut sym_addr = None;
-    let instruction_addr = HexValue(lookup_result.expose_preferred_addr(relative_addr));
-
-    for source_location in symcache.lookup(relative_addr) {
-        let abs_path = source_location
-            .file()
-            .map(|f| f.full_path())
-            .unwrap_or_default();
-        let filename = split_path(&abs_path).1;
-
-        let func = source_location.function();
-        let symbol = func.name();
-
-        // Detect the language from the bare name, ignoring any pre-set language. There are a few
-        // languages that we should always be able to demangle. Only complain about those that we
-        // detect explicitly, but silently ignore the rest. For instance, there are C-identifiers
-        // reported as C++, which are expected not to demangle.
-        let detected_language = Name::from(symbol).detect_language();
-        let should_demangle = match (func.language(), detected_language) {
-            (_, Language::Unknown) => false, // can't demangle what we cannot detect
-            (Language::ObjCpp, Language::Cpp) => true, // C++ demangles even if it was in ObjC++
-            (Language::Unknown, _) => true,  // if there was no language, then rely on detection
-            (lang, detected) => lang == detected, // avoid false-positive detections
-        };
-
-        let demangled_opt = func.name_for_demangling().demangle(DEMANGLE_OPTIONS);
-        if should_demangle && demangled_opt.is_none() {
-            sentry::with_scope(
-                |scope| scope.set_extra("identifier", symbol.to_string().into()),
-                || {
-                    let message = format!("Failed to demangle {} identifier", func.language());
-                    sentry::capture_message(&message, sentry::Level::Error);
-                },
-            );
-        }
-
-        sym_addr = Some(HexValue(
-            lookup_result.expose_preferred_addr(func.entry_pc() as u64),
-        ));
-        let filename = if !filename.is_empty() {
-            Some(filename.to_string())
-        } else {
-            frame.filename.clone()
-        };
-        rv.push(SymbolicatedFrame {
-            status: FrameStatus::Symbolicated,
-            original_index: Some(index),
-            raw: RawFrame {
-                package: lookup_result.object_info.raw.code_file.clone(),
-                addr_mode: lookup_result.preferred_addr_mode(),
-                instruction_addr,
-                symbol: Some(symbol.to_string()),
-                abs_path: if !abs_path.is_empty() {
-                    Some(abs_path)
-                } else {
-                    frame.abs_path.clone()
-                },
-                function: Some(match demangled_opt {
-                    Some(demangled) => demangled,
-                    None => symbol.to_string(),
-                }),
-                filename,
-                lineno: Some(source_location.line()),
-                pre_context: vec![],
-                context_line: None,
-                post_context: vec![],
-                sym_addr: None,
-                lang: match func.language() {
-                    Language::Unknown => None,
-                    language => Some(language),
-                },
-                trust: frame.trust,
-            },
-        });
-    }
-
-    if let Some(last_frame) = rv.last_mut() {
-        last_frame.raw.sym_addr = sym_addr;
-    }
-
-    if rv.is_empty() {
-        return Err(FrameStatus::MissingSymbol);
-    }
-
-    Ok(rv)
-}
-
-/// Stacktrace related Metrics
-///
-/// This gives some metrics about the quality of the stack traces included
-/// in a symbolication request. See the individual members for more information.
-///
-/// These numbers are being accumulated across one symbolication request, and are emitted
-/// as a histogram.
-#[derive(Default)]
-struct StacktraceMetrics {
-    /// A truncated stack trace is one that does not end in a
-    /// well known thread base.
-    truncated_traces: u64,
-
-    /// We classify a short stacktrace as one that has less that 5 frames.
-    short_traces: u64,
-
-    /// This indicated a stack trace that has at least one bad frame
-    /// from the below categories.
-    bad_traces: u64,
-
-    /// Frames that were scanned.
-    ///
-    /// These are frequently wrong and lead to bad and incomplete stack traces.
-    /// We can improve (lower) these numbers by having more usable CFI info.
-    scanned_frames: u64,
-
-    /// Unsymbolicated Frames.
-    ///
-    /// These may be the result of unavailable or broken debug info.
-    /// We can improve (lower) these numbers by having more usable debug info.
-    unsymbolicated_frames: u64,
-
-    /// Unsymbolicated Context Frames.
-    ///
-    /// This is an indication of broken contexts, or failure to extract it from minidumps.
-    unsymbolicated_context_frames: u64,
-
-    /// Unsymbolicated Frames found by scanning.
-    unsymbolicated_scanned_frames: u64,
-
-    /// Unsymbolicated Frames found by CFI.
-    ///
-    /// These are the result of the *previous* frame being wrongly scanned.
-    unsymbolicated_cfi_frames: u64,
-
-    /// Frames referencing unmapped memory regions.
-    ///
-    /// These may be the result of issues in the client-side module finder, or
-    /// broken debug-id information.
-    ///
-    /// We can improve this by fixing client-side implementations and having
-    /// proper debug-ids.
-    unmapped_frames: u64,
-}
-
-/// Determine if the [`SymbolicatedFrame`] is likely to be a thread base.
-///
-/// This is just a heuristic that matches the function to well known thread entry points.
-fn is_likely_base_frame(frame: &SymbolicatedFrame) -> bool {
-    let function = match frame
-        .raw
-        .function
-        .as_deref()
-        .or(frame.raw.symbol.as_deref())
-    {
-        Some(f) => f,
-        None => return false,
-    };
-
-    // C start/main
-    if matches!(function, "main" | "start" | "_start") {
-        return true;
-    }
-
-    // Windows and posix thread base. These often have prefixes depending on the OS and Version, so
-    // we use a substring match here.
-    if function.contains("UserThreadStart")
-        || function.contains("thread_start")
-        || function.contains("start_thread")
-        || function.contains("start_wqthread")
-    {
-        return true;
-    }
-
-    false
-}
-
-fn record_symbolication_metrics(
-    origin: StacktraceOrigin,
-    metrics: StacktraceMetrics,
-    modules: &[CompleteObjectInfo],
-    stacktraces: &[CompleteStacktrace],
-) {
-    let origin = origin.to_string();
-
-    let platform = modules
-        .iter()
-        .find_map(|m| {
-            if m.raw.ty == ObjectType::Unknown {
-                None
-            } else {
-                Some(m.raw.ty)
-            }
-        })
-        .unwrap_or(ObjectType::Unknown)
-        .to_string();
-
-    // Unusable modules that don’t have any kind of ID to look them up with
-    let mut unusable_modules = 0;
-    // Modules that failed parsing
-    let mut unparsable_modules = 0;
-
-    for m in modules {
-        metric!(
-            counter("symbolication.debug_status") += 1,
-            "status" => m.debug_status.name()
-        );
-
-        let usable_code_id = !matches!(m.raw.code_id.as_deref(), None | Some(""));
-
-        // NOTE: this is a closure as a way to short-circuit the computation because
-        // it is expensive
-        let usable_debug_id = || match m.raw.debug_id.as_deref() {
-            None | Some("") => false,
-            Some(string) => string.parse::<DebugId>().is_ok(),
-        };
-
-        if !usable_code_id && !usable_debug_id() {
-            unusable_modules += 1;
-        }
-
-        if m.debug_status == ObjectFileStatus::Malformed {
-            unparsable_modules += 1;
-        }
-    }
-
-    metric!(
-        time_raw("symbolication.num_modules") = modules.len() as u64,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unusable_modules") = unusable_modules,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unparsable_modules") = unparsable_modules,
-        "platform" => &platform, "origin" => &origin
-    );
-
-    metric!(
-        time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.short_stacktraces") = metrics.short_traces,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.truncated_stacktraces") = metrics.truncated_traces,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.bad_stacktraces") = metrics.bad_traces,
-        "platform" => &platform, "origin" => &origin
-    );
-
-    metric!(
-        time_raw("symbolication.num_frames") =
-            stacktraces.iter().map(|s| s.frames.len() as u64).sum::<u64>(),
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.scanned_frames") = metrics.scanned_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unsymbolicated_frames") = metrics.unsymbolicated_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unsymbolicated_context_frames") =
-            metrics.unsymbolicated_context_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unsymbolicated_cfi_frames") =
-            metrics.unsymbolicated_cfi_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unsymbolicated_scanned_frames") =
-            metrics.unsymbolicated_scanned_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-    metric!(
-        time_raw("symbolication.unmapped_frames") = metrics.unmapped_frames,
-        "platform" => &platform, "origin" => &origin
-    );
-}
-
-fn symbolicate_stacktrace(
-    thread: RawStacktrace,
-    caches: &ModuleLookup,
-    metrics: &mut StacktraceMetrics,
-    signal: Option<Signal>,
-) -> CompleteStacktrace {
-    let mut symbolicated_frames = vec![];
-    let mut unsymbolicated_frames_iter = thread.frames.into_iter().enumerate().peekable();
-
-    while let Some((index, mut frame)) = unsymbolicated_frames_iter.next() {
-        match symbolicate_frame(caches, &thread.registers, signal, &mut frame, index) {
-            Ok(frames) => {
-                if matches!(frame.trust, FrameTrust::Scan) {
-                    metrics.scanned_frames += 1;
-                }
-                symbolicated_frames.extend(frames)
-            }
-            Err(status) => {
-                // Since symbolication failed, the function name was not demangled. In case there is
-                // either one of `function` or `symbol`, treat that as mangled name and try to
-                // demangle it. If that succeeds, write the demangled name back.
-                let mangled = frame.function.as_deref().xor(frame.symbol.as_deref());
-                let demangled = mangled.and_then(|m| Name::from(m).demangle(DEMANGLE_OPTIONS));
-                if let Some(demangled) = demangled {
-                    if let Some(old_mangled) = frame.function.replace(demangled) {
-                        frame.symbol = Some(old_mangled);
-                    }
-                }
-
-                // Temporary workaround: Skip false-positive frames from stack scanning after the
-                // fact.
-                //
-                // Usually, the stack scanner would skip all scanned frames when it *knows* that
-                // they cannot be symbolized. However, in our case we supply breakpad symbols
-                // without function records. This breaks its original heuristic, since it would now
-                // *always* skip scan frames. Our patch in breakpad omits this check.
-                //
-                // Here, we fix this after the fact.
-                //
-                // - MissingSymbol: If symbolication failed for a scanned frame where we *know* we
-                //   have a debug info, but the lookup inside that file failed.
-                // - UnknownImage: If symbolication failed because the stackscanner found an
-                //   instruction_addr that is not in any image *we* consider valid. We discard
-                //   images which do not have a debug id, while the stackscanner considers them
-                //   perfectly fine.
-                if frame.trust == FrameTrust::Scan
-                    && (status == FrameStatus::MissingSymbol || status == FrameStatus::UnknownImage)
-                {
-                    continue;
-                }
-
-                // Glibc inserts an explicit `DW_CFA_undefined: RIP` DWARF rule to say that `_start`
-                // has no return address.
-                // See https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86_64/start.S;h=1b3e36826b8a477474cee24d1c931429fbdf6d8f;hb=HEAD#l59
-                // We do not support this due to lack of breakpad support, and will thus use the
-                // previous rule for RIP, which says to look it up the value on the stack,
-                // resulting in an unmapped garbage frame. We work around this by trimming the
-                // trailing garbage frame on the following conditions:
-                // * it is unmapped (UnknownImage)
-                // * this is the last frame to symbolicate (via peek)
-                // * the previous symbolicated frame is `_start`
-                let is_start =
-                    |frame: &SymbolicatedFrame| frame.raw.function.as_deref() == Some("_start");
-                if status == FrameStatus::UnknownImage
-                    && unsymbolicated_frames_iter.peek().is_none()
-                    && symbolicated_frames.last().map_or(false, is_start)
-                {
-                    continue;
-                }
-
-                metrics.unsymbolicated_frames += 1;
-                match frame.trust {
-                    FrameTrust::Scan => {
-                        metrics.scanned_frames += 1;
-                        metrics.unsymbolicated_scanned_frames += 1;
-                    }
-                    FrameTrust::Cfi => metrics.unsymbolicated_cfi_frames += 1,
-                    FrameTrust::Context => metrics.unsymbolicated_context_frames += 1,
-                    _ => {}
-                }
-                if status == FrameStatus::UnknownImage {
-                    metrics.unmapped_frames += 1;
-                }
-
-                symbolicated_frames.push(SymbolicatedFrame {
-                    status,
-                    original_index: Some(index),
-                    raw: frame,
-                });
-            }
-        }
-    }
-
-    // we try to find a base frame among the bottom 5
-    if !symbolicated_frames
-        .iter()
-        .rev()
-        .take(5)
-        .any(is_likely_base_frame)
-    {
-        metrics.truncated_traces += 1;
-    }
-    // macOS has some extremely short but perfectly fine stacks, such as:
-    // `__workq_kernreturn` > `_pthread_wqthread` > `start_wqthread`
-    if symbolicated_frames.len() < 3 {
-        metrics.short_traces += 1;
-    }
-
-    if metrics.scanned_frames > 0 || metrics.unsymbolicated_frames > 0 {
-        metrics.bad_traces += 1;
-    }
-
-    CompleteStacktrace {
-        thread_id: thread.thread_id,
-        thread_name: thread.thread_name,
-        is_requesting: thread.is_requesting,
-        registers: thread.registers,
-        frames: symbolicated_frames,
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-/// Where the Stack Traces in the [`SymbolicateStacktraces`] originated from.
-pub enum StacktraceOrigin {
-    /// The stack traces came from a direct request to symbolicate.
-    Symbolicate,
-    /// The stack traces were extracted from a minidump.
-    Minidump,
-    /// The stack traces came from an Apple Crash Report.
-    AppleCrashReport,
-}
-
-impl std::fmt::Display for StacktraceOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            StacktraceOrigin::Symbolicate => "symbolicate",
-            StacktraceOrigin::Minidump => "minidump",
-            StacktraceOrigin::AppleCrashReport => "applecrashreport",
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-/// A request for symbolication of multiple stack traces.
-pub struct SymbolicateStacktraces {
-    /// The scope of this request which determines access to cached files.
-    pub scope: Scope,
-
-    /// The signal thrown on certain operating systems.
-    ///
-    ///  Signal handlers sometimes mess with the runtime stack. This is used to determine whether
-    /// the top frame should be fixed or not.
-    pub signal: Option<Signal>,
-
-    /// A list of external sources to load debug files.
-    pub sources: Arc<[SourceConfig]>,
-
-    /// Where the stacktraces originated from.
-    pub origin: StacktraceOrigin,
-
-    /// A list of threads containing stack traces.
-    pub stacktraces: Vec<RawStacktrace>,
-
-    /// A list of images that were loaded into the process.
-    ///
-    /// This list must cover the instruction addresses of the frames in
-    /// [`stacktraces`](Self::stacktraces). If a frame is not covered by any image, the frame cannot
-    /// be symbolicated as it is not clear which debug file to load.
-    pub modules: Vec<CompleteObjectInfo>,
-
-    /// Options that came with this request, see [`RequestOptions`].
-    pub options: RequestOptions,
-}
-
-impl SymbolicationActor {
-    #[tracing::instrument(skip_all)]
-    async fn do_symbolicate(
-        &self,
-        request: SymbolicateStacktraces,
-    ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
-        let serialize_dif_candidates = request.options.dif_candidates;
-
-        let f = self.do_symbolicate_impl(request);
-        let f = tokio::time::timeout(Duration::from_secs(3600), f);
-        let f = measure("symbolicate", m::timed_result, None, f);
-
-        let mut response = f
-            .await
-            .map(|res| res.map_err(SymbolicationError::from))
-            .unwrap_or(Err(SymbolicationError::Timeout))?;
-
-        if !serialize_dif_candidates {
-            response.clear_dif_candidates();
-        }
-
-        Ok(response)
-    }
-
-    async fn do_symbolicate_impl(
-        &self,
-        request: SymbolicateStacktraces,
-    ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
-        let SymbolicateStacktraces {
-            stacktraces,
-            sources,
-            scope,
-            signal,
-            origin,
-            modules,
-            ..
-        } = request;
-
-        let mut module_lookup = ModuleLookup::new(scope, sources, modules.into_iter());
-        module_lookup
-            .fetch_symcaches(self.symcaches.clone(), &stacktraces)
-            .await;
-
-        let future = async move {
-            let mut metrics = StacktraceMetrics::default();
-            let stacktraces: Vec<_> = stacktraces
-                .into_iter()
-                .map(|trace| symbolicate_stacktrace(trace, &module_lookup, &mut metrics, signal))
-                .collect();
-
-            (module_lookup, stacktraces, metrics)
-        };
-
-        let (mut module_lookup, mut stacktraces, metrics) =
-            CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
-                .await
-                .context("Symbolication future cancelled")?;
-
-        module_lookup
-            .fetch_sources(self.objects.clone(), &stacktraces)
-            .await;
-
-        let future = async move {
-            let debug_sessions = module_lookup.prepare_debug_sessions();
-
-            for trace in &mut stacktraces {
-                for frame in &mut trace.frames {
-                    let (abs_path, lineno) = match (&frame.raw.abs_path, frame.raw.lineno) {
-                        (&Some(ref abs_path), Some(lineno)) => (abs_path, lineno),
-                        _ => continue,
-                    };
-
-                    let result = module_lookup.get_context_lines(
-                        &debug_sessions,
-                        frame.raw.instruction_addr.0,
-                        frame.raw.addr_mode,
-                        abs_path,
-                        lineno,
-                        5,
-                    );
-
-                    if let Some((pre_context, context_line, post_context)) = result {
-                        frame.raw.pre_context = pre_context;
-                        frame.raw.context_line = Some(context_line);
-                        frame.raw.post_context = post_context;
-                    }
-                }
-            }
-            // explicitly drop this, so it does not borrow `module_lookup` anymore.
-            drop(debug_sessions);
-
-            // bring modules back into the original order
-            let modules = module_lookup.into_inner();
-            record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
-
-            CompletedSymbolicationResponse {
-                signal,
-                stacktraces,
-                modules,
-                ..Default::default()
-            }
-        };
-
-        CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
-            .await
-            .context("Source lookup future cancelled")
-    }
-
-    /// Creates a new request to symbolicate stacktraces.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn symbolicate_stacktraces(
-        &self,
-        request: SymbolicateStacktraces,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "symbolicate_stacktraces",
-            "symbolicate_stacktraces",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf.do_symbolicate(request).await;
-            transaction.finish();
-            res
-        })
-    }
-
-    /// Polls the status for a started symbolication task.
-    ///
-    /// If the timeout is set and no result is ready within the given time,
-    /// [`SymbolicationResponse::Pending`] is returned.
-    pub async fn get_response(
-        &self,
-        request_id: RequestId,
-        timeout: Option<u64>,
-    ) -> Option<SymbolicationResponse> {
-        let channel_opt = self.requests.lock().get(&request_id).cloned();
-        match channel_opt {
-            Some(channel) => Some(wrap_response_channel(request_id, timeout, channel).await),
-            None => {
-                // This is okay to occur during deploys, but if it happens all the time we have a state
-                // bug somewhere. Could be a misconfigured load balancer (supposed to be pinned to
-                // scopes).
-                metric!(counter("symbolication.request_id_unknown") += 1);
-                None
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-struct AppleCrashReportState {
-    timestamp: Option<DateTime<Utc>>,
-    system_info: SystemInfo,
-    crash_reason: Option<String>,
-    crash_details: Option<String>,
-}
-
-impl AppleCrashReportState {
-    fn merge_into(mut self, response: &mut CompletedSymbolicationResponse) {
-        if self.system_info.cpu_arch == Arch::Unknown {
-            self.system_info.cpu_arch = response
-                .modules
-                .iter()
-                .map(|object| object.arch)
-                .find(|arch| *arch != Arch::Unknown)
-                .unwrap_or_default();
-        }
-
-        response.timestamp = self.timestamp;
-        response.system_info = Some(self.system_info);
-        response.crash_reason = self.crash_reason;
-        response.crash_details = self.crash_details;
-        response.crashed = Some(true);
-    }
-}
-
-fn map_apple_binary_image(image: apple_crash_report_parser::BinaryImage) -> CompleteObjectInfo {
-    let code_id = CodeId::from_binary(&image.uuid.as_bytes()[..]);
-    let debug_id = DebugId::from_uuid(image.uuid);
-
-    let raw_info = RawObjectInfo {
-        ty: ObjectType::Macho,
-        code_id: Some(code_id.to_string()),
-        code_file: Some(image.path.clone()),
-        debug_id: Some(debug_id.to_string()),
-        debug_file: Some(image.path),
-        image_addr: HexValue(image.addr.0),
-        image_size: match image.size {
-            0 => None,
-            size => Some(size),
-        },
-    };
-
-    raw_info.into()
-}
-
-impl SymbolicationActor {
-    async fn parse_apple_crash_report(
-        &self,
-        scope: Scope,
-        report: File,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), SymbolicationError> {
-        let parse_future = async {
-            let report = AppleCrashReport::from_reader(report)?;
-            let mut metadata = report.metadata;
-
-            let arch = report
-                .code_type
-                .as_ref()
-                .and_then(|code_type| code_type.split(' ').next())
-                .and_then(|word| word.parse().ok())
-                .unwrap_or_default();
-
-            let modules = report
-                .binary_images
-                .into_iter()
-                .map(map_apple_binary_image)
-                .collect();
-
-            let mut stacktraces = Vec::with_capacity(report.threads.len());
-
-            for thread in report.threads {
-                let registers = thread
-                    .registers
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|(name, addr)| (name, HexValue(addr.0)))
-                    .collect();
-
-                let frames = thread
-                    .frames
-                    .into_iter()
-                    .map(|frame| RawFrame {
-                        instruction_addr: HexValue(frame.instruction_addr.0),
-                        package: frame.module,
-                        ..RawFrame::default()
-                    })
-                    .collect();
-
-                stacktraces.push(RawStacktrace {
-                    thread_id: Some(thread.id),
-                    thread_name: thread.name,
-                    is_requesting: Some(thread.crashed),
-                    registers,
-                    frames,
-                });
-            }
-
-            let request = SymbolicateStacktraces {
-                modules,
-                scope,
-                sources,
-                origin: StacktraceOrigin::AppleCrashReport,
-                signal: None,
-                stacktraces,
-                options,
-            };
-
-            let mut system_info = SystemInfo {
-                os_name: metadata.remove("OS Version").unwrap_or_default(),
-                device_model: metadata.remove("Hardware Model").unwrap_or_default(),
-                cpu_arch: arch,
-                ..SystemInfo::default()
-            };
-
-            if let Some(captures) = OS_MACOS_REGEX.captures(&system_info.os_name) {
-                system_info.os_version = captures
-                    .name("version")
-                    .map(|m| m.as_str().to_string())
-                    .unwrap_or_default();
-                system_info.os_build = captures
-                    .name("build")
-                    .map(|m| m.as_str().to_string())
-                    .unwrap_or_default();
-                system_info.os_name = "macOS".to_string();
-            }
-
-            // https://developer.apple.com/library/archive/technotes/tn2151/_index.html
-            let crash_reason = metadata.remove("Exception Type");
-            let crash_details = report
-                .application_specific_information
-                .or_else(|| metadata.remove("Exception Message"))
-                .or_else(|| metadata.remove("Exception Subtype"))
-                .or_else(|| metadata.remove("Exception Codes"));
-
-            let state = AppleCrashReportState {
-                timestamp: report.timestamp,
-                system_info,
-                crash_reason,
-                crash_details,
-            };
-
-            Ok((request, state))
-        };
-
-        let future = async move {
-            CancelOnDrop::new(
-                self.cpu_pool
-                    .spawn(parse_future.bind_hub(sentry::Hub::current())),
-            )
-            .await
-            .context("Parse applecrashreport future cancelled")
-        };
-
-        let future = tokio::time::timeout(Duration::from_secs(1200), future);
-        let future = measure("parse_apple_crash_report", m::timed_result, None, future);
-        future
-            .await
-            .map(|res| res.map_err(SymbolicationError::from))
-            .unwrap_or(Err(SymbolicationError::Timeout))?
-    }
-
-    async fn do_process_apple_crash_report(
-        self,
-        scope: Scope,
-        report: File,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
-        let (request, state) = self
-            .parse_apple_crash_report(scope, report, sources, options)
-            .await?;
-        let mut response = self.do_symbolicate(request).await?;
-
-        state.merge_into(&mut response);
-        Ok(response)
-    }
-
-    /// Creates a new request to process an Apple crash report.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn process_apple_crash_report(
-        &self,
-        scope: Scope,
-        apple_crash_report: File,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_apple_crash_report",
-            "process_apple_crash_report",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .do_process_apple_crash_report(scope, apple_crash_report, sources, options)
-                .await;
-            transaction.finish();
-            res
-        })
     }
 }
 
@@ -1227,14 +395,33 @@ impl From<&SymCacheError> for ObjectFileStatus {
     }
 }
 
+fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
+    ObjectId {
+        debug_id: match object_info.debug_id.as_deref() {
+            None | Some("") => None,
+            Some(string) => string.parse().ok(),
+        },
+        code_id: match object_info.code_id.as_deref() {
+            None | Some("") => None,
+            Some(string) => string.parse().ok(),
+        },
+        debug_file: object_info.debug_file.clone(),
+        code_file: object_info.code_file.clone(),
+        object_type: object_info.ty,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use crate::config::Config;
+    use crate::services::symbolication::module_lookup::ModuleLookup;
     use crate::services::Service;
     use crate::test::{self, fixture};
+    use crate::types::{CompleteObjectInfo, ObjectType, RawFrame, RawStacktrace};
     use crate::utils::addr::AddrMode;
+    use crate::utils::hex::HexValue;
 
     /// Setup tests and create a test service.
     ///

--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -28,7 +28,7 @@ mod module_lookup;
 mod process_minidump;
 mod symbolication;
 
-use symbolication::{StacktraceOrigin, SymbolicateStacktraces};
+pub use symbolication::{StacktraceOrigin, SymbolicateStacktraces};
 
 // We want a shared future here because otherwise polling for a response would hold the global lock.
 type ComputationChannel = future::Shared<oneshot::Receiver<(Instant, SymbolicationResponse)>>;

--- a/crates/symbolicator/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator/src/services/symbolication/process_minidump.rs
@@ -30,14 +30,14 @@ use crate::sources::SourceConfig;
 use crate::types::{
     AllObjectCandidates, CompleteObjectInfo, CompletedSymbolicationResponse, FrameTrust,
     ObjectFeatures, ObjectFileStatus, ObjectType, RawFrame, RawObjectInfo, RawStacktrace,
-    Registers, RequestId, RequestOptions, Scope, SystemInfo,
+    Registers, RequestOptions, Scope, SystemInfo,
 };
 use crate::utils::futures::{m, measure};
 use crate::utils::hex::HexValue;
 
 use super::{
-    object_id_from_object_info, MaxRequestsError, StacktraceOrigin, SymbolicateStacktraces,
-    SymbolicationActor, SymbolicationError,
+    object_id_from_object_info, StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor,
+    SymbolicationError,
 };
 
 type CfiCacheResult = (DebugId, Result<Arc<CfiCacheFile>, Arc<CfiCacheError>>);
@@ -647,7 +647,7 @@ impl SymbolicationActor {
         }
     }
 
-    async fn do_process_minidump(
+    pub(super) async fn do_process_minidump(
         &self,
         scope: Scope,
         minidump_file: TempPath,
@@ -662,35 +662,6 @@ impl SymbolicationActor {
         state.merge_into(&mut response);
 
         Ok(response)
-    }
-
-    /// Creates a new request to process a minidump.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn process_minidump(
-        &self,
-        scope: Scope,
-        minidump_file: TempPath,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_minidump",
-            "process_minidump",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .do_process_minidump(scope, minidump_file, sources, options)
-                .await;
-            transaction.finish();
-            res
-        })
     }
 
     /// Iteratively stackwalks/processes the given `minidump_file`.
@@ -764,7 +735,7 @@ impl SymbolicationActor {
     }
 
     #[tracing::instrument(skip_all)]
-    pub(super) async fn do_stackwalk_minidump(
+    async fn do_stackwalk_minidump(
         &self,
         scope: Scope,
         minidump_file: TempPath,

--- a/crates/symbolicator/src/services/symbolication/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication/symbolication.rs
@@ -1,0 +1,671 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use sentry::SentryFutureExt;
+use symbolic::common::{split_path, DebugId, InstructionInfo, Language, Name};
+use symbolic::demangle::{Demangle, DemangleOptions};
+
+use crate::sources::SourceConfig;
+use crate::types::{
+    CompleteObjectInfo, CompleteStacktrace, CompletedSymbolicationResponse, FrameStatus,
+    FrameTrust, ObjectFileStatus, ObjectType, RawFrame, RawStacktrace, Registers, RequestOptions,
+    Scope, Signal, SymbolicatedFrame,
+};
+use crate::utils::futures::{m, measure, CancelOnDrop};
+use crate::utils::hex::HexValue;
+
+use super::module_lookup::ModuleLookup;
+use super::{SymbolicationActor, SymbolicationError};
+
+impl SymbolicationActor {
+    #[tracing::instrument(skip_all)]
+    pub(super) async fn do_symbolicate(
+        &self,
+        request: SymbolicateStacktraces,
+    ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
+        let serialize_dif_candidates = request.options.dif_candidates;
+
+        let f = self.do_symbolicate_impl(request);
+        let f = tokio::time::timeout(Duration::from_secs(3600), f);
+        let f = measure("symbolicate", m::timed_result, None, f);
+
+        let mut response = f
+            .await
+            .map(|res| res.map_err(SymbolicationError::from))
+            .unwrap_or(Err(SymbolicationError::Timeout))?;
+
+        if !serialize_dif_candidates {
+            response.clear_dif_candidates();
+        }
+
+        Ok(response)
+    }
+
+    async fn do_symbolicate_impl(
+        &self,
+        request: SymbolicateStacktraces,
+    ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
+        let SymbolicateStacktraces {
+            stacktraces,
+            sources,
+            scope,
+            signal,
+            origin,
+            modules,
+            ..
+        } = request;
+
+        let mut module_lookup = ModuleLookup::new(scope, sources, modules.into_iter());
+        module_lookup
+            .fetch_symcaches(self.symcaches.clone(), &stacktraces)
+            .await;
+
+        let future = async move {
+            let mut metrics = StacktraceMetrics::default();
+            let stacktraces: Vec<_> = stacktraces
+                .into_iter()
+                .map(|trace| symbolicate_stacktrace(trace, &module_lookup, &mut metrics, signal))
+                .collect();
+
+            (module_lookup, stacktraces, metrics)
+        };
+
+        let (mut module_lookup, mut stacktraces, metrics) =
+            CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
+                .await
+                .context("Symbolication future cancelled")?;
+
+        module_lookup
+            .fetch_sources(self.objects.clone(), &stacktraces)
+            .await;
+
+        let future = async move {
+            let debug_sessions = module_lookup.prepare_debug_sessions();
+
+            for trace in &mut stacktraces {
+                for frame in &mut trace.frames {
+                    let (abs_path, lineno) = match (&frame.raw.abs_path, frame.raw.lineno) {
+                        (&Some(ref abs_path), Some(lineno)) => (abs_path, lineno),
+                        _ => continue,
+                    };
+
+                    let result = module_lookup.get_context_lines(
+                        &debug_sessions,
+                        frame.raw.instruction_addr.0,
+                        frame.raw.addr_mode,
+                        abs_path,
+                        lineno,
+                        5,
+                    );
+
+                    if let Some((pre_context, context_line, post_context)) = result {
+                        frame.raw.pre_context = pre_context;
+                        frame.raw.context_line = Some(context_line);
+                        frame.raw.post_context = post_context;
+                    }
+                }
+            }
+            // explicitly drop this, so it does not borrow `module_lookup` anymore.
+            drop(debug_sessions);
+
+            // bring modules back into the original order
+            let modules = module_lookup.into_inner();
+            record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
+
+            CompletedSymbolicationResponse {
+                signal,
+                stacktraces,
+                modules,
+                ..Default::default()
+            }
+        };
+
+        CancelOnDrop::new(self.cpu_pool.spawn(future.bind_hub(sentry::Hub::current())))
+            .await
+            .context("Source lookup future cancelled")
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A request for symbolication of multiple stack traces.
+pub struct SymbolicateStacktraces {
+    /// The scope of this request which determines access to cached files.
+    pub scope: Scope,
+
+    /// The signal thrown on certain operating systems.
+    ///
+    ///  Signal handlers sometimes mess with the runtime stack. This is used to determine whether
+    /// the top frame should be fixed or not.
+    pub signal: Option<Signal>,
+
+    /// A list of external sources to load debug files.
+    pub sources: Arc<[SourceConfig]>,
+
+    /// Where the stacktraces originated from.
+    pub origin: StacktraceOrigin,
+
+    /// A list of threads containing stack traces.
+    pub stacktraces: Vec<RawStacktrace>,
+
+    /// A list of images that were loaded into the process.
+    ///
+    /// This list must cover the instruction addresses of the frames in
+    /// [`stacktraces`](Self::stacktraces). If a frame is not covered by any image, the frame cannot
+    /// be symbolicated as it is not clear which debug file to load.
+    pub modules: Vec<CompleteObjectInfo>,
+
+    /// Options that came with this request, see [`RequestOptions`].
+    pub options: RequestOptions,
+}
+
+fn symbolicate_frame(
+    caches: &ModuleLookup,
+    registers: &Registers,
+    signal: Option<Signal>,
+    frame: &mut RawFrame,
+    index: usize,
+) -> Result<Vec<SymbolicatedFrame>, FrameStatus> {
+    let lookup_result = caches
+        .lookup_symcache(frame.instruction_addr.0, frame.addr_mode)
+        .ok_or(FrameStatus::UnknownImage)?;
+
+    frame.package = lookup_result.object_info.raw.code_file.clone();
+    if lookup_result.symcache.is_none() {
+        if lookup_result.object_info.debug_status == ObjectFileStatus::Malformed {
+            return Err(FrameStatus::Malformed);
+        } else {
+            return Err(FrameStatus::Missing);
+        }
+    }
+
+    tracing::trace!("Loading symcache");
+    let symcache = match lookup_result
+        .symcache
+        .as_ref()
+        .expect("symcache should always be available at this point")
+        .parse()
+    {
+        Ok(Some(x)) => x,
+        Ok(None) => return Err(FrameStatus::Missing),
+        Err(_) => return Err(FrameStatus::Malformed),
+    };
+
+    // get the relative caller address
+    let relative_addr = if let Some(addr) = lookup_result.relative_addr {
+        // heuristics currently are only supported when we can work with absolute addresses.
+        // In cases where this is not possible we skip this part entirely and use the relative
+        // address calculated by the lookup result as lookup address in the module.
+        if let Some(absolute_addr) = lookup_result.object_info.rel_to_abs_addr(addr) {
+            let is_crashing_frame = index == 0;
+            let ip_register_value = if is_crashing_frame {
+                symcache
+                    .arch()
+                    .cpu_family()
+                    .ip_register_name()
+                    .and_then(|ip_reg_name| registers.get(ip_reg_name))
+                    .map(|x| x.0)
+            } else {
+                None
+            };
+            let absolute_caller_addr = InstructionInfo::new(symcache.arch(), absolute_addr)
+                .is_crashing_frame(is_crashing_frame)
+                .signal(signal.map(|signal| signal.0))
+                .ip_register_value(ip_register_value)
+                .caller_address();
+            lookup_result
+                .object_info
+                .abs_to_rel_addr(absolute_caller_addr)
+                .ok_or_else(|| {
+                    tracing::warn!(
+                            "Underflow when trying to subtract image start addr from caller address after heuristics"
+                        );
+                    metric!(counter("relative_addr.underflow") += 1);
+                    FrameStatus::MissingSymbol
+                })?
+        } else {
+            addr
+        }
+    } else {
+        tracing::warn!("Underflow when trying to subtract image start addr from caller address before heuristics");
+        metric!(counter("relative_addr.underflow") += 1);
+        return Err(FrameStatus::MissingSymbol);
+    };
+
+    tracing::trace!("Symbolicating {:#x}", relative_addr);
+    let mut rv = vec![];
+
+    // The symbol addr only makes sense for the outermost top-level function, and not its inlinees.
+    // We keep track of it while iterating and only set it for the last frame,
+    // which is the top-level function.
+    let mut sym_addr = None;
+    let instruction_addr = HexValue(lookup_result.expose_preferred_addr(relative_addr));
+
+    for source_location in symcache.lookup(relative_addr) {
+        let abs_path = source_location
+            .file()
+            .map(|f| f.full_path())
+            .unwrap_or_default();
+        let filename = split_path(&abs_path).1;
+
+        let func = source_location.function();
+        let symbol = func.name();
+
+        // Detect the language from the bare name, ignoring any pre-set language. There are a few
+        // languages that we should always be able to demangle. Only complain about those that we
+        // detect explicitly, but silently ignore the rest. For instance, there are C-identifiers
+        // reported as C++, which are expected not to demangle.
+        let detected_language = Name::from(symbol).detect_language();
+        let should_demangle = match (func.language(), detected_language) {
+            (_, Language::Unknown) => false, // can't demangle what we cannot detect
+            (Language::ObjCpp, Language::Cpp) => true, // C++ demangles even if it was in ObjC++
+            (Language::Unknown, _) => true,  // if there was no language, then rely on detection
+            (lang, detected) => lang == detected, // avoid false-positive detections
+        };
+
+        let demangled_opt = func.name_for_demangling().demangle(DEMANGLE_OPTIONS);
+        if should_demangle && demangled_opt.is_none() {
+            sentry::with_scope(
+                |scope| scope.set_extra("identifier", symbol.to_string().into()),
+                || {
+                    let message = format!("Failed to demangle {} identifier", func.language());
+                    sentry::capture_message(&message, sentry::Level::Error);
+                },
+            );
+        }
+
+        sym_addr = Some(HexValue(
+            lookup_result.expose_preferred_addr(func.entry_pc() as u64),
+        ));
+        let filename = if !filename.is_empty() {
+            Some(filename.to_string())
+        } else {
+            frame.filename.clone()
+        };
+        rv.push(SymbolicatedFrame {
+            status: FrameStatus::Symbolicated,
+            original_index: Some(index),
+            raw: RawFrame {
+                package: lookup_result.object_info.raw.code_file.clone(),
+                addr_mode: lookup_result.preferred_addr_mode(),
+                instruction_addr,
+                symbol: Some(symbol.to_string()),
+                abs_path: if !abs_path.is_empty() {
+                    Some(abs_path)
+                } else {
+                    frame.abs_path.clone()
+                },
+                function: Some(match demangled_opt {
+                    Some(demangled) => demangled,
+                    None => symbol.to_string(),
+                }),
+                filename,
+                lineno: Some(source_location.line()),
+                pre_context: vec![],
+                context_line: None,
+                post_context: vec![],
+                sym_addr: None,
+                lang: match func.language() {
+                    Language::Unknown => None,
+                    language => Some(language),
+                },
+                trust: frame.trust,
+            },
+        });
+    }
+
+    if let Some(last_frame) = rv.last_mut() {
+        last_frame.raw.sym_addr = sym_addr;
+    }
+
+    if rv.is_empty() {
+        return Err(FrameStatus::MissingSymbol);
+    }
+
+    Ok(rv)
+}
+
+/// Options for demangling all symbols.
+const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
+
+/// Stacktrace related Metrics
+///
+/// This gives some metrics about the quality of the stack traces included
+/// in a symbolication request. See the individual members for more information.
+///
+/// These numbers are being accumulated across one symbolication request, and are emitted
+/// as a histogram.
+#[derive(Default)]
+struct StacktraceMetrics {
+    /// A truncated stack trace is one that does not end in a
+    /// well known thread base.
+    truncated_traces: u64,
+
+    /// We classify a short stacktrace as one that has less that 5 frames.
+    short_traces: u64,
+
+    /// This indicated a stack trace that has at least one bad frame
+    /// from the below categories.
+    bad_traces: u64,
+
+    /// Frames that were scanned.
+    ///
+    /// These are frequently wrong and lead to bad and incomplete stack traces.
+    /// We can improve (lower) these numbers by having more usable CFI info.
+    scanned_frames: u64,
+
+    /// Unsymbolicated Frames.
+    ///
+    /// These may be the result of unavailable or broken debug info.
+    /// We can improve (lower) these numbers by having more usable debug info.
+    unsymbolicated_frames: u64,
+
+    /// Unsymbolicated Context Frames.
+    ///
+    /// This is an indication of broken contexts, or failure to extract it from minidumps.
+    unsymbolicated_context_frames: u64,
+
+    /// Unsymbolicated Frames found by scanning.
+    unsymbolicated_scanned_frames: u64,
+
+    /// Unsymbolicated Frames found by CFI.
+    ///
+    /// These are the result of the *previous* frame being wrongly scanned.
+    unsymbolicated_cfi_frames: u64,
+
+    /// Frames referencing unmapped memory regions.
+    ///
+    /// These may be the result of issues in the client-side module finder, or
+    /// broken debug-id information.
+    ///
+    /// We can improve this by fixing client-side implementations and having
+    /// proper debug-ids.
+    unmapped_frames: u64,
+}
+
+/// Determine if the [`SymbolicatedFrame`] is likely to be a thread base.
+///
+/// This is just a heuristic that matches the function to well known thread entry points.
+fn is_likely_base_frame(frame: &SymbolicatedFrame) -> bool {
+    let function = match frame
+        .raw
+        .function
+        .as_deref()
+        .or(frame.raw.symbol.as_deref())
+    {
+        Some(f) => f,
+        None => return false,
+    };
+
+    // C start/main
+    if matches!(function, "main" | "start" | "_start") {
+        return true;
+    }
+
+    // Windows and posix thread base. These often have prefixes depending on the OS and Version, so
+    // we use a substring match here.
+    if function.contains("UserThreadStart")
+        || function.contains("thread_start")
+        || function.contains("start_thread")
+        || function.contains("start_wqthread")
+    {
+        return true;
+    }
+
+    false
+}
+
+fn record_symbolication_metrics(
+    origin: StacktraceOrigin,
+    metrics: StacktraceMetrics,
+    modules: &[CompleteObjectInfo],
+    stacktraces: &[CompleteStacktrace],
+) {
+    let origin = origin.to_string();
+
+    let platform = modules
+        .iter()
+        .find_map(|m| {
+            if m.raw.ty == ObjectType::Unknown {
+                None
+            } else {
+                Some(m.raw.ty)
+            }
+        })
+        .unwrap_or(ObjectType::Unknown)
+        .to_string();
+
+    // Unusable modules that don’t have any kind of ID to look them up with
+    let mut unusable_modules = 0;
+    // Modules that failed parsing
+    let mut unparsable_modules = 0;
+
+    for m in modules {
+        metric!(
+            counter("symbolication.debug_status") += 1,
+            "status" => m.debug_status.name()
+        );
+
+        let usable_code_id = !matches!(m.raw.code_id.as_deref(), None | Some(""));
+
+        // NOTE: this is a closure as a way to short-circuit the computation because
+        // it is expensive
+        let usable_debug_id = || match m.raw.debug_id.as_deref() {
+            None | Some("") => false,
+            Some(string) => string.parse::<DebugId>().is_ok(),
+        };
+
+        if !usable_code_id && !usable_debug_id() {
+            unusable_modules += 1;
+        }
+
+        if m.debug_status == ObjectFileStatus::Malformed {
+            unparsable_modules += 1;
+        }
+    }
+
+    metric!(
+        time_raw("symbolication.num_modules") = modules.len() as u64,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unusable_modules") = unusable_modules,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unparsable_modules") = unparsable_modules,
+        "platform" => &platform, "origin" => &origin
+    );
+
+    metric!(
+        time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.short_stacktraces") = metrics.short_traces,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.truncated_stacktraces") = metrics.truncated_traces,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.bad_stacktraces") = metrics.bad_traces,
+        "platform" => &platform, "origin" => &origin
+    );
+
+    metric!(
+        time_raw("symbolication.num_frames") =
+            stacktraces.iter().map(|s| s.frames.len() as u64).sum::<u64>(),
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.scanned_frames") = metrics.scanned_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unsymbolicated_frames") = metrics.unsymbolicated_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unsymbolicated_context_frames") =
+            metrics.unsymbolicated_context_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unsymbolicated_cfi_frames") =
+            metrics.unsymbolicated_cfi_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unsymbolicated_scanned_frames") =
+            metrics.unsymbolicated_scanned_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+    metric!(
+        time_raw("symbolication.unmapped_frames") = metrics.unmapped_frames,
+        "platform" => &platform, "origin" => &origin
+    );
+}
+
+fn symbolicate_stacktrace(
+    thread: RawStacktrace,
+    caches: &ModuleLookup,
+    metrics: &mut StacktraceMetrics,
+    signal: Option<Signal>,
+) -> CompleteStacktrace {
+    let mut symbolicated_frames = vec![];
+    let mut unsymbolicated_frames_iter = thread.frames.into_iter().enumerate().peekable();
+
+    while let Some((index, mut frame)) = unsymbolicated_frames_iter.next() {
+        match symbolicate_frame(caches, &thread.registers, signal, &mut frame, index) {
+            Ok(frames) => {
+                if matches!(frame.trust, FrameTrust::Scan) {
+                    metrics.scanned_frames += 1;
+                }
+                symbolicated_frames.extend(frames)
+            }
+            Err(status) => {
+                // Since symbolication failed, the function name was not demangled. In case there is
+                // either one of `function` or `symbol`, treat that as mangled name and try to
+                // demangle it. If that succeeds, write the demangled name back.
+                let mangled = frame.function.as_deref().xor(frame.symbol.as_deref());
+                let demangled = mangled.and_then(|m| Name::from(m).demangle(DEMANGLE_OPTIONS));
+                if let Some(demangled) = demangled {
+                    if let Some(old_mangled) = frame.function.replace(demangled) {
+                        frame.symbol = Some(old_mangled);
+                    }
+                }
+
+                // Temporary workaround: Skip false-positive frames from stack scanning after the
+                // fact.
+                //
+                // Usually, the stack scanner would skip all scanned frames when it *knows* that
+                // they cannot be symbolized. However, in our case we supply breakpad symbols
+                // without function records. This breaks its original heuristic, since it would now
+                // *always* skip scan frames. Our patch in breakpad omits this check.
+                //
+                // Here, we fix this after the fact.
+                //
+                // - MissingSymbol: If symbolication failed for a scanned frame where we *know* we
+                //   have a debug info, but the lookup inside that file failed.
+                // - UnknownImage: If symbolication failed because the stackscanner found an
+                //   instruction_addr that is not in any image *we* consider valid. We discard
+                //   images which do not have a debug id, while the stackscanner considers them
+                //   perfectly fine.
+                if frame.trust == FrameTrust::Scan
+                    && (status == FrameStatus::MissingSymbol || status == FrameStatus::UnknownImage)
+                {
+                    continue;
+                }
+
+                // Glibc inserts an explicit `DW_CFA_undefined: RIP` DWARF rule to say that `_start`
+                // has no return address.
+                // See https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86_64/start.S;h=1b3e36826b8a477474cee24d1c931429fbdf6d8f;hb=HEAD#l59
+                // We do not support this due to lack of breakpad support, and will thus use the
+                // previous rule for RIP, which says to look it up the value on the stack,
+                // resulting in an unmapped garbage frame. We work around this by trimming the
+                // trailing garbage frame on the following conditions:
+                // * it is unmapped (UnknownImage)
+                // * this is the last frame to symbolicate (via peek)
+                // * the previous symbolicated frame is `_start`
+                let is_start =
+                    |frame: &SymbolicatedFrame| frame.raw.function.as_deref() == Some("_start");
+                if status == FrameStatus::UnknownImage
+                    && unsymbolicated_frames_iter.peek().is_none()
+                    && symbolicated_frames.last().map_or(false, is_start)
+                {
+                    continue;
+                }
+
+                metrics.unsymbolicated_frames += 1;
+                match frame.trust {
+                    FrameTrust::Scan => {
+                        metrics.scanned_frames += 1;
+                        metrics.unsymbolicated_scanned_frames += 1;
+                    }
+                    FrameTrust::Cfi => metrics.unsymbolicated_cfi_frames += 1,
+                    FrameTrust::Context => metrics.unsymbolicated_context_frames += 1,
+                    _ => {}
+                }
+                if status == FrameStatus::UnknownImage {
+                    metrics.unmapped_frames += 1;
+                }
+
+                symbolicated_frames.push(SymbolicatedFrame {
+                    status,
+                    original_index: Some(index),
+                    raw: frame,
+                });
+            }
+        }
+    }
+
+    // we try to find a base frame among the bottom 5
+    if !symbolicated_frames
+        .iter()
+        .rev()
+        .take(5)
+        .any(is_likely_base_frame)
+    {
+        metrics.truncated_traces += 1;
+    }
+    // macOS has some extremely short but perfectly fine stacks, such as:
+    // `__workq_kernreturn` > `_pthread_wqthread` > `start_wqthread`
+    if symbolicated_frames.len() < 3 {
+        metrics.short_traces += 1;
+    }
+
+    if metrics.scanned_frames > 0 || metrics.unsymbolicated_frames > 0 {
+        metrics.bad_traces += 1;
+    }
+
+    CompleteStacktrace {
+        thread_id: thread.thread_id,
+        thread_name: thread.thread_name,
+        is_requesting: thread.is_requesting,
+        registers: thread.registers,
+        frames: symbolicated_frames,
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Where the Stack Traces in the [`SymbolicateStacktraces`] originated from.
+pub enum StacktraceOrigin {
+    /// The stack traces came from a direct request to symbolicate.
+    Symbolicate,
+    /// The stack traces were extracted from a minidump.
+    Minidump,
+    /// The stack traces came from an Apple Crash Report.
+    AppleCrashReport,
+}
+
+impl std::fmt::Display for StacktraceOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            StacktraceOrigin::Symbolicate => "symbolicate",
+            StacktraceOrigin::Minidump => "minidump",
+            StacktraceOrigin::AppleCrashReport => "applecrashreport",
+        })
+    }
+}


### PR DESCRIPTION
This splits the main `symbolication/mod.rs` into smaller modules,
in particular this moves all the apple crash report, and symbolication
specific parts out of the main module which now concerns itself with
request dispatching.
However, each of the modules still includes way too much timeout and metrics-related code/wrappers. We might want to clean those up later as well.

These modules could also use a few more comments explaining the separation.

#skip-changelog