### PR TITLE
Move HTTPS server changelog entry to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - Use Unity il2cpp line mapping files in symcache creation ([#831](https://github.com/getsentry/symbolicator/pull/831))
 - Read thread names from minidumps and Apple crash reports ([#834](https://github.com/getsentry/symbolicator/pull/834))
+- Add support for serving web requests using HTTPS ([#829](https://github.com/getsentry/symbolicator/pull/829))
 
 ## 0.5.1
 
 ### Features
 
 - Added an internal option to capture minidumps for hard crashes. This has to be enabled via the `_crash_db` config parameter. ([#795](https://github.com/getsentry/symbolicator/pull/795))
-- Add support for serving web requests using HTTPS ([#829](https://github.com/getsentry/symbolicator/pull/829))
 
 ### Fixes
 


### PR DESCRIPTION
I accidentally added the HTTPS server changelog entry to the 0.5.1 release entries.

#skip-changelog