### PR TITLE
fix: Use an ObjectId for il2cpp lookup

### DIFF
--- a/crates/symbolicator/src/services/il2cpp.rs
+++ b/crates/symbolicator/src/services/il2cpp.rs
@@ -24,6 +24,7 @@ use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
 use crate::utils::futures::{m, measure};
 
+use super::download::ObjectId;
 use super::shared_cache::SharedCacheService;
 
 /// Handle to a valid [`LineMapping`].
@@ -194,13 +195,19 @@ impl Il2cppService {
     /// Returns a `LineMapping` if one is found for the `debug_id`.
     pub async fn fetch_line_mapping(
         &self,
+        object_id: &ObjectId,
         debug_id: DebugId,
         scope: Scope,
         sources: Arc<[SourceConfig]>,
     ) -> Option<Il2cppHandle> {
         let jobs = sources.iter().map(|source| {
-            self.fetch_file_from_source_with_error(debug_id, scope.clone(), source.clone())
-                .bind_hub(Hub::new_from_top(Hub::current()))
+            self.fetch_file_from_source_with_error(
+                object_id,
+                debug_id,
+                scope.clone(),
+                source.clone(),
+            )
+            .bind_hub(Hub::new_from_top(Hub::current()))
         });
         let results = future::join_all(jobs).await;
         let mut line_mapping_handle = None;
@@ -221,6 +228,7 @@ impl Il2cppService {
     /// Wraps `fetch_file_from_source` in sentry error handling.
     async fn fetch_file_from_source_with_error(
         &self,
+        object_id: &ObjectId,
         debug_id: DebugId,
         scope: Scope,
         source: SourceConfig,
@@ -231,7 +239,7 @@ impl Il2cppService {
             scope.set_extra("il2cpp.source", source.type_name().into());
         });
         match self
-            .fetch_file_from_source(debug_id, scope, source)
+            .fetch_file_from_source(object_id, debug_id, scope, source)
             .await
             .context("il2cpp svc failed for single source")
         {
@@ -247,13 +255,14 @@ impl Il2cppService {
     /// Fetches a file and returns the [`CacheHandle`] if found.
     async fn fetch_file_from_source(
         &self,
+        object_id: &ObjectId,
         debug_id: DebugId,
         scope: Scope,
         source: SourceConfig,
     ) -> Result<Option<Arc<CacheHandle>>, Error> {
         let file_sources = self
             .download_svc
-            .list_files(source, &[FileType::Il2cpp], debug_id.into())
+            .list_files(source, &[FileType::Il2cpp], object_id.clone())
             .await?;
 
         let fetch_jobs = file_sources.into_iter().map(|file_source| {

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -335,6 +335,7 @@ impl SymCacheActor {
                             tracing::trace!("Fetching line mapping");
                             self.il2cpp_svc
                                 .fetch_line_mapping(
+                                    handle.object_id(),
                                     debug_id,
                                     handle.scope().clone(),
                                     request.sources.clone(),

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -327,7 +327,8 @@ fn get_debuginfod_path(filetype: FileType, identifier: &ObjectId) -> Option<Stri
 fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow<str>> {
     match filetype {
         // For these we fall back to the identifier's object type.
-        FileType::SourceBundle | FileType::Breakpad => {
+        FileType::SourceBundle | FileType::Breakpad | FileType::Il2cpp => {
+            dbg!(filetype, identifier);
             let filetype = match identifier.object_type {
                 ObjectType::Elf => FileType::ElfCode,
                 ObjectType::Macho => FileType::MachCode,
@@ -347,15 +348,13 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
         )),
         // On mach we can always determine the code ID from the debug ID if the
         // code ID is unavailable.  We apply the same rule to WASM files as well as
-        // auxiliary DIFs, as we
-        // suggest Uuids to be used as build ids.
+        // auxiliary DIFs, as we suggest Uuids to be used as build ids.
         FileType::MachCode
         | FileType::MachDebug
         | FileType::WasmDebug
         | FileType::WasmCode
         | FileType::UuidMap
-        | FileType::BcSymbolMap
-        | FileType::Il2cpp => {
+        | FileType::BcSymbolMap => {
             if identifier.code_id.is_none() {
                 Some(Cow::Owned(
                     identifier.debug_id?.uuid().as_simple().to_string(),

--- a/crates/symbolicator/src/utils/paths.rs
+++ b/crates/symbolicator/src/utils/paths.rs
@@ -328,7 +328,6 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
     match filetype {
         // For these we fall back to the identifier's object type.
         FileType::SourceBundle | FileType::Breakpad | FileType::Il2cpp => {
-            dbg!(filetype, identifier);
             let filetype = match identifier.object_type {
                 ObjectType::Elf => FileType::ElfCode,
                 ObjectType::Macho => FileType::MachCode,


### PR DESCRIPTION
This way, the unified symbol source (for example local file system) can use object-type specific formatting for those IDs, as for example PDB debug-ids have an additional age appended.

Though this should not have an effect on the sentry source. It seems like things are being looked up correctly, but the file candidates are not being output.

#skip-changelog