### PR TITLE
ci: Update sentry integration test for sentry actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions/
           cp -r sentry/.github/actions/setup-sentry .github/actions/
-          cp -r sentry/.github/actions/setup-python .github/actions/
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry


### PR DESCRIPTION
The setup-python action was removed upstream:
https://github.com/getsentry/sentry/pull/36687

#skip-changelog