### PR TITLE
fix: Fetch/use CFI for modules that only have a CodeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - fixed problems with PDB/DWARF when parent functions don't have matching line records
   - using a new TypeFormatter for PDB that can pretty-print function arguments
 - Extract the correct `code_id` from iOS minidumps. ([#858](https://github.com/getsentry/symbolicator/pull/858))
+- Fetch/use CFI for modules that only have a CodeId. ([#860](https://github.com/getsentry/symbolicator/pull/860))
 
 ### Internal
 


### PR DESCRIPTION
Previously, we would not even try fetching CFI for modules that have no debug_id, though they could have a code_id that we can look up on an external symbol server, which we now do.

This is the symbolicator followup of https://github.com/getsentry/symbolic/pull/653#issuecomment-1204071737

I also removed the `SymbolProvider::stats`, which is now defaulted by rust-minidump and we never use the output of that function anywhere anyway.