### PR TITLE
feat: Pretty-print process-event output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,6 +2194,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -11,3 +11,4 @@ reqwest = { version = "0.11.0", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
+symbolic-common = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes" }


### PR DESCRIPTION
This adds a new `-p`/`-pretty` option that will pretty-print the crashing thread of a processed minidump.

#skip-changelog