### PR TITLE
ref: Avoid git dependencies in favor of cargo patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.29.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -1014,7 +1014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
  "tokio",
  "url",
  "which",
@@ -1048,7 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
- "indexmap",
  "stable_deref_trait",
 ]
 
@@ -1587,7 +1586,7 @@ dependencies = [
  "range-map",
  "scroll",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
  "tracing",
  "uuid",
 ]
@@ -1803,16 +1802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "flate2",
- "memchr",
 ]
 
 [[package]]
@@ -2731,25 +2720,25 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2867,7 +2856,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.15",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
 ]
 
 [[package]]
@@ -2999,9 +2988,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7cb9f92456814241cca5984dac2ef4deced2bedd8ed2cbd7ae2e1a74f86af6"
+checksum = "88dc71d44a86d4ae9e3c9b6d36c6c3664f19afe1b863f1563548c69969596b43"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -3013,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e940c2b9dffac8a624b43b71918c5ff677db6952fa6f74d967272a32ea71e6f"
+checksum = "888e41d514ec9632121c0d5cf87df20e4486129117608a582c92e1f378d37f9f"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3024,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e4ba9eec41633b820fe1d1a2db3c51a6c00992ed6858300b645bef2f2d7ddb"
+checksum = "3e555b2c3ebd97b963c8a3e94ce5e5137ba42da4a26687f81c700d8de1c997f0"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3037,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a8a9e8a09332209e8d6541b7b5d19f072a8587ec5c1ecd52800c7104c9645d"
+checksum = "5be6fd1cf9ae6cbcc162b19199da2e2e10e9944d58bf8e32226eeadbad5303de"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3068,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4da73cc082fa227dfa279dbff0393d9a67d390a8232a929af2732cbc48e66dc"
+checksum = "71a1425bccf0a24c68c9faea6c4f1f84b4865a3dd5976454d8a796c80216e38a"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3081,26 +3070,21 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d472a0f5c14e4b38d05ffe07bae829687a9c46c05dfe2c49ce029f6adfb20"
+checksum = "179a82ef0b185eaf8c97dccd32859c299eefd4ff3c9c48da7f002e6b211e07d7"
 dependencies = [
- "anyhow",
- "gimli",
  "indexmap",
- "object 0.28.4",
- "scroll",
  "serde_json",
  "symbolic-common",
  "symbolic-debuginfo",
- "thiserror",
 ]
 
 [[package]]
 name = "symbolic-symcache"
-version = "9.1.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a004b2797535e231d27c612baa2ffa1f4005e7787584f959fdf1cbfdcf66d06d"
+checksum = "362385aa2245eeb8ebbe0391c45bb929a53d1cdf37c09564500472f86a6c0dc8"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3334,12 +3318,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
- "js-sys",
  "libc",
  "num_threads",
  "serde",
@@ -3599,7 +3582,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.12",
+ "time 0.3.13",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 dependencies = [
  "backtrace",
 ]
@@ -131,9 +140,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -231,7 +240,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 3.2.16",
+ "clap 3.2.17",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -391,10 +400,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
@@ -438,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -911,9 +921,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -926,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -936,15 +946,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -953,15 +963,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -970,21 +980,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1059,9 +1069,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91766b1121940d622933a13e20665857648681816089c9bc2075c4b75a6e4f6b"
+checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
 dependencies = [
  "log",
  "plain",
@@ -1070,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1280,6 +1290,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.18.0"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49de01ff8a0781c5414e674b4469b81f6693d6bda6a4d405600c2acd06ebc6d3"
+checksum = "57a9aec10c9a062ef0454fd49ebaefa59239f836d1b30891d9cc2289978dd970"
 dependencies = [
  "console",
  "linked-hash-map",
@@ -1431,9 +1454,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -1540,9 +1563,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -1815,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
@@ -1872,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -2025,18 +2048,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 dependencies = [
  "backtrace",
 ]
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b26e2731cf84d9c54b3768a2faebe97626cb0568babf04bad68077e8b60c555"
+checksum = "87ba6170b61f7b086609dabcae68d2e07352539c6ef04a7c82980bdfa01a159d"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -206,7 +206,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.29.0",
  "rustc-demangle",
 ]
 
@@ -391,15 +391,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits 0.2.15",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -501,7 +502,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "cpp_demangle"
 version = "0.3.5"
-source = "git+https://github.com/Swatinem/cpp_demangle?branch=sentry-patches#a81a96a0c5e6b514b14638c1e09cb0489fef31bc"
+source = "git+https://github.com/getsentry/cpp_demangle?branch=sentry-patches#9a28d762cfb754d39756f015abde5805526778bc"
 dependencies = [
  "cfg-if",
 ]
@@ -1047,6 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -1316,18 +1318,18 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1585a0f4924236ca3c8dac97bc6a3efaacc08b1ed9264ff2155ec7ab2906a8ea"
+checksum = "49de01ff8a0781c5414e674b4469b81f6693d6bda6a4d405600c2acd06ebc6d3"
 dependencies = [
  "console",
+ "linked-hash-map",
  "once_cell",
  "pest",
  "pest_derive",
  "serde",
- "serde_json",
- "serde_yaml",
  "similar",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1805,6 +1807,16 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
@@ -2116,7 +2128,7 @@ name = "process-event"
 version = "0.5.1"
 dependencies = [
  "anyhow",
- "reqwest 0.11.11",
+ "reqwest",
  "serde",
  "serde_json",
  "structopt",
@@ -2276,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.11.0"
-source = "git+https://github.com/jan-auer/reqwest?tag=v0.11.0#62edd49dd1eb0ab54b43d315c6c6ebb17ef15b99"
+source = "git+https://github.com/getsentry/reqwest?branch=restricted-connector#62edd49dd1eb0ab54b43d315c6c6ebb17ef15b99"
 dependencies = [
  "async-compression",
  "base64",
@@ -2309,44 +2321,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg 0.7.0",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.10.1",
 ]
 
 [[package]]
@@ -2628,7 +2602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
 dependencies = [
  "httpdate",
- "reqwest 0.11.11",
+ "reqwest",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -3026,7 +3000,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "symbolic"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7cb9f92456814241cca5984dac2ef4deced2bedd8ed2cbd7ae2e1a74f86af6"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -3039,7 +3014,8 @@ dependencies = [
 [[package]]
 name = "symbolic-cfi"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e940c2b9dffac8a624b43b71918c5ff677db6952fa6f74d967272a32ea71e6f"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3049,7 +3025,8 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e4ba9eec41633b820fe1d1a2db3c51a6c00992ed6858300b645bef2f2d7ddb"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3061,7 +3038,8 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a8a9e8a09332209e8d6541b7b5d19f072a8587ec5c1ecd52800c7104c9645d"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3091,7 +3069,8 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4da73cc082fa227dfa279dbff0393d9a67d390a8232a929af2732cbc48e66dc"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3103,18 +3082,25 @@ dependencies = [
 [[package]]
 name = "symbolic-il2cpp"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d472a0f5c14e4b38d05ffe07bae829687a9c46c05dfe2c49ce029f6adfb20"
 dependencies = [
+ "anyhow",
+ "gimli",
  "indexmap",
+ "object 0.28.4",
+ "scroll",
  "serde_json",
  "symbolic-common",
  "symbolic-debuginfo",
+ "thiserror",
 ]
 
 [[package]]
 name = "symbolic-symcache"
 version = "9.1.0"
-source = "git+https://github.com/getsentry/symbolic?branch=fix/demangle-fixes#f8bec4059ae87ef572c859ab573fd552bd1a8345"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a004b2797535e231d27c612baa2ffa1f4005e7787584f959fdf1cbfdcf66d06d"
 dependencies = [
  "dmsort",
  "fnv",
@@ -3157,7 +3143,7 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.12.1",
  "regex",
- "reqwest 0.11.0",
+ "reqwest",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_s3",
@@ -4130,15 +4116,6 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,24 @@ inherits = "release"
 incremental = true
 codegen-units = 256
 
+[patch.crates-io]
+# This patch adds an `ip_filter` able to filter out internal IP addresses in DNS resolution
+reqwest = { git = "https://github.com/getsentry/reqwest", branch = "restricted-connector" }
+
+# This patch adds limited "templated lambdas" demangling support
+cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "sentry-patches" }
+
+# This patch adds more logging and support for http connections
+gcp_auth = { git = "https://github.com/getsentry/gcp_auth", branch = "sentry-main" }
+
+
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.
+# This only works for the very specific crate listed here, and not for its dependency tree.
+# Alternatively, the whole dependency tree can be changed at once by putting this line into
+# `crates/symbolicator/Cargo.toml`:
+# symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 # See also https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
-# [patch."https://github.com/getsentry/symbolic"]
+# [patch.crates-io]
 # symbolic = { path = "../symbolic/symbolic" }
 # symbolic-minidump = { path = "../symbolic/symbolic-minidump" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ debug = 1
 # iteration times.
 # You can compile/run this with: `cargo run --profile local -- --config local.yml run`
 inherits = "release"
+debug = false
 incremental = true
 codegen-units = 256
 

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -11,4 +11,4 @@ reqwest = { version = "0.11.0", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
-symbolic-common = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes" }
+symbolic-common = "9.1.0"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -19,7 +19,7 @@ console = "0.15.0"
 filetime = "0.2.16"
 flate2 = "1.0.23"
 futures = "0.3.12"
-gcp_auth = { git = "https://github.com/getsentry/gcp_auth", branch = "sentry-main" }
+gcp_auth = "0.6.1"
 glob = "0.3.0"
 hostname = "0.3.1"
 humantime-serde = "1.1.1"
@@ -32,7 +32,7 @@ minidump-processor = "0.14.0"
 num_cpus = "1.13.0"
 parking_lot = "0.12.0"
 regex = "1.5.5"
-reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
+reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
 rusoto_core = "0.48.0"
 rusoto_credential = "0.48.0"
 rusoto_s3 = "0.48.0"
@@ -43,7 +43,7 @@ serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
+symbolic = { version = "9.1.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }
@@ -60,7 +60,7 @@ zstd = "0.11.1"
 
 [dev-dependencies]
 insta = { version = "1.14.0", features = ["redactions"] }
-reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["multipart"] }
+reqwest = { version = "0.11.0", features = ["multipart"] }
 sha-1 = "0.10.0"
 test-assembler = "0.1.5"
 warp = "0.3.0"

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
-symbolic = { version = "9.1.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
+symbolic = { version = "9.1.1", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp"] }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -87,7 +87,7 @@ pub fn configure_statsd<A: ToSocketAddrs>(prefix: &str, host: A, tags: BTreeMap<
 /// Invoke a callback with the current statsd client.
 ///
 /// If statsd is not configured the callback is not invoked. For the most part
-/// the [`metric!`] macro should be used instead.
+/// the [`metric!`](crate::metric) macro should be used instead.
 #[inline(always)]
 pub fn with_client<F, R>(f: F) -> R
 where

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
-symbolic = { git = "https://github.com/getsentry/symbolic", branch = "fix/demangle-fixes", features = ["debuginfo-serde"] }
+symbolic = { version = "9.1.0", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2"] }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
-symbolic = { version = "9.1.0", features = ["debuginfo-serde"] }
+symbolic = { version = "9.1.1", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2"] }


### PR DESCRIPTION
This uses a cargo patch section to replace very specific dependencies, instead of whole dependency trees.
The advantage here is that we can get rid of the log running demangle-branch of symbolic, and rather pull in
a targeted `cpp_demangle` dependency which is a transitive dependency of symbolic.

I also took the liberty to do the same for `reqwest`, which also gets rid of a duplication that previously happened
due to reqwest being pulled in as a transitive dependency from cargo through the sentry SDK.

This also means that we now depend on a *published* version of symbolic, which means we need to publish it more often ;-)

#skip-changelog