### PR TITLE
fix: Some clippy and insta fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,18 +1316,18 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1585a0f4924236ca3c8dac97bc6a3efaacc08b1ed9264ff2155ec7ab2906a8ea"
+checksum = "49de01ff8a0781c5414e674b4469b81f6693d6bda6a4d405600c2acd06ebc6d3"
 dependencies = [
  "console",
+ "linked-hash-map",
  "once_cell",
  "pest",
  "pest_derive",
  "serde",
- "serde_json",
- "serde_yaml",
  "similar",
+ "yaml-rust",
 ]
 
 [[package]]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -59,7 +59,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 zstd = "0.11.1"
 
 [dev-dependencies]
-insta = { version = "1.14.0", features = ["redactions"] }
+insta = { version = "1.18.0", features = ["redactions", "yaml"] }
 reqwest = { git = "https://github.com/jan-auer/reqwest", tag = "v0.11.0", features = ["multipart"] }
 sha-1 = "0.10.0"
 test-assembler = "0.1.5"

--- a/crates/symbolicator/src/metrics.rs
+++ b/crates/symbolicator/src/metrics.rs
@@ -96,7 +96,7 @@ where
 {
     CURRENT_CLIENT.with(|client| {
         if let Some(client) = client {
-            f(&*client)
+            f(client)
         } else {
             Default::default()
         }

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -156,7 +156,7 @@ async fn compute_cficache(
         return Ok(object.status().clone());
     }
 
-    let status = if let Err(e) = write_cficache(&path, &*object) {
+    let status = if let Err(e) = write_cficache(&path, &object) {
         tracing::warn!("Could not write cficache: {}", e);
         sentry::capture_error(&e);
 

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -36,7 +36,7 @@ impl SourceLocation {
     }
 
     /// Return an iterator of the location segments.
-    pub fn segments<'a>(&'a self) -> impl Iterator<Item = &str> + 'a {
+    pub fn segments(&self) -> impl Iterator<Item = &str> + '_ {
         self.0.split('/').filter(|s| !s.is_empty())
     }
 

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -103,7 +103,7 @@ impl S3Downloader {
 
     fn get_s3_client(&self, key: &Arc<S3SourceKey>) -> Arc<rusoto_s3::S3Client> {
         let mut container = self.client_cache.lock();
-        if let Some(client) = container.get(&*key) {
+        if let Some(client) = container.get(key) {
             metric!(counter("source.s3.client.cached") += 1);
             client.clone()
         } else {

--- a/crates/symbolicator/src/services/symcaches/markers.rs
+++ b/crates/symbolicator/src/services/symcaches/markers.rs
@@ -20,7 +20,7 @@ const MARKER_BCSYMBOLMAP: u32 = 1 << 0;
 const MARKER_IL2CPP: u32 = 1 << 1;
 
 /// This is the markers that are being embedded into, and read from, a SymCache file.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct SymCacheMarkers {
     markers: u32,
 }

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -213,7 +213,7 @@ async fn fetch_difs_and_compute_symcache(
         return Ok(object_handle.status().clone());
     }
 
-    let status = match write_symcache(&path, &*object_handle, secondary_sources) {
+    let status = match write_symcache(&path, &object_handle, secondary_sources) {
         Ok(_) => CacheStatus::Positive,
         Err(err) => {
             tracing::warn!("Failed to write symcache: {}", err);

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -164,7 +164,7 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 }
 
 /// An unsymbolicated frame from a symbolication request.
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct RawFrame {
     /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
     /// [`sym_addr`](Self::sym_addr).
@@ -237,7 +237,7 @@ pub struct RawFrame {
 /// pointer and thus detected frame, especially if there was not enough Call Frame
 /// Information available.  Frames that were detected by scanning may contain dubious
 /// information.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum FrameTrust {
     /// Unknown.
@@ -280,7 +280,7 @@ impl From<minidump_processor::FrameTrust> for FrameTrust {
 }
 
 /// A stack trace containing unsymbolicated stack frames.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct RawStacktrace {
     /// The OS-dependent identifier of the thread.
     #[serde(default)]


### PR DESCRIPTION
Updates insta to the newest version with the `yaml` feature,
and fixes some clippy suggestions.
Clippy still complains over something which looks like a false positive however:
https://github.com/rust-lang/rust-clippy/issues/9309

#skip-changelog