### PR TITLE
fix: Use feature resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 default-members = ["crates/symbolicator"]
 


### PR DESCRIPTION
Even though feature resolver 2 is the default for rust2021 crates,
it still needs to be opted in explicitly for virtual workspaces.
See https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
for more details.

#skip-changelog