### PR TITLE
ref: Remove fallback cache versions

### DIFF
--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -47,7 +47,7 @@ use super::shared_cache::SharedCacheService;
 /// - `1`: Generate higher fidelity CFI for Win-x64 binaries.
 const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 2,
-    fallbacks: &[1, 0],
+    fallbacks: &[],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -63,7 +63,7 @@ mod markers;
 /// - `1`: New binary format based on instruction addr lookup.
 const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 3,
-    fallbacks: &[2, 1, 0],
+    fallbacks: &[],
 };
 static_assert!(symbolic::symcache::SYMCACHE_VERSION == 7);
 


### PR DESCRIPTION
According to our metrics, we are still falling back to very old cache
versions in some cases, even though we are ~3 weeks in rolling out the
latest version. Removing the fallback version means we are eagerly
creating the latest version whenever an event needs a certain cache.

#skip-changelog