### PR TITLE
ref: Replace custom shared-cache Queue with barbados

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-channel"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +228,15 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "barbados"
+version = "0.1.0"
+source = "git+https://github.com/getsentry/barbados#17fb72a00a43558bb370338c599ca344f8ddf524"
+dependencies = [
+ "async-channel",
+ "tokio",
 ]
 
 [[package]]
@@ -366,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cadence"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -832,6 +867,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fallible-iterator"
@@ -3123,6 +3164,7 @@ dependencies = [
  "axum",
  "axum-server",
  "backtrace",
+ "barbados",
  "base64",
  "cadence",
  "chrono",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1.53"
 axum = { version = "0.5.4", features = ["multipart"] }
 axum-server = { version = "0.4.0" }
 backtrace = "0.3.65"
+barbados = { git = "https://github.com/getsentry/barbados" }
 base64 = "0.13.0"
 cadence = "0.29.0"
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -246,8 +246,8 @@ pub struct Cache {
     /// Options intended to be user-configurable.
     cache_config: CacheConfig,
 
-    /// The maximum number of lazy refreshes of this cache.
-    max_lazy_refreshes: Arc<AtomicIsize>,
+    /// A queue for lazy refreshes of this cache.
+    lazy_refresh_queue: Arc<barbados::Queue>,
 }
 
 impl Cache {
@@ -256,7 +256,7 @@ impl Cache {
         cache_dir: Option<PathBuf>,
         tmp_dir: Option<PathBuf>,
         cache_config: CacheConfig,
-        max_lazy_refreshes: Arc<AtomicIsize>,
+        lazy_refresh_queue: Arc<barbados::Queue>,
     ) -> io::Result<Self> {
         if let Some(ref dir) = cache_dir {
             std::fs::create_dir_all(dir)?;
@@ -267,7 +267,7 @@ impl Cache {
             tmp_dir,
             start_time: SystemTime::now(),
             cache_config,
-            max_lazy_refreshes,
+            lazy_refresh_queue,
         })
     }
 
@@ -279,8 +279,8 @@ impl Cache {
         self.cache_dir.as_deref()
     }
 
-    pub fn max_lazy_refreshes(&self) -> Arc<AtomicIsize> {
-        self.max_lazy_refreshes.clone()
+    pub fn lazy_refresh_queue(&self) -> &barbados::Queue {
+        &self.lazy_refresh_queue
     }
 
     pub fn cleanup(&self) -> Result<()> {


### PR DESCRIPTION
This does simplify the shared-cache queue code a little bit.
Next step would be to figure out how to also replace the lazy cache refresh feature with this code.

#skip-changelog