### PR TITLE
fix: Bump symbolic to 9.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,12 +703,11 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elementtree"
-version = "0.7.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6319c9433cf1e95c60c8533978bccf0614f27f03bb4e514253468eeeaa7fe3"
+checksum = "83e91f812124e4fc7f82605feda4da357307185a4619baee415ae0b7f6d5e031"
 dependencies = [
  "string_cache",
- "xml-rs",
 ]
 
 [[package]]
@@ -3028,9 +3027,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a0694dd350fd6fe299a07704965767e65ab468ec598aa392689cfe3b37dc3b"
+checksum = "a25d209528aa05da204db74a60a04c3a7afd2b36c51c252eaf58b2b7e0cdf4a8"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -3042,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f59a6b4cf37858dd73a1407cdd402626188903240bfeb22179335eeef054c44"
+checksum = "90f6c104c6d37db19853e41b7dced3a5d28ec9bf55a722f6893c844931460185"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -3053,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d274c0d8258c39545aaeaef6445e3a86825ce90b2e1506e82740578691656537"
+checksum = "d431a4117e17192ca2d46b9261919bc34561b7dd2dcba4ab4c93801826fcbd33"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3066,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d58e63d5da2963123d7631362ff797c431efe786360dd8ec8168aae1ba7a6ba"
+checksum = "084052554bfcf55a5df749b0bf98209cdc3b48e584229f41431a45809c13f179"
 dependencies = [
  "bitvec",
  "dmsort",
@@ -3097,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e73ebb4ab251981348a29003f7eaaef8f7dcbef091cb4d2b76c1be7e0ae69c"
+checksum = "93b77867bcc7fb2a4e9fc02b58b965858f5e4c35ad86da89ec6d9b2a00b64ece"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -3110,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdec97e68177383fa6b12b46df9733fd4828c45dd2d8510396d04bd489a33e3b"
+checksum = "f241a432cc325fd6324d6b34c991cd00b67b5b036d8d81d1406de5e610c8556f"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -3122,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "9.1.3"
+version = "9.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3f55e1031d66039b8f1263154112ede9510f351f5fe2e63bfe5eaa2ab37d3a"
+checksum = "438d1b2f67a390fd1f899030254e70d9fc9a52746e77f814c8840344effc5e33"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -4014,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.89.1"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
+checksum = "b62c8d843f4423efee314dc75a1049886deba3214f7e7f9ff0e4e58b4d618581"
 dependencies = [
  "indexmap",
 ]


### PR DESCRIPTION
This should fix some EOF errors due to overeager DWARF `Abbreviations` parsing.

#skip-changelog