### PR TITLE
build: Use bullseye as docker base image & use jemalloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - Bump Native SDK to v0.5.0 ([#865](https://github.com/getsentry/symbolicator/pull/865))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#050)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.4.17-2-gbd56100...0.5.0)
-- Use `rust:bullseye-slim` as base image for docker container builder. ([#578](https://github.com/getsentry/symbolicator/pull/578))
-- Use `debian:bullseye-slim` as base image for docker container runner. ([#578](https://github.com/getsentry/symbolicator/pull/578))
+- Use `rust:bullseye-slim` as base image for docker container builder. ([#885](https://github.com/getsentry/symbolicator/pull/885))
+- Use `debian:bullseye-slim` as base image for docker container runner. ([#885](https://github.com/getsentry/symbolicator/pull/885))
+- Use jemalloc as global allocater (for Rust and C). ([#885](https://github.com/getsentry/symbolicator/pull/885))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Bump Native SDK to v0.5.0 ([#865](https://github.com/getsentry/symbolicator/pull/865))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#050)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.4.17-2-gbd56100...0.5.0)
+- Use `rust:bullseye-slim` as base image for docker container builder. ([#578](https://github.com/getsentry/symbolicator/pull/578))
+- Use `debian:bullseye-slim` as base image for docker container runner. ([#578](https://github.com/getsentry/symbolicator/pull/578))
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1415,27 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.1+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2b313609b95939cb0c5a5c6917fb9b7c9394562aa3ef44eb66ffa51736432"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -3156,6 +3183,7 @@ dependencies = [
  "humantime-serde",
  "insta",
  "ipnetwork",
+ "jemallocator",
  "jsonwebtoken",
  "lazy_static",
  "lru",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,13 @@
 FROM getsentry/sentry-cli:1 AS sentry-cli
-FROM debian:stretch-slim AS symbolicator-build
+FROM rust:slim-bullseye AS symbolicator-build
 
 WORKDIR /work
-
-# Hooray for running with a totally outdated debian image
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/cmake-backports.list
-RUN echo 'deb http://deb.debian.org/debian stretch-backports-sloppy main' >> /etc/apt/sources.list.d/cmake-backports.list
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates curl libssl-dev pkg-config git zip \
     # below required for sentry-native
-    clang-11 cmake/stretch-backports libarchive13/stretch-backports-sloppy libuv1/stretch-backports libcurl4-openssl-dev \
+    cmake libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# Because the image has gcc-6 as default compiler, and 3.8 as default clang. We are at 11 and 14 respectively. Let that sink in.
-ENV CC=clang-11 CXX=clang++-11
-
-ENV CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-
-# We should really depend on the rust:slim-buster images again as this
-# will automatically upgrade our Rust toolchains when a new one is
-# released.  But while we can't: bump versions manually.
-ENV RUST_TOOLCHAIN=1.62.1
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_TOOLCHAIN
 
 ARG SYMBOLICATOR_FEATURES=symbolicator-crash
 ENV SYMBOLICATOR_FEATURES=${SYMBOLICATOR_FEATURES}
@@ -70,7 +53,7 @@ RUN sentry-cli --version \
 # Copy the compiled binary to a clean image #
 #############################################
 
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates gosu curl cabextract \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM getsentry/sentry-cli:1 AS sentry-cli
+FROM getsentry/sentry-cli:2 AS sentry-cli
 FROM rust:slim-bullseye AS symbolicator-build
 
 WORKDIR /work
@@ -6,7 +6,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates curl libssl-dev pkg-config git zip \
     # below required for sentry-native
-    cmake libcurl4-openssl-dev \
+    cmake clang libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ARG SYMBOLICATOR_FEATURES=symbolicator-crash

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -58,6 +58,9 @@ url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 zstd = "0.11.1"
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { version = "0.5", features = ["unprefixed_malloc_on_supported_platforms"] }
+
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }
 reqwest = { version = "0.11.0", features = ["multipart"] }

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -12,6 +12,13 @@
     clippy::all
 )]
 
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
This PR does two things:

- It updates our docker base image from EOL stretch to the current stable bullseye.
- The updated base image also comes with an always up-to-date Rust compiler.
- We also use an up-to-date sentry-cli image, as the previous one did not correctly process the debug files.
- Last but certainly not least, this pulls in jemalloc as global allocater for both Rust code as well as C code (via the `unprefixed_malloc_on_supported_platforms` feature).

So far this has been running on canary for some time and has a considerably lower baseline memory usage (~3G vs ~9G) compared to current master, and does not appear to be leaking memory (updating *just* the base image without jemalloc has slow and steady memory growth over time).