### PR TITLE
ref: Clean up empty cache directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Use `rust:bullseye-slim` as base image for docker container builder. ([#885](https://github.com/getsentry/symbolicator/pull/885))
 - Use `debian:bullseye-slim` as base image for docker container runner. ([#885](https://github.com/getsentry/symbolicator/pull/885))
 - Use jemalloc as global allocater (for Rust and C). ([#885](https://github.com/getsentry/symbolicator/pull/885))
+- Clean up empty cache directories. ([#887](https://github.com/getsentry/symbolicator/pull/887))
 
 ### Fixes
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -1,7 +1,7 @@
 //! Core logic for cache files. Used by `crate::services::common::cache`.
 
 use core::fmt;
-use std::fs::{read_dir, remove_file};
+use std::fs::{read_dir, remove_dir, remove_file};
 use std::io::{self, Read, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicIsize;
@@ -285,48 +285,69 @@ impl Cache {
 
     pub fn cleanup(&self) -> Result<()> {
         tracing::info!("Cleaning up cache: {}", self.name);
-        let cache_dir = self.cache_dir.clone().ok_or_else(|| {
+        let cache_dir = self.cache_dir.as_ref().ok_or_else(|| {
             anyhow!("no caching configured! Did you provide a path to your config file?")
         })?;
 
-        let mut directories = vec![cache_dir];
-        while !directories.is_empty() {
-            let directory = directories.pop().unwrap();
-
-            let entries = match catch_not_found(|| read_dir(directory))? {
-                Some(x) => x,
-                None => {
-                    tracing::warn!("Directory not found");
-                    return Ok(());
-                }
-            };
-
-            for entry in entries {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() {
-                    directories.push(path.to_owned());
-                } else if let Err(e) = self.try_cleanup_path(&path) {
-                    sentry::with_scope(
-                        |scope| scope.set_extra("path", path.display().to_string().into()),
-                        || tracing::error!("Failed to clean cache file: {:?}", e),
-                    );
-                }
-            }
-        }
+        self.cleanup_directory_recursive(cache_dir)?;
 
         Ok(())
     }
 
-    fn try_cleanup_path(&self, path: &Path) -> Result<()> {
+    /// Cleans up the directory recursively, returning `true` if the directory is left empty after cleanup.
+    fn cleanup_directory_recursive(&self, directory: &Path) -> Result<bool> {
+        let entries = match catch_not_found(|| read_dir(directory))? {
+            Some(x) => x,
+            None => {
+                tracing::warn!("Directory not found: {}", directory.display());
+                return Ok(true);
+            }
+        };
+
+        let mut is_empty = true;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                let mut dir_is_empty = self.cleanup_directory_recursive(&path)?;
+                if dir_is_empty {
+                    if let Err(e) = remove_dir(&path) {
+                        sentry::with_scope(
+                            |scope| scope.set_extra("path", path.display().to_string().into()),
+                            || tracing::error!("Failed to clean cache directory: {:?}", e),
+                        );
+                        dir_is_empty = false;
+                    }
+                }
+                is_empty = is_empty && dir_is_empty;
+            } else {
+                match self.try_cleanup_path(&path) {
+                    Err(e) => {
+                        sentry::with_scope(
+                            |scope| scope.set_extra("path", path.display().to_string().into()),
+                            || tracing::error!("Failed to clean cache file: {:?}", e),
+                        );
+                    }
+                    Ok(file_removed) => is_empty = is_empty && file_removed,
+                }
+            }
+        }
+
+        Ok(is_empty)
+    }
+
+    /// Tries to clean up the file at `path`, returning `true` if it was removed.
+    fn try_cleanup_path(&self, path: &Path) -> Result<bool> {
         tracing::trace!("Checking {}", path.display());
         anyhow::ensure!(path.is_file(), "not a file");
         if catch_not_found(|| self.check_expiry(path))?.is_none() {
             tracing::debug!("Removing {}", path.display());
             catch_not_found(|| remove_file(path))?;
+
+            return Ok(true);
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Validate cache expiration of path. If cache should not be used,
@@ -421,8 +442,38 @@ impl Cache {
     pub fn tempfile(&self) -> io::Result<NamedTempFile> {
         match self.tmp_dir {
             Some(ref path) => {
-                std::fs::create_dir_all(path)?;
-                Ok(tempfile::Builder::new().prefix("tmp").tempfile_in(path)?)
+                // The `cleanup` process could potentially remove the parent directories we are
+                // operating in, so be defensive here and retry the fs operations.
+                const MAX_RETRIES: usize = 2;
+                let mut retries = 0;
+                loop {
+                    retries += 1;
+
+                    if let Err(e) = std::fs::create_dir_all(path) {
+                        sentry::with_scope(
+                            |scope| scope.set_extra("path", path.display().to_string().into()),
+                            || tracing::error!("Failed to create cache directory: {:?}", e),
+                        );
+                        if retries >= MAX_RETRIES {
+                            return Err(e);
+                        }
+                        continue;
+                    }
+
+                    match tempfile::Builder::new().prefix("tmp").tempfile_in(path) {
+                        Ok(temp_file) => return Ok(temp_file),
+                        Err(e) => {
+                            sentry::with_scope(
+                                |scope| scope.set_extra("path", path.display().to_string().into()),
+                                || tracing::error!("Failed to create cache file: {:?}", e),
+                            );
+                            if retries >= MAX_RETRIES {
+                                return Err(e);
+                            }
+                            continue;
+                        }
+                    }
+                }
             }
             None => Ok(NamedTempFile::new()?),
         }
@@ -763,10 +814,6 @@ mod tests {
 
     #[test]
     fn test_retry_misses_after() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-        use std::thread::sleep;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
@@ -801,10 +848,6 @@ mod tests {
 
     #[test]
     fn test_cleanup_malformed() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-        use std::thread::sleep;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
@@ -846,10 +889,6 @@ mod tests {
 
     #[test]
     fn test_cleanup_cache_specific_error_derived() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-        use std::thread::sleep;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
@@ -894,10 +933,6 @@ mod tests {
 
     #[test]
     fn test_cleanup_cache_specific_error_download() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-        use std::thread::sleep;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("foo"))?;
 
@@ -940,9 +975,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_positive() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 
@@ -986,9 +1018,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_negative() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 
@@ -1012,9 +1041,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_malformed() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 
@@ -1050,9 +1076,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_cache_specific_err_derived() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 
@@ -1083,9 +1106,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_cache_specific_err_diagnostics() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 
@@ -1116,9 +1136,6 @@ mod tests {
 
     #[test]
     fn test_expiration_strategy_cache_specific_err_downloaded() -> Result<()> {
-        use std::fs::create_dir_all;
-        use std::io::Write;
-
         let tempdir = tempdir()?;
         create_dir_all(tempdir.path().join("honk"))?;
 

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -318,7 +318,7 @@ impl Cache {
                         dir_is_empty = false;
                     }
                 }
-                is_empty = is_empty && dir_is_empty;
+                is_empty &= dir_is_empty;
             } else {
                 match self.try_cleanup_path(&path) {
                     Err(e) => {
@@ -327,7 +327,7 @@ impl Cache {
                             || tracing::error!("Failed to clean cache file: {:?}", e),
                         );
                     }
-                    Ok(file_removed) => is_empty = is_empty && file_removed,
+                    Ok(file_removed) => is_empty &= file_removed,
                 }
             }
         }

--- a/crates/symbolicator/src/cache.rs
+++ b/crates/symbolicator/src/cache.rs
@@ -306,8 +306,7 @@ impl Cache {
 
         let mut is_empty = true;
         for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
+            let path = entry?.path();
             if path.is_dir() {
                 let mut dir_is_empty = self.cleanup_directory_recursive(&path)?;
                 if dir_is_empty {
@@ -454,7 +453,7 @@ impl Cache {
                             |scope| scope.set_extra("path", path.display().to_string().into()),
                             || tracing::error!("Failed to create cache directory: {:?}", e),
                         );
-                        if retries >= MAX_RETRIES {
+                        if retries > MAX_RETRIES {
                             return Err(e);
                         }
                         continue;
@@ -467,7 +466,7 @@ impl Cache {
                                 |scope| scope.set_extra("path", path.display().to_string().into()),
                                 || tracing::error!("Failed to create cache file: {:?}", e),
                             );
-                            if retries >= MAX_RETRIES {
+                            if retries > MAX_RETRIES {
                                 return Err(e);
                             }
                             continue;

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -392,7 +392,7 @@ impl<T: CacheItemRequest> Cacher<T> {
                             |scope| scope.set_extra("path", parent.display().to_string().into()),
                             || tracing::error!("Failed to create cache directory: {:?}", e),
                         );
-                        if retries >= MAX_RETRIES {
+                        if retries > MAX_RETRIES {
                             return Err(e.into());
                         }
                         continue;
@@ -407,7 +407,7 @@ impl<T: CacheItemRequest> Cacher<T> {
                             },
                             || tracing::error!("Failed to create cache file: {:?}", err),
                         );
-                        if retries >= MAX_RETRIES {
+                        if retries > MAX_RETRIES {
                             return Err(err.into());
                         }
                         continue;

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -320,7 +320,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             return Ok(item);
         }
 
-        let temp_file = self.tempfile()?;
+        let mut temp_file = self.tempfile()?;
         let shared_cache_key = SharedCacheKey {
             name: self.config.name(),
             version: T::VERSIONS.current,
@@ -379,8 +379,42 @@ impl<T: CacheItemRequest> Cacher<T> {
                         "no parent directory to persist item",
                     )
                 })?;
-                fs::create_dir_all(parent).await?;
-                temp_file.persist(&cache_path).map_err(|x| x.error)?;
+
+                // The `cleanup` process could potentially remove the parent directories we are
+                // operating in, so be defensive here and retry the fs operations.
+                const MAX_RETRIES: usize = 2;
+                let mut retries = 0;
+                loop {
+                    retries += 1;
+
+                    if let Err(e) = fs::create_dir_all(parent).await {
+                        sentry::with_scope(
+                            |scope| scope.set_extra("path", parent.display().to_string().into()),
+                            || tracing::error!("Failed to create cache directory: {:?}", e),
+                        );
+                        if retries >= MAX_RETRIES {
+                            return Err(e.into());
+                        }
+                        continue;
+                    }
+
+                    if let Err(e) = temp_file.persist(&cache_path) {
+                        temp_file = e.file;
+                        let err = e.error;
+                        sentry::with_scope(
+                            |scope| {
+                                scope.set_extra("path", cache_path.display().to_string().into())
+                            },
+                            || tracing::error!("Failed to create cache file: {:?}", err),
+                        );
+                        if retries >= MAX_RETRIES {
+                            return Err(err.into());
+                        }
+                        continue;
+                    }
+
+                    break;
+                }
 
                 metric!(
                     counter(&format!("caches.{}.file.write", self.config.name())) += 1,


### PR DESCRIPTION
Thus far, the cleanup process never removed empty cache directories. For one, the worklist based approach cleaning the parent before the children, did not make this possible in the first place, but also because normal operations would have errored out on failing FS operations, for example when a directory or file could not be created in a non-existent directory.

This changes the cleanup process to be depth-first, cleaning up empty directories as it goes. It also makes the writing side of things extra defensive and retries FS operations in the unlikely case that a directory is being removed while operating in it.