### PR TITLE
ref: Extract symbolicator-sources as its own workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,6 @@ dependencies = [
  "flate2",
  "futures",
  "gcp_auth",
- "glob",
  "hostname",
  "humantime-serde",
  "insta",
@@ -3288,6 +3287,7 @@ dependencies = [
  "structopt",
  "symbolic",
  "symbolicator-crash",
+ "symbolicator-sources",
  "tempfile",
  "test-assembler",
  "thiserror",
@@ -3311,6 +3311,20 @@ version = "0.5.1"
 dependencies = [
  "bindgen",
  "cmake",
+]
+
+[[package]]
+name = "symbolicator-sources"
+version = "0.5.1"
+dependencies = [
+ "glob",
+ "insta",
+ "lazy_static",
+ "rusoto_core",
+ "serde",
+ "serde_yaml",
+ "symbolic",
+ "url",
 ]
 
 [[package]]

--- a/crates/symbolicator-sources/Cargo.toml
+++ b/crates/symbolicator-sources/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "symbolicator-sources"
+publish = false
+version = "0.5.1"
+authors = ["Sentry <hello@getsentry.com>"]
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+glob = "0.3.0"
+lazy_static = "1.4.0"
+rusoto_core = "0.48.0"
+serde = { version = "1.0.137", features = ["derive", "rc"] }
+symbolic = "10.0.0"
+url = { version = "2.2.0", features = ["serde"] }
+
+[dev-dependencies]
+insta = { version = "1.18.0", features = ["redactions", "yaml"] }
+serde_yaml = "0.8.15"

--- a/crates/symbolicator-sources/src/filetype.rs
+++ b/crates/symbolicator-sources/src/filetype.rs
@@ -1,0 +1,141 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::ObjectType;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileType {
+    /// Windows/PDB code files
+    Pe,
+    /// Windows/PDB debug files
+    Pdb,
+    /// Macos/Mach debug files
+    MachDebug,
+    /// Macos/Mach code files
+    MachCode,
+    /// Linux/ELF debug files
+    ElfDebug,
+    /// Linux/ELF code files
+    ElfCode,
+    /// A WASM debug file
+    WasmDebug,
+    /// A WASM code file
+    WasmCode,
+    /// Breakpad files (this is the reason we have a flat enum for what at first sight could've
+    /// been two enums)
+    Breakpad,
+    /// Source bundle
+    #[serde(rename = "sourcebundle")]
+    SourceBundle,
+    /// A file mapping a MachO [`DebugId`] to an originating [`DebugId`].
+    ///
+    /// For the MachO format a [`DebugId`] is always a UUID.
+    ///
+    /// This is used when compilation introduces intermediate outputs, like Apple BitCode.
+    /// In this case some Debug Information Files will have the [`DebugId`] of the
+    /// intermediate compilation rather than of the final executable code.  Thus these maps
+    /// point to which other [`DebugId`]s provide DIFs.
+    ///
+    /// At the time of writing this is only used to map a dSYM UUID to a BCSymbolMap UUID
+    /// for MachO.  The only format supported for this is currently the XML PropertyList
+    /// format.  In the future other formats could be added to this.
+    ///
+    /// [`DebugId`]: symbolic::common::DebugId
+    #[serde(rename = "uuidmap")]
+    UuidMap,
+    /// BCSymbolMap, de-obfuscates symbol names for MachO.
+    #[serde(rename = "bcsymbolmap")]
+    BcSymbolMap,
+    /// The il2cpp `LineNumberMapping.json` file.
+    ///
+    /// This file maps from C++ source locations to the original C# source location it was transpiled from.
+    #[serde(rename = "il2cpp")]
+    Il2cpp,
+    #[serde(rename = "portablepdb")]
+    PortablePdb,
+}
+
+impl FileType {
+    /// Lists all available file types.
+    #[inline]
+    pub fn all() -> &'static [Self] {
+        use FileType::*;
+        &[
+            Pdb,
+            MachDebug,
+            ElfDebug,
+            Pe,
+            MachCode,
+            ElfCode,
+            WasmCode,
+            WasmDebug,
+            Breakpad,
+            SourceBundle,
+            UuidMap,
+            BcSymbolMap,
+            PortablePdb,
+        ]
+    }
+
+    /// Source providing file types.
+    #[inline]
+    pub fn sources() -> &'static [Self] {
+        &[FileType::SourceBundle]
+    }
+
+    /// Given an object type, returns filetypes in the order they should be tried.
+    #[inline]
+    pub fn from_object_type(ty: ObjectType) -> &'static [Self] {
+        match ty {
+            // There are instances where an application's debug files are ELFs despite the
+            // executable not being ELFs themselves. It probably isn't correct to assume that any
+            // specific debug file type is heavily coupled with a particular executable type so we
+            // return a union of all possible debug file types for native applications.
+            ObjectType::Macho => &[
+                FileType::MachCode,
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::Pdb,
+                FileType::ElfDebug,
+            ],
+            ObjectType::Pe => &[
+                FileType::Pe,
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::Pdb,
+                FileType::ElfDebug,
+            ],
+            ObjectType::Elf => &[
+                FileType::ElfCode,
+                FileType::Breakpad,
+                FileType::MachDebug,
+                FileType::Pdb,
+                FileType::ElfDebug,
+            ],
+            ObjectType::Wasm => &[FileType::WasmCode, FileType::WasmDebug],
+            ObjectType::PeDotnet => &[FileType::PortablePdb],
+            _ => Self::all(),
+        }
+    }
+}
+
+impl AsRef<str> for FileType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            FileType::Pe => "pe",
+            FileType::Pdb => "pdb",
+            FileType::MachDebug => "mach_debug",
+            FileType::MachCode => "mach_code",
+            FileType::ElfDebug => "elf_debug",
+            FileType::ElfCode => "elf_code",
+            FileType::WasmDebug => "wasm_debug",
+            FileType::WasmCode => "wasm_code",
+            FileType::Breakpad => "breakpad",
+            FileType::SourceBundle => "sourcebundle",
+            FileType::UuidMap => "uuidmap",
+            FileType::BcSymbolMap => "bcsymbolmap",
+            FileType::Il2cpp => "il2cpp",
+            FileType::PortablePdb => "portablepdb",
+        }
+    }
+}

--- a/crates/symbolicator-sources/src/filetype.rs
+++ b/crates/symbolicator-sources/src/filetype.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ObjectType;
 
+/// Different file types that can be fetched from symbol sources.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FileType {
@@ -9,6 +10,9 @@ pub enum FileType {
     Pe,
     /// Windows/PDB debug files
     Pdb,
+    /// Portable PDB files used for .NET
+    #[serde(rename = "portablepdb")]
+    PortablePdb,
     /// Macos/Mach debug files
     MachDebug,
     /// Macos/Mach code files
@@ -51,8 +55,6 @@ pub enum FileType {
     /// This file maps from C++ source locations to the original C# source location it was transpiled from.
     #[serde(rename = "il2cpp")]
     Il2cpp,
-    #[serde(rename = "portablepdb")]
-    PortablePdb,
 }
 
 impl FileType {

--- a/crates/symbolicator-sources/src/lib.rs
+++ b/crates/symbolicator-sources/src/lib.rs
@@ -1,3 +1,10 @@
+//! Utilities dealing with symbol sources.
+//!
+//! Includes configuration and definition of symbol source, directory layouts and
+//! utilities for formatting symbol paths on various directory layouts.
+
+#![warn(missing_docs)]
+
 mod filetype;
 mod paths;
 mod sources;

--- a/crates/symbolicator-sources/src/lib.rs
+++ b/crates/symbolicator-sources/src/lib.rs
@@ -1,0 +1,9 @@
+mod filetype;
+mod paths;
+mod sources;
+mod types;
+
+pub use filetype::*;
+pub use paths::*;
+pub use sources::*;
+pub use types::*;

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -464,6 +464,7 @@ pub fn get_directory_paths(
     paths
 }
 
+/// Parses a symstore path into a possible [`FileType`] and an [`ObjectId`].
 pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)> {
     let mut split = path.splitn(4, '/');
     // Skip the leading / that the path contains
@@ -548,6 +549,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
     }
 }
 
+/// Checks whether an [`ObjectId`] matches any of the [`Glob`] patterns.
 pub fn matches_path_patterns(object_id: &ObjectId, patterns: &[Glob]) -> bool {
     fn canonicalize_path(s: &str) -> String {
         s.replace('\\', "/")

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -3,7 +3,8 @@ use std::fmt::Write;
 
 use symbolic::common::{CodeId, DebugId, Uuid};
 
-use crate::sources::{DirectoryLayout, DirectoryLayoutType, FileType, FilenameCasing};
+use crate::filetype::FileType;
+use crate::sources::{DirectoryLayout, DirectoryLayoutType, FilenameCasing};
 use crate::types::{Glob, ObjectId, ObjectType};
 
 const GLOB_OPTIONS: glob::MatchOptions = glob::MatchOptions {

--- a/crates/symbolicator-sources/src/sources.rs
+++ b/crates/symbolicator-sources/src/sources.rs
@@ -21,11 +21,13 @@ pub struct SourceId(String);
 
 // For now we allow this to be unused, some tests use these already.
 impl SourceId {
+    /// Creates a new [`SourceId`].
     #[allow(unused)]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Deref the [`SourceId`] to a `&str`.
     #[allow(unused)]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -70,6 +72,7 @@ impl SourceConfig {
         }
     }
 
+    /// Name of this source.
     pub fn type_name(&self) -> &'static str {
         match *self {
             SourceConfig::Sentry(..) => "sentry",
@@ -107,6 +110,7 @@ pub struct HttpSourceConfig {
     #[serde(default)]
     pub headers: BTreeMap<String, String>,
 
+    /// Configuration common to all sources.
     #[serde(flatten)]
     pub files: CommonSourceConfig,
 }
@@ -120,6 +124,7 @@ pub struct FilesystemSourceConfig {
     /// Path to symbol directory.
     pub path: PathBuf,
 
+    /// Configuration common to all sources.
     #[serde(flatten)]
     pub files: CommonSourceConfig,
 }
@@ -166,7 +171,9 @@ where
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AwsCredentialsProvider {
+    /// Static Credentials
     Static,
+    /// Credentials derived from the container.
     Container,
 }
 
@@ -241,6 +248,7 @@ pub struct GcsSourceConfig {
     #[serde(flatten)]
     pub source_key: Arc<GcsSourceKey>,
 
+    /// Configuration common to all sources.
     #[serde(flatten)]
     pub files: CommonSourceConfig,
 }
@@ -262,6 +270,7 @@ pub struct S3SourceConfig {
     #[serde(flatten)]
     pub source_key: Arc<S3SourceKey>,
 
+    /// Configuration common to all sources.
     #[serde(flatten)]
     pub files: CommonSourceConfig,
 }
@@ -281,6 +290,7 @@ pub struct CommonSourceConfig {
 }
 
 impl CommonSourceConfig {
+    /// Creates a config with the given [`DirectoryLayoutType`]
     pub fn with_layout(layout_type: DirectoryLayoutType) -> Self {
         Self {
             layout: DirectoryLayout {
@@ -311,6 +321,7 @@ pub struct SourceFilters {
 }
 
 impl SourceFilters {
+    /// Whether the [`ObjectId`] / [`FileType`] combination is allowed on this source.
     pub fn is_allowed(&self, object_id: &ObjectId, filetype: FileType) -> bool {
         (self.filetypes.is_empty() || self.filetypes.contains(&filetype))
             && paths::matches_path_patterns(object_id, &self.path_patterns)
@@ -366,11 +377,15 @@ pub enum DirectoryLayoutType {
     Unified,
 }
 
+/// Casing of filenames on the symbol server
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FilenameCasing {
+    /// Default casing depending on layout type.
     Default,
+    /// Uppercase filenames.
     Uppercase,
+    /// Lowercase filenames.
     Lowercase,
 }
 

--- a/crates/symbolicator-sources/src/sources.rs
+++ b/crates/symbolicator-sources/src/sources.rs
@@ -1,6 +1,5 @@
 //! Download sources types and related implementations.
 
-use anyhow::Result;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
@@ -10,8 +9,9 @@ use std::sync::Arc;
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
-use crate::types::{Glob, ObjectId, ObjectType};
-use crate::utils::paths;
+use crate::filetype::FileType;
+use crate::paths;
+use crate::types::{Glob, ObjectId};
 
 /// An identifier for DIF sources.
 ///
@@ -281,7 +281,6 @@ pub struct CommonSourceConfig {
 }
 
 impl CommonSourceConfig {
-    #[cfg(test)]
     pub fn with_layout(layout_type: DirectoryLayoutType) -> Self {
         Self {
             layout: DirectoryLayout {
@@ -378,144 +377,6 @@ pub enum FilenameCasing {
 impl Default for FilenameCasing {
     fn default() -> Self {
         FilenameCasing::Default
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FileType {
-    /// Windows/PDB code files
-    Pe,
-    /// Windows/PDB debug files
-    Pdb,
-    /// Macos/Mach debug files
-    MachDebug,
-    /// Macos/Mach code files
-    MachCode,
-    /// Linux/ELF debug files
-    ElfDebug,
-    /// Linux/ELF code files
-    ElfCode,
-    /// A WASM debug file
-    WasmDebug,
-    /// A WASM code file
-    WasmCode,
-    /// Breakpad files (this is the reason we have a flat enum for what at first sight could've
-    /// been two enums)
-    Breakpad,
-    /// Source bundle
-    #[serde(rename = "sourcebundle")]
-    SourceBundle,
-    /// A file mapping a MachO [`DebugId`] to an originating [`DebugId`].
-    ///
-    /// For the MachO format a [`DebugId`] is always a UUID.
-    ///
-    /// This is used when compilation introduces intermediate outputs, like Apple BitCode.
-    /// In this case some Debug Information Files will have the [`DebugId`] of the
-    /// intermediate compilation rather than of the final executable code.  Thus these maps
-    /// point to which other [`DebugId`]s provide DIFs.
-    ///
-    /// At the time of writing this is only used to map a dSYM UUID to a BCSymbolMap UUID
-    /// for MachO.  The only format supported for this is currently the XML PropertyList
-    /// format.  In the future other formats could be added to this.
-    ///
-    /// [`DebugId`]: symbolic::common::DebugId
-    #[serde(rename = "uuidmap")]
-    UuidMap,
-    /// BCSymbolMap, de-obfuscates symbol names for MachO.
-    #[serde(rename = "bcsymbolmap")]
-    BcSymbolMap,
-    /// The il2cpp `LineNumberMapping.json` file.
-    ///
-    /// This file maps from C++ source locations to the original C# source location it was transpiled from.
-    #[serde(rename = "il2cpp")]
-    Il2cpp,
-    #[serde(rename = "portablepdb")]
-    PortablePdb,
-}
-
-impl FileType {
-    /// Lists all available file types.
-    #[inline]
-    pub fn all() -> &'static [Self] {
-        use FileType::*;
-        &[
-            Pdb,
-            MachDebug,
-            ElfDebug,
-            Pe,
-            MachCode,
-            ElfCode,
-            WasmCode,
-            WasmDebug,
-            Breakpad,
-            SourceBundle,
-            UuidMap,
-            BcSymbolMap,
-            PortablePdb,
-        ]
-    }
-
-    /// Source providing file types.
-    #[inline]
-    pub fn sources() -> &'static [Self] {
-        &[FileType::SourceBundle]
-    }
-
-    /// Given an object type, returns filetypes in the order they should be tried.
-    #[inline]
-    pub fn from_object_type(ty: ObjectType) -> &'static [Self] {
-        match ty {
-            // There are instances where an application's debug files are ELFs despite the
-            // executable not being ELFs themselves. It probably isn't correct to assume that any
-            // specific debug file type is heavily coupled with a particular executable type so we
-            // return a union of all possible debug file types for native applications.
-            ObjectType::Macho => &[
-                FileType::MachCode,
-                FileType::Breakpad,
-                FileType::MachDebug,
-                FileType::Pdb,
-                FileType::ElfDebug,
-            ],
-            ObjectType::Pe => &[
-                FileType::Pe,
-                FileType::Breakpad,
-                FileType::MachDebug,
-                FileType::Pdb,
-                FileType::ElfDebug,
-            ],
-            ObjectType::Elf => &[
-                FileType::ElfCode,
-                FileType::Breakpad,
-                FileType::MachDebug,
-                FileType::Pdb,
-                FileType::ElfDebug,
-            ],
-            ObjectType::Wasm => &[FileType::WasmCode, FileType::WasmDebug],
-            ObjectType::PeDotnet => &[FileType::PortablePdb],
-            _ => Self::all(),
-        }
-    }
-}
-
-impl AsRef<str> for FileType {
-    fn as_ref(&self) -> &str {
-        match *self {
-            FileType::Pe => "pe",
-            FileType::Pdb => "pdb",
-            FileType::MachDebug => "mach_debug",
-            FileType::MachCode => "mach_code",
-            FileType::ElfDebug => "elf_debug",
-            FileType::ElfCode => "elf_code",
-            FileType::WasmDebug => "wasm_debug",
-            FileType::WasmCode => "wasm_code",
-            FileType::Breakpad => "breakpad",
-            FileType::SourceBundle => "sourcebundle",
-            FileType::UuidMap => "uuidmap",
-            FileType::BcSymbolMap => "bcsymbolmap",
-            FileType::Il2cpp => "il2cpp",
-            FileType::PortablePdb => "portablepdb",
-        }
     }
 }
 

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -1,0 +1,134 @@
+use std::borrow::Cow;
+use std::convert::Infallible;
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+use serde::{de, Deserialize, Deserializer, Serialize};
+use symbolic::common::{split_path, CodeId, DebugId};
+
+#[derive(Debug, Clone)]
+pub struct Glob(pub glob::Pattern);
+
+impl<'de> Deserialize<'de> for Glob {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = Cow::<str>::deserialize(deserializer)?;
+        s.parse().map_err(de::Error::custom).map(Glob)
+    }
+}
+
+impl Serialize for Glob {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl Deref for Glob {
+    type Target = glob::Pattern;
+
+    fn deref(&self) -> &glob::Pattern {
+        &self.0
+    }
+}
+
+/// The type of an object file.
+#[derive(Serialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectType {
+    Elf,
+    Macho,
+    Pe,
+    Wasm,
+    PeDotnet,
+    Unknown,
+}
+
+impl FromStr for ObjectType {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<ObjectType, Infallible> {
+        Ok(match s {
+            "elf" => ObjectType::Elf,
+            "macho" => ObjectType::Macho,
+            "pe" => ObjectType::Pe,
+            "pe_dotnet" => ObjectType::PeDotnet,
+            "wasm" => ObjectType::Wasm,
+            _ => ObjectType::Unknown,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ObjectType {
+    fn deserialize<D>(deserializer: D) -> Result<ObjectType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+        Ok(s.parse().unwrap())
+    }
+}
+
+impl fmt::Display for ObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ObjectType::Elf => write!(f, "elf"),
+            ObjectType::Macho => write!(f, "macho"),
+            ObjectType::Pe => write!(f, "pe"),
+            ObjectType::PeDotnet => write!(f, "pe_dotnet"),
+            ObjectType::Wasm => write!(f, "wasm"),
+            ObjectType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+impl Default for ObjectType {
+    fn default() -> ObjectType {
+        ObjectType::Unknown
+    }
+}
+
+/// Information to find an object in external sources and also internal cache.
+///
+/// See [`ObjectId::match_object`] for how these can be compared.
+#[derive(Debug, Clone, Default)]
+pub struct ObjectId {
+    /// Identifier of the code file.
+    pub code_id: Option<CodeId>,
+
+    /// Path to the code file (executable or library).
+    pub code_file: Option<String>,
+
+    /// Identifier of the debug file.
+    pub debug_id: Option<DebugId>,
+
+    /// Path to the debug file.
+    pub debug_file: Option<String>,
+
+    /// Hint to what we believe the file type should be.
+    pub object_type: ObjectType,
+}
+
+impl From<DebugId> for ObjectId {
+    fn from(source: DebugId) -> Self {
+        Self {
+            debug_id: Some(source),
+            ..Default::default()
+        }
+    }
+}
+
+impl ObjectId {
+    pub fn code_file_basename(&self) -> Option<&str> {
+        Some(split_path(self.code_file.as_ref()?).1)
+    }
+
+    pub fn debug_file_basename(&self) -> Option<&str> {
+        Some(split_path(self.debug_file.as_ref()?).1)
+    }
+}

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use symbolic::common::{split_path, CodeId, DebugId};
 
+/// A Wrapper around [`glob::Pattern`] that allows de/serialization.
 #[derive(Debug, Clone)]
 pub struct Glob(pub glob::Pattern);
 
@@ -37,15 +38,21 @@ impl Deref for Glob {
     }
 }
 
-/// The type of an object file.
+/// The type of an executable object file.
 #[derive(Serialize, Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ObjectType {
+    /// ELF Object.
     Elf,
+    /// Mach-O Object.
     Macho,
+    /// Portable Executable.
     Pe,
+    /// A WASM executable.
     Wasm,
+    /// Portable Executable containing .NET code, which has a Portable PDB companion.
     PeDotnet,
+    /// Unknown Object.
     Unknown,
 }
 
@@ -94,8 +101,6 @@ impl Default for ObjectType {
 }
 
 /// Information to find an object in external sources and also internal cache.
-///
-/// See [`ObjectId::match_object`] for how these can be compared.
 #[derive(Debug, Clone, Default)]
 pub struct ObjectId {
     /// Identifier of the code file.
@@ -124,10 +129,12 @@ impl From<DebugId> for ObjectId {
 }
 
 impl ObjectId {
+    /// Basename of the `code_file` field.
     pub fn code_file_basename(&self) -> Option<&str> {
         Some(split_path(self.code_file.as_ref()?).1)
     }
 
+    /// Basename of the `debug_file` field.
     pub fn debug_file_basename(&self) -> Option<&str> {
         Some(split_path(self.debug_file.as_ref()?).1)
     }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -20,7 +20,6 @@ filetime = "0.2.16"
 flate2 = "1.0.23"
 futures = "0.3.12"
 gcp_auth = "0.7.3"
-glob = "0.3.0"
 hostname = "0.3.1"
 humantime-serde = "1.1.1"
 ipnetwork = "0.20.0"
@@ -43,7 +42,8 @@ serde_json = "1.0.81"
 serde_yaml = "0.8.15"
 structopt = "0.3.21"
 symbolic = { version = "10.0.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp", "ppdb"] }
-symbolicator-crash = { path = "../symbolicator-crash/", optional = true }
+symbolicator-crash = { path = "../symbolicator-crash", optional = true }
+symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }

--- a/crates/symbolicator/src/config.rs
+++ b/crates/symbolicator/src/config.rs
@@ -11,8 +11,9 @@ use sentry::types::Dsn;
 use serde::{de, Deserialize, Deserializer};
 use tracing::level_filters::LevelFilter;
 
+use symbolicator_sources::SourceConfig;
+
 use crate::cache::SharedCacheConfig;
-use crate::sources::SourceConfig;
 
 /// Controls the log format
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]

--- a/crates/symbolicator/src/endpoints/proxy.rs
+++ b/crates/symbolicator/src/endpoints/proxy.rs
@@ -1,15 +1,16 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
 use anyhow::Context;
 use axum::body::Body;
 use axum::extract;
 use axum::http::{Method, Request, Response, StatusCode};
 
-use std::io::Cursor;
-use std::sync::Arc;
+use symbolicator_sources::parse_symstore_path;
 
 use crate::services::objects::{FindObject, ObjectHandle, ObjectPurpose};
 use crate::services::Service;
 use crate::types::Scope;
-use crate::utils::paths::parse_symstore_path;
 
 use super::ResponseError;
 

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -2,9 +2,10 @@ use axum::extract;
 use axum::response::Json;
 use serde::Deserialize;
 
+use symbolicator_sources::SourceConfig;
+
 use crate::services::symbolication::{StacktraceOrigin, SymbolicateStacktraces};
 use crate::services::Service;
-use crate::sources::SourceConfig;
 use crate::types::{
     RawObjectInfo, RawStacktrace, RequestOptions, Scope, Signal, SymbolicationResponse,
 };

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -32,7 +32,6 @@ mod endpoints;
 mod logging;
 mod server;
 mod services;
-mod sources;
 mod types;
 mod utils;
 

--- a/crates/symbolicator/src/services/bitcode.rs
+++ b/crates/symbolicator/src/services/bitcode.rs
@@ -13,14 +13,15 @@ use std::time::Duration;
 use anyhow::{Context, Error};
 use futures::future::{self, BoxFuture};
 use sentry::{Hub, SentryFutureExt};
+use tempfile::tempfile_in;
+
 use symbolic::common::{ByteView, DebugId};
 use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
-use tempfile::tempfile_in;
+use symbolicator_sources::{FileType, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
-use crate::sources::{FileType, SourceConfig};
 use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
 use crate::utils::futures::{m, measure};

--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -6,19 +6,18 @@ use std::time::Duration;
 
 use futures::future::BoxFuture;
 use futures::prelude::*;
+use thiserror::Error;
+
 use symbolic::cfi::CfiCache;
 use symbolic::common::ByteView;
-use thiserror::Error;
+use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, CacheVersions, Cacher};
 use crate::services::objects::{
     FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
-use crate::sources::{FileType, SourceConfig};
-use crate::types::{
-    AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
-};
+use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 

--- a/crates/symbolicator/src/services/download/filesystem.rs
+++ b/crates/symbolicator/src/services/download/filesystem.rs
@@ -10,10 +10,10 @@ use std::sync::Arc;
 
 use tokio::fs;
 
+use symbolicator_sources::{FileType, FilesystemSourceConfig, ObjectId};
+
 use super::locations::SourceLocation;
 use super::{DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
-use crate::sources::{FileType, FilesystemSourceConfig};
-use crate::types::ObjectId;
 
 /// Filesystem-specific [`RemoteDif`].
 #[derive(Debug, Clone)]

--- a/crates/symbolicator/src/services/download/gcs.rs
+++ b/crates/symbolicator/src/services/download/gcs.rs
@@ -9,8 +9,8 @@ use futures::prelude::*;
 use parking_lot::Mutex;
 use reqwest::{header, Client, StatusCode};
 
-use crate::sources::{FileType, GcsSourceConfig, GcsSourceKey};
-use crate::types::ObjectId;
+use symbolicator_sources::{FileType, GcsSourceConfig, GcsSourceKey, ObjectId};
+
 use crate::utils::gcs::{self, request_new_token, GcsError, GcsToken};
 
 use super::locations::SourceLocation;
@@ -216,9 +216,9 @@ mod tests {
     use super::super::locations::SourceLocation;
     use super::*;
 
-    use crate::sources::{CommonSourceConfig, DirectoryLayoutType, SourceId};
+    use symbolicator_sources::{CommonSourceConfig, DirectoryLayoutType, ObjectType, SourceId};
+
     use crate::test;
-    use crate::types::ObjectType;
 
     use sha1::{Digest as _, Sha1};
 

--- a/crates/symbolicator/src/services/download/http.rs
+++ b/crates/symbolicator/src/services/download/http.rs
@@ -11,12 +11,12 @@ use futures::prelude::*;
 use reqwest::{header, Client, StatusCode};
 use url::Url;
 
+use symbolicator_sources::{FileType, HttpSourceConfig, ObjectId};
+
 use super::{
     content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri, SourceLocation,
     USER_AGENT,
 };
-use crate::sources::{FileType, HttpSourceConfig};
-use crate::types::ObjectId;
 
 /// The HTTP-specific [`RemoteDif`].
 #[derive(Debug, Clone)]
@@ -169,7 +169,8 @@ mod tests {
     use super::super::locations::SourceLocation;
     use super::*;
 
-    use crate::sources::SourceConfig;
+    use symbolicator_sources::SourceConfig;
+
     use crate::test;
 
     #[tokio::test]

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -10,8 +10,9 @@ use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use symbolicator_sources::SourceId;
+
 use crate::services::cacher::CacheKey;
-use crate::sources::SourceId;
 use crate::types::Scope;
 use crate::utils::sentry::ConfigureScope;
 

--- a/crates/symbolicator/src/services/download/locations.rs
+++ b/crates/symbolicator/src/services/download/locations.rs
@@ -27,7 +27,7 @@ use super::sentry::SentryRemoteDif;
 /// It is essentially a `/`-separated string. This is currently used by all sources other than
 /// [`SentrySourceConfig`]. This may change in the future.
 ///
-/// [`SentrySourceConfig`]: crate::sources::SentrySourceConfig
+/// [`SentrySourceConfig`]: symbolicator_sources::SentrySourceConfig
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SourceLocation(String);
 
@@ -92,7 +92,7 @@ impl fmt::Display for SourceLocation {
 /// information to retrieve the DIF from its source.  The file could be any DIF type: an
 /// auxiliary DIF or an object file.
 ///
-/// [`SourceConfig`]: crate::sources::SourceConfig
+/// [`SourceConfig`]: symbolicator_sources::SourceConfig
 #[derive(Debug, Clone)]
 pub enum RemoteDif {
     Sentry(SentryRemoteDif),

--- a/crates/symbolicator/src/services/download/mod.rs
+++ b/crates/symbolicator/src/services/download/mod.rs
@@ -15,9 +15,13 @@ use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
+use symbolicator_sources::get_directory_paths;
+pub use symbolicator_sources::{
+    DirectoryLayout, FileType, ObjectId, ObjectType, SourceConfig, SourceFilters,
+};
+
 use crate::cache::CacheStatus;
 use crate::utils::futures::{self as future_utils, m, measure, CancelOnDrop};
-use crate::utils::paths::get_directory_paths;
 
 mod filesystem;
 mod gcs;
@@ -27,8 +31,6 @@ mod s3;
 mod sentry;
 
 use crate::config::Config;
-pub use crate::sources::{DirectoryLayout, FileType, SourceConfig, SourceFilters};
-pub use crate::types::ObjectId;
 pub use locations::{RemoteDif, RemoteDifUri, SourceLocation};
 
 /// HTTP User-Agent string to use.
@@ -467,15 +469,14 @@ fn content_length_timeout(content_length: u32, timeout_per_gb: Duration) -> Dura
 #[cfg(test)]
 mod tests {
     use symbolic::common::{CodeId, DebugId, Uuid};
+    use symbolicator_sources::{ObjectType, SourceConfig};
 
     // Actual implementation is tested in the sub-modules, this only needs to
     // ensure the service interface works correctly.
     use super::http::HttpRemoteDif;
     use super::*;
 
-    use crate::sources::SourceConfig;
     use crate::test;
-    use crate::types::ObjectType;
 
     #[tokio::test]
     async fn test_download() {

--- a/crates/symbolicator/src/services/download/s3.rs
+++ b/crates/symbolicator/src/services/download/s3.rs
@@ -12,16 +12,17 @@ use std::time::Duration;
 use futures::TryStreamExt;
 use parking_lot::Mutex;
 use reqwest::StatusCode;
+use rusoto_core::credential::ProvideAwsCredentials;
+use rusoto_core::region::Region;
 use rusoto_core::RusotoError;
 use rusoto_s3::{GetObjectError, S3};
 
-use rusoto_core::credential::ProvideAwsCredentials;
-use rusoto_core::region::Region;
+use symbolicator_sources::{
+    AwsCredentialsProvider, FileType, ObjectId, S3SourceConfig, S3SourceKey,
+};
 
 use super::locations::SourceLocation;
 use super::{content_length_timeout, DownloadError, DownloadStatus, RemoteDif, RemoteDifUri};
-use crate::sources::{AwsCredentialsProvider, FileType, S3SourceConfig, S3SourceKey};
-use crate::types::ObjectId;
 
 type ClientCache = lru::LruCache<Arc<S3SourceKey>, Arc<rusoto_s3::S3Client>>;
 
@@ -275,13 +276,14 @@ impl S3Downloader {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::path::Path;
 
-    use crate::sources::{CommonSourceConfig, DirectoryLayoutType, SourceId};
-    use crate::test;
-    use crate::types::ObjectType;
+    use symbolicator_sources::{CommonSourceConfig, DirectoryLayoutType, ObjectType, SourceId};
 
-    use super::*;
+    use crate::test;
+
     use rusoto_s3::S3Client;
     use sha1::{Digest as _, Sha1};
 

--- a/crates/symbolicator/src/services/download/sentry.rs
+++ b/crates/symbolicator/src/services/download/sentry.rs
@@ -16,13 +16,13 @@ use serde::Deserialize;
 use thiserror::Error;
 use url::Url;
 
+use symbolicator_sources::{ObjectId, SentrySourceConfig};
+
 use super::{
     content_length_timeout, DownloadError, DownloadStatus, FileType, RemoteDif, RemoteDifUri,
     USER_AGENT,
 };
 use crate::config::Config;
-use crate::sources::SentrySourceConfig;
-use crate::types::ObjectId;
 use crate::utils::futures::{self as future_utils, CancelOnDrop};
 
 /// Maximum number of cached Sentry `list_files` requests.
@@ -342,7 +342,7 @@ impl SentryDownloader {
 mod tests {
     use super::*;
 
-    use crate::sources::SourceId;
+    use symbolicator_sources::SourceId;
 
     #[test]
     fn test_download_url() {

--- a/crates/symbolicator/src/services/il2cpp.rs
+++ b/crates/symbolicator/src/services/il2cpp.rs
@@ -12,19 +12,19 @@ use std::time::Duration;
 use anyhow::{Context, Error};
 use futures::future::{self, BoxFuture};
 use sentry::{Hub, SentryFutureExt};
+use tempfile::tempfile_in;
+
 use symbolic::common::{ByteView, DebugId};
 use symbolic::il2cpp::LineMapping;
-use tempfile::tempfile_in;
+use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
-use crate::sources::{FileType, SourceConfig};
 use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
 use crate::utils::futures::{m, measure};
 
-use super::download::ObjectId;
 use super::shared_cache::SharedCacheService;
 
 /// Handle to a valid [`LineMapping`].

--- a/crates/symbolicator/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator/src/services/objects/meta_cache.rs
@@ -13,14 +13,15 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use futures::future::BoxFuture;
+
 use symbolic::common::ByteView;
 use symbolic::debuginfo::Object;
+use symbolicator_sources::{ObjectId, SourceId};
 
 use crate::cache::CacheStatus;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
 use crate::services::download::{RemoteDif, RemoteDifUri};
-use crate::sources::SourceId;
-use crate::types::{ObjectFeatures, ObjectId, Scope};
+use crate::types::{ObjectFeatures, Scope};
 
 use super::{FetchFileDataRequest, ObjectError};
 

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -124,7 +124,6 @@ impl From<debuginfo::ObjectError> for ObjectError {
 /// along some errors, so we use this wrapper.
 ///
 /// [`CacheItemRequest`]: crate::services::cacher::CacheItemRequest
-/// [`SourceId`]: crate::sources::SourceId
 /// [`SourceLocation`]: crate::services::download::SourceLocation
 #[derive(Debug)]
 struct CacheLookupError {

--- a/crates/symbolicator/src/services/objects/mod.rs
+++ b/crates/symbolicator/src/services/objects/mod.rs
@@ -7,13 +7,14 @@ use std::sync::Arc;
 use backtrace::Backtrace;
 use futures::future;
 use sentry::{Hub, SentryFutureExt};
+
 use symbolic::debuginfo;
+use symbolicator_sources::{FileType, ObjectId, SourceConfig, SourceId};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::cacher::Cacher;
 use crate::services::download::{DownloadError, DownloadService, RemoteDif, RemoteDifUri};
-use crate::sources::{FileType, SourceConfig, SourceId};
-use crate::types::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectId, Scope};
+use crate::types::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, Scope};
 
 use data_cache::FetchFileDataRequest;
 use meta_cache::FetchFileMetaRequest;

--- a/crates/symbolicator/src/services/ppdb_caches.rs
+++ b/crates/symbolicator/src/services/ppdb_caches.rs
@@ -1,25 +1,24 @@
-use futures::future::BoxFuture;
-use symbolic::common::ByteView;
-use symbolic::debuginfo::Object;
-use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
-
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::future::BoxFuture;
 use thiserror::Error;
+
+use symbolic::common::ByteView;
+use symbolic::debuginfo::Object;
+use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
+use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::objects::ObjectError;
-use crate::sources::{FileType, SourceConfig};
 use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
 use super::cacher::{CacheItemRequest, CacheKey, CachePath, CacheVersions, Cacher};
-use super::download::ObjectId;
 use super::objects::{
     FindObject, FoundObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };

--- a/crates/symbolicator/src/services/symbolication/apple.rs
+++ b/crates/symbolicator/src/services/symbolication/apple.rs
@@ -5,12 +5,13 @@ use std::time::Duration;
 use apple_crash_report_parser::{AppleCrashReport, ParseError};
 use chrono::{DateTime, Utc};
 use regex::Regex;
-use symbolic::common::{Arch, CodeId, DebugId};
 
-use crate::sources::SourceConfig;
+use symbolic::common::{Arch, CodeId, DebugId};
+use symbolicator_sources::{ObjectType, SourceConfig};
+
 use crate::types::{
-    CompleteObjectInfo, CompletedSymbolicationResponse, ObjectType, RawFrame, RawObjectInfo,
-    RawStacktrace, RequestOptions, Scope, SystemInfo,
+    CompleteObjectInfo, CompletedSymbolicationResponse, RawFrame, RawObjectInfo, RawStacktrace,
+    RequestOptions, Scope, SystemInfo,
 };
 use crate::utils::futures::{m, measure};
 use crate::utils::hex::HexValue;

--- a/crates/symbolicator/src/services/symbolication/mod.rs
+++ b/crates/symbolicator/src/services/symbolication/mod.rs
@@ -13,14 +13,15 @@ use sentry::SentryFutureExt;
 use tempfile::TempPath;
 use thiserror::Error;
 
+use symbolicator_sources::{ObjectId, SourceConfig};
+
 use crate::services::cficaches::{CfiCacheActor, CfiCacheError};
 use crate::services::objects::ObjectsActor;
 use crate::services::ppdb_caches::{PortablePdbCacheActor, PortablePdbCacheError};
 use crate::services::symcaches::{SymCacheActor, SymCacheError};
-use crate::sources::SourceConfig;
 use crate::types::{
-    CompletedSymbolicationResponse, ObjectFileStatus, ObjectId, RawObjectInfo, RequestId,
-    RequestOptions, Scope, SymbolicationResponse,
+    CompletedSymbolicationResponse, ObjectFileStatus, RawObjectInfo, RequestId, RequestOptions,
+    Scope, SymbolicationResponse,
 };
 use crate::utils::futures::CallOnDrop;
 
@@ -439,11 +440,13 @@ fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
 mod tests {
     use super::*;
 
+    use symbolicator_sources::ObjectType;
+
     use crate::config::Config;
     use crate::services::symbolication::module_lookup::ModuleLookup;
     use crate::services::Service;
     use crate::test::{self, fixture};
-    use crate::types::{CompleteObjectInfo, ObjectType, RawFrame, RawStacktrace};
+    use crate::types::{CompleteObjectInfo, RawFrame, RawStacktrace};
     use crate::utils::addr::AddrMode;
     use crate::utils::hex::HexValue;
 

--- a/crates/symbolicator/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator/src/services/symbolication/module_lookup.rs
@@ -3,18 +3,19 @@ use std::sync::Arc;
 
 use futures::future;
 use sentry::{Hub, SentryFutureExt};
+use thiserror::Error;
+
 use symbolic::common::{ByteView, SelfCell};
 use symbolic::debuginfo::{Object, ObjectDebugSession};
-use thiserror::Error;
+use symbolicator_sources::{FileType, ObjectType, SourceConfig};
 
 use crate::services::objects::{FindObject, FoundObject, ObjectPurpose, ObjectsActor};
 use crate::services::ppdb_caches::{
     FetchPortablePdbCache, PortablePdbCacheActor, PortablePdbCacheError, PortablePdbCacheFile,
 };
 use crate::services::symcaches::{FetchSymCache, SymCacheActor, SymCacheError, SymCacheFile};
-use crate::sources::{FileType, SourceConfig};
 use crate::types::{
-    CompleteObjectInfo, CompleteStacktrace, ObjectFileStatus, ObjectType, RawStacktrace, Scope,
+    CompleteObjectInfo, CompleteStacktrace, ObjectFileStatus, RawStacktrace, Scope,
 };
 use crate::utils::addr::AddrMode;
 

--- a/crates/symbolicator/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator/src/services/symbolication/process_minidump.rs
@@ -19,20 +19,20 @@ use minidump_processor::{
 use parking_lot::{Mutex, RwLock};
 use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
+use tempfile::TempPath;
+
 use symbolic::cfi::CfiCache;
 use symbolic::common::{Arch, ByteView, CodeId, DebugId};
-use tempfile::TempPath;
+use symbolicator_sources::{ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::CacheStatus;
 use crate::services::cficaches::{CfiCacheActor, CfiCacheError, FetchCfiCache};
-use crate::services::download::ObjectId;
 use crate::services::minidump::parse_stacktraces_from_minidump;
 use crate::services::objects::ObjectError;
-use crate::sources::SourceConfig;
 use crate::types::{
     AllObjectCandidates, CompleteObjectInfo, CompletedSymbolicationResponse, ObjectFeatures,
-    ObjectFileStatus, ObjectType, RawFrame, RawObjectInfo, RawStacktrace, Registers,
-    RequestOptions, Scope, SystemInfo,
+    ObjectFileStatus, RawFrame, RawObjectInfo, RawStacktrace, Registers, RequestOptions, Scope,
+    SystemInfo,
 };
 use crate::utils::futures::{m, measure};
 use crate::utils::hex::HexValue;

--- a/crates/symbolicator/src/services/symbolication/symbolication.rs
+++ b/crates/symbolicator/src/services/symbolication/symbolication.rs
@@ -3,14 +3,14 @@ use std::time::Duration;
 
 use symbolic::common::{split_path, DebugId, InstructionInfo, Language, Name};
 use symbolic::demangle::{Demangle, DemangleOptions};
+use symbolicator_sources::{ObjectType, SourceConfig};
 
 use crate::services::ppdb_caches::PortablePdbCacheFile;
 use crate::services::symcaches::SymCacheFile;
-use crate::sources::SourceConfig;
 use crate::types::{
     CompleteObjectInfo, CompleteStacktrace, CompletedSymbolicationResponse, FrameStatus,
-    FrameTrust, ObjectFileStatus, ObjectType, RawFrame, RawStacktrace, Registers, RequestOptions,
-    Scope, Signal, SymbolicatedFrame,
+    FrameTrust, ObjectFileStatus, RawFrame, RawStacktrace, Registers, RequestOptions, Scope,
+    Signal, SymbolicatedFrame,
 };
 use crate::utils::futures::{m, measure};
 use crate::utils::hex::HexValue;

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 
 use anyhow::Error;
 use futures::future::BoxFuture;
+use thiserror::Error;
+
 use symbolic::common::{Arch, ByteView};
 use symbolic::symcache::{self, SymCache, SymCacheConverter};
-use thiserror::Error;
+use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus};
 use crate::services::bitcode::BitcodeService;
@@ -17,10 +19,7 @@ use crate::services::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
     ObjectsActor,
 };
-use crate::sources::{FileType, SourceConfig};
-use crate::types::{
-    AllObjectCandidates, ObjectFeatures, ObjectId, ObjectType, ObjectUseInfo, Scope,
-};
+use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
@@ -478,10 +477,10 @@ mod tests {
     use crate::config::{CacheConfigs, Config};
     use crate::services::bitcode::BitcodeService;
     use crate::services::DownloadService;
-    use crate::sources::{
+    use crate::test::{self, fixture};
+    use symbolicator_sources::{
         CommonSourceConfig, DirectoryLayoutType, FilesystemSourceConfig, SourceConfig, SourceId,
     };
-    use crate::test::{self, fixture};
 
     /// Creates a `SymCacheActor` with the given cache directory
     /// and timeout for download cache misses.

--- a/crates/symbolicator/src/test.rs
+++ b/crates/symbolicator/src/test.rs
@@ -29,13 +29,14 @@ use warp::filters::fs::File;
 use warp::reject::{Reject, Rejection};
 use warp::Filter;
 
+use symbolicator_sources::{
+    CommonSourceConfig, DirectoryLayoutType, FileType, FilesystemSourceConfig, GcsSourceKey,
+    HttpSourceConfig, SourceConfig, SourceFilters, SourceId,
+};
+
 use crate::config::Config;
 use crate::endpoints;
 use crate::services::Service;
-use crate::sources::{
-    CommonSourceConfig, FileType, FilesystemSourceConfig, GcsSourceKey, HttpSourceConfig,
-    SourceConfig, SourceFilters, SourceId,
-};
 
 pub use tempfile::TempDir;
 
@@ -295,8 +296,7 @@ impl FailingSymbolServer {
 
         let server = Server::new(reject.or(not_found).or(pending).or(forbidden));
 
-        let files_config =
-            CommonSourceConfig::with_layout(crate::sources::DirectoryLayoutType::Unified);
+        let files_config = CommonSourceConfig::with_layout(DirectoryLayoutType::Unified);
 
         let reject_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
             id: SourceId::new("reject"),

--- a/crates/symbolicator/src/types/mod.rs
+++ b/crates/symbolicator/src/types/mod.rs
@@ -4,22 +4,17 @@
 //! HTTP API.  Its messy and things probably need a better place and different way to signal
 //! they are part of the public API.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::convert::Infallible;
 use std::fmt;
-use std::ops::Deref;
-use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use serde::{de, Deserialize, Deserializer, Serialize};
-use symbolic::common::{split_path, Arch, CodeId, DebugId, Language};
-use symbolic::debuginfo::Object;
+use serde::{Deserialize, Deserializer, Serialize};
+use symbolic::common::{Arch, CodeId, DebugId, Language};
+use symbolicator_sources::ObjectType;
 use uuid::Uuid;
 
 use crate::utils::addr::AddrMode;
 use crate::utils::hex::HexValue;
-use crate::utils::sentry::ConfigureScope;
 
 mod objects;
 
@@ -56,36 +51,6 @@ impl<'de> Deserialize<'de> for RequestId {
 // TODO(markus): Also accept POSIX signal name as defined in signal.h
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Signal(pub u32);
-
-#[derive(Debug, Clone)]
-pub struct Glob(pub glob::Pattern);
-
-impl<'de> Deserialize<'de> for Glob {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = Cow::<str>::deserialize(deserializer)?;
-        s.parse().map_err(de::Error::custom).map(Glob)
-    }
-}
-
-impl Serialize for Glob {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
-    }
-}
-
-impl Deref for Glob {
-    type Target = glob::Pattern;
-
-    fn deref(&self) -> &glob::Pattern {
-        &self.0
-    }
-}
 
 /// The scope of a source or debug file.
 ///
@@ -354,62 +319,6 @@ pub struct RawObjectInfo {
     /// Checksum of the file's contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
-}
-
-/// The type of an object file.
-#[derive(Serialize, Clone, Copy, Debug, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum ObjectType {
-    Elf,
-    Macho,
-    Pe,
-    Wasm,
-    PeDotnet,
-    Unknown,
-}
-
-impl FromStr for ObjectType {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<ObjectType, Infallible> {
-        Ok(match s {
-            "elf" => ObjectType::Elf,
-            "macho" => ObjectType::Macho,
-            "pe" => ObjectType::Pe,
-            "pe_dotnet" => ObjectType::PeDotnet,
-            "wasm" => ObjectType::Wasm,
-            _ => ObjectType::Unknown,
-        })
-    }
-}
-
-impl<'de> Deserialize<'de> for ObjectType {
-    fn deserialize<D>(deserializer: D) -> Result<ObjectType, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
-        Ok(s.parse().unwrap())
-    }
-}
-
-impl fmt::Display for ObjectType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ObjectType::Elf => write!(f, "elf"),
-            ObjectType::Macho => write!(f, "macho"),
-            ObjectType::Pe => write!(f, "pe"),
-            ObjectType::PeDotnet => write!(f, "pe_dotnet"),
-            ObjectType::Wasm => write!(f, "wasm"),
-            ObjectType::Unknown => write!(f, "unknown"),
-        }
-    }
-}
-
-impl Default for ObjectType {
-    fn default() -> ObjectType {
-        ObjectType::Unknown
-    }
 }
 
 /// Information on the symbolication status of this frame.
@@ -746,99 +655,4 @@ pub struct SystemInfo {
 
     /// Device model name
     pub device_model: String,
-}
-
-/// Information to find an object in external sources and also internal cache.
-///
-/// See [`ObjectId::match_object`] for how these can be compared.
-#[derive(Debug, Clone, Default)]
-pub struct ObjectId {
-    /// Identifier of the code file.
-    pub code_id: Option<CodeId>,
-
-    /// Path to the code file (executable or library).
-    pub code_file: Option<String>,
-
-    /// Identifier of the debug file.
-    pub debug_id: Option<DebugId>,
-
-    /// Path to the debug file.
-    pub debug_file: Option<String>,
-
-    /// Hint to what we believe the file type should be.
-    pub object_type: ObjectType,
-}
-
-impl From<DebugId> for ObjectId {
-    fn from(source: DebugId) -> Self {
-        Self {
-            debug_id: Some(source),
-            ..Default::default()
-        }
-    }
-}
-
-impl ObjectId {
-    pub fn code_file_basename(&self) -> Option<&str> {
-        Some(split_path(self.code_file.as_ref()?).1)
-    }
-
-    pub fn debug_file_basename(&self) -> Option<&str> {
-        Some(split_path(self.debug_file.as_ref()?).1)
-    }
-
-    /// Validates that the object matches expected identifiers.
-    pub fn match_object(&self, object: &Object<'_>) -> bool {
-        if let Some(ref debug_id) = self.debug_id {
-            let parsed_id = object.debug_id();
-
-            // Microsoft symbol server sometimes stores updated files with a more recent
-            // (=higher) age, but resolves it for requests with lower ages as well. Thus, we
-            // need to check whether the parsed debug file fullfills the *miniumum* age bound.
-            // For example:
-            // `4A236F6A0B3941D1966B41A4FC77738C2` is reported as
-            // `4A236F6A0B3941D1966B41A4FC77738C4` from the server.
-            //                                  ^
-            return parsed_id.uuid() == debug_id.uuid()
-                && parsed_id.appendix() >= debug_id.appendix();
-        }
-
-        if let Some(ref code_id) = self.code_id {
-            if let Some(ref object_code_id) = object.code_id() {
-                if object_code_id != code_id {
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-}
-
-impl ConfigureScope for ObjectId {
-    fn to_scope(&self, scope: &mut sentry::Scope) {
-        scope.set_tag(
-            "object_id.code_id",
-            self.code_id
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_else(|| "None".to_string()),
-        );
-        scope.set_tag(
-            "object_id.code_file_basename",
-            self.code_file_basename().unwrap_or("None"),
-        );
-        scope.set_tag(
-            "object_id.debug_id",
-            self.debug_id
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_else(|| "None".to_string()),
-        );
-        scope.set_tag(
-            "object_id.debug_file_basename",
-            self.debug_file_basename().unwrap_or("None"),
-        );
-        scope.set_tag("object_id.object_type", self.object_type.to_string());
-    }
 }

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -19,7 +19,7 @@ use super::ObjectFeatures;
 /// which ID this DIF info was for.
 ///
 /// [`CompleteObjectInfo`]: crate::types::CompleteObjectInfo
-/// [`ObjectId`]: crate::types::ObjectId
+/// [`ObjectId`]: symbolicator_sources::ObjectId
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ObjectCandidate {
     /// The ID of the object source where this DIF was expected to be found.

--- a/crates/symbolicator/src/types/objects.rs
+++ b/crates/symbolicator/src/types/objects.rs
@@ -2,9 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use symbolicator_sources::SourceId;
+
 use crate::cache::CacheStatus;
 use crate::services::download::RemoteDifUri;
-use crate::sources::SourceId;
 
 use super::ObjectFeatures;
 

--- a/crates/symbolicator/src/utils/gcs.rs
+++ b/crates/symbolicator/src/utils/gcs.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
-use crate::sources::GcsSourceKey;
+use symbolicator_sources::GcsSourceKey;
 
 /// A JWT token usable for GCS.
 #[derive(Debug)]

--- a/crates/symbolicator/src/utils/mod.rs
+++ b/crates/symbolicator/src/utils/mod.rs
@@ -4,5 +4,4 @@ pub mod futures;
 pub mod gcs;
 pub mod hex;
 pub mod http;
-pub mod paths;
 pub mod sentry;

--- a/crates/symbolicator/src/utils/sentry.rs
+++ b/crates/symbolicator/src/utils/sentry.rs
@@ -1,3 +1,5 @@
+use symbolicator_sources::ObjectId;
+
 /// Write own data to [`sentry::Scope`], only the subset that is considered useful for debugging.
 pub trait ConfigureScope {
     /// Writes information to the given scope.
@@ -6,5 +8,33 @@ pub trait ConfigureScope {
     /// Configures the current scope.
     fn configure_scope(&self) {
         sentry::configure_scope(|scope| self.to_scope(scope));
+    }
+}
+
+impl ConfigureScope for ObjectId {
+    fn to_scope(&self, scope: &mut sentry::Scope) {
+        scope.set_tag(
+            "object_id.code_id",
+            self.code_id
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "None".to_string()),
+        );
+        scope.set_tag(
+            "object_id.code_file_basename",
+            self.code_file_basename().unwrap_or("None"),
+        );
+        scope.set_tag(
+            "object_id.debug_id",
+            self.debug_id
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "None".to_string()),
+        );
+        scope.set_tag(
+            "object_id.debug_file_basename",
+            self.debug_file_basename().unwrap_or("None"),
+        );
+        scope.set_tag("object_id.object_type", self.object_type.to_string());
     }
 }


### PR DESCRIPTION
Moves the paths and sourceconfig related types to its own workspace crate.

The split might not be perfect, and I’m open to suggestions.

#skip-changelog