### PR TITLE
fix: Avoid a redundant open/read and fix shared cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Extract the correct `code_id` from iOS minidumps. ([#858](https://github.com/getsentry/symbolicator/pull/858))
 - Fetch/use CFI for modules that only have a CodeId. ([#860](https://github.com/getsentry/symbolicator/pull/860))
 - Properly mask Portable PDB Age for symstore/SSQP lookups. ([#888](https://github.com/getsentry/symbolicator/pull/888))
+- Avoid a redundant open/read and fix shared cache refresh. ([#893](https://github.com/getsentry/symbolicator/pull/893))
 
 ### Internal
 

--- a/crates/symbolicator/src/services/cacher.rs
+++ b/crates/symbolicator/src/services/cacher.rs
@@ -255,7 +255,13 @@ impl<T: CacheItemRequest> Cacher<T> {
                     metric!(counter(&format!("caches.{}.file.discarded", name)) += 1);
                     return Ok(None);
                 }
-                if status == CacheStatus::Positive && mtime_bumped {
+
+                // store things into the shared cache when:
+                // - we have a positive cache
+                // - that has the latest version (we don’t want to upload old versions)
+                // - we refreshed the local cache time, so we also refresh the shared cache time.
+                if status == CacheStatus::Positive && version == T::VERSIONS.current && mtime_bumped
+                {
                     let shared_cache_key = SharedCacheKey {
                         name: self.config.name(),
                         version: T::VERSIONS.current,


### PR DESCRIPTION
- `check_expiry`/`expiration_strategy` would previously do a redundant open/read that would be later duplicated by an open/mmap anyway, which is now deduplicated.
- The shared cache refresh in `lookup_local_cache` was buggy and was refreshing/uploading caches with the `current` version even if the local cache had an older version.

In a very unscientific stress test, RPS increased from ~2.8k to ~3.4k with lot lower latency.