### PR TITLE
Fix typo in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal --target x86_64-apple-darwin --target aarch64-apple-darwin
 
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal


### PR DESCRIPTION
Noticed this error after my latest update PR.

Error: https://github.com/getsentry/symbolicator/actions/runs/3371706410

#skip-changelog