### PR TITLE
ref: Bump CFI/Sym Caches proactively

### DIFF
--- a/crates/symbolicator/src/services/cficaches.rs
+++ b/crates/symbolicator/src/services/cficaches.rs
@@ -41,12 +41,15 @@ use super::shared_cache::SharedCacheService;
 ///
 /// # Version History
 ///
+/// - `3`: Proactive bump, as a bug in shared cache could have potentially
+///   uploaded `v1` cache files as `v2` erroneously.
+///
 /// - `2`: Allow underflow in Win-x64 CFI which allows loading registers from outside the stack frame.
 ///
 /// - `1`: Generate higher fidelity CFI for Win-x64 binaries.
 const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 2,
-    fallbacks: &[],
+    current: 3,
+    fallbacks: &[2],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 

--- a/crates/symbolicator/src/services/symcaches/mod.rs
+++ b/crates/symbolicator/src/services/symcaches/mod.rs
@@ -48,6 +48,9 @@ mod markers;
 ///
 /// # Version History
 ///
+/// - `5`: Proactive bump, as a bug in shared cache could have potentially
+///   uploaded `v2` cache files as `v3` (and later `v4`) erroneously.
+///
 /// - `4`: An updated symbolic symcache that uses a LEB128 prefixed string table.
 ///
 /// - `3`: Another round of fixes in symcache generation:
@@ -63,8 +66,8 @@ mod markers;
 ///
 /// - `1`: New binary format based on instruction addr lookup.
 const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 4,
-    fallbacks: &[3],
+    current: 5,
+    fallbacks: &[4],
 };
 static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -226,7 +226,7 @@ def test_basic_windows(symbolicator, cache_dir_param, is_public, hitcounter):
 
             (symcache,) = (
                 cache_dir_param.join("symcaches")
-                .join("4")
+                .join("5")
                 .join(stored_in_scope)
                 .listdir()
             )


### PR DESCRIPTION
A previous bug in the shared cache refresh path could have erroneously uploaded an outdated cache version as a newer (up to date) version. (See https://github.com/getsentry/symbolicator/pull/893)

Now that the shared cache upload/refresh is fixed, this forces another cache refresh. This time files uploaded to and downloaded from shared cache should have the correct version they are advertising.

#skip-changelog