### PR TITLE
ref: Move Request handling into web frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fetch CFI on-demand during stackwalking ([#838](https://github.com/getsentry/symbolicator/pull/838))
 - Deduplicate SymbolFile computations in SymbolicatorSymbolProvider ([#856](https://github.com/getsentry/symbolicator/pull/856))
 - Separated the symbolication service from the http interface. ([#903](https://github.com/getsentry/symbolicator/pull/903))
+- Move Request/Response/Poll handling into web frontend. ([#904](https://github.com/getsentry/symbolicator/pull/904))
 
 ## 0.5.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,13 +3254,16 @@ dependencies = [
  "symbolicator-sources",
  "symbolicator-test",
  "tempfile",
+ "thiserror",
  "tokio",
+ "tokio-metrics",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3314,7 +3317,6 @@ dependencies = [
  "test-assembler",
  "thiserror",
  "tokio",
- "tokio-metrics",
  "tokio-util",
  "tracing",
  "url",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -44,7 +44,6 @@ symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }
-tokio-metrics = "0.1.0"
 tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = "0.1.34"
 url = { version = "2.2.0", features = ["serde"] }

--- a/crates/symbolicator-service/src/metrics.rs
+++ b/crates/symbolicator-service/src/metrics.rs
@@ -163,28 +163,3 @@ macro_rules! metric {
         })
     }};
 }
-
-trait ToMaxingI64: TryInto<i64> + Copy {
-    fn to_maxing_i64(self) -> i64 {
-        self.try_into().unwrap_or(i64::MAX)
-    }
-}
-
-impl<T: TryInto<i64> + Copy> ToMaxingI64 for T {}
-
-pub fn record_task_metrics(name: &str, metrics: &tokio_metrics::TaskMetrics) {
-    metric!(counter("tasks.instrumented_count") += metrics.instrumented_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.dropped_count") += metrics.dropped_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.first_poll_count") += metrics.first_poll_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_first_poll_delay") += metrics.total_first_poll_delay.as_millis().to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_idled_count") += metrics.total_idled_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_idle_duration") += metrics.total_idle_duration.as_millis().to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_scheduled_count") += metrics.total_scheduled_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_scheduled_duration") += metrics.total_scheduled_duration.as_millis().to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_poll_count") += metrics.total_poll_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_poll_duration") += metrics.total_poll_duration.as_millis().to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_fast_poll_count") += metrics.total_fast_poll_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_fast_poll_durations") += metrics.total_fast_poll_duration.as_millis().to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_slow_poll_count") += metrics.total_slow_poll_count.to_maxing_i64(), "taskname" => name);
-    metric!(counter("tasks.total_slow_poll_duration") += metrics.total_slow_poll_duration.as_millis().to_maxing_i64(), "taskname" => name);
-}

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -1,20 +1,13 @@
-//! Provides the symbolicator [`Service`] and internal services.
+//! Provides the internal Symbolicator services and a way to initialize them.
 //!
 //! Symbolicator operates a number of independent services defined in this module for downloading,
-//! cache management, and symbolication. They are created by the main [`Service`] and can be
-//! accessed via that.
+//! cache management, and symbolication.
+//! The main [`create_service`] fn creates all these internal services according to the provided
+//! [`Config`] and returns a [`SymbolicationActor`] as the main Symbolicator interface, and an
+//! [`ObjectsActor`] which abstracts object access.
 //!
-//! In general, services are created once in the [`crate::services::Service`] and accessed via this
-//! state.
-//!
-//! The internal services require two separate asynchronous runtimes.
-//! (There is a third runtime dedicated to serving http requests)
-//! For regular scheduling and I/O-intensive work, services will use the `io_pool`.
-//! For CPU intensive workloads, services will use the `cpu_pool`.
-//!
-//! When a request comes in on the web pool, it is handed off to the `cpu_pool` for processing, which
-//! is primarily synchronous work in the best case (everything is cached).
-//! When file fetching is needed, that fetching will happen on the `io_pool`.
+//! The internal services require a separate asynchronous runtimes dedicated for I/O-intensive work,
+//! such as downloads and access to the shared cache.
 
 use std::sync::Arc;
 

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -47,85 +47,50 @@ use self::shared_cache::SharedCacheService;
 use self::symbolication::SymbolicationActor;
 use self::symcaches::SymCacheActor;
 
-/// The shared state for the service.
-#[derive(Clone, Debug)]
-pub struct Service {
-    /// Actor for minidump and stacktrace processing
-    symbolication: SymbolicationActor,
-    /// Actor for downloading and caching objects (no symcaches or cficaches)
-    objects: ObjectsActor,
-    /// The config object.
-    config: Arc<Config>,
-}
+pub async fn create_service(
+    config: &Config,
+    io_pool: tokio::runtime::Handle,
+) -> Result<(SymbolicationActor, ObjectsActor)> {
+    let caches = Caches::from_config(&config).context("failed to create local caches")?;
+    caches
+        .clear_tmp(&config)
+        .context("failed to clear tmp caches")?;
 
-impl Service {
-    pub async fn create(
-        config: Config,
-        io_pool: tokio::runtime::Handle,
-        cpu_pool: tokio::runtime::Handle,
-    ) -> Result<Self> {
-        let config = Arc::new(config);
+    let downloader = DownloadService::new(&config, io_pool.clone());
 
-        let downloader = DownloadService::new(&config, io_pool.clone());
-        let shared_cache =
-            SharedCacheService::new(config.shared_cache.clone(), io_pool.clone()).await;
-        let shared_cache = Arc::new(shared_cache);
-        let caches = Caches::from_config(&config).context("failed to create local caches")?;
-        caches
-            .clear_tmp(&config)
-            .context("failed to clear tmp caches")?;
-        let objects = ObjectsActor::new(
-            caches.object_meta,
-            caches.objects,
-            shared_cache.clone(),
-            downloader.clone(),
-        );
-        let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader.clone());
-        let il2cpp = Il2cppService::new(caches.il2cpp, shared_cache.clone(), downloader);
-        let symcaches = SymCacheActor::new(
-            caches.symcaches,
-            shared_cache.clone(),
-            objects.clone(),
-            bitcode,
-            il2cpp,
-        );
-        let cficaches = CfiCacheActor::new(caches.cficaches, shared_cache.clone(), objects.clone());
-        let ppdb_caches =
-            PortablePdbCacheActor::new(caches.ppdb_caches, shared_cache, objects.clone());
+    let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool.clone()).await;
+    let shared_cache = Arc::new(shared_cache);
 
-        let symbolication = SymbolicationActor::new(
-            objects.clone(),
-            symcaches,
-            cficaches,
-            ppdb_caches,
-            caches.diagnostics,
-            cpu_pool,
-            config.max_concurrent_requests,
-        );
-        let symbolication_taskmon = symbolication.symbolication_task_monitor();
-        io_pool.spawn(async move {
-            for interval in symbolication_taskmon.intervals() {
-                record_task_metrics("symbolication", &interval);
-                tokio::time::sleep(Duration::from_secs(5)).await;
-            }
-        });
+    let objects = ObjectsActor::new(
+        caches.object_meta,
+        caches.objects,
+        shared_cache.clone(),
+        downloader.clone(),
+    );
 
-        Ok(Self {
-            symbolication,
-            objects,
-            config,
-        })
-    }
+    let bitcode = BitcodeService::new(caches.auxdifs, shared_cache.clone(), downloader.clone());
 
-    pub fn symbolication(&self) -> &SymbolicationActor {
-        &self.symbolication
-    }
+    let il2cpp = Il2cppService::new(caches.il2cpp, shared_cache.clone(), downloader);
 
-    pub fn objects(&self) -> &ObjectsActor {
-        &self.objects
-    }
+    let symcaches = SymCacheActor::new(
+        caches.symcaches,
+        shared_cache.clone(),
+        objects.clone(),
+        bitcode,
+        il2cpp,
+    );
 
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
+    let cficaches = CfiCacheActor::new(caches.cficaches, shared_cache.clone(), objects.clone());
+
+    let ppdb_caches = PortablePdbCacheActor::new(caches.ppdb_caches, shared_cache, objects.clone());
+
+    let symbolication = SymbolicationActor::new(
+        objects.clone(),
+        symcaches,
+        cficaches,
+        ppdb_caches,
+        caches.diagnostics,
+    );
+
+    Ok((symbolication, objects))
 }

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -17,13 +17,11 @@
 //! When file fetching is needed, that fetching will happen on the `io_pool`.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 
 use crate::cache::Caches;
 use crate::config::Config;
-use crate::metrics::record_task_metrics;
 
 pub mod bitcode;
 pub mod cacher;
@@ -51,12 +49,12 @@ pub async fn create_service(
     config: &Config,
     io_pool: tokio::runtime::Handle,
 ) -> Result<(SymbolicationActor, ObjectsActor)> {
-    let caches = Caches::from_config(&config).context("failed to create local caches")?;
+    let caches = Caches::from_config(config).context("failed to create local caches")?;
     caches
-        .clear_tmp(&config)
+        .clear_tmp(config)
         .context("failed to clear tmp caches")?;
 
-    let downloader = DownloadService::new(&config, io_pool.clone());
+    let downloader = DownloadService::new(config, io_pool.clone());
 
     let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool.clone()).await;
     let shared_cache = Arc::new(shared_cache);

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -127,8 +127,8 @@ impl SymbolicationActor {
             .unwrap_or(Err(SymbolicationError::Timeout))
     }
 
-    pub(super) async fn do_process_apple_crash_report(
-        self,
+    pub async fn do_process_apple_crash_report(
+        &self,
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -8,7 +8,7 @@ use crate::services::cficaches::{CfiCacheActor, CfiCacheError};
 use crate::services::objects::ObjectsActor;
 use crate::services::ppdb_caches::{PortablePdbCacheActor, PortablePdbCacheError};
 use crate::services::symcaches::{SymCacheActor, SymCacheError};
-use crate::types::{ObjectFileStatus, RawObjectInfo, SymbolicationResponse};
+use crate::types::{ObjectFileStatus, RawObjectInfo};
 
 mod apple;
 mod module_lookup;
@@ -69,19 +69,6 @@ pub enum SymbolicationError {
 
     #[error("failed to parse apple crash report")]
     InvalidAppleCrashReport(#[from] apple_crash_report_parser::ParseError),
-}
-
-impl SymbolicationError {
-    pub fn to_symbolication_response(&self) -> SymbolicationResponse {
-        match self {
-            SymbolicationError::Timeout => SymbolicationResponse::Timeout,
-            SymbolicationError::Failed(_) | SymbolicationError::InvalidAppleCrashReport(_) => {
-                SymbolicationResponse::Failed {
-                    message: self.to_string(),
-                }
-            }
-        }
-    }
 }
 
 impl From<&CfiCacheError> for ObjectFileStatus {

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -1,29 +1,14 @@
-use std::collections::BTreeMap;
 use std::fmt;
-use std::fs::File;
-use std::future::Future;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
 
-use futures::{channel::oneshot, future, FutureExt as _};
-use parking_lot::Mutex;
-use sentry::protocol::SessionStatus;
-use sentry::SentryFutureExt;
-use tempfile::TempPath;
 use thiserror::Error;
 
-use symbolicator_sources::{ObjectId, SourceConfig};
+use symbolicator_sources::ObjectId;
 
 use crate::services::cficaches::{CfiCacheActor, CfiCacheError};
 use crate::services::objects::ObjectsActor;
 use crate::services::ppdb_caches::{PortablePdbCacheActor, PortablePdbCacheError};
 use crate::services::symcaches::{SymCacheActor, SymCacheError};
-use crate::types::{
-    CompletedSymbolicationResponse, ObjectFileStatus, RawObjectInfo, RequestId, RequestOptions,
-    Scope, SymbolicationResponse,
-};
-use crate::utils::futures::CallOnDrop;
+use crate::types::{ObjectFileStatus, RawObjectInfo, SymbolicationResponse};
 
 mod apple;
 mod module_lookup;
@@ -35,11 +20,6 @@ mod symbolication;
 
 pub use symbolication::{StacktraceOrigin, SymbolicateStacktraces};
 
-// We want a shared future here because otherwise polling for a response would hold the global lock.
-type ComputationChannel = future::Shared<oneshot::Receiver<(Instant, SymbolicationResponse)>>;
-
-type ComputationMap = Arc<Mutex<BTreeMap<RequestId, ComputationChannel>>>;
-
 #[derive(Clone)]
 pub struct SymbolicationActor {
     objects: ObjectsActor,
@@ -47,23 +27,15 @@ pub struct SymbolicationActor {
     cficaches: CfiCacheActor,
     ppdb_caches: PortablePdbCacheActor,
     diagnostics_cache: crate::cache::Cache,
-    cpu_pool: tokio::runtime::Handle,
-    requests: ComputationMap,
-    max_concurrent_requests: Option<usize>,
-    current_requests: Arc<AtomicUsize>,
-    symbolication_taskmon: tokio_metrics::TaskMonitor,
 }
 
 impl SymbolicationActor {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         objects: ObjectsActor,
         symcaches: SymCacheActor,
         cficaches: CfiCacheActor,
         ppdb_caches: PortablePdbCacheActor,
         diagnostics_cache: crate::cache::Cache,
-        cpu_pool: tokio::runtime::Handle,
-        max_concurrent_requests: Option<usize>,
     ) -> Self {
         SymbolicationActor {
             objects,
@@ -71,204 +43,7 @@ impl SymbolicationActor {
             cficaches,
             ppdb_caches,
             diagnostics_cache,
-            cpu_pool,
-            requests: Arc::new(Mutex::new(BTreeMap::new())),
-            max_concurrent_requests,
-            current_requests: Arc::new(AtomicUsize::new(0)),
-            symbolication_taskmon: tokio_metrics::TaskMonitor::new(),
         }
-    }
-
-    /// Creates a new request to symbolicate stacktraces.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn symbolicate_stacktraces(
-        &self,
-        request: SymbolicateStacktraces,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "symbolicate_stacktraces",
-            "symbolicate_stacktraces",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf.do_symbolicate(request).await;
-            transaction.finish();
-            res
-        })
-    }
-
-    /// Creates a new request to process a minidump.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn process_minidump(
-        &self,
-        scope: Scope,
-        minidump_file: TempPath,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_minidump",
-            "process_minidump",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .do_process_minidump(scope, minidump_file, sources, options)
-                .await;
-            transaction.finish();
-            res
-        })
-    }
-
-    /// Creates a new request to process an Apple crash report.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    pub fn process_apple_crash_report(
-        &self,
-        scope: Scope,
-        apple_crash_report: File,
-        sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
-    ) -> Result<RequestId, MaxRequestsError> {
-        let slf = self.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_apple_crash_report",
-            "process_apple_crash_report",
-            span,
-        );
-        self.create_symbolication_request(async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .do_process_apple_crash_report(scope, apple_crash_report, sources, options)
-                .await;
-            transaction.finish();
-            res
-        })
-    }
-
-    /// Polls the status for a started symbolication task.
-    ///
-    /// If the timeout is set and no result is ready within the given time,
-    /// [`SymbolicationResponse::Pending`] is returned.
-    pub async fn get_response(
-        &self,
-        request_id: RequestId,
-        timeout: Option<u64>,
-    ) -> Option<SymbolicationResponse> {
-        let channel_opt = self.requests.lock().get(&request_id).cloned();
-        match channel_opt {
-            Some(channel) => Some(wrap_response_channel(request_id, timeout, channel).await),
-            None => {
-                // This is okay to occur during deploys, but if it happens all the time we have a state
-                // bug somewhere. Could be a misconfigured load balancer (supposed to be pinned to
-                // scopes).
-                metric!(counter("symbolication.request_id_unknown") += 1);
-                None
-            }
-        }
-    }
-
-    /// Returns a clone of the task monitor for symbolication requests.
-    pub fn symbolication_task_monitor(&self) -> tokio_metrics::TaskMonitor {
-        self.symbolication_taskmon.clone()
-    }
-
-    /// Creates a new request to compute the given future.
-    ///
-    /// Returns `None` if the `SymbolicationActor` is already processing the
-    /// maximum number of requests, as given by `max_concurrent_requests`.
-    fn create_symbolication_request<F>(&self, f: F) -> Result<RequestId, MaxRequestsError>
-    where
-        F: Future<Output = Result<CompletedSymbolicationResponse, SymbolicationError>>
-            + Send
-            + 'static,
-    {
-        let (sender, receiver) = oneshot::channel();
-
-        let hub = Arc::new(sentry::Hub::new_from_top(sentry::Hub::current()));
-
-        // Assume that there are no UUID4 collisions in practice.
-        let requests = Arc::clone(&self.requests);
-        let current_requests = Arc::clone(&self.current_requests);
-
-        let num_requests = current_requests.load(Ordering::Relaxed);
-        metric!(gauge("requests.in_flight") = num_requests as u64);
-
-        // Reject the request if `requests` already contains `max_concurrent_requests` elements.
-        if let Some(max_concurrent_requests) = self.max_concurrent_requests {
-            if num_requests >= max_concurrent_requests {
-                metric!(counter("requests.rejected") += 1);
-                return Err(MaxRequestsError);
-            }
-        }
-
-        let request_id = RequestId::new(uuid::Uuid::new_v4());
-        requests.lock().insert(request_id, receiver.shared());
-        current_requests.fetch_add(1, Ordering::Relaxed);
-        let drop_hub = hub.clone();
-        let token = CallOnDrop::new(move || {
-            requests.lock().remove(&request_id);
-            // we consider every premature drop of the future as fatal crash, which works fine
-            // since ending a session consumes it and its not possible to double-end.
-            drop_hub.end_session_with_status(SessionStatus::Crashed);
-        });
-
-        let spawn_time = Instant::now();
-        let request_future = async move {
-            metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
-            let response = match f.await {
-                Ok(response) => {
-                    sentry::end_session_with_status(SessionStatus::Exited);
-                    SymbolicationResponse::Completed(Box::new(response))
-                }
-                Err(error) => {
-                    // a timeout is an abnormal session exit, all other errors are considered "crashed"
-                    let status = match &error {
-                        SymbolicationError::Timeout => SessionStatus::Abnormal,
-                        _ => SessionStatus::Crashed,
-                    };
-                    sentry::end_session_with_status(status);
-
-                    let response = error.to_symbolication_response();
-                    let error = anyhow::Error::new(error);
-                    tracing::error!("Symbolication error: {:?}", error);
-                    response
-                }
-            };
-
-            sender.send((Instant::now(), response)).ok();
-
-            // We stop counting the request as an in-flight request at this point, even though
-            // it will stay in the `requests` map for another 90s.
-            current_requests.fetch_sub(1, Ordering::Relaxed);
-
-            // Wait before removing the channel from the computation map to allow clients to
-            // poll the status.
-            tokio::time::sleep(MAX_POLL_DELAY).await;
-
-            drop(token);
-        }
-        .bind_hub(hub);
-
-        self.cpu_pool
-            .spawn(self.symbolication_taskmon.instrument(request_future));
-
-        Ok(request_id)
     }
 }
 
@@ -279,17 +54,9 @@ impl fmt::Debug for SymbolicationActor {
             .field("symcaches", &self.symcaches)
             .field("cficaches", &self.cficaches)
             .field("diagnostics_cache", &self.diagnostics_cache)
-            .field("cpu_pool", &self.cpu_pool)
-            .field("requests", &self.requests)
-            .field("max_concurrent_requests", &self.max_concurrent_requests)
-            .field("current_requests", &self.current_requests)
-            .field("symbolication_taskmon", &"<TaskMonitor>")
             .finish()
     }
 }
-
-/// The maximum delay we allow for polling a finished request before dropping it.
-const MAX_POLL_DELAY: Duration = Duration::from_secs(90);
 
 /// Errors during symbolication.
 #[derive(Debug, Error)]
@@ -314,46 +81,6 @@ impl SymbolicationError {
                 }
             }
         }
-    }
-}
-
-/// An error returned when symbolicator receives a request while already processing
-/// the maximum number of requests.
-#[derive(Debug, Clone, Error)]
-#[error("maximum number of concurrent requests reached")]
-pub struct MaxRequestsError;
-
-async fn wrap_response_channel(
-    request_id: RequestId,
-    timeout: Option<u64>,
-    channel: ComputationChannel,
-) -> SymbolicationResponse {
-    let channel_result = if let Some(timeout) = timeout {
-        match tokio::time::timeout(Duration::from_secs(timeout), channel).await {
-            Ok(outcome) => outcome,
-            Err(_elapsed) => {
-                return SymbolicationResponse::Pending {
-                    request_id,
-                    // We should estimate this better, but at some point the
-                    // architecture will probably change to pushing results on a
-                    // queue instead of polling so it's unlikely we'll ever do
-                    // better here.
-                    retry_after: 30,
-                };
-            }
-        }
-    } else {
-        channel.await
-    };
-
-    match channel_result {
-        Ok((finished_at, response)) => {
-            metric!(timer("requests.response_idling") = finished_at.elapsed());
-            response
-        }
-        // If the sender is dropped, this is likely due to a panic that is captured at the source.
-        // Therefore, we do not need to capture an error at this point.
-        Err(_canceled) => SymbolicationResponse::InternalError,
     }
 }
 

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -531,7 +531,7 @@ impl SymbolicationActor {
         }
     }
 
-    pub(super) async fn do_process_minidump(
+    pub async fn do_process_minidump(
         &self,
         scope: Scope,
         minidump_file: TempPath,
@@ -701,48 +701,47 @@ mod tests {
         }};
         ($path:expr, $options:expr) => {{
             async {
-                let (service, _cache_dir) = setup_service().await;
-                let symbolication = service.symbolication();
+                let (symbolication, cache_dir) = setup_service().await;
                 let (_symsrv, source) = test::symbol_server();
 
                 let minidump = test::read_fixture($path);
-                let mut minidump_file = NamedTempFile::new()?;
-                minidump_file.write_all(&minidump)?;
-                let request_id = symbolication.process_minidump(
-                    Scope::Global,
-                    minidump_file.into_temp_path(),
-                    Arc::new([source]),
-                    $options,
-                );
-                let response = symbolication.get_response(request_id.unwrap(), None).await;
+                let mut minidump_file = NamedTempFile::new().unwrap();
+                minidump_file.write_all(&minidump).unwrap();
+                let response = symbolication
+                    .do_process_minidump(
+                        Scope::Global,
+                        minidump_file.into_temp_path(),
+                        Arc::new([source]),
+                        $options,
+                    )
+                    .await;
 
                 assert_snapshot!(response.unwrap());
 
-                let global_dir = service.config().cache_dir("object_meta/global").unwrap();
-                let mut cache_entries: Vec<_> = fs::read_dir(global_dir)?
+                let global_dir = cache_dir.path().join("object_meta/global");
+                let mut cache_entries: Vec<_> = fs::read_dir(global_dir)
+                    .unwrap()
                     .map(|x| x.unwrap().file_name().into_string().unwrap())
                     .collect();
 
                 cache_entries.sort();
                 assert_snapshot!(cache_entries);
-
-                Ok(())
             }
         }};
     }
 
     #[tokio::test]
-    async fn test_minidump_windows() -> anyhow::Result<()> {
+    async fn test_minidump_windows() {
         stackwalk_minidump!("windows.dmp").await
     }
 
     #[tokio::test]
-    async fn test_minidump_macos() -> anyhow::Result<()> {
+    async fn test_minidump_macos() {
         stackwalk_minidump!("macos.dmp").await
     }
 
     #[tokio::test]
-    async fn test_minidump_linux() -> anyhow::Result<()> {
+    async fn test_minidump_linux() {
         stackwalk_minidump!("linux.dmp").await
     }
 }

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_linux.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_linux.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/process_minidump.rs
-assertion_line: 746
+assertion_line: 745
 expression: response.unwrap()
 ---
-status: completed
 timestamp: 1522061032
 system_info:
   os_name: Linux

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_macos.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_macos.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/process_minidump.rs
-assertion_line: 741
+assertion_line: 740
 expression: response.unwrap()
 ---
-status: completed
 timestamp: 1521713398
 system_info:
   os_name: macOS

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_windows.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__process_minidump__tests__minidump_windows.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/process_minidump.rs
-assertion_line: 736
+assertion_line: 735
 expression: response.unwrap()
 ---
-status: completed
 timestamp: 1521713273
 system_info:
   os_name: Windows

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__add_bucket-2.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__add_bucket-2.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 574
+assertion_line: 293
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: symbolicated

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__add_bucket.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__add_bucket.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 568
+assertion_line: 288
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: missing

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__apple_crash_report.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__apple_crash_report.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 642
+assertion_line: 314
 expression: response.unwrap()
 ---
-status: completed
 timestamp: 1547055742
 system_info:
   os_name: macOS

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__dotnet_integration.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__dotnet_integration.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 866
+assertion_line: 502
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: symbolicated

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__remove_bucket-2.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__remove_bucket-2.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 550
+assertion_line: 274
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: missing

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__remove_bucket.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__remove_bucket.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 544
+assertion_line: 269
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: symbolicated

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__source_candidates.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__source_candidates.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 739
+assertion_line: 409
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: symbolicated

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__wasm_payload.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__wasm_payload.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 689
+assertion_line: 360
 expression: response.unwrap()
 ---
-status: completed
 stacktraces:
   - frames:
       - status: symbolicated

--- a/crates/symbolicator-service/src/services/symbolication/symbolication.rs
+++ b/crates/symbolicator-service/src/services/symbolication/symbolication.rs
@@ -20,7 +20,7 @@ use super::{SymbolicationActor, SymbolicationError};
 
 impl SymbolicationActor {
     #[tracing::instrument(skip_all)]
-    pub(super) async fn do_symbolicate(
+    pub async fn do_symbolicate(
         &self,
         request: SymbolicateStacktraces,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -8,10 +8,9 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use symbolic::common::{Arch, CodeId, DebugId, Language};
 use symbolicator_sources::ObjectType;
-use uuid::Uuid;
 
 use crate::utils::addr::AddrMode;
 use crate::utils::hex::HexValue;
@@ -19,33 +18,6 @@ use crate::utils::hex::HexValue;
 mod objects;
 
 pub use objects::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectUseInfo};
-
-/// Symbolication task identifier.
-#[derive(Debug, Clone, Copy, Serialize, Ord, PartialOrd, Eq, PartialEq)]
-pub struct RequestId(Uuid);
-
-impl RequestId {
-    /// Creates a new symbolication task identifier.
-    pub fn new(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl fmt::Display for RequestId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl<'de> Deserialize<'de> for RequestId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let uuid = Uuid::deserialize(deserializer);
-        Ok(Self(uuid.unwrap_or_default()))
-    }
-}
 
 /// OS-specific crash signal value.
 // TODO(markus): Also accept POSIX signal name as defined in signal.h
@@ -550,25 +522,6 @@ impl From<RawObjectInfo> for CompleteObjectInfo {
             candidates: AllObjectCandidates::default(),
         }
     }
-}
-
-/// The response of a symbolication request or poll request.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
-pub enum SymbolicationResponse {
-    /// Symbolication is still running.
-    Pending {
-        /// The id with which further updates can be polled.
-        request_id: RequestId,
-        /// An indication when the next poll would be suitable.
-        retry_after: usize,
-    },
-    Completed(Box<CompletedSymbolicationResponse>),
-    Failed {
-        message: String,
-    },
-    Timeout,
-    InternalError,
 }
 
 /// The symbolicated crash data.

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -61,21 +61,6 @@ impl fmt::Display for Scope {
     }
 }
 
-/// Extra JSON request data for multipart requests.
-///
-/// Multipart requests like `/minidump` and `/applecrashreport` often need some extra
-/// request data together with their main data payload which is included as a JSON-formatted
-/// multi-part.  This can represent this data.
-///
-/// This is meant to be extensible, it is conceivable that the existing `sources` mutli-part
-/// would merge into this one at some point.
-#[derive(Debug, Deserialize)]
-pub struct RequestData {
-    /// Common symbolication per-request options.
-    #[serde(default)]
-    pub options: RequestOptions,
-}
-
 /// Common options for all symbolication API requests.
 ///
 /// These options control some features which control the symbolication and general request
@@ -529,11 +514,7 @@ impl From<RawObjectInfo> for CompleteObjectInfo {
 /// It contains the symbolicated stack frames, module information as well as other
 /// meta-information about the crash.
 ///
-/// This object is the main type containing the symblicated crash as returned by the
-/// `/minidump`, `/symbolicate` and `/applecrashreport` endpoints.  It is publicly
-/// documented at <https://getsentry.github.io/symbolicator/api/response/>.  For the actual
-/// HTTP response this is further wrapped in [`SymbolicationResponse`] which can also return a
-/// pending or failed state etc instead of a result.
+/// It is publicly documented at <https://getsentry.github.io/symbolicator/api/response/>.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct CompletedSymbolicationResponse {
     /// When the crash occurred.

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -28,7 +28,10 @@ tokio = { version = "1.18.1", features = ["rt", "macros", "fs"] }
 tokio-util = { version = "0.7.1", features = ["io"] }
 tower = "0.4"
 tower-layer = "0.3"
+tokio-metrics = "0.1.0"
+thiserror = "1.0.31"
 tower-service = "0.3"
+uuid = { version = "1.0.0", features = ["v4", "serde"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "local-time", "env-filter", "json"] }
 

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use structopt::StructOpt;
 
-use crate::cache;
+use symbolicator_service::cache;
+use symbolicator_service::metrics;
+
 use crate::config::Config;
 use crate::logging;
-use crate::metrics;
 use crate::server;
 
 fn get_crate_version() -> &'static str {

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -4,15 +4,14 @@ use axum::response::Json;
 use tokio::fs::File;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::services::Service;
-use crate::types::{RequestOptions, SymbolicationResponse};
+use crate::service::{RequestOptions, RequestService, SymbolicationResponse};
 use crate::utils::sentry::ConfigureScope;
 
 use super::multipart::{read_multipart_data, stream_multipart_file};
 use super::ResponseError;
 
 pub async fn handle_apple_crash_report_request(
-    extract::Extension(state): extract::Extension<Service>,
+    extract::Extension(service): extract::Extension<RequestService>,
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     mut multipart: extract::Multipart,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
@@ -21,7 +20,7 @@ pub async fn handle_apple_crash_report_request(
     params.configure_scope();
 
     let mut report = None;
-    let mut sources = state.config().default_sources();
+    let mut sources = service.config().default_sources();
     let mut options = RequestOptions::default();
 
     while let Some(field) = multipart.next_field().await? {
@@ -45,11 +44,9 @@ pub async fn handle_apple_crash_report_request(
 
     let report = report.ok_or((StatusCode::BAD_REQUEST, "missing apple crash report"))?;
 
-    let symbolication = state.symbolication();
-    let request_id =
-        symbolication.process_apple_crash_report(params.scope, report, sources, options)?;
+    let request_id = service.process_apple_crash_report(params.scope, report, sources, options)?;
 
-    match symbolication.get_response(request_id, params.timeout).await {
+    match service.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),
         None => Err("symbolication request did not start".into()),
     }
@@ -59,8 +56,8 @@ pub async fn handle_apple_crash_report_request(
 mod tests {
     use reqwest::{multipart, Client, StatusCode};
 
+    use crate::service::SymbolicationResponse;
     use crate::test;
-    use crate::types::SymbolicationResponse;
 
     #[tokio::test]
     async fn test_basic() {

--- a/crates/symbolicator/src/endpoints/error.rs
+++ b/crates/symbolicator/src/endpoints/error.rs
@@ -5,7 +5,7 @@ use axum::Json;
 use sentry::integrations::anyhow::capture_anyhow;
 use serde::{Deserialize, Serialize};
 
-use crate::services::symbolication::MaxRequestsError;
+use crate::service::MaxRequestsError;
 
 #[derive(Debug)]
 pub struct ResponseError {

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -4,7 +4,7 @@ use axum::Router;
 use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use tower::ServiceBuilder;
 
-use crate::services::Service;
+use crate::service::RequestService;
 
 mod applecrashreport;
 mod error;
@@ -29,7 +29,7 @@ pub async fn healthcheck() -> &'static str {
     "ok"
 }
 
-pub fn create_app(service: Service) -> Router {
+pub fn create_app(service: RequestService) -> Router {
     // The layers here go "top to bottom" according to the reading order here.
     let layer = ServiceBuilder::new()
         .layer(axum::extract::Extension(service))

--- a/crates/symbolicator/src/endpoints/requests.rs
+++ b/crates/symbolicator/src/endpoints/requests.rs
@@ -3,8 +3,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde::Deserialize;
 
-use crate::services::Service;
-use crate::types::{RequestId, SymbolicationResponse};
+use crate::service::{RequestId, RequestService, SymbolicationResponse};
 
 /// Query parameters of the symbolication poll request.
 #[derive(Deserialize)]
@@ -14,7 +13,7 @@ pub struct PollSymbolicationRequestQueryParams {
 }
 
 pub async fn poll_request(
-    extract::Extension(state): extract::Extension<Service>,
+    extract::Extension(service): extract::Extension<RequestService>,
     extract::Path(request_id): extract::Path<RequestId>,
     extract::Query(query): extract::Query<PollSymbolicationRequestQueryParams>,
 ) -> Result<Json<SymbolicationResponse>, StatusCode> {
@@ -22,10 +21,7 @@ pub async fn poll_request(
         scope.set_transaction(Some("GET /requests"));
     });
 
-    let response_opt = state
-        .symbolication()
-        .get_response(request_id, query.timeout)
-        .await;
+    let response_opt = service.get_response(request_id, query.timeout).await;
 
     match response_opt {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -19,26 +19,27 @@ use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-pub use symbolicator_service::*;
+pub use symbolicator_service::{config, metric, utils};
 
 mod cli;
 mod endpoints;
 mod logging;
 mod server;
+mod service;
 
 #[cfg(test)]
 mod test {
     use std::net::SocketAddr;
 
     use crate::config::Config;
+    use crate::service::RequestService;
     pub use symbolicator_test::*;
 
     use crate::endpoints;
-    use crate::services::Service;
 
     pub async fn server_with_default_service() -> Server {
         let handle = tokio::runtime::Handle::current();
-        let service = Service::create(Config::default(), handle.clone(), handle.clone())
+        let service = RequestService::create(Config::default(), handle.clone(), handle.clone())
             .await
             .unwrap();
 

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -59,6 +59,7 @@ pub fn run(config: Config) -> Result<()> {
 
     let handle_http = Handle::new();
     let socket_http = config.bind.parse::<SocketAddr>()?;
+    #[allow(clippy::redundant_clone)] // we need `svc` for the https case below
     let server_http = axum_server::bind(socket_http)
         .handle(handle_http.clone())
         .serve(svc.clone());

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -15,7 +15,7 @@ use futures::future::BoxFuture;
 use crate::config::Config;
 use crate::endpoints;
 use crate::metric;
-use crate::services::Service;
+use crate::service::RequestService;
 
 #[cfg(feature = "https")]
 fn read_pem_file(path: &PathBuf) -> Result<Vec<u8>> {
@@ -48,7 +48,7 @@ pub fn run(config: Config) -> Result<()> {
     let mut servers: Vec<BoxFuture<_>> = vec![];
 
     let service = web_pool
-        .block_on(Service::create(
+        .block_on(RequestService::create(
             config.clone(),
             io_pool.handle().to_owned(),
             cpu_pool.handle().to_owned(),

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -1,0 +1,118 @@
+use std::fs::File;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tempfile::TempPath;
+
+use symbolicator_service::config::Config;
+use symbolicator_service::services::Service as SymbolicatorService;
+use symbolicator_sources::SourceConfig;
+
+pub use symbolicator_service::services::objects::{
+    FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
+};
+pub use symbolicator_service::services::symbolication::{
+    MaxRequestsError, StacktraceOrigin, SymbolicateStacktraces,
+};
+pub use symbolicator_service::types::{
+    RawObjectInfo, RawStacktrace, RequestId, RequestOptions, Scope, Signal, SymbolicationResponse,
+};
+
+/// The underlying service for the HTTP request handlers.
+#[derive(Debug, Clone)]
+pub struct RequestService {
+    inner: Arc<SymbolicatorService>,
+}
+
+impl RequestService {
+    /// Creates a new [`RequestService`].
+    pub async fn create(
+        config: Config,
+        io_pool: tokio::runtime::Handle,
+        cpu_pool: tokio::runtime::Handle,
+    ) -> Result<Self> {
+        let inner = SymbolicatorService::create(config, io_pool, cpu_pool).await?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    /// Gives access to the [`Config`].
+    pub fn config(&self) -> &Config {
+        self.inner.config()
+    }
+
+    /// Looks up the object according to the [`FindObject`] request.
+    pub async fn find_object(&self, request: FindObject) -> Result<FoundObject, ObjectError> {
+        self.inner.objects().find(request).await
+    }
+
+    /// Fetches the object given by the [`ObjectMetaHandle`].
+    pub async fn fetch_object(
+        &self,
+        handle: Arc<ObjectMetaHandle>,
+    ) -> Result<Arc<ObjectHandle>, ObjectError> {
+        self.inner.objects().fetch(handle).await
+    }
+
+    /// Creates a new request to symbolicate stacktraces.
+    ///
+    /// Returns an `Err` if the [`RequestService`] is already processing the
+    /// maximum number of requests, as configured by the `max_concurrent_requests` option.
+    pub fn symbolicate_stacktraces(
+        &self,
+        request: SymbolicateStacktraces,
+    ) -> Result<RequestId, MaxRequestsError> {
+        self.inner.symbolication().symbolicate_stacktraces(request)
+    }
+
+    /// Creates a new request to process a minidump.
+    ///
+    /// Returns an `Err` if the [`RequestService`] is already processing the
+    /// maximum number of requests, as configured by the `max_concurrent_requests` option.
+    pub fn process_minidump(
+        &self,
+        scope: Scope,
+        minidump_file: TempPath,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<RequestId, MaxRequestsError> {
+        self.inner
+            .symbolication()
+            .process_minidump(scope, minidump_file, sources, options)
+    }
+
+    /// Creates a new request to process an Apple crash report.
+    ///
+    /// Returns an `Err` if the [`RequestService`] is already processing the
+    /// maximum number of requests, as configured by the `max_concurrent_requests` option.
+    pub fn process_apple_crash_report(
+        &self,
+        scope: Scope,
+        apple_crash_report: File,
+        sources: Arc<[SourceConfig]>,
+        options: RequestOptions,
+    ) -> Result<RequestId, MaxRequestsError> {
+        self.inner.symbolication().process_apple_crash_report(
+            scope,
+            apple_crash_report,
+            sources,
+            options,
+        )
+    }
+
+    /// Polls the status for a started symbolication task.
+    ///
+    /// If the timeout is set and no result is ready within the given time,
+    /// [`SymbolicationResponse::Pending`] is returned.
+    pub async fn get_response(
+        &self,
+        request_id: RequestId,
+        timeout: Option<u64>,
+    ) -> Option<SymbolicationResponse> {
+        self.inner
+            .symbolication()
+            .get_response(request_id, timeout)
+            .await
+    }
+}

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -1,11 +1,26 @@
+use std::collections::BTreeMap;
+use std::fmt;
 use std::fs::File;
+use std::fs::File;
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use futures::future;
+use futures::{channel::oneshot, future, FutureExt as _};
+use parking_lot::Mutex;
+use sentry::protocol::SessionStatus;
+use sentry::SentryFutureExt;
+use symbolicator_service::services::objects::ObjectsActor;
+use tempfile::TempPath;
 use tempfile::TempPath;
 
 use symbolicator_service::config::Config;
 use symbolicator_service::services::Service as SymbolicatorService;
+use symbolicator_service::utils::futures::CallOnDrop;
 use symbolicator_sources::SourceConfig;
 
 pub use symbolicator_service::services::objects::{
@@ -24,6 +39,24 @@ pub struct RequestService {
     inner: Arc<SymbolicatorService>,
 }
 
+// We want a shared future here because otherwise polling for a response would hold the global lock.
+type ComputationChannel = future::Shared<oneshot::Receiver<(Instant, SymbolicationResponse)>>;
+
+type ComputationMap = Arc<Mutex<BTreeMap<RequestId, ComputationChannel>>>;
+
+struct RequestServiceInner {
+    config: Config,
+
+    symbolication: SymbolicationActor,
+    objects: ObjectsActor,
+
+    cpu_pool: tokio::runtime::Handle,
+    requests: ComputationMap,
+    max_concurrent_requests: Option<usize>,
+    current_requests: Arc<AtomicUsize>,
+    symbolication_taskmon: tokio_metrics::TaskMonitor,
+}
+
 impl RequestService {
     /// Creates a new [`RequestService`].
     pub async fn create(
@@ -31,7 +64,32 @@ impl RequestService {
         io_pool: tokio::runtime::Handle,
         cpu_pool: tokio::runtime::Handle,
     ) -> Result<Self> {
-        let inner = SymbolicatorService::create(config, io_pool, cpu_pool).await?;
+        let (symbolication, objects) = create_service(&config, io_pool).await?;
+
+        let symbolication_taskmon = tokio_metrics::TaskMonitor::new();
+        {
+            let symbolication_taskmon = symbolication_taskmon.clone();
+            io_pool.spawn(async move {
+                for interval in symbolication_taskmon.intervals() {
+                    record_task_metrics("symbolication", &interval);
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+            });
+        }
+
+        let inner = RequestServiceInner {
+            config,
+
+            symbolication,
+            objects,
+
+            cpu_pool,
+            requests: Arc::new(Mutex::new(BTreeMap::new())),
+            max_concurrent_requests,
+            current_requests: Arc::new(AtomicUsize::new(0)),
+            symbolication_taskmon,
+        };
+
         Ok(Self {
             inner: Arc::new(inner),
         })
@@ -39,12 +97,12 @@ impl RequestService {
 
     /// Gives access to the [`Config`].
     pub fn config(&self) -> &Config {
-        self.inner.config()
+        &self.inner.config
     }
 
     /// Looks up the object according to the [`FindObject`] request.
     pub async fn find_object(&self, request: FindObject) -> Result<FoundObject, ObjectError> {
-        self.inner.objects().find(request).await
+        self.inner.objects.find(request).await
     }
 
     /// Fetches the object given by the [`ObjectMetaHandle`].
@@ -52,7 +110,7 @@ impl RequestService {
         &self,
         handle: Arc<ObjectMetaHandle>,
     ) -> Result<Arc<ObjectHandle>, ObjectError> {
-        self.inner.objects().fetch(handle).await
+        self.inner.objects.fetch(handle).await
     }
 
     /// Creates a new request to symbolicate stacktraces.
@@ -63,7 +121,20 @@ impl RequestService {
         &self,
         request: SymbolicateStacktraces,
     ) -> Result<RequestId, MaxRequestsError> {
-        self.inner.symbolication().symbolicate_stacktraces(request)
+        let slf = self.inner.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "symbolicate_stacktraces",
+            "symbolicate_stacktraces",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf.symbolication.do_symbolicate(request).await;
+            transaction.finish();
+            res
+        })
     }
 
     /// Creates a new request to process a minidump.
@@ -77,9 +148,23 @@ impl RequestService {
         sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
-        self.inner
-            .symbolication()
-            .process_minidump(scope, minidump_file, sources, options)
+        let slf = self.inner.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "process_minidump",
+            "process_minidump",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf
+                .symbolication
+                .do_process_minidump(scope, minidump_file, sources, options)
+                .await;
+            transaction.finish();
+            res
+        })
     }
 
     /// Creates a new request to process an Apple crash report.
@@ -93,12 +178,23 @@ impl RequestService {
         sources: Arc<[SourceConfig]>,
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
-        self.inner.symbolication().process_apple_crash_report(
-            scope,
-            apple_crash_report,
-            sources,
-            options,
-        )
+        let slf = self.inner.clone();
+        let span = sentry::configure_scope(|scope| scope.get_span());
+        let ctx = sentry::TransactionContext::continue_from_span(
+            "process_apple_crash_report",
+            "process_apple_crash_report",
+            span,
+        );
+        self.create_symbolication_request(async move {
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let res = slf
+                .symbolication
+                .do_process_apple_crash_report(scope, apple_crash_report, sources, options)
+                .await;
+            transaction.finish();
+            res
+        })
     }
 
     /// Polls the status for a started symbolication task.
@@ -110,9 +206,147 @@ impl RequestService {
         request_id: RequestId,
         timeout: Option<u64>,
     ) -> Option<SymbolicationResponse> {
-        self.inner
-            .symbolication()
-            .get_response(request_id, timeout)
-            .await
+        let channel_opt = self.requests.lock().get(&request_id).cloned();
+        match channel_opt {
+            Some(channel) => Some(wrap_response_channel(request_id, timeout, channel).await),
+            None => {
+                // This is okay to occur during deploys, but if it happens all the time we have a state
+                // bug somewhere. Could be a misconfigured load balancer (supposed to be pinned to
+                // scopes).
+                metric!(counter("symbolication.request_id_unknown") += 1);
+                None
+            }
+        }
+    }
+
+    /// Returns a clone of the task monitor for symbolication requests.
+    pub fn symbolication_task_monitor(&self) -> tokio_metrics::TaskMonitor {
+        self.symbolication_taskmon.clone()
+    }
+
+    /// Creates a new request to compute the given future.
+    ///
+    /// Returns `None` if the `SymbolicationActor` is already processing the
+    /// maximum number of requests, as given by `max_concurrent_requests`.
+    fn create_symbolication_request<F>(&self, f: F) -> Result<RequestId, MaxRequestsError>
+    where
+        F: Future<Output = Result<CompletedSymbolicationResponse, SymbolicationError>>
+            + Send
+            + 'static,
+    {
+        let (sender, receiver) = oneshot::channel();
+
+        let hub = Arc::new(sentry::Hub::new_from_top(sentry::Hub::current()));
+
+        // Assume that there are no UUID4 collisions in practice.
+        let requests = Arc::clone(&self.requests);
+        let current_requests = Arc::clone(&self.current_requests);
+
+        let num_requests = current_requests.load(Ordering::Relaxed);
+        metric!(gauge("requests.in_flight") = num_requests as u64);
+
+        // Reject the request if `requests` already contains `max_concurrent_requests` elements.
+        if let Some(max_concurrent_requests) = self.max_concurrent_requests {
+            if num_requests >= max_concurrent_requests {
+                metric!(counter("requests.rejected") += 1);
+                return Err(MaxRequestsError);
+            }
+        }
+
+        let request_id = RequestId::new(uuid::Uuid::new_v4());
+        requests.lock().insert(request_id, receiver.shared());
+        current_requests.fetch_add(1, Ordering::Relaxed);
+        let drop_hub = hub.clone();
+        let token = CallOnDrop::new(move || {
+            requests.lock().remove(&request_id);
+            // we consider every premature drop of the future as fatal crash, which works fine
+            // since ending a session consumes it and its not possible to double-end.
+            drop_hub.end_session_with_status(SessionStatus::Crashed);
+        });
+
+        let spawn_time = Instant::now();
+        let request_future = async move {
+            metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
+            let response = match f.await {
+                Ok(response) => {
+                    sentry::end_session_with_status(SessionStatus::Exited);
+                    SymbolicationResponse::Completed(Box::new(response))
+                }
+                Err(error) => {
+                    // a timeout is an abnormal session exit, all other errors are considered "crashed"
+                    let status = match &error {
+                        SymbolicationError::Timeout => SessionStatus::Abnormal,
+                        _ => SessionStatus::Crashed,
+                    };
+                    sentry::end_session_with_status(status);
+
+                    let response = error.to_symbolication_response();
+                    let error = anyhow::Error::new(error);
+                    tracing::error!("Symbolication error: {:?}", error);
+                    response
+                }
+            };
+
+            sender.send((Instant::now(), response)).ok();
+
+            // We stop counting the request as an in-flight request at this point, even though
+            // it will stay in the `requests` map for another 90s.
+            current_requests.fetch_sub(1, Ordering::Relaxed);
+
+            // Wait before removing the channel from the computation map to allow clients to
+            // poll the status.
+            tokio::time::sleep(MAX_POLL_DELAY).await;
+
+            drop(token);
+        }
+        .bind_hub(hub);
+
+        self.cpu_pool
+            .spawn(self.symbolication_taskmon.instrument(request_future));
+
+        Ok(request_id)
+    }
+}
+
+/// The maximum delay we allow for polling a finished request before dropping it.
+const MAX_POLL_DELAY: Duration = Duration::from_secs(90);
+
+/// An error returned when symbolicator receives a request while already processing
+/// the maximum number of requests.
+#[derive(Debug, Clone, Error)]
+#[error("maximum number of concurrent requests reached")]
+pub struct MaxRequestsError;
+
+async fn wrap_response_channel(
+    request_id: RequestId,
+    timeout: Option<u64>,
+    channel: ComputationChannel,
+) -> SymbolicationResponse {
+    let channel_result = if let Some(timeout) = timeout {
+        match tokio::time::timeout(Duration::from_secs(timeout), channel).await {
+            Ok(outcome) => outcome,
+            Err(_elapsed) => {
+                return SymbolicationResponse::Pending {
+                    request_id,
+                    // We should estimate this better, but at some point the
+                    // architecture will probably change to pushing results on a
+                    // queue instead of polling so it's unlikely we'll ever do
+                    // better here.
+                    retry_after: 30,
+                };
+            }
+        }
+    } else {
+        channel.await
+    };
+
+    match channel_result {
+        Ok((finished_at, response)) => {
+            metric!(timer("requests.response_idling") = finished_at.elapsed());
+            response
+        }
+        // If the sender is dropped, this is likely due to a panic that is captured at the source.
+        // Therefore, we do not need to capture an error at this point.
+        Err(_canceled) => SymbolicationResponse::InternalError,
     }
 }


### PR DESCRIPTION
Creates a separate `RequestService` which handles the request/response and poll-response parts of the symbolicator frontend.

This leaves mostly the "pure" `SymbolicationActor` as the main entrypoint of "symbolicator as a library".