### PR TITLE
ref: Move RequestOptions to frontend

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -11,7 +11,7 @@ use symbolicator_sources::{ObjectType, SourceConfig};
 
 use crate::types::{
     CompleteObjectInfo, CompletedSymbolicationResponse, RawFrame, RawObjectInfo, RawStacktrace,
-    RequestOptions, Scope, SystemInfo,
+    Scope, SystemInfo,
 };
 use crate::utils::futures::{m, measure};
 use crate::utils::hex::HexValue;
@@ -24,7 +24,6 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
     ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), SymbolicationError> {
         let parse_future = async {
             let report = AppleCrashReport::from_reader(report)?;
@@ -79,7 +78,6 @@ impl SymbolicationActor {
                 origin: StacktraceOrigin::AppleCrashReport,
                 signal: None,
                 stacktraces,
-                options,
             };
 
             let mut system_info = SystemInfo {
@@ -132,10 +130,9 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-        options: RequestOptions,
     ) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
         let (request, state) = self
-            .parse_apple_crash_report(scope, report, sources, options)
+            .parse_apple_crash_report(scope, report, sources)
             .await?;
         let mut response = self.do_symbolicate(request).await?;
 

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -162,7 +162,7 @@ mod tests {
     use crate::services::create_service;
     use crate::services::symbolication::module_lookup::ModuleLookup;
     use crate::test::{self, fixture};
-    use crate::types::{CompleteObjectInfo, RawFrame, RawStacktrace, RequestOptions, Scope};
+    use crate::types::{CompleteObjectInfo, RawFrame, RawStacktrace, Scope};
     use crate::utils::addr::AddrMode;
     use crate::utils::hex::HexValue;
 
@@ -213,9 +213,6 @@ mod tests {
                 debug_file: None,
                 checksum: None,
             })],
-            options: RequestOptions {
-                dif_candidates: true,
-            },
         }
     }
 
@@ -288,14 +285,7 @@ mod tests {
         let report_file = std::fs::File::open(fixture("apple_crash_report.txt")).unwrap();
 
         let response = symbolication
-            .do_process_apple_crash_report(
-                Scope::Global,
-                report_file,
-                Arc::new([source]),
-                RequestOptions {
-                    dif_candidates: true,
-                },
-            )
+            .do_process_apple_crash_report(Scope::Global, report_file, Arc::new([source]))
             .await;
 
         assert_snapshot!(response.unwrap());
@@ -339,7 +329,6 @@ mod tests {
             origin: StacktraceOrigin::Symbolicate,
             sources: Arc::new([source]),
             scope: Default::default(),
-            options: Default::default(),
         };
 
         let response = symbolication.do_symbolicate(request).await;
@@ -386,9 +375,6 @@ mod tests {
             origin: StacktraceOrigin::Symbolicate,
             sources: Arc::new([source]),
             scope: Default::default(),
-            options: RequestOptions {
-                dif_candidates: true,
-            },
         };
 
         let response = symbolication.do_symbolicate(request).await;
@@ -479,9 +465,6 @@ mod tests {
             origin: StacktraceOrigin::Symbolicate,
             sources: Arc::new([source]),
             scope: Default::default(),
-            options: RequestOptions {
-                dif_candidates: true,
-            },
         };
 
         let response = symbolication.do_symbolicate(request).await;

--- a/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__wasm_payload.snap
+++ b/crates/symbolicator-service/src/services/symbolication/snapshots/symbolicator_service__services__symbolication__tests__wasm_payload.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/src/services/symbolication/mod.rs
-assertion_line: 360
+assertion_line: 336
 expression: response.unwrap()
 ---
 stacktraces:
@@ -29,4 +29,20 @@ modules:
     debug_id: bda18fd8-5d4a-4eb8-9302-2d6bfad846b1
     debug_file: "file://foo.invalid/demo.wasm"
     image_addr: "0x0"
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/download/bd/a18fd85d4a4eb893022d6bfad846b1"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/download/bd/a18fd85d4a4eb893022d6bfad846b1.debug"
+        download:
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: false
+            has_symbols: true
+            has_sources: false
+        debug:
+          status: ok
 

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -61,23 +61,6 @@ impl fmt::Display for Scope {
     }
 }
 
-/// Common options for all symbolication API requests.
-///
-/// These options control some features which control the symbolication and general request
-/// handling behaviour.
-#[derive(Clone, Debug, Default, Deserialize)]
-pub struct RequestOptions {
-    /// Whether to return detailed information on DIF object candidates.
-    ///
-    /// Symbolication requires DIF object files and which ones selected and not selected
-    /// influences the quality of symbolication.  Enabling this will return extra
-    /// information in the modules list section of the response detailing all DIF objects
-    /// considered, any problems with them and what they were used for.  See the
-    /// [`ObjectCandidate`] struct for which extra information is returned for DIF objects.
-    #[serde(default)]
-    pub dif_candidates: bool,
-}
-
 /// A map of register values.
 pub type Registers = BTreeMap<String, HexValue>;
 
@@ -558,18 +541,6 @@ pub struct CompletedSymbolicationResponse {
 
     /// A list of images, extended with status information.
     pub modules: Vec<CompleteObjectInfo>,
-}
-
-impl CompletedSymbolicationResponse {
-    /// Clears out all the information about the DIF object candidates in the modules list.
-    ///
-    /// This will avoid this from being serialised as the DIF object candidates list is not
-    /// serialised when it is empty.
-    pub fn clear_dif_candidates(&mut self) {
-        for module in self.modules.iter_mut() {
-            module.candidates.clear()
-        }
-    }
 }
 
 /// Information about the operating system.

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -64,15 +64,17 @@ pub async fn symbolicate_frames(
         None => service.config().default_sources(),
     };
 
-    let request_id = service.symbolicate_stacktraces(SymbolicateStacktraces {
-        scope: params.scope,
-        signal: body.signal,
-        sources,
-        origin: StacktraceOrigin::Symbolicate,
-        stacktraces: body.stacktraces,
-        modules: body.modules.into_iter().map(From::from).collect(),
-        options: body.options,
-    })?;
+    let request_id = service.symbolicate_stacktraces(
+        SymbolicateStacktraces {
+            scope: params.scope,
+            signal: body.signal,
+            sources,
+            origin: StacktraceOrigin::Symbolicate,
+            stacktraces: body.stacktraces,
+            modules: body.modules.into_iter().map(From::from).collect(),
+        },
+        body.options,
+    )?;
 
     match service.get_response(request_id, params.timeout).await {
         Some(response) => Ok(Json(response)),

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -39,9 +39,7 @@ pub use symbolicator_service::services::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
 };
 pub use symbolicator_service::services::symbolication::{StacktraceOrigin, SymbolicateStacktraces};
-pub use symbolicator_service::types::{
-    RawObjectInfo, RawStacktrace, RequestOptions, Scope, Signal,
-};
+pub use symbolicator_service::types::{RawObjectInfo, RawStacktrace, Scope, Signal};
 
 /// Symbolication task identifier.
 #[derive(Debug, Clone, Copy, Serialize, Ord, PartialOrd, Eq, PartialEq)]
@@ -111,6 +109,32 @@ impl From<&SymbolicationError> for SymbolicationResponse {
     }
 }
 
+/// Common options for all symbolication API requests.
+///
+/// These options control some features which control the symbolication and general request
+/// handling behaviour.
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RequestOptions {
+    /// Whether to return detailed information on DIF object candidates.
+    ///
+    /// Symbolication requires DIF object files and which ones selected and not selected
+    /// influences the quality of symbolication.  Enabling this will return extra
+    /// information in the modules list section of the response detailing all DIF objects
+    /// considered, any problems with them and what they were used for.  See the
+    /// [`ObjectCandidate`] struct for which extra information is returned for DIF objects.
+    #[serde(default)]
+    pub dif_candidates: bool,
+}
+
+/// Clears out all the information about the DIF object candidates in the modules list.
+///
+/// This will avoid this from being serialised as the DIF object candidates list is not
+/// serialised when it is empty.
+fn clear_dif_candidates(response: &mut CompletedSymbolicationResponse) {
+    for module in response.modules.iter_mut() {
+        module.candidates.clear()
+    }
+}
 /// The underlying service for the HTTP request handlers.
 #[derive(Clone)]
 pub struct RequestService {
@@ -201,6 +225,7 @@ impl RequestService {
     pub fn symbolicate_stacktraces(
         &self,
         request: SymbolicateStacktraces,
+        options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
         let span = sentry::configure_scope(|scope| scope.get_span());
@@ -209,7 +234,7 @@ impl RequestService {
             "symbolicate_stacktraces",
             span,
         );
-        self.create_symbolication_request(async move {
+        self.create_symbolication_request(options, async move {
             let transaction = sentry::start_transaction(ctx);
             sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
             let res = slf.symbolication.do_symbolicate(request).await;
@@ -236,12 +261,12 @@ impl RequestService {
             "process_minidump",
             span,
         );
-        self.create_symbolication_request(async move {
+        self.create_symbolication_request(options, async move {
             let transaction = sentry::start_transaction(ctx);
             sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
             let res = slf
                 .symbolication
-                .do_process_minidump(scope, minidump_file, sources, options)
+                .do_process_minidump(scope, minidump_file, sources)
                 .await;
             transaction.finish();
             res
@@ -266,12 +291,12 @@ impl RequestService {
             "process_apple_crash_report",
             span,
         );
-        self.create_symbolication_request(async move {
+        self.create_symbolication_request(options, async move {
             let transaction = sentry::start_transaction(ctx);
             sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
             let res = slf
                 .symbolication
-                .do_process_apple_crash_report(scope, apple_crash_report, sources, options)
+                .do_process_apple_crash_report(scope, apple_crash_report, sources)
                 .await;
             transaction.finish();
             res
@@ -310,7 +335,11 @@ impl RequestService {
     ///
     /// Returns `None` if the `SymbolicationActor` is already processing the
     /// maximum number of requests, as given by `max_concurrent_requests`.
-    fn create_symbolication_request<F>(&self, f: F) -> Result<RequestId, MaxRequestsError>
+    fn create_symbolication_request<F>(
+        &self,
+        options: RequestOptions,
+        f: F,
+    ) -> Result<RequestId, MaxRequestsError>
     where
         F: Future<Output = Result<CompletedSymbolicationResponse, SymbolicationError>>
             + Send
@@ -353,7 +382,10 @@ impl RequestService {
         let request_future = async move {
             metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
             let response = match f.await {
-                Ok(response) => {
+                Ok(mut response) => {
+                    if !options.dif_candidates {
+                        clear_dif_candidates(&mut response);
+                    }
                     sentry::end_session_with_status(SessionStatus::Exited);
                     SymbolicationResponse::Completed(Box::new(response))
                 }
@@ -502,10 +534,11 @@ mod tests {
             origin: StacktraceOrigin::Symbolicate,
             sources: Arc::new([]),
             scope: Default::default(),
-            options: Default::default(),
         };
 
-        let request_id = service.symbolicate_stacktraces(request).unwrap();
+        let request_id = service
+            .symbolicate_stacktraces(request, RequestOptions::default())
+            .unwrap();
 
         for _ in 0..2 {
             let response = service.get_response(request_id, None).await.unwrap();
@@ -541,9 +574,6 @@ mod tests {
                 debug_file: None,
                 checksum: None,
             })],
-            options: RequestOptions {
-                dif_candidates: true,
-            },
         }
     }
 
@@ -570,12 +600,18 @@ mod tests {
         // Make three requests that never get resolved. Since the server is configured to only accept a maximum of
         // two concurrent requests, the first two should succeed and the third one should fail.
         let request = get_symbolication_request(vec![symbol_server.pending_source.clone()]);
-        assert!(service.symbolicate_stacktraces(request).is_ok());
+        assert!(service
+            .symbolicate_stacktraces(request, RequestOptions::default())
+            .is_ok());
 
         let request = get_symbolication_request(vec![symbol_server.pending_source.clone()]);
-        assert!(service.symbolicate_stacktraces(request).is_ok());
+        assert!(service
+            .symbolicate_stacktraces(request, RequestOptions::default())
+            .is_ok());
 
         let request = get_symbolication_request(vec![symbol_server.pending_source]);
-        assert!(service.symbolicate_stacktraces(request).is_err());
+        assert!(service
+            .symbolicate_stacktraces(request, RequestOptions::default())
+            .is_err());
     }
 }


### PR DESCRIPTION
The `RequestOptions` type is currently only used to control whether DIF candidates are returned with a symbolication response. This PR moves all of this logic from `symbolicator-service` to `symbolicator`, which means that responses returned from `symbolicator-service` will now always contain DIF candidates.