### PR TITLE
ref: Move task measure, timeouts and SymbolicationError to frontend

### DIFF
--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use symbolicator_service::config::Config as SymbolicatorConfig;
 use symbolicator_service::services::download::SourceConfig;
 use symbolicator_service::services::symbolication::{
-    StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor, SymbolicationError,
+    StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor,
 };
 use symbolicator_service::types::{
     CompletedSymbolicationResponse, RawObjectInfo, RawStacktrace, Scope,
@@ -212,7 +212,7 @@ async fn main() -> Result<()> {
 async fn process_payload(
     symbolication: &SymbolicationActor,
     workload: ParsedPayload,
-) -> Result<CompletedSymbolicationResponse, SymbolicationError> {
+) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
     match workload {
         ParsedPayload::Minidump(payload) => {
             let MinidumpPayload {
@@ -236,9 +236,9 @@ async fn process_payload(
                 .unwrap();
 
             symbolication
-                .do_process_minidump(scope, temp_path, sources)
+                .process_minidump(scope, temp_path, sources)
                 .await
         }
-        ParsedPayload::Event(payload) => symbolication.do_symbolicate(payload).await,
+        ParsedPayload::Event(payload) => symbolication.symbolicate(payload).await,
     }
 }


### PR DESCRIPTION
Moves the timeouts and metrics for the symbolication tasks into the frontend.

This simplifies the `SymbolicationActor` further, also replacing the `SymbolicationError` with `anyhow::Error`. The frontend still uses the enum to distinguish between timeouts and errors.

The metric names were adapted from the previous implementation, and the both the metrics and the timeouts measure something slightly different now. They now measure (and timeout) the *complete* task, as opposed to parts of it. I believe that especially with regard to the timeouts this is more correct, as previously the stackwalking of a minidump *and* the symbolication of it could both take up to an hour, so two hours in total. Now each task is limited to an hour, no matter of the internal time distribution. Similarly, this now measures the whole task instead of its parts separately.

#skip-changelog