### PR TITLE
ref: Remove unused `processing_pool_size` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Deduplicate SymbolFile computations in SymbolicatorSymbolProvider ([#856](https://github.com/getsentry/symbolicator/pull/856))
 - Separated the symbolication service from the http interface. ([#903](https://github.com/getsentry/symbolicator/pull/903))
 - Move Request/Response/Poll handling into web frontend. ([#904](https://github.com/getsentry/symbolicator/pull/904))
+- Remove unused `processing_pool_size` config. ([#910](https://github.com/getsentry/symbolicator/pull/910))
 
 ## 0.5.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,6 @@ dependencies = [
  "lru",
  "minidump",
  "minidump-processor",
- "num_cpus",
  "parking_lot",
  "regex",
  "reqwest",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -27,7 +27,6 @@ lazy_static = "1.4.0"
 lru = "0.8.0"
 minidump = "0.14.0"
 minidump-processor = "0.14.0"
-num_cpus = "1.13.0"
 parking_lot = "0.12.0"
 regex = "1.5.5"
 reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -298,9 +298,6 @@ pub struct Config {
     /// Allow reserved IP addresses for requests to sources.
     pub connect_to_reserved_ips: bool,
 
-    /// Number of subprocesses in the internal processing pool.
-    pub processing_pool_size: usize,
-
     /// The maximum timeout for downloads.
     ///
     /// This is the upper limit the download service will take for downloading from a single
@@ -411,7 +408,6 @@ impl Default for Config {
             symstore_proxy: true,
             sources: Arc::from(vec![]),
             connect_to_reserved_ips: false,
-            processing_pool_size: num_cpus::get(),
             // Allow a 4MB/s connection to download 2GB without timing out
             max_download_timeout: Duration::from_secs(315),
             connect_timeout: Duration::from_secs(15),

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,8 +85,6 @@ metrics:
   `true`.
 - `connect_to_reserved_ips`: Allow reserved IP addresses for requests to
   sources. See [Security](#security). Defaults to `false`.
-- `processing_pool_size`: The number of subprocesses in Symbolicator's internal
-  processing pool. Defaults to the total number of logical CPUs on the machine.
 - `max_concurrent_requests`: The maximum number of requests symbolicator will process concurrently. Further requests will result in a 503 status code.
   Set it to `null` to turn off the limit. Defaults to 120.
 


### PR DESCRIPTION
The config was previously used to control the number of procspawn subprocesses. It is being completely unused since procspawn usage was removed.