### PR TITLE
ref: Add Configuration options for in-memory Caches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use jemalloc as global allocater (for Rust and C). ([#885](https://github.com/getsentry/symbolicator/pull/885))
 - Clean up empty cache directories. ([#887](https://github.com/getsentry/symbolicator/pull/887))
 - Update symbolic and increase SymCache Version to `4` which now uses a LEB128-prefixed string table. ([#886](https://github.com/getsentry/symbolicator/pull/886))
+- Add Configuration options for in-memory Caches. ([#911](https://github.com/getsentry/symbolicator/pull/911))
 
 ### Fixes
 

--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -1306,6 +1306,7 @@ mod tests {
                 diagnostics: DiagnosticsCacheConfig {
                     retention: Some(Duration::from_secs(60)),
                 },
+                ..Default::default()
             },
             ..Default::default()
         })

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fmt;
 use std::fs;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -256,7 +257,7 @@ pub struct InMemoryCacheConfig {
     /// the full request URL + token.
     ///
     /// Defaults to `100_000`.
-    pub sentry_index_capacity: usize,
+    pub sentry_index_capacity: NonZeroUsize,
 
     /// The TTL for Sentry Index entries.
     ///
@@ -278,7 +279,7 @@ pub struct InMemoryCacheConfig {
     /// metrics.
     ///
     /// Defaults to `100`.
-    pub gcs_token_capacity: usize,
+    pub gcs_token_capacity: NonZeroUsize,
 
     /// Capacity for the S3 Client Cache.
     ///
@@ -292,16 +293,16 @@ pub struct InMemoryCacheConfig {
     /// metrics.
     ///
     /// Defaults to `100`.
-    pub s3_client_capacity: usize,
+    pub s3_client_capacity: NonZeroUsize,
 }
 
 impl Default for InMemoryCacheConfig {
     fn default() -> Self {
         Self {
-            sentry_index_capacity: 100_000,
+            sentry_index_capacity: 100_000.try_into().unwrap(),
             sentry_index_ttl: Duration::from_secs(3600),
-            gcs_token_capacity: 100,
-            s3_client_capacity: 100,
+            gcs_token_capacity: 100.try_into().unwrap(),
+            s3_client_capacity: 100.try_into().unwrap(),
         }
     }
 }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -293,7 +293,7 @@ pub struct InMemoryCacheConfig {
     /// metrics.
     ///
     /// Defaults to `100`.
-    pub s3_client_capacity: NonZeroUsize,
+    pub s3_client_capacity: u64,
 }
 
 impl Default for InMemoryCacheConfig {
@@ -302,7 +302,7 @@ impl Default for InMemoryCacheConfig {
             sentry_index_capacity: 100_000.try_into().unwrap(),
             sentry_index_ttl: Duration::from_secs(3600),
             gcs_token_capacity: 100.try_into().unwrap(),
-            s3_client_capacity: 100.try_into().unwrap(),
+            s3_client_capacity: 100,
         }
     }
 }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -247,6 +247,65 @@ impl From<DiagnosticsCacheConfig> for CacheConfig {
     }
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct InMemoryCacheConfig {
+    /// Capacity for the Sentry Index Cache.
+    ///
+    /// This cache is used for requests to the Sentry symbol source and is keyed by
+    /// the full request URL + token.
+    ///
+    /// Defaults to `100_000`.
+    pub sentry_index_capacity: usize,
+
+    /// The TTL for Sentry Index entries.
+    ///
+    /// Controls the TTL for entries in the Sentry Index Cache.
+    ///
+    /// Defaults to `1h`.
+    #[serde(with = "humantime_serde")]
+    pub sentry_index_ttl: Duration,
+
+    /// Capacity for the GCS Token Cache.
+    ///
+    /// This number defines the size of the internal cache for GCS authentication and should be higher
+    /// than expected concurrency across GCS buckets. If this number is too low, the downloader will
+    /// re-authenticate between every request.
+    ///
+    /// The cache is keyed by GCS source keys.
+    ///
+    /// This can be monitored with the `source.gcs.token.requests` and `source.gcs.token.cached` counter
+    /// metrics.
+    ///
+    /// Defaults to `100`.
+    pub gcs_token_capacity: usize,
+
+    /// Capacity for the S3 Client Cache.
+    ///
+    /// This number defines the size of the internal cache for S3 clients and should be higher than
+    /// expected concurrency across S3 buckets. If this number is too low, the downloader will
+    /// re-authenticate between every request.
+    ///
+    /// The cache is keyed by S3 source keys.
+    ///
+    /// This can be monitored with the `source.s3.client.create` and `source.s3.client.cached` counter
+    /// metrics.
+    ///
+    /// Defaults to `100`.
+    pub s3_client_capacity: usize,
+}
+
+impl Default for InMemoryCacheConfig {
+    fn default() -> Self {
+        Self {
+            sentry_index_capacity: 100_000,
+            sentry_index_ttl: Duration::from_secs(3600),
+            gcs_token_capacity: 100,
+            s3_client_capacity: 100,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Default)]
 #[serde(default)]
 pub struct CacheConfigs {
@@ -258,6 +317,9 @@ pub struct CacheConfigs {
     ///
     /// E.g. minidumps which caused a crash in symbolicator will be stored here.
     pub diagnostics: DiagnosticsCacheConfig,
+
+    /// Configuration of various in-memory caches.
+    pub in_memory: InMemoryCacheConfig,
 }
 
 /// See docs/index.md for more information on config values.

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -108,7 +108,7 @@ impl S3Downloader {
                 "Using AWS credentials provider: {:?}",
                 key.aws_credentials_provider
             );
-            let s3 = Arc::new(match key.aws_credentials_provider {
+            Arc::new(match key.aws_credentials_provider {
                 AwsCredentialsProvider::Container => {
                     let container_provider = rusoto_credential::ContainerProvider::new();
                     let provider =
@@ -128,8 +128,7 @@ impl S3Downloader {
                     );
                     self.create_s3_client(provider, region)
                 }
-            });
-            s3
+            })
         })
     }
 

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -32,8 +32,7 @@ type ClientCache = lru::LruCache<Arc<S3SourceKey>, Arc<rusoto_s3::S3Client>>;
 /// expected concurrency across S3 buckets. If this number is too low, the downloader will
 /// re-authenticate between every request.
 ///
-/// TODO(ja):
-/// This can be monitored with the `source.gcs.token.requests` and `source.gcs.token.cached` counter
+/// This can be monitored with the `source.s3.client.create` and `source.s3.client.cached` counter
 /// metrics.
 const S3_CLIENT_CACHE_SIZE: usize = 100;
 

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -173,10 +173,17 @@ struct RequestServiceInner {
 impl RequestService {
     /// Creates a new [`RequestService`].
     pub async fn create(
-        config: Config,
+        mut config: Config,
         io_pool: tokio::runtime::Handle,
         cpu_pool: tokio::runtime::Handle,
     ) -> Result<Self> {
+        // FIXME(swatinem):
+        // The Sentry<->Symbolicator tests currently rely on the fact that the Sentry Downloader cache
+        // is deactivated depending on the file system cache directory:
+        if config.cache_dir.is_none() {
+            config.caches.in_memory.sentry_index_ttl = Duration::ZERO;
+        }
+
         let (symbolication, objects) =
             symbolicator_service::services::create_service(&config, io_pool.clone()).await?;
 


### PR DESCRIPTION
Makes a few in-memory caches configurable. Right now thats the Sentry Index, S3 Clients and GCS Tokens.