### PR TITLE
ref: Test outcome of various download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fetch/use CFI for modules that only have a CodeId. ([#860](https://github.com/getsentry/symbolicator/pull/860))
 - Properly mask Portable PDB Age for symstore/SSQP lookups. ([#888](https://github.com/getsentry/symbolicator/pull/888))
 - Avoid a redundant open/read and fix shared cache refresh. ([#893](https://github.com/getsentry/symbolicator/pull/893))
+- Correctly return object candidates for malformed caches. ([#917](https://github.com/getsentry/symbolicator/pull/917))
 
 ### Internal
 

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -398,9 +398,7 @@ mod tests {
         let objects_actor = objects_actor(&cachedir).await;
 
         let find_object = FindObject {
-            // A request for a bcsymbolmap will expand to only one file that is being looked up.
-            // Other filetypes will lead to multiple requests, trying different file extensions, etc
-            filetypes: &[FileType::BcSymbolMap],
+            filetypes: &[FileType::MachCode],
             purpose: ObjectPurpose::Debug,
             scope: Scope::Global,
             identifier: DebugId::default().into(),
@@ -444,9 +442,7 @@ mod tests {
         let objects_actor = objects_actor(&cachedir).await;
 
         let find_object = FindObject {
-            // A request for a bcsymbolmap will expand to only one file that is being looked up.
-            // Other filetypes will lead to multiple requests, trying different file extensions, etc
-            filetypes: &[FileType::BcSymbolMap],
+            filetypes: &[FileType::MachCode],
             purpose: ObjectPurpose::Debug,
             scope: Scope::Global,
             identifier: DebugId::default().into(),
@@ -480,9 +476,7 @@ mod tests {
         let objects_actor = objects_actor(&cachedir).await;
 
         let find_object = FindObject {
-            // A request for a bcsymbolmap will expand to only one file that is being looked up.
-            // Other filetypes will lead to multiple requests, trying different file extensions, etc
-            filetypes: &[FileType::BcSymbolMap],
+            filetypes: &[FileType::MachCode],
             purpose: ObjectPurpose::Debug,
             scope: Scope::Global,
             identifier: DebugId::default().into(),
@@ -522,9 +516,7 @@ mod tests {
         let objects_actor = objects_actor(&cachedir).await;
 
         let find_object = FindObject {
-            // A request for a bcsymbolmap will expand to only one file that is being looked up.
-            // Other filetypes will lead to multiple requests, trying different file extensions, etc
-            filetypes: &[FileType::BcSymbolMap],
+            filetypes: &[FileType::MachCode],
             purpose: ObjectPurpose::Debug,
             scope: Scope::Global,
             identifier: DebugId::default().into(),

--- a/crates/symbolicator-service/src/types/objects.rs
+++ b/crates/symbolicator-service/src/types/objects.rs
@@ -176,7 +176,7 @@ impl From<Vec<ObjectCandidate>> for AllObjectCandidates {
 ///
 /// [`CacheItemRequest`]: ../actors/common/cache/trait.CacheItemRequest.html
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
-pub struct AllObjectCandidates(Vec<ObjectCandidate>);
+pub struct AllObjectCandidates(pub Vec<ObjectCandidate>);
 
 impl AllObjectCandidates {
     /// Sets the [`ObjectCandidate::debug`] field for the specified DIF object.

--- a/crates/symbolicator-service/tests/integration/main.rs
+++ b/crates/symbolicator-service/tests/integration/main.rs
@@ -1,6 +1,7 @@
 // See <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html>
 
 pub mod process_minidump;
+pub mod source_errors;
 pub mod symbolication;
 #[macro_use]
 pub mod utils;

--- a/crates/symbolicator-service/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-service/tests/integration/process_minidump.rs
@@ -13,7 +13,7 @@ use crate::symbolication::setup_service;
 macro_rules! stackwalk_minidump {
     ($path:expr) => {
         async {
-            let (symbolication, cache_dir) = setup_service().await;
+            let (symbolication, cache_dir) = setup_service(|_| ()).await;
             let (_symsrv, source) = test::symbol_server();
 
             let minidump = test::read_fixture($path);

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -1,0 +1,108 @@
+use std::time::Duration;
+
+use symbolicator_service::types::{
+    CompletedSymbolicationResponse, FrameStatus, ObjectDownloadInfo, ObjectFileStatus,
+    ObjectUseInfo,
+};
+use symbolicator_test::FailingSymbolServer;
+
+use crate::symbolication::{get_symbolication_request, setup_service};
+
+#[tokio::test]
+async fn test_download_errors() {
+    let (symbolication, _cache_dir) = setup_service(|config| {
+        config.max_download_timeout = Duration::from_millis(100);
+    })
+    .await;
+
+    let server = FailingSymbolServer::new();
+
+    // This returns frame and module statuses:
+    // (
+    //     frame.status,
+    //     module.debug_status,
+    //     module.candidate.debug
+    //     module.candidate.download
+    // )
+    let get_statuses = |mut res: CompletedSymbolicationResponse| {
+        dbg!(&res);
+        let frame = &res.stacktraces[0].frames[0];
+        let mut module = res.modules.remove(0);
+        let candidate = module.candidates.0.remove(0);
+        (
+            frame.status,
+            module.debug_status,
+            candidate.debug,
+            candidate.download,
+        )
+    };
+
+    let request = get_symbolication_request(vec![server.reject_source]);
+    let response = symbolication.symbolicate(request).await.unwrap();
+
+    assert_eq!(
+        get_statuses(response),
+        (
+            FrameStatus::Missing,
+            ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
+            ObjectUseInfo::None,
+            ObjectDownloadInfo::Error {
+                details: "failed to download: 500 Internal Server Error".into()
+            }
+        )
+    );
+
+    let request = get_symbolication_request(vec![server.pending_source]);
+    let response = symbolication.symbolicate(request).await.unwrap();
+
+    assert_eq!(
+        get_statuses(response),
+        (
+            FrameStatus::Missing,
+            ObjectFileStatus::Missing, // XXX: should be `Timeout`
+            ObjectUseInfo::None,
+            ObjectDownloadInfo::Error {
+                details: "download was cancelled".into()
+            }
+        )
+    );
+
+    let request = get_symbolication_request(vec![server.not_found_source]);
+    let response = symbolication.symbolicate(request).await.unwrap();
+
+    assert_eq!(
+        get_statuses(response),
+        (
+            FrameStatus::Missing,
+            ObjectFileStatus::Missing,
+            ObjectUseInfo::None,
+            ObjectDownloadInfo::NotFound
+        )
+    );
+
+    let request = get_symbolication_request(vec![server.forbidden_source]);
+    let response = symbolication.symbolicate(request).await.unwrap();
+
+    assert_eq!(
+        get_statuses(response),
+        (
+            FrameStatus::Missing,
+            ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
+            ObjectUseInfo::None,
+            ObjectDownloadInfo::NoPerm { details: "".into() }
+        )
+    );
+
+    let request = get_symbolication_request(vec![server.invalid_file_source]);
+    let response = symbolication.symbolicate(request).await.unwrap();
+
+    assert_eq!(
+        get_statuses(response),
+        (
+            FrameStatus::Malformed,
+            ObjectFileStatus::Malformed,
+            ObjectUseInfo::Malformed,
+            ObjectDownloadInfo::Malformed
+        )
+    );
+}

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -184,7 +184,7 @@ impl Drop for Server {
 /// Spawn an actual HTTP symbol server for local fixtures.
 ///
 /// The symbol server serves static files from the local symbols fixture location under the
-/// `/download` prefix. The layout of this folder is [`DirectoryLayoutType::Native`]. This function
+/// `/download` prefix. The layout of this folder is `DirectoryLayoutType::Native`. This function
 /// returns the test server as well as a source configuration, which can be used to access the
 /// symbol server in symbolication requests.
 ///

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -25,13 +25,12 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt::fmt;
-use warp::filters::fs::File;
 use warp::reject::{Reject, Rejection};
 use warp::Filter;
 
 use symbolicator_sources::{
-    CommonSourceConfig, DirectoryLayoutType, FileType, FilesystemSourceConfig, GcsSourceKey,
-    HttpSourceConfig, SourceConfig, SourceFilters, SourceId,
+    CommonSourceConfig, FileType, FilesystemSourceConfig, GcsSourceKey, HttpSourceConfig,
+    SourceConfig, SourceFilters, SourceId,
 };
 
 pub use tempfile::TempDir;
@@ -221,6 +220,7 @@ pub struct FailingSymbolServer {
     pub pending_source: SourceConfig,
     pub not_found_source: SourceConfig,
     pub forbidden_source: SourceConfig,
+    pub invalid_file_source: SourceConfig,
 }
 
 impl FailingSymbolServer {
@@ -229,47 +229,59 @@ impl FailingSymbolServer {
 
         let times = times_accessed.clone();
         let reject = warp::path("reject").and_then(move || {
-            let times = Arc::clone(&times);
-            async move {
-                (*times).fetch_add(1, Ordering::SeqCst);
+            (*times).fetch_add(1, Ordering::SeqCst);
 
-                Err::<File, _>(warp::reject::custom(GoAway))
-            }
+            std::future::ready(Err::<&str, _>(warp::reject::custom(GoAway)))
         });
 
         let times = times_accessed.clone();
         let not_found = warp::path("not-found").and_then(move || {
-            let times = Arc::clone(&times);
-            async move {
-                (*times).fetch_add(1, Ordering::SeqCst);
-
-                Err::<File, _>(warp::reject::not_found())
-            }
+            (*times).fetch_add(1, Ordering::SeqCst);
+            std::future::ready(Err::<&str, _>(warp::reject::not_found()))
         });
 
         let times = times_accessed.clone();
         let pending = warp::path("pending").and_then(move || {
             (*times).fetch_add(1, Ordering::SeqCst);
 
-            std::future::pending::<Result<File, Rejection>>()
+            std::future::pending::<Result<&str, Rejection>>()
         });
 
         let times = times_accessed.clone();
         let forbidden = warp::path("forbidden").and_then(move || {
             (*times).fetch_add(1, Ordering::SeqCst);
 
-            async move {
-                let result: Result<_, Rejection> = Ok(warp::reply::with_status(
-                    warp::reply(),
-                    warp::http::StatusCode::FORBIDDEN,
-                ));
-                result
-            }
+            let result: Result<_, Rejection> = Ok(warp::reply::with_status(
+                warp::reply(),
+                warp::http::StatusCode::FORBIDDEN,
+            ));
+            std::future::ready(result)
         });
 
-        let server = Server::new(reject.or(not_found).or(pending).or(forbidden));
+        let times = times_accessed.clone();
+        let invalid_file = warp::path("invalid-file").and_then(move || {
+            (*times).fetch_add(1, Ordering::SeqCst);
 
-        let files_config = CommonSourceConfig::with_layout(DirectoryLayoutType::Unified);
+            let result = Ok::<_, Rejection>("not a valid object");
+            std::future::ready(result)
+        });
+
+        let server = Server::new(
+            reject
+                .or(not_found)
+                .or(pending)
+                .or(forbidden)
+                .or(invalid_file),
+        );
+
+        let files_config = CommonSourceConfig {
+            filters: SourceFilters {
+                filetypes: vec![FileType::MachCode],
+                path_patterns: vec![],
+            },
+            layout: Default::default(),
+            is_public: false,
+        };
 
         let reject_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
             id: SourceId::new("reject"),
@@ -296,6 +308,13 @@ impl FailingSymbolServer {
             id: SourceId::new("forbidden"),
             url: server.url("forbidden/"),
             headers: Default::default(),
+            files: files_config.clone(),
+        }));
+
+        let invalid_file_source = SourceConfig::Http(Arc::new(HttpSourceConfig {
+            id: SourceId::new("invalid-file"),
+            url: server.url("invalid-file/"),
+            headers: Default::default(),
             files: files_config,
         }));
 
@@ -306,6 +325,7 @@ impl FailingSymbolServer {
             pending_source,
             not_found_source,
             forbidden_source,
+            invalid_file_source,
         }
     }
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -596,10 +596,13 @@ def test_malformed_objects(symbolicator, hitcounter):
 
     expected = _make_error_result(
         status="malformed",
-        download_error={"status": "notfound"},
-        source=None,
-        base_url=f"{hitcounter.url}/msdl/",
+        download_error={"status": "malformed"},
+        source=("broken", False),
+        base_url=f"{hitcounter.url}/garbage_data/",
     )
+    # add a debug error to the candidate
+    expected["modules"][0]["candidates"][0]["debug"] = {"status": "malformed"}
+
     assert_symbolication(response, expected)
 
 


### PR DESCRIPTION
Adds tests for how various download errors manifest themselves in the frame status and module list.

Also fixes a bug where the candidate info was not correctly retained for malformed symbol files.