### PR TITLE
ref: Load CFI from a ByteView not a CachePath

### DIFF
--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -555,6 +555,11 @@ impl ExpirationTime {
             }
         }
     }
+
+    /// Says whether the cache was just touched.
+    pub fn was_touched(&self) -> bool {
+        matches!(self, ExpirationTime::TouchIn(TOUCH_EVERY))
+    }
 }
 
 /// Checks the cache contents in `buf` and returns the cleanup strategy that should be used

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -20,7 +20,7 @@ use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use symbolicator_sources::{FileType, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus, ExpirationTime};
-use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
 use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
@@ -193,10 +193,8 @@ impl CacheItemRequest for FetchFileRequest {
 
     fn load(
         &self,
-        _scope: Scope,
         status: CacheStatus,
         data: ByteView<'static>,
-        _path: CachePath,
         _expiration: ExpirationTime,
     ) -> Self::Item {
         CacheHandle {

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -19,7 +19,7 @@ use symbolic::il2cpp::LineMapping;
 use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus, ExpirationTime};
-use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, Cacher};
 use crate::services::download::{DownloadService, DownloadStatus, RemoteDif};
 use crate::types::Scope;
 use crate::utils::compression::decompress_object_file;
@@ -161,10 +161,8 @@ impl CacheItemRequest for FetchFileRequest {
 
     fn load(
         &self,
-        _scope: Scope,
         status: CacheStatus,
         data: ByteView<'static>,
-        _path: CachePath,
         _expiration: ExpirationTime,
     ) -> Self::Item {
         CacheHandle {

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -19,7 +19,7 @@ use symbolic::debuginfo::Object;
 use symbolicator_sources::{ObjectId, SourceId};
 
 use crate::cache::{CacheStatus, ExpirationTime};
-use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, Cacher};
 use crate::services::download::{RemoteDif, RemoteDifUri};
 use crate::types::{ObjectFeatures, Scope};
 
@@ -160,10 +160,8 @@ impl CacheItemRequest for FetchFileMetaRequest {
     /// returned will contain the default [`ObjectMetaHandle::features`].
     fn load(
         &self,
-        scope: Scope,
         status: CacheStatus,
         data: ByteView<'static>,
-        _path: CachePath,
         _expiration: ExpirationTime,
     ) -> Self::Item {
         // When CacheStatus::Negative we get called with an empty ByteView, for Malformed we
@@ -182,7 +180,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
         };
 
         ObjectMetaHandle {
-            scope,
+            scope: self.scope.clone(),
             object_id: self.object_id.clone(),
             file_source: self.file_source.clone(),
             features,

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -18,7 +18,7 @@ use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
-use super::cacher::{CacheItemRequest, CacheKey, CachePath, CacheVersions, Cacher};
+use super::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use super::objects::{
     FindObject, FoundObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
@@ -259,10 +259,8 @@ impl CacheItemRequest for FetchPortablePdbCacheInternal {
 
     fn load(
         &self,
-        _scope: Scope,
         status: CacheStatus,
         data: ByteView<'static>,
-        _path: CachePath,
         _expiration: ExpirationTime,
     ) -> Self::Item {
         let mut candidates = self.candidates.clone(); // yuk!
@@ -289,9 +287,7 @@ fn write_ppdb_cache(
     path: &Path,
     object_handle: &ObjectHandle,
 ) -> Result<(), PortablePdbCacheError> {
-    sentry::configure_scope(|scope| {
-        object_handle.to_scope(scope);
-    });
+    object_handle.configure_scope();
 
     let ppdb_obj = match object_handle.parse() {
         Ok(Some(Object::PortablePdb(ppdb_obj))) => ppdb_obj,

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -14,7 +14,7 @@ use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{Cache, CacheStatus, ExpirationTime};
 use crate::services::bitcode::BitcodeService;
-use crate::services::cacher::{CacheItemRequest, CacheKey, CachePath, CacheVersions, Cacher};
+use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use crate::services::objects::{
     FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
     ObjectsActor,
@@ -279,10 +279,8 @@ impl CacheItemRequest for FetchSymCacheInternal {
 
     fn load(
         &self,
-        _scope: Scope,
         status: CacheStatus,
         data: ByteView<'static>,
-        _path: CachePath,
         _expiration: ExpirationTime,
     ) -> Self::Item {
         // TODO: Figure out if this double-parsing could be avoided
@@ -408,9 +406,7 @@ fn write_symcache(
     object_handle: &ObjectHandle,
     secondary_sources: SecondarySymCacheSources,
 ) -> Result<(), SymCacheError> {
-    sentry::configure_scope(|scope| {
-        object_handle.to_scope(scope);
-    });
+    object_handle.configure_scope();
 
     let symbolic_object = object_handle
         .parse()


### PR DESCRIPTION
This removes the now unused `path` param to `CacheItemRequest::load` along with the `CachePath` type. Similarly, it removed the `scope` param as well, as all the `CacheItemRequest` types have it on `self` anyways, and it was unused in most cases. Also simplifies usage of sentry `to_scope`/`configure_scope`.

And lastly, fixes shared cache refreshes which are not happening anymore as the `expiration` was refreshed prior to refreshing the shared cache.

#skip-changelog