### PR TITLE
ci: Update workflows and release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,13 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Run cargo build
-        run: cargo build --workspace --bins --release --locked
+        run: cargo build --bins --release --locked
 
       - name: Split and archive debug info
         run: |
@@ -54,28 +52,19 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal --target x86_64-apple-darwin --target aarch64-apple-darwin
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: x86_64-apple-darwin
+        run: rustup toolchain install stable --profile minimal --target x86_64-apple-darwin --target aarch64-apple-darwin --no-self-update
 
       - name: Run cargo build for x86_64
-        run: cargo build --workspace --bins --release --locked --target=x86_64-apple-darwin
+        run: cargo build --bins --release --locked --target=x86_64-apple-darwin
         env:
           # Generates separate debug symbol files alongside release builds
           CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
 
       - name: Run cargo build for ARM
-        run: cargo build --workspace --bins --release --locked --target=aarch64-apple-darwin
+        run: cargo build --bins --release --locked --target=aarch64-apple-darwin
         env:
           # Generates separate debug symbol files alongside release builds
           CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: packed
@@ -114,24 +103,20 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
-      - name: Run Cargo Build (symsorter)
-        run: cargo build -p symsorter --release --locked
-
-      - name: Run Cargo Build (wasm-split)
-        run: cargo build -p wasm-split --release --locked
+      - name: Run cargo build
+        run: cargo build --bins --release --locked
 
       - name: Rename Binaries
         run: |
           cd target/release
+          mv symbolicator.exe symbolicator-Windows-x86_64.exe
           mv symsorter.exe symsorter-Windows-x86_64.exe
           mv wasm-split.exe wasm-split-Windows-x86_64.exe
 
@@ -146,10 +131,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -39,9 +39,7 @@ jobs:
         run: flake8 tests
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+        run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
@@ -62,12 +60,10 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
@@ -91,12 +87,10 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
@@ -105,7 +99,7 @@ jobs:
         run: cargo build --locked
 
       - name: Install python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -126,11 +120,11 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Checkout Symbolicator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Checkout Sentry and run integration tests against latest Symbolicator
       - name: Checkout sentry
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: getsentry/sentry
           path: sentry
@@ -152,9 +146,7 @@ jobs:
           python-version: 3.8
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
@@ -175,18 +167,11 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - name: Install libcurl-dev
-        run: |
-          sudo apt update
-          sudo apt-get install -y libcurl4-openssl-dev
-
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal --component rust-docs
+        run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
@@ -198,10 +183,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -226,12 +211,10 @@ jobs:
           sudo apt update
           sudo apt-get install -y libcurl4-openssl-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install rust stable toolchain
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal --component llvm-tools-preview
+        run: rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,11 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
+      - name: Install libcurl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
+
       - name: Checkout sources
         uses: actions/checkout@v3
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,8 +11,8 @@ jobs:
     name: Changelogs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
       - run: npx danger@10.5.2 ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,14 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Install rust stable toolchain
         run: |
-          rustup set auto-self-update disable
-          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy --no-self-update
           rustup default ${{ matrix.rust }}
 
       - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
@@ -37,8 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
+      # FIXME: find a maintained alternative to audit-check
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
-default-members = ["crates/symbolicator", "crates/symbolicator-service"]
+default-members = ["crates/symbolicator", "crates/symsorter", "crates/wasm-split"]
 
 [profile.dev]
 # Debug information slows down the build and increases caches in the


### PR DESCRIPTION
- Updates all the GHA usages, except `actions-rs/audit-check` which is unmaintained and needs a replacement.
- Changes the rustup invocations to pass --no-self-update as a flag.
- Builds only relevant release artifacts via default-members, which also means we build the symbolicator server on Windows.

#skip-changelog