### PR TITLE
ref: Fix clippy lints and CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install libcurl-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -y libcurl4-openssl-dev
+
       - uses: actions/checkout@v3
         with:
           submodules: recursive

--- a/crates/process-event/src/main.rs
+++ b/crates/process-event/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek};
 use std::path::PathBuf;
 
 use ::reqwest::blocking::multipart;
@@ -52,7 +52,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let mut magic = [0; 4];
     file.read_exact(&mut magic)?;
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     let req = if &magic == b"MDMP" || &magic == b"PMDM" {
         let req = client.post(&format!("{}/minidump", symbolicator));

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::{self, Display};
 use std::fs::File;
-use std::io::{self, Cursor, Seek, SeekFrom};
+use std::io::{self, Cursor, Seek};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -127,7 +127,7 @@ impl FetchFileRequest {
         };
 
         // Seek back to the start and parse this DIF.
-        decompressed.seek(SeekFrom::Start(0))?;
+        decompressed.rewind()?;
         let view = ByteView::map_file(decompressed)?;
 
         match self.kind {

--- a/crates/symbolicator-service/src/services/download/gcs.rs
+++ b/crates/symbolicator-service/src/services/download/gcs.rs
@@ -280,7 +280,7 @@ mod tests {
         assert_eq!(download_status, DownloadStatus::Completed);
         assert!(target_path.exists());
 
-        let hash = Sha1::digest(&std::fs::read(target_path).unwrap());
+        let hash = Sha1::digest(std::fs::read(target_path).unwrap());
         let hash = format!("{:x}", hash);
         assert_eq!(hash, "206e63c06da135be1858dde03778caf25f8465b8");
     }

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(download_status, DownloadStatus::Completed);
         assert!(target_path.exists());
 
-        let hash = Sha1::digest(&std::fs::read(target_path).unwrap());
+        let hash = Sha1::digest(std::fs::read(target_path).unwrap());
         let hash = format!("{:x}", hash);
         assert_eq!(hash, "e0195c064783997b26d6e2e625da7417d9f63677");
     }

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -4,7 +4,7 @@
 //! generated C++ source files back to the original C# sources.
 
 use std::fs::File;
-use std::io::{self, Cursor, Seek, SeekFrom};
+use std::io::{self, Cursor, Seek};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -109,7 +109,7 @@ impl FetchFileRequest {
         };
 
         // Seek back to the start and parse this DIF.
-        decompressed.seek(SeekFrom::Start(0))?;
+        decompressed.rewind()?;
         let view = ByteView::map_file(decompressed)?;
 
         if LineMapping::parse(&view).is_none() {

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -9,7 +9,7 @@
 use std::cmp;
 use std::fmt;
 use std::fs;
-use std::io::{self, Seek, SeekFrom};
+use std::io::{self, Seek};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -211,7 +211,7 @@ async fn fetch_file(
     // Since objects in Sentry (and potentially also other sources) might be
     // multi-arch files (e.g. FatMach), we parse as Archive and try to
     // extract the wanted file.
-    decompressed.seek(SeekFrom::Start(0))?;
+    decompressed.rewind()?;
     let view = ByteView::map_file(decompressed)?;
     let archive = match Archive::parse(&view) {
         Ok(archive) => archive,

--- a/crates/symbolicator-service/src/services/symbolication/symbolication.rs
+++ b/crates/symbolicator-service/src/services/symbolication/symbolication.rs
@@ -56,7 +56,7 @@ impl SymbolicationActor {
         for trace in &mut stacktraces {
             for frame in &mut trace.frames {
                 let (abs_path, lineno) = match (&frame.raw.abs_path, frame.raw.lineno) {
-                    (&Some(ref abs_path), Some(lineno)) => (abs_path, lineno),
+                    (Some(abs_path), Some(lineno)) => (abs_path, lineno),
                     _ => continue,
                 };
 

--- a/crates/symbolicator-service/src/utils/compression.rs
+++ b/crates/symbolicator-service/src/utils/compression.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{self, Read, Seek};
 use std::process::{Command, Stdio};
 
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
@@ -17,10 +17,10 @@ pub fn decompress_object_file(src: &NamedTempFile, mut dst: File) -> io::Result<
     let metadata = src.as_file().metadata()?;
     metric!(time_raw("objects.size") = metadata.len());
 
-    src.as_file().seek(SeekFrom::Start(0))?;
+    src.as_file().rewind()?;
     let mut magic_bytes: [u8; 4] = [0, 0, 0, 0];
     src.as_file().read_exact(&mut magic_bytes)?;
-    src.as_file().seek(SeekFrom::Start(0))?;
+    src.as_file().rewind()?;
 
     // For a comprehensive list also refer to
     // https://en.wikipedia.org/wiki/List_of_file_signatures

--- a/crates/symbolicator-service/src/utils/hex.rs
+++ b/crates/symbolicator-service/src/utils/hex.rs
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for HexValue {
             }
 
             fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
-                Ok(HexValue(v as u64))
+                Ok(HexValue(v))
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // always print the build id.
     if !cli.quiet {
-        println!("{}", hex::encode(&build_id));
+        println!("{}", hex::encode(build_id));
     }
 
     Ok(())


### PR DESCRIPTION
Mostly using `rewind` insdeat of `seek`, otherwise removing needless derefs.

CI was also broken previously as it tried to build symbolicator-crash.