### PR TITLE
ref: Test cached Error Statuses

### DIFF
--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -420,7 +420,7 @@ mod tests {
                 "failed to download: 500 Internal Server Error"
             ))
         );
-        assert_eq!(server.accesses(), 1 + 3); // 1 initial attempt + 3 retries
+        assert_eq!(server.accesses(), 3); // up to 3 tries on failure
         let result = objects_actor.find(find_object.clone()).await.unwrap();
         assert_eq!(
             result.meta.unwrap().status,
@@ -496,6 +496,7 @@ mod tests {
             result.meta.unwrap().status,
             CacheStatus::CacheSpecificError(String::from("download was cancelled"))
         );
+        // XXX: why are we not trying this 3 times?
         assert_eq!(server.accesses(), 1);
         let result = objects_actor.find(find_object.clone()).await.unwrap();
         assert_eq!(
@@ -536,7 +537,8 @@ mod tests {
             result.meta.clone().unwrap().status,
             CacheStatus::CacheSpecificError(DownloadError::Permissions.to_string())
         );
-        assert_eq!(server.accesses(), 1 + 3); // 1 initial attempt + 3 retries
+        // XXX: why *are* we trying this 3 times?
+        assert_eq!(server.accesses(), 3); // up to 3 tries on failure
         let result = objects_actor.find(find_object.clone()).await.unwrap();
         assert_eq!(
             result.meta.unwrap().status,

--- a/crates/symbolicator-service/src/utils/futures.rs
+++ b/crates/symbolicator-service/src/utils/futures.rs
@@ -216,20 +216,20 @@ pub mod m {
     }
 }
 
-/// Retry a future 3 times with 20 millisecond delays.
+/// Try to run a future up to 3 times with 20 millisecond delays on failure.
 pub async fn retry<G, F, T, E>(mut task_gen: G) -> Result<T, E>
 where
     G: FnMut() -> F,
     F: Future<Output = Result<T, E>>,
 {
-    let mut retries = 0;
+    let mut tries = 0;
     loop {
+        tries += 1;
         let result = task_gen().await;
-        if result.is_ok() || retries >= 3 {
+        if result.is_ok() || tries >= 3 {
             break result;
         }
 
-        retries += 1;
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -11,7 +11,7 @@ use crate::symbolication::{get_symbolication_request, setup_service};
 #[tokio::test]
 async fn test_download_errors() {
     let (symbolication, _cache_dir) = setup_service(|config| {
-        config.max_download_timeout = Duration::from_millis(100);
+        config.max_download_timeout = Duration::from_millis(200);
     })
     .await;
 
@@ -25,7 +25,6 @@ async fn test_download_errors() {
     //     module.candidate.download
     // )
     let get_statuses = |mut res: CompletedSymbolicationResponse| {
-        dbg!(&res);
         let frame = &res.stacktraces[0].frames[0];
         let mut module = res.modules.remove(0);
         let candidate = module.candidates.0.remove(0);
@@ -37,72 +36,82 @@ async fn test_download_errors() {
         )
     };
 
-    let request = get_symbolication_request(vec![server.reject_source]);
-    let response = symbolication.symbolicate(request).await.unwrap();
+    // NOTE: we run requests twice to make sure that round-trips through the cache give us the same results.
+    for _ in 0..2 {
+        // NOTE: we try this 3 times on error
+        let request = get_symbolication_request(vec![server.reject_source.clone()]);
+        let response = symbolication.symbolicate(request).await.unwrap();
 
-    assert_eq!(
-        get_statuses(response),
-        (
-            FrameStatus::Missing,
-            ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
-            ObjectUseInfo::None,
-            ObjectDownloadInfo::Error {
-                details: "failed to download: 500 Internal Server Error".into()
-            }
-        )
-    );
+        assert_eq!(
+            get_statuses(response),
+            (
+                FrameStatus::Missing,
+                ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
+                ObjectUseInfo::None,
+                ObjectDownloadInfo::Error {
+                    details: "failed to download: 500 Internal Server Error".into()
+                }
+            )
+        );
 
-    let request = get_symbolication_request(vec![server.pending_source]);
-    let response = symbolication.symbolicate(request).await.unwrap();
+        // NOTE: we should probably try this 3 times?
+        let request = get_symbolication_request(vec![server.pending_source.clone()]);
+        let response = symbolication.symbolicate(request).await.unwrap();
 
-    assert_eq!(
-        get_statuses(response),
-        (
-            FrameStatus::Missing,
-            ObjectFileStatus::Missing, // XXX: should be `Timeout`
-            ObjectUseInfo::None,
-            ObjectDownloadInfo::Error {
-                details: "download was cancelled".into()
-            }
-        )
-    );
+        assert_eq!(
+            get_statuses(response),
+            (
+                FrameStatus::Missing,
+                ObjectFileStatus::Missing, // XXX: should be `Timeout`
+                ObjectUseInfo::None,
+                ObjectDownloadInfo::Error {
+                    details: "download was cancelled".into()
+                }
+            )
+        );
 
-    let request = get_symbolication_request(vec![server.not_found_source]);
-    let response = symbolication.symbolicate(request).await.unwrap();
+        let request = get_symbolication_request(vec![server.not_found_source.clone()]);
+        let response = symbolication.symbolicate(request).await.unwrap();
 
-    assert_eq!(
-        get_statuses(response),
-        (
-            FrameStatus::Missing,
-            ObjectFileStatus::Missing,
-            ObjectUseInfo::None,
-            ObjectDownloadInfo::NotFound
-        )
-    );
+        assert_eq!(
+            get_statuses(response),
+            (
+                FrameStatus::Missing,
+                ObjectFileStatus::Missing,
+                ObjectUseInfo::None,
+                ObjectDownloadInfo::NotFound
+            )
+        );
 
-    let request = get_symbolication_request(vec![server.forbidden_source]);
-    let response = symbolication.symbolicate(request).await.unwrap();
+        // NOTE: we try this 3 times on error, why though?
+        let request = get_symbolication_request(vec![server.forbidden_source.clone()]);
+        let response = symbolication.symbolicate(request).await.unwrap();
 
-    assert_eq!(
-        get_statuses(response),
-        (
-            FrameStatus::Missing,
-            ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
-            ObjectUseInfo::None,
-            ObjectDownloadInfo::NoPerm { details: "".into() }
-        )
-    );
+        assert_eq!(
+            get_statuses(response),
+            (
+                FrameStatus::Missing,
+                ObjectFileStatus::Missing, // XXX: should be `FetchingFailed`
+                ObjectUseInfo::None,
+                ObjectDownloadInfo::NoPerm { details: "".into() }
+            )
+        );
 
-    let request = get_symbolication_request(vec![server.invalid_file_source]);
-    let response = symbolication.symbolicate(request).await.unwrap();
+        let request = get_symbolication_request(vec![server.invalid_file_source.clone()]);
+        let response = symbolication.symbolicate(request).await.unwrap();
 
-    assert_eq!(
-        get_statuses(response),
-        (
-            FrameStatus::Malformed,
-            ObjectFileStatus::Malformed,
-            ObjectUseInfo::Malformed,
-            ObjectDownloadInfo::Malformed
-        )
-    );
+        assert_eq!(
+            get_statuses(response),
+            (
+                FrameStatus::Malformed,
+                ObjectFileStatus::Malformed,
+                ObjectUseInfo::Malformed,
+                ObjectDownloadInfo::Malformed
+            )
+        );
+    }
+
+    // server errors and permission errors are tried up to 3 times, all others once, for a total of
+    // 9 requests, as the second requests should be served from cache
+    assert_eq!(server.accesses(), 9);
 }


### PR DESCRIPTION
This adds a second iteration to the download-errors test, making sure that round trips through the on-disk cache yield the same statuses.

This also tightens up the retry logic, as we should try things 3 times, not an additional 3 times. It also adds a couple of notes for where the retry logic does not match the expectation. Why are we retrying permission errors that most likely will not change after retry, while we are *not* retrying timeouts which we probably should, as an intermittent timeout can be gone on the next try.