### PR TITLE
ref: Thread a `NamedTempFile` through the `DownloadStatus`

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -83,6 +83,7 @@ struct FetchFileRequest {
     uuid: DebugId,
     kind: AuxDifKind,
     download_svc: Arc<DownloadService>,
+    // FIXME: this is used only to put the tempfile in the right place
     cache: Arc<Cacher<FetchFileRequest>>,
 }
 
@@ -92,15 +93,13 @@ impl FetchFileRequest {
     /// Actual implementation of [`FetchFileRequest::compute`].
     // XXX: We use a `PathBuf` here because the resulting future needs to be `'static`
     async fn fetch_file(self, path: PathBuf) -> Result<CacheStatus, Error> {
-        let download_file = self.cache.tempfile()?;
         let cache_key = self.get_cache_key();
 
-        let result = self
+        let download_file = match self
             .download_svc
-            .download(self.file_source, download_file.path())
-            .await;
-
-        match result {
+            .download(self.file_source, self.cache.tempfile()?)
+            .await
+        {
             Ok(DownloadStatus::NotFound) => {
                 tracing::debug!("No auxiliary DIF file found for {}", cache_key);
                 return Ok(CacheStatus::Negative);
@@ -116,21 +115,20 @@ impl FetchFileRequest {
                 tracing::debug!(stderr, "Error while downloading file");
                 return Ok(CacheStatus::CacheSpecificError(e.for_cache()));
             }
-            Ok(DownloadStatus::Completed) => {
-                // fall through
-            }
-        }
+            Ok(DownloadStatus::Completed(download_file)) => download_file,
+        };
+
         let download_dir = download_file
             .path()
             .parent()
             .ok_or_else(|| Error::msg("Parent of download dir not found"))?;
-        let decompressed_path = tempfile_in(download_dir)?;
-        let mut decompressed = match decompress_object_file(&download_file, decompressed_path) {
-            Ok(file) => file,
-            Err(err) => {
-                return Ok(CacheStatus::Malformed(err.to_string()));
-            }
-        };
+        let mut decompressed =
+            match decompress_object_file(&download_file, tempfile_in(download_dir)?) {
+                Ok(file) => file,
+                Err(err) => {
+                    return Ok(CacheStatus::Malformed(err.to_string()));
+                }
+            };
 
         // Seek back to the start and parse this DIF.
         decompressed.rewind()?;

--- a/crates/symbolicator-service/src/services/download/filesystem.rs
+++ b/crates/symbolicator-service/src/services/download/filesystem.rs
@@ -62,12 +62,12 @@ impl FilesystemDownloader {
         &self,
         file_source: FilesystemRemoteDif,
         dest: &Path,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<DownloadStatus<()>, DownloadError> {
         // All file I/O in this function is blocking!
         let abspath = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", abspath);
         match fs::copy(abspath, dest).await {
-            Ok(_) => Ok(DownloadStatus::Completed),
+            Ok(_) => Ok(DownloadStatus::Completed(())),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),
                 _ => Err(DownloadError::Io(e)),

--- a/crates/symbolicator-service/src/services/download/gcs.rs
+++ b/crates/symbolicator-service/src/services/download/gcs.rs
@@ -106,7 +106,7 @@ impl GcsDownloader {
         &self,
         file_source: GcsRemoteDif,
         destination: &Path,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<DownloadStatus<()>, DownloadError> {
         let key = file_source.key();
         let bucket = file_source.source.bucket.clone();
         tracing::debug!("Fetching from GCS: {} (from {})", &key, bucket);
@@ -273,7 +273,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(download_status, DownloadStatus::Completed);
+        assert!(matches!(download_status, DownloadStatus::Completed(_)));
         assert!(target_path.exists());
 
         let hash = Sha1::digest(std::fs::read(target_path).unwrap());
@@ -304,7 +304,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(download_status, DownloadStatus::NotFound);
+        assert!(matches!(download_status, DownloadStatus::NotFound));
         assert!(!target_path.exists());
     }
 

--- a/crates/symbolicator-service/src/services/download/http.rs
+++ b/crates/symbolicator-service/src/services/download/http.rs
@@ -76,7 +76,7 @@ impl HttpDownloader {
         &self,
         file_source: HttpRemoteDif,
         destination: &Path,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<DownloadStatus<()>, DownloadError> {
         let download_url = match file_source.url() {
             Ok(x) => x,
             Err(_) => return Ok(DownloadStatus::NotFound),
@@ -191,7 +191,7 @@ mod tests {
         );
         let download_status = downloader.download_source(file_source, dest).await.unwrap();
 
-        assert_eq!(download_status, DownloadStatus::Completed);
+        assert!(matches!(download_status, DownloadStatus::Completed(_)));
 
         let content = std::fs::read_to_string(dest).unwrap();
         assert_eq!(content, "hello world\n");
@@ -219,6 +219,6 @@ mod tests {
         );
         let download_status = downloader.download_source(file_source, dest).await.unwrap();
 
-        assert_eq!(download_status, DownloadStatus::NotFound);
+        assert!(matches!(download_status, DownloadStatus::NotFound));
     }
 }

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -149,7 +149,7 @@ impl S3Downloader {
         &self,
         file_source: S3RemoteDif,
         destination: &Path,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<DownloadStatus<()>, DownloadError> {
         let key = file_source.key();
         let bucket = file_source.bucket();
         tracing::debug!("Fetching from s3: {} (from {})", &key, &bucket);
@@ -452,7 +452,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(download_status, DownloadStatus::Completed);
+        assert!(matches!(download_status, DownloadStatus::Completed(_)));
         assert!(target_path.exists());
 
         let hash = Sha1::digest(std::fs::read(target_path).unwrap());
@@ -481,7 +481,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(download_status, DownloadStatus::NotFound);
+        assert!(matches!(download_status, DownloadStatus::NotFound));
         assert!(!target_path.exists());
     }
 

--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -264,7 +264,7 @@ impl SentryDownloader {
         &self,
         file_source: SentryRemoteDif,
         destination: &Path,
-    ) -> Result<DownloadStatus, DownloadError> {
+    ) -> Result<DownloadStatus<()>, DownloadError> {
         let request = self
             .client
             .get(file_source.url())


### PR DESCRIPTION
This is a first step towards #931.
#skip-changelog