### PR TITLE
ref: Use CacheEntry for CFI Caches

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
@@ -26,7 +26,7 @@ use crate::utils::addr::AddrMode;
 
 use super::object_id_from_object_info;
 
-fn object_file_status_from_cache_entry<T>(cache_entry: &CacheEntry<T>) -> ObjectFileStatus {
+pub fn object_file_status_from_cache_entry<T>(cache_entry: &CacheEntry<T>) -> ObjectFileStatus {
     match cache_entry {
         Ok(_) => ObjectFileStatus::Found,
         Err(CacheError::NotFound) => ObjectFileStatus::Missing,


### PR DESCRIPTION
This is on top of #929 and applies the same code patterns to usage of CFI.

#skip-changelog