### PR TITLE
ref: Refactor fetching/computing derived Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Internal
 
-- Simplified internal error architecture. ([#929](https://github.com/getsentry/symbolicator/pull/929))
+- Simplified internal error and cache architecture. ([#929](https://github.com/getsentry/symbolicator/pull/929),
+  [#936](https://github.com/getsentry/symbolicator/pull/936))
 
 ## 0.6.0
 

--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -18,8 +18,6 @@ use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
 use crate::config::{CacheConfig, Config};
-use crate::services::objects::{FoundObject, ObjectError, ObjectMetaHandle};
-use crate::types::{AllObjectCandidates, CandidateStatus, ObjectFeatures, ObjectUseInfo};
 
 /// Starting content of cache items whose writing failed.
 ///
@@ -291,90 +289,6 @@ pub fn cache_entry_as_cache_status<T>(entry: &CacheEntry<T>) -> CacheStatus {
     match entry {
         Ok(_) => CacheStatus::Positive,
         Err(e) => e.as_cache_status(),
-    }
-}
-
-/// This is the result of fetching a derived cache file.
-///
-/// This has the requested [`CacheEntry`], as well as [`AllObjectCandidates`] that were considered
-/// and the [`ObjectFeatures`] of the primarily used object file.
-#[derive(Clone, Debug)]
-pub struct DerivedCache<T> {
-    pub cache: CacheEntry<T>,
-    pub candidates: AllObjectCandidates,
-    pub features: ObjectFeatures,
-}
-
-/// Derives a [`DerivedCache`] from the provided object handle and derive function.
-///
-/// This function is mainly a wrapper that simplifies error handling and propagation of
-/// [`AllObjectCandidates`] and [`ObjectFeatures`].
-pub async fn derive_from_object_handle<T, Derive, DeriveErr, Fut>(
-    found_object: Result<FoundObject, ObjectError>,
-    candidate_status: CandidateStatus,
-    derive: Derive,
-) -> DerivedCache<T>
-where
-    T: Clone,
-    Derive: FnOnce(Arc<ObjectMetaHandle>) -> Fut,
-    Fut: std::future::Future<Output = Result<Arc<CacheEntry<T>>, Arc<DeriveErr>>>,
-    for<'a> &'a DeriveErr: Into<CacheError>,
-{
-    let (meta, mut candidates) = match found_object {
-        Ok(FoundObject { meta, candidates }) => (meta, candidates),
-        Err(e) => {
-            // NOTE: the only error that can happen here is if the Sentry downloader `list_files`
-            // fails, which we can consider a download error
-            let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
-            tracing::error!(error = dynerr, "Error finding object candidates");
-            return DerivedCache {
-                cache: Err(CacheError::DownloadError(e.to_string())),
-                candidates: Default::default(),
-                features: Default::default(),
-            };
-        }
-    };
-
-    // No handle => NotFound
-    let Some(handle) = meta else {
-        return DerivedCache {
-            cache: Err(CacheError::NotFound),
-            candidates,
-            features: ObjectFeatures::default(),
-        }
-    };
-
-    // Fetch cache file from handle
-    let derived_cache = derive(Arc::clone(&handle)).await;
-
-    match derived_cache {
-        Ok(cache) => {
-            candidates.set_status(
-                candidate_status,
-                handle.source_id(),
-                &handle.uri(),
-                ObjectUseInfo::from_derived_status(
-                    &cache_entry_as_cache_status(&cache),
-                    handle.status(),
-                ),
-            );
-
-            DerivedCache {
-                cache: Arc::try_unwrap(cache).unwrap_or_else(|arc| (*arc).clone()),
-                candidates,
-                features: handle.features(),
-            }
-        }
-
-        // TODO: Internal Err fetching from cache, this should really be merged with `Ok`, as this is
-        // essentially a `Result<Result>` right now.
-        // `Cacher::compute_memoized` should just convert all the internal caching-related errors to
-        // `CacheError` instead of taking a detour through a type parameter.
-        Err(e) => DerivedCache {
-            cache: Err(e.as_ref().into()),
-            candidates,
-            features: ObjectFeatures::default(),
-        },
     }
 }
 

--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -18,6 +18,8 @@ use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
 use crate::config::{CacheConfig, Config};
+use crate::services::objects::{FoundObject, ObjectError, ObjectMetaHandle};
+use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo};
 
 /// Starting content of cache items whose writing failed.
 ///
@@ -289,6 +291,107 @@ pub fn cache_entry_as_cache_status<T>(entry: &CacheEntry<T>) -> CacheStatus {
     match entry {
         Ok(_) => CacheStatus::Positive,
         Err(e) => e.as_cache_status(),
+    }
+}
+
+/// This is the result of fetching a derived cache file.
+///
+/// This has the requested [`CacheEntry`], as well as [`AllObjectCandidates`] that were considered
+/// and the [`ObjectFeatures`] of the primarily used object file.
+#[derive(Clone, Debug)]
+pub struct DerivedCache<T> {
+    pub cache: CacheEntry<T>,
+    pub candidates: AllObjectCandidates,
+    pub features: ObjectFeatures,
+}
+
+pub enum CandidateStatus {
+    Debug,
+    Unwind,
+    None,
+}
+
+/// Derives a [`DerivedCache`] from the provided object handle and derive function.
+///
+/// This function is mainly a wrapper that simplifies error handling and propagation of
+/// [`AllObjectCandidates`] and [`ObjectFeatures`].
+pub async fn derive_from_object_handle<T, Derive, DeriveErr, Fut>(
+    found_object: Result<FoundObject, ObjectError>,
+    candidate_status: CandidateStatus,
+    derive: Derive,
+) -> DerivedCache<T>
+where
+    T: Clone,
+    Derive: FnOnce(Arc<ObjectMetaHandle>) -> Fut,
+    Fut: std::future::Future<Output = Result<Arc<CacheEntry<T>>, Arc<DeriveErr>>>,
+    for<'a> &'a DeriveErr: Into<CacheError>,
+{
+    let (meta, mut candidates) = match found_object {
+        Ok(FoundObject { meta, candidates }) => (meta, candidates),
+        Err(e) => {
+            // NOTE: the only error that can happen here is if the Sentry downloader `list_files`
+            // fails, which we can consider a download error
+            let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
+            tracing::error!(error = dynerr, "Error finding object candidates");
+            return DerivedCache {
+                cache: Err(CacheError::DownloadError(e.to_string())),
+                candidates: Default::default(),
+                features: Default::default(),
+            };
+        }
+    };
+
+    // No handle => NotFound
+    let Some(handle) = meta else {
+        return DerivedCache {
+            cache: Err(CacheError::NotFound),
+            candidates,
+            features: ObjectFeatures::default(),
+        }
+    };
+
+    // Fetch cache file from handle
+    let derived_cache = derive(Arc::clone(&handle)).await;
+
+    match derived_cache {
+        Ok(cache) => {
+            // TODO: can we dedupe these two functions?
+            match candidate_status {
+                CandidateStatus::Debug => candidates.set_debug(
+                    handle.source_id(),
+                    &handle.uri(),
+                    ObjectUseInfo::from_derived_status(
+                        &cache_entry_as_cache_status(&cache),
+                        handle.status(),
+                    ),
+                ),
+                CandidateStatus::Unwind => candidates.set_unwind(
+                    handle.source_id(),
+                    &handle.uri(),
+                    ObjectUseInfo::from_derived_status(
+                        &cache_entry_as_cache_status(&cache),
+                        handle.status(),
+                    ),
+                ),
+                CandidateStatus::None => {}
+            }
+
+            DerivedCache {
+                cache: Arc::try_unwrap(cache).unwrap_or_else(|arc| (*arc).clone()),
+                candidates,
+                features: handle.features(),
+            }
+        }
+
+        // TODO: Internal Err fetching from cache, this should really be merged with `Ok`, as this is
+        // essentially a `Result<Result>` right now.
+        // `Cacher::compute_memoized` should just convert all the internal caching-related errors to
+        // `CacheError` instead of taking a detour through a type parameter.
+        Err(e) => DerivedCache {
+            cache: Err(e.as_ref().into()),
+            candidates,
+            features: ObjectFeatures::default(),
+        },
     }
 }
 

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -14,13 +14,13 @@ use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{
     cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, CandidateStatus, DerivedCache, ExpirationTime,
+    CacheStatus, DerivedCache, ExpirationTime,
 };
 use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use crate::services::objects::{
     FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
-use crate::types::{AllObjectCandidates, ObjectFeatures, Scope};
+use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
@@ -138,38 +138,6 @@ impl CfiCacheActor {
             cficaches: Arc::new(Cacher::new(cache, shared_cache_svc)),
             objects,
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct CfiCacheFile {
-    features: ObjectFeatures,
-    status: CacheStatus,
-    data: ByteView<'static>,
-    candidates: AllObjectCandidates,
-}
-
-impl CfiCacheFile {
-    /// Returns the status of this cache file.
-    pub fn status(&self) -> &CacheStatus {
-        &self.status
-    }
-
-    /// Returns the features of the object file this symcache was constructed from.
-    pub fn features(&self) -> ObjectFeatures {
-        self.features
-    }
-
-    /// Returns the cfi contents as a [`ByteView`].
-    // FIXME(swatinem): symbolic `CfiCache::from_bytes` should actually take a `&[u8]` instead of
-    // an explicit `ByteView`.
-    pub fn data(&self) -> ByteView {
-        self.data.clone()
-    }
-
-    /// Returns all the DIF object candidates.
-    pub fn candidates(&self) -> &AllObjectCandidates {
-        &self.candidates
     }
 }
 

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -13,8 +13,7 @@ use symbolic::common::ByteView;
 use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{
-    cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, DerivedCache, ExpirationTime,
+    cache_entry_from_cache_status, Cache, CacheEntry, CacheError, CacheStatus, ExpirationTime,
 };
 use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use crate::services::objects::{
@@ -24,6 +23,7 @@ use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
+use super::derived::{derive_from_object_handle, DerivedCache};
 use super::shared_cache::SharedCacheService;
 
 /// The supported cficache versions.

--- a/crates/symbolicator-service/src/services/derived.rs
+++ b/crates/symbolicator-service/src/services/derived.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use crate::cache::{cache_entry_as_cache_status, CacheEntry, CacheError};
+use crate::services::objects::{FoundObject, ObjectError, ObjectMetaHandle};
+use crate::types::{AllObjectCandidates, CandidateStatus, ObjectFeatures, ObjectUseInfo};
+
+/// This is the result of fetching a derived cache file.
+///
+/// This has the requested [`CacheEntry`], as well as [`AllObjectCandidates`] that were considered
+/// and the [`ObjectFeatures`] of the primarily used object file.
+#[derive(Clone, Debug)]
+pub struct DerivedCache<T> {
+    pub cache: CacheEntry<T>,
+    pub candidates: AllObjectCandidates,
+    pub features: ObjectFeatures,
+}
+
+/// Derives a [`DerivedCache`] from the provided object handle and derive function.
+///
+/// This function is mainly a wrapper that simplifies error handling and propagation of
+/// [`AllObjectCandidates`] and [`ObjectFeatures`].
+/// The [`CandidateStatus`] is responsible for telling which status to set on the found candidate.
+pub async fn derive_from_object_handle<T, Derive, DeriveErr, Fut>(
+    found_object: Result<FoundObject, ObjectError>,
+    candidate_status: CandidateStatus,
+    derive: Derive,
+) -> DerivedCache<T>
+where
+    T: Clone,
+    Derive: FnOnce(Arc<ObjectMetaHandle>) -> Fut,
+    Fut: std::future::Future<Output = Result<Arc<CacheEntry<T>>, Arc<DeriveErr>>>,
+    for<'a> &'a DeriveErr: Into<CacheError>,
+{
+    let (meta, mut candidates) = match found_object {
+        Ok(FoundObject { meta, candidates }) => (meta, candidates),
+        Err(e) => {
+            // NOTE: the only error that can happen here is if the Sentry downloader `list_files`
+            // fails, which we can consider a download error
+            let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
+            tracing::error!(error = dynerr, "Error finding object candidates");
+            return DerivedCache {
+                cache: Err(CacheError::DownloadError(e.to_string())),
+                candidates: Default::default(),
+                features: Default::default(),
+            };
+        }
+    };
+
+    // No handle => NotFound
+    let Some(handle) = meta else {
+        return DerivedCache {
+            cache: Err(CacheError::NotFound),
+            candidates,
+            features: ObjectFeatures::default(),
+        }
+    };
+
+    // Fetch cache file from handle
+    let derived_cache = derive(Arc::clone(&handle)).await;
+
+    match derived_cache {
+        Ok(cache) => {
+            candidates.set_status(
+                candidate_status,
+                handle.source_id(),
+                &handle.uri(),
+                ObjectUseInfo::from_derived_status(
+                    &cache_entry_as_cache_status(&cache),
+                    handle.status(),
+                ),
+            );
+
+            DerivedCache {
+                cache: Arc::try_unwrap(cache).unwrap_or_else(|arc| (*arc).clone()),
+                candidates,
+                features: handle.features(),
+            }
+        }
+
+        // TODO: Internal Err fetching from cache, this should really be merged with `Ok`, as this is
+        // essentially a `Result<Result>` right now.
+        // `Cacher::compute_memoized` should just convert all the internal caching-related errors to
+        // `CacheError` instead of taking a detour through a type parameter.
+        Err(e) => DerivedCache {
+            cache: Err(e.as_ref().into()),
+            candidates,
+            features: ObjectFeatures::default(),
+        },
+    }
+}

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -19,6 +19,7 @@ use crate::config::Config;
 pub mod bitcode;
 pub mod cacher;
 pub mod cficaches;
+pub mod derived;
 pub mod download;
 pub mod il2cpp;
 mod minidump;

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -13,18 +13,16 @@ use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{
-    cache_entry_as_cache_status, cache_entry_from_cache_status, Cache, CacheEntry, CacheError,
-    CacheStatus, ExpirationTime,
+    cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
+    CacheStatus, CandidateStatus, DerivedCache, ExpirationTime,
 };
 use crate::services::objects::ObjectError;
-use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
+use crate::types::{AllObjectCandidates, ObjectFeatures, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
 use super::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
-use super::objects::{
-    FindObject, FoundObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
-};
+use super::objects::{FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor};
 use super::shared_cache::SharedCacheService;
 
 /// The supported ppdb_cache versions.
@@ -154,8 +152,11 @@ impl PortablePdbCacheActor {
         }
     }
 
-    pub async fn fetch(&self, request: FetchPortablePdbCache) -> FetchPortablePdbCacheResponse {
-        let Ok(FoundObject { meta, mut candidates }) = self
+    pub async fn fetch(
+        &self,
+        request: FetchPortablePdbCache,
+    ) -> DerivedCache<OwnedPortablePdbCache> {
+        let found_object = self
             .objects
             .find(FindObject {
                 filetypes: &[FileType::PortablePdb],
@@ -164,51 +165,16 @@ impl PortablePdbCacheActor {
                 scope: request.scope.clone(),
                 purpose: ObjectPurpose::Debug,
             })
-            .await else {
-                return FetchPortablePdbCacheResponse::default()
-        };
-
-        match meta {
-            Some(handle) => {
-                match self
-                    .ppdb_caches
-                    .compute_memoized(FetchPortablePdbCacheInternal {
-                        request,
-                        objects_actor: self.objects.clone(),
-                        object_meta: Arc::clone(&handle),
-                    })
-                    .await
-                {
-                    Ok(ppdb_cache_file) => {
-                        candidates.set_debug(
-                            handle.source_id(),
-                            &handle.uri(),
-                            ObjectUseInfo::from_derived_status(
-                                &cache_entry_as_cache_status(&ppdb_cache_file),
-                                handle.status(),
-                            ),
-                        );
-
-                        FetchPortablePdbCacheResponse {
-                            cache: Arc::try_unwrap(ppdb_cache_file)
-                                .unwrap_or_else(|arc| (*arc).clone()),
-                            candidates,
-                            features: handle.features(),
-                        }
-                    }
-                    Err(e) => FetchPortablePdbCacheResponse {
-                        cache: Err(e.as_ref().into()),
-                        candidates,
-                        features: ObjectFeatures::default(),
-                    },
-                }
-            }
-            None => FetchPortablePdbCacheResponse {
-                cache: Err(CacheError::NotFound),
-                candidates,
-                features: ObjectFeatures::default(),
-            },
-        }
+            .await;
+        derive_from_object_handle(found_object, CandidateStatus::Debug, |object_meta| {
+            self.ppdb_caches
+                .compute_memoized(FetchPortablePdbCacheInternal {
+                    request,
+                    objects_actor: self.objects.clone(),
+                    object_meta,
+                })
+        })
+        .await
     }
 }
 

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -14,10 +14,10 @@ use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{
     cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, CandidateStatus, DerivedCache, ExpirationTime,
+    CacheStatus, DerivedCache, ExpirationTime,
 };
 use crate::services::objects::ObjectError;
-use crate::types::{AllObjectCandidates, ObjectFeatures, Scope};
+use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
@@ -115,23 +115,6 @@ pub struct FetchPortablePdbCache {
     pub identifier: ObjectId,
     pub sources: Arc<[SourceConfig]>,
     pub scope: Scope,
-}
-
-#[derive(Debug, Clone)]
-pub struct FetchPortablePdbCacheResponse {
-    pub cache: CacheEntry<OwnedPortablePdbCache>,
-    pub candidates: AllObjectCandidates,
-    pub features: ObjectFeatures,
-}
-
-impl Default for FetchPortablePdbCacheResponse {
-    fn default() -> Self {
-        Self {
-            cache: Err(CacheError::InternalError),
-            candidates: Default::default(),
-            features: Default::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -13,8 +13,7 @@ use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::cache::{
-    cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, DerivedCache, ExpirationTime,
+    cache_entry_from_cache_status, Cache, CacheEntry, CacheError, CacheStatus, ExpirationTime,
 };
 use crate::services::objects::ObjectError;
 use crate::types::{CandidateStatus, Scope};
@@ -22,6 +21,7 @@ use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
 use super::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
+use super::derived::{derive_from_object_handle, DerivedCache};
 use super::objects::{FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor};
 use super::shared_cache::SharedCacheService;
 

--- a/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
@@ -9,7 +9,8 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolic::debuginfo::{Object, ObjectDebugSession};
 use symbolicator_sources::{FileType, ObjectType, SourceConfig};
 
-use crate::cache::{CacheEntry, CacheError, DerivedCache};
+use crate::cache::{CacheEntry, CacheError};
+use crate::services::derived::DerivedCache;
 use crate::services::objects::{FindObject, FoundObject, ObjectPurpose, ObjectsActor};
 use crate::services::ppdb_caches::{
     FetchPortablePdbCache, OwnedPortablePdbCache, PortablePdbCacheActor, PortablePdbCacheError,

--- a/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
@@ -9,15 +9,12 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolic::debuginfo::{Object, ObjectDebugSession};
 use symbolicator_sources::{FileType, ObjectType, SourceConfig};
 
-use crate::cache::{CacheEntry, CacheError};
+use crate::cache::{CacheEntry, CacheError, DerivedCache};
 use crate::services::objects::{FindObject, FoundObject, ObjectPurpose, ObjectsActor};
 use crate::services::ppdb_caches::{
-    FetchPortablePdbCache, FetchPortablePdbCacheResponse, OwnedPortablePdbCache,
-    PortablePdbCacheActor, PortablePdbCacheError,
+    FetchPortablePdbCache, OwnedPortablePdbCache, PortablePdbCacheActor, PortablePdbCacheError,
 };
-use crate::services::symcaches::{
-    FetchSymCache, FetchSymCacheResponse, OwnedSymCache, SymCacheActor, SymCacheError,
-};
+use crate::services::symcaches::{FetchSymCache, OwnedSymCache, SymCacheActor, SymCacheError};
 use crate::types::{
     AllObjectCandidates, CompleteObjectInfo, CompleteStacktrace, ObjectFeatures, ObjectFileStatus,
     RawStacktrace, Scope,
@@ -210,7 +207,7 @@ impl ModuleLookup {
                                 scope,
                             };
 
-                            let FetchPortablePdbCacheResponse {
+                            let DerivedCache {
                                 cache,
                                 candidates,
                                 features,
@@ -233,7 +230,7 @@ impl ModuleLookup {
                                 scope,
                             };
 
-                            let FetchSymCacheResponse {
+                            let DerivedCache {
                                 cache,
                                 candidates,
                                 features,

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -19,7 +19,7 @@ use tempfile::TempPath;
 use symbolic::common::{Arch, ByteView, CodeId, DebugId};
 use symbolicator_sources::{ObjectId, ObjectType, SourceConfig};
 
-use crate::services::cficaches::{CfiCacheActor, FetchCfiCache, FetchCfiCacheResponse};
+use crate::services::cficaches::{CfiCacheActor, FetchCfiCache, FetchedCfiCache};
 use crate::services::minidump::parse_stacktraces_from_minidump;
 use crate::services::symbolication::module_lookup::object_file_status_from_cache_entry;
 use crate::types::{
@@ -155,7 +155,7 @@ struct SymbolicatorSymbolProvider {
     /// An internal database of loaded CFI.
     ///
     /// The key consists of a module's debug identifier and base address.
-    cficaches: moka::future::Cache<LookupKey, FetchCfiCacheResponse>,
+    cficaches: moka::future::Cache<LookupKey, FetchedCfiCache>,
 }
 
 impl SymbolicatorSymbolProvider {
@@ -176,7 +176,7 @@ impl SymbolicatorSymbolProvider {
     }
 
     /// Fetches CFI for the given module, parses it into a `SymbolFile`, and stores it internally.
-    async fn load_cfi_module(&self, module: &(dyn Module + Sync)) -> FetchCfiCacheResponse {
+    async fn load_cfi_module(&self, module: &(dyn Module + Sync)) -> FetchedCfiCache {
         let key = LookupKey::new(module);
         self.cficaches
             .get_with_by_ref(&key, async {

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -13,16 +13,15 @@ use symbolic::symcache::{self, SymCache, SymCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{
-    cache_entry_as_cache_status, cache_entry_from_cache_status, Cache, CacheEntry, CacheError,
-    CacheStatus, ExpirationTime,
+    cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
+    CacheStatus, CandidateStatus, DerivedCache, ExpirationTime,
 };
 use crate::services::bitcode::BitcodeService;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use crate::services::objects::{
-    FindObject, FoundObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose,
-    ObjectsActor,
+    FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
-use crate::types::{AllObjectCandidates, ObjectFeatures, ObjectUseInfo, Scope};
+use crate::types::Scope;
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
@@ -300,26 +299,9 @@ pub struct FetchSymCache {
     pub scope: Scope,
 }
 
-#[derive(Debug, Clone)]
-pub struct FetchSymCacheResponse {
-    pub cache: CacheEntry<OwnedSymCache>,
-    pub candidates: AllObjectCandidates,
-    pub features: ObjectFeatures,
-}
-
-impl Default for FetchSymCacheResponse {
-    fn default() -> Self {
-        Self {
-            cache: Err(CacheError::InternalError),
-            candidates: Default::default(),
-            features: Default::default(),
-        }
-    }
-}
-
 impl SymCacheActor {
-    pub async fn fetch(&self, request: FetchSymCache) -> FetchSymCacheResponse {
-        let Ok(FoundObject { meta, mut candidates }) = self
+    pub async fn fetch(&self, request: FetchSymCache) -> DerivedCache<OwnedSymCache> {
+        let found_object = self
             .objects
             .find(FindObject {
                 filetypes: FileType::from_object_type(request.object_type),
@@ -328,94 +310,61 @@ impl SymCacheActor {
                 scope: request.scope.clone(),
                 purpose: ObjectPurpose::Debug,
             })
-            .await else {
-                return FetchSymCacheResponse::default();
-        };
+            .await;
 
-        match meta {
-            Some(handle) => {
-                // TODO: while there is some caching *internally* in the bitcode_svc, the *complete*
-                // fetch request is not cached
-                let fetch_bcsymbolmap = async {
-                    match handle.object_id().debug_id {
-                        Some(debug_id) => {
-                            self.bitcode_svc
-                                .fetch_bcsymbolmap(
-                                    debug_id,
-                                    handle.scope().clone(),
-                                    request.sources.clone(),
-                                )
-                                .await
-                        }
-                        None => None,
+        derive_from_object_handle(found_object, CandidateStatus::Debug, |handle| async move {
+            // TODO: while there is some caching *internally* in the bitcode_svc, the *complete*
+            // fetch request is not cached
+            let fetch_bcsymbolmap = async {
+                match handle.object_id().debug_id {
+                    Some(debug_id) => {
+                        self.bitcode_svc
+                            .fetch_bcsymbolmap(
+                                debug_id,
+                                handle.scope().clone(),
+                                request.sources.clone(),
+                            )
+                            .await
                     }
-                };
-
-                let fetch_il2cpp = async {
-                    match handle.object_id().debug_id {
-                        Some(debug_id) => {
-                            tracing::trace!("Fetching line mapping");
-                            self.il2cpp_svc
-                                .fetch_line_mapping(
-                                    handle.object_id(),
-                                    debug_id,
-                                    handle.scope().clone(),
-                                    request.sources.clone(),
-                                )
-                                .await
-                        }
-                        None => None,
-                    }
-                };
-
-                let (bcsymbolmap_handle, il2cpp_handle) =
-                    futures::future::join(fetch_bcsymbolmap, fetch_il2cpp).await;
-
-                let secondary_sources = SecondarySymCacheSources {
-                    bcsymbolmap_handle,
-                    il2cpp_handle,
-                };
-
-                match self
-                    .symcaches
-                    .compute_memoized(FetchSymCacheInternal {
-                        request,
-                        objects_actor: self.objects.clone(),
-                        secondary_sources,
-                        object_meta: Arc::clone(&handle),
-                    })
-                    .await
-                {
-                    Ok(symcache_file) => {
-                        candidates.set_debug(
-                            handle.source_id(),
-                            &handle.uri(),
-                            ObjectUseInfo::from_derived_status(
-                                &cache_entry_as_cache_status(&symcache_file),
-                                handle.status(),
-                            ),
-                        );
-
-                        FetchSymCacheResponse {
-                            cache: Arc::try_unwrap(symcache_file)
-                                .unwrap_or_else(|arc| (*arc).clone()),
-                            candidates,
-                            features: handle.features(),
-                        }
-                    }
-                    Err(e) => FetchSymCacheResponse {
-                        cache: Err(e.as_ref().into()),
-                        candidates,
-                        features: ObjectFeatures::default(),
-                    },
+                    None => None,
                 }
-            }
-            None => FetchSymCacheResponse {
-                cache: Err(CacheError::NotFound),
-                candidates,
-                features: ObjectFeatures::default(),
-            },
-        }
+            };
+
+            let fetch_il2cpp = async {
+                match handle.object_id().debug_id {
+                    Some(debug_id) => {
+                        tracing::trace!("Fetching line mapping");
+                        self.il2cpp_svc
+                            .fetch_line_mapping(
+                                handle.object_id(),
+                                debug_id,
+                                handle.scope().clone(),
+                                request.sources.clone(),
+                            )
+                            .await
+                    }
+                    None => None,
+                }
+            };
+
+            let (bcsymbolmap_handle, il2cpp_handle) =
+                futures::future::join(fetch_bcsymbolmap, fetch_il2cpp).await;
+
+            let secondary_sources = SecondarySymCacheSources {
+                bcsymbolmap_handle,
+                il2cpp_handle,
+            };
+
+            self.symcaches
+                .compute_memoized(FetchSymCacheInternal {
+                    request,
+                    objects_actor: self.objects.clone(),
+                    secondary_sources,
+                    object_meta: Arc::clone(&handle),
+                })
+                .await
+        })
+        .await
     }
 }
 

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -14,14 +14,14 @@ use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{
     cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, CandidateStatus, DerivedCache, ExpirationTime,
+    CacheStatus, DerivedCache, ExpirationTime,
 };
 use crate::services::bitcode::BitcodeService;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use crate::services::objects::{
     FindObject, ObjectError, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
 };
-use crate::types::Scope;
+use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -13,8 +13,7 @@ use symbolic::symcache::{self, SymCache, SymCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::cache::{
-    cache_entry_from_cache_status, derive_from_object_handle, Cache, CacheEntry, CacheError,
-    CacheStatus, DerivedCache, ExpirationTime,
+    cache_entry_from_cache_status, Cache, CacheEntry, CacheError, CacheStatus, ExpirationTime,
 };
 use crate::services::bitcode::BitcodeService;
 use crate::services::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
@@ -27,6 +26,7 @@ use crate::utils::sentry::ConfigureScope;
 
 use self::markers::{SecondarySymCacheSources, SymCacheMarkers};
 
+use super::derived::{derive_from_object_handle, DerivedCache};
 use super::download::DownloadError;
 use super::il2cpp::Il2cppService;
 use super::shared_cache::SharedCacheService;

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -17,7 +17,9 @@ use crate::utils::hex::HexValue;
 
 mod objects;
 
-pub use objects::{AllObjectCandidates, ObjectCandidate, ObjectDownloadInfo, ObjectUseInfo};
+pub use objects::{
+    AllObjectCandidates, CandidateStatus, ObjectCandidate, ObjectDownloadInfo, ObjectUseInfo,
+};
 
 /// OS-specific crash signal value.
 // TODO(markus): Also accept POSIX signal name as defined in signal.h

--- a/crates/symbolicator-service/src/types/objects.rs
+++ b/crates/symbolicator-service/src/types/objects.rs
@@ -209,12 +209,9 @@ impl AllObjectCandidates {
     ///
     /// You can only request cficaches from a DIF object that was already in the metadata
     /// candidate list, therefore if the candidate is missing it is treated as an error.
-    pub fn set_unwind(&mut self, source: SourceId, uri: &RemoteDifUri, info: ObjectUseInfo) {
-        let found_pos = self.0.binary_search_by(|candidate| {
-            candidate
-                .source
-                .cmp(&source)
-                .then(candidate.location.cmp(uri))
+    pub fn set_unwind(&mut self, source: &SourceId, uri: &RemoteDifUri, info: ObjectUseInfo) {
+        let found_pos = self.0.binary_search_by_key(&(source, uri), |candidate| {
+            (&candidate.source, &candidate.location)
         });
         match found_pos {
             Ok(index) => {

--- a/crates/symbolicator-service/src/types/objects.rs
+++ b/crates/symbolicator-service/src/types/objects.rs
@@ -179,7 +179,7 @@ impl From<Vec<ObjectCandidate>> for AllObjectCandidates {
 pub struct AllObjectCandidates(pub Vec<ObjectCandidate>);
 
 /// The candidate cache status that we want to set
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub enum CandidateStatus {
     Debug,
     Unwind,


### PR DESCRIPTION
Introduces a new helper to deduplicate code related to deriving cache files from object meta handles.

Also cleans up some intermediate types and duplicated functions.

#skip-changelog