### PR TITLE
fix: Use a default crash DB if we have a Cache configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internal
 
+- Use a default crash DB if we have a Cache configured. ([#941](https://github.com/getsentry/symbolicator/pull/941))
 - Simplified internal error and cache architecture. ([#929](https://github.com/getsentry/symbolicator/pull/929),
   [#936](https://github.com/getsentry/symbolicator/pull/936), [#937](https://github.com/getsentry/symbolicator/pull/937))
 

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -67,14 +67,14 @@ pub fn execute() -> Result<()> {
     #[cfg(feature = "symbolicator-crash")]
     {
         let dsn = config.sentry_dsn.as_ref().map(|d| d.to_string());
-        let db = config._crash_db.cloned().or_else(|| {
+        let db = config._crash_db.clone().or_else(|| {
             config
                 .cache_dir
                 .as_ref()
                 .map(|cache_dir| cache_dir.join(".sentry-native"))
         });
         if let (Some(dsn), Some(db)) = (dsn, db) {
-            symbolicator_crash::CrashHandler::new(dsn.as_ref(), db)
+            symbolicator_crash::CrashHandler::new(dsn.as_ref(), &db)
                 .release(sentry::release_name!().as_deref())
                 .install();
         }


### PR DESCRIPTION
Seems like our `symbolicator-crash` (`sentry-native`) integration was never active because it required explicitly setting a crash db path which was not configured for our deployed version.

This will now use a `.sentry-native` folder inside our configured (or defaulted for docker) cache directory.