### PR TITLE
ref: Simplify `list_files`

### DIFF
--- a/crates/symbolicator-service/src/services/download/filesystem.rs
+++ b/crates/symbolicator-service/src/services/download/filesystem.rs
@@ -1,22 +1,17 @@
 //! Support to download from the local filesystem.
 //!
-//! Specifically this supports the [`FilesystemSourceConfig`] source.  It allows
-//! sources to be present on the local filesystem, usually only used for
-//! testing.
+//! It allows sources to be present on the local filesystem, usually only used for testing.
 
 use std::io;
 use std::path::Path;
-use std::sync::Arc;
 
 use tokio::fs;
 
-use symbolicator_sources::{
-    FileType, FilesystemRemoteFile, FilesystemSourceConfig, ObjectId, RemoteFile,
-};
+use symbolicator_sources::FilesystemRemoteFile;
 
 use super::{DownloadError, DownloadStatus};
 
-/// Downloader implementation that supports the [`FilesystemSourceConfig`] source.
+/// Downloader implementation that supports the filesystem source.
 #[derive(Debug)]
 pub struct FilesystemDownloader {}
 
@@ -41,22 +36,5 @@ impl FilesystemDownloader {
                 _ => Err(DownloadError::Io(e)),
             },
         }
-    }
-
-    pub fn list_files(
-        &self,
-        source: Arc<FilesystemSourceConfig>,
-        filetypes: &[FileType],
-        object_id: &ObjectId,
-    ) -> Vec<RemoteFile> {
-        super::SourceLocationIter {
-            filetypes: filetypes.iter(),
-            filters: &source.files.filters,
-            object_id,
-            layout: source.files.layout,
-            next: Vec::new(),
-        }
-        .map(|loc| FilesystemRemoteFile::new(source.clone(), loc).into())
-        .collect()
     }
 }

--- a/crates/symbolicator-service/src/services/download/http.rs
+++ b/crates/symbolicator-service/src/services/download/http.rs
@@ -1,20 +1,17 @@
 //! Support to download from HTTP sources.
-//!
-//! Specifically this supports the [`HttpSourceConfig`] source.
 
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use futures::prelude::*;
 use reqwest::{header, Client, StatusCode};
 
-use symbolicator_sources::{FileType, HttpRemoteFile, HttpSourceConfig, ObjectId, RemoteFile};
+use symbolicator_sources::{HttpRemoteFile, RemoteFile};
 
 use super::{content_length_timeout, DownloadError, DownloadStatus, USER_AGENT};
 
-/// Downloader implementation that supports the [`HttpSourceConfig`] source.
+/// Downloader implementation that supports the HTTP source.
 #[derive(Debug)]
 pub struct HttpDownloader {
     client: Client,
@@ -105,23 +102,6 @@ impl HttpDownloader {
             );
             Err(DownloadError::Rejected(response.status()))
         }
-    }
-
-    pub fn list_files(
-        &self,
-        source: Arc<HttpSourceConfig>,
-        filetypes: &[FileType],
-        object_id: &ObjectId,
-    ) -> Vec<RemoteFile> {
-        super::SourceLocationIter {
-            filetypes: filetypes.iter(),
-            filters: &source.files.filters,
-            object_id,
-            layout: source.files.layout,
-            next: Vec::new(),
-        }
-        .map(|loc| HttpRemoteFile::new(source.clone(), loc).into())
-        .collect()
     }
 }
 

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -17,10 +17,12 @@ use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
-use symbolicator_sources::get_directory_paths;
 pub use symbolicator_sources::{
     DirectoryLayout, FileType, ObjectId, ObjectType, RemoteFile, RemoteFileUri, SourceConfig,
     SourceFilters, SourceLocation,
+};
+use symbolicator_sources::{
+    FilesystemRemoteFile, GcsRemoteFile, HttpRemoteFile, S3RemoteFile, SourceLocationIter,
 };
 
 use crate::cache::{CacheError, CacheStatus};
@@ -315,23 +317,49 @@ impl DownloadService {
     /// downloading you may still need to filter the files.
     pub async fn list_files(
         &self,
-        source: SourceConfig,
+        sources: &[SourceConfig],
         filetypes: &[FileType],
         object_id: &ObjectId,
-    ) -> Result<Vec<RemoteFile>, DownloadError> {
-        match source {
-            SourceConfig::Sentry(cfg) => {
-                let job = self.sentry.list_files(cfg, object_id, filetypes);
-                let job = tokio::time::timeout(Duration::from_secs(30), job);
-                let job = measure("service.download.list_files", m::timed_result, None, job);
+    ) -> Vec<RemoteFile> {
+        let mut remote_files = vec![];
 
-                job.await.map_err(|_| DownloadError::Canceled)?
-            }
-            SourceConfig::Http(cfg) => Ok(self.http.list_files(cfg, filetypes, object_id)),
-            SourceConfig::S3(cfg) => Ok(self.s3.list_files(cfg, filetypes, object_id)),
-            SourceConfig::Gcs(cfg) => Ok(self.gcs.list_files(cfg, filetypes, object_id)),
-            SourceConfig::Filesystem(cfg) => Ok(self.fs.list_files(cfg, filetypes, object_id)),
+        macro_rules! check_source {
+            ($source:ident => $file_ty:ty) => {{
+                let mut iter =
+                    SourceLocationIter::new(&$source.files, filetypes, object_id).peekable();
+                if iter.peek().is_none() {
+                    // TODO: create a special "no file on source" `RemoteFile`?
+                } else {
+                    remote_files
+                        .extend(iter.map(|loc| <$file_ty>::new($source.clone(), loc).into()))
+                }
+            }};
         }
+
+        for source in sources {
+            match source {
+                SourceConfig::Sentry(cfg) => {
+                    let job = self.sentry.list_files(cfg.clone(), object_id, filetypes);
+                    let job = tokio::time::timeout(Duration::from_secs(30), job);
+                    let job = measure("service.download.list_files", m::timed_result, None, job);
+
+                    let sentry_files = job.await.map_err(|_| DownloadError::Canceled);
+                    match sentry_files {
+                        Ok(Ok(files)) => remote_files.extend(files),
+                        Ok(Err(error)) | Err(error) => {
+                            let error: &dyn std::error::Error = &error;
+                            tracing::error!(error, "Failed to fetch file list");
+                            // TODO: create a special "finding files failed" `RemoteFile`?
+                        }
+                    }
+                }
+                SourceConfig::Http(cfg) => check_source!(cfg => HttpRemoteFile),
+                SourceConfig::S3(cfg) => check_source!(cfg => S3RemoteFile),
+                SourceConfig::Gcs(cfg) => check_source!(cfg => GcsRemoteFile),
+                SourceConfig::Filesystem(cfg) => check_source!(cfg => FilesystemRemoteFile),
+            }
+        }
+        remote_files
     }
 }
 
@@ -492,44 +520,6 @@ where
     }
 }
 
-/// Iterator to generate a list of [`SourceLocation`]s to attempt downloading.
-#[derive(Debug)]
-struct SourceLocationIter<'a> {
-    /// Limits search to a set of filetypes.
-    filetypes: std::slice::Iter<'a, FileType>,
-
-    /// Filters from a `SourceConfig` to limit the amount of generated paths.
-    filters: &'a SourceFilters,
-
-    /// Information about the object file to be downloaded.
-    object_id: &'a ObjectId,
-
-    /// Directory from `SourceConfig` to define what kind of paths we generate.
-    layout: DirectoryLayout,
-
-    /// Remaining locations to iterate.
-    next: Vec<String>,
-}
-
-impl Iterator for SourceLocationIter<'_> {
-    type Item = SourceLocation;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while self.next.is_empty() {
-            if let Some(&filetype) = self.filetypes.next() {
-                if !self.filters.is_allowed(self.object_id, filetype) {
-                    continue;
-                }
-                self.next = get_directory_paths(self.layout, filetype, self.object_id);
-            } else {
-                return None;
-            }
-        }
-
-        self.next.pop().map(SourceLocation::new)
-    }
-}
-
 /// Computes a download timeout based on a content length in bytes and a per-gigabyte timeout.
 ///
 /// Returns `content_length / 2^30 * timeout_per_gb`, with a minimum value of 10s.
@@ -543,7 +533,6 @@ mod tests {
     // Actual implementation is tested in the sub-modules, this only needs to
     // ensure the service interface works correctly.
 
-    use symbolic::common::{CodeId, DebugId, Uuid};
     use symbolicator_sources::{HttpRemoteFile, ObjectType, SourceConfig};
 
     use super::*;
@@ -598,9 +587,8 @@ mod tests {
         let config = Config::default();
         let svc = DownloadService::new(&config, tokio::runtime::Handle::current());
         let file_list = svc
-            .list_files(source.clone(), FileType::all(), &objid)
-            .await
-            .unwrap();
+            .list_files(&[source.clone()], FileType::all(), &objid)
+            .await;
 
         assert!(!file_list.is_empty());
         let item = &file_list[0];
@@ -625,36 +613,5 @@ mod tests {
 
         // 1.5 GB
         assert_eq!(timeout(one_gb * 3 / 2), timeout_per_gb.mul_f64(1.5));
-    }
-
-    #[test]
-    fn test_iter_elf() {
-        // Note that for ELF ObjectId *needs* to have the code_id set otherwise nothing is
-        // created.
-        let code_id = CodeId::new(String::from("abcdefghijklmnopqrstuvwxyz1234567890abcd"));
-        let uuid = Uuid::from_slice(&code_id.as_str().as_bytes()[..16]).unwrap();
-        let debug_id = DebugId::from_uuid(uuid);
-
-        let mut all: Vec<_> = SourceLocationIter {
-            filetypes: [FileType::ElfCode, FileType::ElfDebug].iter(),
-            filters: &Default::default(),
-            object_id: &ObjectId {
-                debug_id: Some(debug_id),
-                code_id: Some(code_id),
-                ..Default::default()
-            },
-            layout: Default::default(),
-            next: Default::default(),
-        }
-        .collect();
-        all.sort();
-
-        assert_eq!(
-            all,
-            [
-                SourceLocation::new("ab/cdef1234567890abcd"),
-                SourceLocation::new("ab/cdef1234567890abcd.debug")
-            ]
-        );
     }
 }

--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -1,7 +1,6 @@
 //! Support to download from sentry sources.
 //!
-//! Specifically this supports the [`SentrySourceConfig`] source, which allows
-//! to fetch files which were directly uploaded to Sentry itself.
+//! This allows to fetch files which were directly uploaded to Sentry itself.
 
 use std::fmt;
 use std::path::Path;


### PR DESCRIPTION
- Moves `SourceLocationIter` into `symbolicator-sources`.
- Probes all the sources in the `DownloadService`, avoiding a `join_all`.
- Clean up error handling for the `SentrySource`.
- Deduplicate per-source fetching and error handling in the bitcode / il2cpp service.

#skip-changelog