### PR TITLE
ref: Replace last `CacheStatus` usages with `CacheEntry`

### DIFF
--- a/crates/symbolicator-service/src/services/derived.rs
+++ b/crates/symbolicator-service/src/services/derived.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::cache::{cache_entry_as_cache_status, CacheEntry, CacheError, CacheStatus};
+use crate::cache::{CacheEntry, CacheError};
 use crate::services::objects::{FindResult, ObjectMetaHandle};
 use crate::types::{AllObjectCandidates, CandidateStatus, ObjectFeatures, ObjectUseInfo};
 
@@ -46,10 +46,17 @@ where
             // Fetch cache file from handle
             let derived_cache = derive(Arc::clone(&handle)).await;
 
-            let object_info = ObjectUseInfo::from_derived_status(
-                &cache_entry_as_cache_status(&derived_cache),
-                &CacheStatus::Positive,
-            );
+            let object_info = match &derived_cache {
+                Ok(_) => ObjectUseInfo::Ok,
+                // Edge cases where the original stopped being available
+                Err(CacheError::NotFound) => ObjectUseInfo::Error {
+                    details: String::from("Object file no longer available"),
+                },
+                Err(CacheError::Malformed(_)) => ObjectUseInfo::Malformed,
+                Err(e) => ObjectUseInfo::Error {
+                    details: e.to_string(),
+                },
+            };
             (derived_cache, object_info, handle.features())
         }
         Err(error) => {
@@ -62,10 +69,7 @@ where
                     // previously. we should probably decide on a better solution here.
                     ObjectUseInfo::None
                 }
-                error => {
-                    let status = error.as_cache_status();
-                    ObjectUseInfo::from_derived_status(&status, &status)
-                }
+                _ => ObjectUseInfo::Malformed,
             };
 
             (Err(error), object_info, Default::default())

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -23,7 +23,7 @@ pub use symbolicator_sources::{
     SourceFilters, SourceLocation,
 };
 
-use crate::cache::{CacheError, CacheStatus};
+use crate::cache::CacheError;
 use crate::config::{CacheConfigs, Config, InMemoryCacheConfig};
 use crate::utils::futures::{self as future_utils, m, measure, CancelOnDrop};
 use crate::utils::sentry::ConfigureScope;
@@ -127,39 +127,6 @@ impl From<DownloadError> for CacheError {
             DownloadError::Permissions => Self::PermissionDenied(String::new()),
             DownloadError::Rejected(status_code) => Self::DownloadError(status_code.to_string()),
             _ => Self::from_std_error(error),
-        }
-    }
-}
-
-impl DownloadError {
-    /// This produces a user-facing string representation of a download error if it is a variant
-    /// that needs to be stored as a [`CacheStatus::CacheSpecificError`] entry in the download cache.
-    pub fn for_cache(&self) -> String {
-        match self {
-            DownloadError::Gcs(inner) => format!("{self}: {inner}"),
-            DownloadError::Sentry(inner) => format!("{self}: {inner}"),
-            DownloadError::S3(inner) => format!("{self}: {inner}"),
-            DownloadError::Permissions => self.to_string(),
-            DownloadError::CachedError(original_message) => original_message.clone(),
-            _ => format!("{self}"),
-        }
-    }
-
-    /// If a given cache entry is [`CacheStatus::CacheSpecificError`], this parses and extracts its
-    /// contents into a [`DownloadError`]. This will return none if a
-    /// non-[`CacheStatus::CacheSpecificError`] is provided.
-    pub fn from_cache(status: &CacheStatus) -> Option<Self> {
-        match status {
-            CacheStatus::Positive => None,
-            CacheStatus::Negative => None,
-            CacheStatus::Malformed(_) => None,
-            CacheStatus::CacheSpecificError(message) => {
-                if message.starts_with(&Self::Permissions.to_string()) {
-                    Some(Self::Permissions)
-                } else {
-                    Some(Self::CachedError(message.clone()))
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Teaches the `CacheError` to read and write legacy markers, and replace all former usages of `CacheStatus`.

#skip-changelog