### PR TITLE
ref: Remove `DownloadError` in favor of `CacheError`

### DIFF
--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -192,7 +192,7 @@ impl CacheError {
 
 /// An entry in a cache, containing either `Ok(T)` or an error denoting the reason why an
 /// object could not be fetched or is otherwise unusable.
-pub type CacheEntry<T> = Result<T, CacheError>;
+pub type CacheEntry<T = ()> = Result<T, CacheError>;
 
 /// Parses a [`CacheEntry`] from a [`ByteView`](ByteView).
 pub fn cache_entry_from_bytes(bytes: ByteView<'static>) -> CacheEntry<ByteView<'static>> {

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -196,7 +196,7 @@ impl CfiCacheActor {
 /// The source file is probably an executable or so, the resulting file is in the format of
 /// [`CfiCache`].
 #[tracing::instrument(skip_all)]
-fn write_cficache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry<()> {
+fn write_cficache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry {
     object_handle.configure_scope();
 
     tracing::debug!("Converting cficache for {}", object_handle.cache_key);

--- a/crates/symbolicator-service/src/services/derived.rs
+++ b/crates/symbolicator-service/src/services/derived.rs
@@ -65,8 +65,9 @@ where
                 | CacheError::PermissionDenied(_)
                 | CacheError::Timeout(_)
                 | CacheError::DownloadError(_) => {
-                    // FIXME(swatinem): all the download errors so far lead to `None`
-                    // previously. we should probably decide on a better solution here.
+                    // NOTE: all download related errors are already exposed as the candidates
+                    // `ObjectDownloadInfo`. It is not necessary to duplicate that into the
+                    // `ObjectUseInfo`.
                     ObjectUseInfo::None
                 }
                 _ => ObjectUseInfo::Malformed,

--- a/crates/symbolicator-service/src/services/download/filesystem.rs
+++ b/crates/symbolicator-service/src/services/download/filesystem.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 
 use symbolicator_sources::FilesystemRemoteFile;
 
-use super::{DownloadError, DownloadStatus};
+use crate::cache::{CacheEntry, CacheError};
 
 /// Downloader implementation that supports the filesystem source.
 #[derive(Debug)]
@@ -25,16 +25,17 @@ impl FilesystemDownloader {
         &self,
         file_source: FilesystemRemoteFile,
         dest: &Path,
-    ) -> Result<DownloadStatus<()>, DownloadError> {
+    ) -> CacheEntry {
         // All file I/O in this function is blocking!
         let abspath = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", abspath);
-        match fs::copy(abspath, dest).await {
-            Ok(_) => Ok(DownloadStatus::Completed(())),
-            Err(e) => match e.kind() {
-                io::ErrorKind::NotFound => Ok(DownloadStatus::NotFound),
-                _ => Err(DownloadError::Io(e)),
-            },
-        }
+
+        fs::copy(abspath, dest)
+            .await
+            .map(|_| ())
+            .map_err(|e| match e.kind() {
+                io::ErrorKind::NotFound => CacheError::NotFound,
+                _ => e.into(),
+            })
     }
 }

--- a/crates/symbolicator-service/src/services/download/gcs.rs
+++ b/crates/symbolicator-service/src/services/download/gcs.rs
@@ -2,17 +2,12 @@
 
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::sync::Arc;
-
-use futures::prelude::*;
-use parking_lot::Mutex;
-use reqwest::{header, Client, StatusCode};
+use std::sync::{Arc, Mutex};
 
 use symbolicator_sources::{GcsRemoteFile, GcsSourceKey, RemoteFile};
 
-use crate::utils::gcs::{self, request_new_token, GcsError, GcsToken};
-
-use super::{content_length_timeout, DownloadError, DownloadStatus};
+use crate::cache::CacheEntry;
+use crate::utils::gcs::{self, GcsError, GcsToken};
 
 /// An LRU cache for GCS OAuth tokens.
 type GcsTokenCache = lru::LruCache<Arc<GcsSourceKey>, Arc<GcsToken>>;
@@ -28,7 +23,7 @@ pub struct GcsDownloader {
 
 impl GcsDownloader {
     pub fn new(
-        client: Client,
+        client: reqwest::Client,
         connect_timeout: std::time::Duration,
         streaming_timeout: std::time::Duration,
         token_capacity: NonZeroUsize,
@@ -46,7 +41,7 @@ impl GcsDownloader {
     /// If the cache contains a valid token, then this token is returned. Otherwise, a new token is
     /// requested from GCS and stored in the cache.
     async fn get_token(&self, source_key: &Arc<GcsSourceKey>) -> Result<Arc<GcsToken>, GcsError> {
-        if let Some(token) = self.token_cache.lock().get(source_key) {
+        if let Some(token) = self.token_cache.lock().unwrap().get(source_key) {
             if !token.is_expired() {
                 metric!(counter("source.gcs.token.cached") += 1);
                 return Ok(token.clone());
@@ -54,25 +49,22 @@ impl GcsDownloader {
         }
 
         let source_key = source_key.clone();
-        let token = request_new_token(&self.client, &source_key).await?;
+        let token = gcs::request_new_token(&self.client, &source_key).await?;
         metric!(counter("source.gcs.token.requests") += 1);
         let token = Arc::new(token);
-        self.token_cache.lock().put(source_key, token.clone());
+        self.token_cache
+            .lock()
+            .unwrap()
+            .put(source_key, token.clone());
         Ok(token)
     }
 
     /// Downloads a source hosted on GCS.
-    ///
-    /// # Directly thrown errors
-    /// - [`GcsError::InvalidUrl`]
-    /// - [`DownloadError::Reqwest`]
-    /// - [`DownloadError::Rejected`]
-    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: GcsRemoteFile,
         destination: &Path,
-    ) -> Result<DownloadStatus<()>, DownloadError> {
+    ) -> CacheEntry {
         let key = file_source.key();
         let bucket = file_source.source.bucket.clone();
         tracing::debug!("Fetching from GCS: {} (from {})", &key, bucket);
@@ -85,66 +77,16 @@ impl GcsDownloader {
         let request = self
             .client
             .get(url.clone())
-            .header("authorization", token.bearer_token())
-            .send();
-        let request = tokio::time::timeout(self.connect_timeout, request);
-        let request = super::measure_download_time(source.source_metric_key(), request);
+            .header("authorization", token.bearer_token());
 
-        let response = request
-            .await
-            .map_err(|_| DownloadError::Canceled)? // Timeout
-            .map_err(|e| {
-                tracing::debug!(
-                    "Skipping response from GCS {} (from {}): {}",
-                    &key,
-                    &bucket,
-                    &e
-                );
-                DownloadError::Reqwest(e)
-            })?;
-
-        if response.status().is_success() {
-            tracing::trace!("Success hitting GCS {} (from {})", &key, bucket);
-
-            let content_length = response
-                .headers()
-                .get(header::CONTENT_LENGTH)
-                .and_then(|hv| hv.to_str().ok())
-                .and_then(|s| s.parse::<i64>().ok());
-
-            let timeout =
-                content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
-            let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
-
-            super::download_stream(&source, stream, destination, timeout).await
-        } else if matches!(
-            response.status(),
-            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
-        ) {
-            tracing::debug!(
-                "Insufficient permissions to download from GCS {} (from {})",
-                &key,
-                &bucket,
-            );
-            Ok(DownloadStatus::PermissionDenied)
-        // If it's a client error, chances are either it's a 404 or it's permission-related.
-        } else if response.status().is_client_error() {
-            tracing::debug!(
-                "Unexpected client error status code from GCS {} (from {}): {}",
-                &key,
-                &bucket,
-                response.status()
-            );
-            Ok(DownloadStatus::NotFound)
-        } else {
-            tracing::debug!(
-                "Unexpected status code from GCS {} (from {}): {}",
-                &key,
-                &bucket,
-                response.status()
-            );
-            Err(DownloadError::Rejected(response.status()))
-        }
+        super::download_reqwest(
+            &source,
+            request,
+            self.connect_timeout,
+            self.streaming_timeout,
+            destination,
+        )
+        .await
     }
 }
 
@@ -157,8 +99,10 @@ mod tests {
         SourceLocation,
     };
 
+    use crate::cache::CacheError;
     use crate::test;
 
+    use reqwest::Client;
     use sha1::{Digest as _, Sha1};
 
     fn gcs_source(source_key: GcsSourceKey) -> Arc<GcsSourceConfig> {
@@ -190,12 +134,9 @@ mod tests {
         let source_location = SourceLocation::new("e5/14c9464eed3be5943a2c61d9241fad/executable");
         let file_source = GcsRemoteFile::new(source, source_location);
 
-        let download_status = downloader
-            .download_source(file_source, &target_path)
-            .await
-            .unwrap();
+        let download_status = downloader.download_source(file_source, &target_path).await;
 
-        assert!(matches!(download_status, DownloadStatus::Completed(_)));
+        assert!(download_status.is_ok());
         assert!(target_path.exists());
 
         let hash = Sha1::digest(std::fs::read(target_path).unwrap());
@@ -221,12 +162,9 @@ mod tests {
         let source_location = SourceLocation::new("does/not/exist");
         let file_source = GcsRemoteFile::new(source, source_location);
 
-        let download_status = downloader
-            .download_source(file_source, &target_path)
-            .await
-            .unwrap();
+        let download_status = downloader.download_source(file_source, &target_path).await;
 
-        assert!(matches!(download_status, DownloadStatus::NotFound));
+        assert_eq!(download_status, Err(CacheError::NotFound));
         assert!(!target_path.exists());
     }
 

--- a/crates/symbolicator-service/src/services/download/http.rs
+++ b/crates/symbolicator-service/src/services/download/http.rs
@@ -3,13 +3,13 @@
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::Result;
-use futures::prelude::*;
-use reqwest::{header, Client, StatusCode};
+use reqwest::{header, Client};
 
 use symbolicator_sources::{HttpRemoteFile, RemoteFile};
 
-use super::{content_length_timeout, DownloadError, DownloadStatus, USER_AGENT};
+use crate::cache::{CacheEntry, CacheError};
+
+use super::USER_AGENT;
 
 /// Downloader implementation that supports the HTTP source.
 #[derive(Debug)]
@@ -29,20 +29,12 @@ impl HttpDownloader {
     }
 
     /// Downloads a source hosted on an HTTP server.
-    ///
-    /// # Directly thrown errors
-    /// - [`DownloadError::Reqwest`]
-    /// - [`DownloadError::Rejected`]
-    /// - [`DownloadError::Canceled`]
     pub async fn download_source(
         &self,
         file_source: HttpRemoteFile,
         destination: &Path,
-    ) -> Result<DownloadStatus<()>, DownloadError> {
-        let download_url = match file_source.url() {
-            Ok(x) => x,
-            Err(_) => return Ok(DownloadStatus::NotFound),
-        };
+    ) -> CacheEntry {
+        let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 
         tracing::debug!("Fetching debug file from {}", download_url);
         let mut builder = self.client.get(download_url.clone());
@@ -53,55 +45,16 @@ impl HttpDownloader {
             }
         }
         let source = RemoteFile::from(file_source);
-        let request = builder.header(header::USER_AGENT, USER_AGENT).send();
-        let request = tokio::time::timeout(self.connect_timeout, request);
-        let request = super::measure_download_time(source.source_metric_key(), request);
+        let request = builder.header(header::USER_AGENT, USER_AGENT);
 
-        let response = request
-            .await
-            .map_err(|_| DownloadError::Canceled)? // Timeout
-            .map_err(|e| {
-                tracing::debug!("Skipping response from {}: {}", download_url, e);
-                DownloadError::Reqwest(e)
-            })?;
-
-        if response.status().is_success() {
-            tracing::trace!("Success hitting {}", download_url);
-
-            let content_length = response
-                .headers()
-                .get(header::CONTENT_LENGTH)
-                .and_then(|hv| hv.to_str().ok())
-                .and_then(|s| s.parse::<i64>().ok());
-
-            let timeout =
-                content_length.map(|cl| content_length_timeout(cl, self.streaming_timeout));
-
-            let stream = response.bytes_stream().map_err(DownloadError::Reqwest);
-
-            super::download_stream(&source, stream, destination, timeout).await
-        } else if matches!(
-            response.status(),
-            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
-        ) {
-            tracing::debug!("Insufficient permissions to download from {}", download_url);
-            Ok(DownloadStatus::PermissionDenied)
-        // If it's a client error, chances are either it's a 404 or it's permission-related.
-        } else if response.status().is_client_error() {
-            tracing::debug!(
-                "Unexpected client error status code from {}: {}",
-                download_url,
-                response.status()
-            );
-            Ok(DownloadStatus::NotFound)
-        } else {
-            tracing::debug!(
-                "Unexpected status code from {}: {}",
-                download_url,
-                response.status()
-            );
-            Err(DownloadError::Rejected(response.status()))
-        }
+        super::download_reqwest(
+            &source,
+            request,
+            self.connect_timeout,
+            self.streaming_timeout,
+            destination,
+        )
+        .await
     }
 }
 
@@ -133,9 +86,9 @@ mod tests {
             Duration::from_secs(30),
             Duration::from_secs(30),
         );
-        let download_status = downloader.download_source(file_source, dest).await.unwrap();
+        let download_status = downloader.download_source(file_source, dest).await;
 
-        assert!(matches!(download_status, DownloadStatus::Completed(_)));
+        assert!(download_status.is_ok());
 
         let content = std::fs::read_to_string(dest).unwrap();
         assert_eq!(content, "hello world\n");
@@ -161,8 +114,8 @@ mod tests {
             Duration::from_secs(30),
             Duration::from_secs(30),
         );
-        let download_status = downloader.download_source(file_source, dest).await.unwrap();
+        let download_status = downloader.download_source(file_source, dest).await;
 
-        assert!(matches!(download_status, DownloadStatus::NotFound));
+        assert_eq!(download_status, Err(CacheError::NotFound));
     }
 }

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -10,11 +10,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ::sentry::SentryFutureExt;
-use aws_smithy_http;
 use futures::prelude::*;
 use reqwest::StatusCode;
 use tempfile::NamedTempFile;
-use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
@@ -26,9 +24,10 @@ use symbolicator_sources::{
     FilesystemRemoteFile, GcsRemoteFile, HttpRemoteFile, S3RemoteFile, SourceLocationIter,
 };
 
-use crate::cache::CacheError;
+use crate::cache::{CacheEntry, CacheError};
 use crate::config::{CacheConfigs, Config, InMemoryCacheConfig};
-use crate::utils::futures::{self as future_utils, m, measure, CancelOnDrop};
+use crate::utils::futures::{m, measure, CancelOnDrop};
+use crate::utils::gcs::GcsError;
 use crate::utils::sentry::ConfigureScope;
 
 mod filesystem;
@@ -49,100 +48,37 @@ impl ConfigureScope for RemoteFile {
 /// HTTP User-Agent string to use.
 const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
 
-/// Errors happening while downloading from sources.
-#[derive(Debug, Error)]
-pub enum DownloadError {
-    #[error("failed to perform an IO operation")]
-    Io(#[source] std::io::Error),
-    #[error("failed to stream file")]
-    Reqwest(#[source] reqwest::Error),
-    #[error("bad file destination")]
-    BadDestination(#[source] std::io::Error),
-    #[error("failed writing the downloaded file")]
-    Write(#[source] std::io::Error),
-    #[error("download was cancelled")]
-    Canceled,
-    #[error("failed to fetch data from GCS")]
-    Gcs(#[from] crate::utils::gcs::GcsError),
-    #[error("failed to fetch data from Sentry")]
-    Sentry(sentry::SentryError),
-    #[error("failed to fetch data from S3")]
-    S3(#[from] s3::S3Error),
-    #[error("failed to fetch data from S3")]
-    S3Stream(#[from] aws_smithy_http::byte_stream::error::Error),
-    #[error("missing permissions for file")]
-    Permissions,
-    /// Typically means the initial HEAD request received a non-200, non-400 response.
-    #[error("failed to download: {0}")]
-    Rejected(StatusCode),
-    #[error("failed to fetch object: {0}")]
-    CachedError(String),
-}
-
-impl From<sentry::SentryError> for DownloadError {
-    fn from(err: sentry::SentryError) -> Self {
-        if matches!(
-            err,
-            sentry::SentryError::BadStatusCode(StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED)
-        ) {
-            DownloadError::Permissions
-        } else {
-            DownloadError::Sentry(err)
+impl CacheError {
+    fn download_error(mut error: &dyn Error) -> Self {
+        while let Some(src) = error.source() {
+            error = src;
         }
+
+        let mut error_string = error.to_string();
+
+        // Special-case a few error strings
+        if error_string.contains("certificate verify failed") {
+            error_string = "certificate verify failed".to_string();
+        }
+
+        if error_string.contains("SSL routines") {
+            error_string = "SSL error".to_string();
+        }
+
+        Self::DownloadError(error_string)
     }
 }
 
-impl From<DownloadError> for CacheError {
-    fn from(error: DownloadError) -> Self {
-        match error {
-            DownloadError::Reqwest(e) => {
-                let mut innermost: &dyn Error = &e;
-                while let Some(src) = innermost.source() {
-                    innermost = src;
-                }
-
-                let mut error_string = innermost.to_string();
-
-                // Special-case a few error strings
-                if error_string.contains("certificate verify failed") {
-                    error_string = "certificate verify failed".to_string();
-                }
-
-                if error_string.contains("SSL routines") {
-                    error_string = "SSL error".to_string();
-                }
-
-                Self::DownloadError(error_string)
-            }
-            DownloadError::Canceled => Self::Timeout(Duration::default()),
-            DownloadError::Gcs(e) => {
-                Self::DownloadError(format!("failed to fetch data from GCS: {e}"))
-            }
-            DownloadError::Sentry(e) => {
-                Self::DownloadError(format!("failed to fetch data from Sentry: {e}"))
-            }
-            DownloadError::S3(e) => {
-                Self::DownloadError(format!("failed to fetch data from S3: {e}"))
-            }
-            DownloadError::S3Stream(e) => {
-                Self::DownloadError(format!("failed to fetch data from S3: {e}"))
-            }
-            DownloadError::Permissions => Self::PermissionDenied(String::new()),
-            DownloadError::Rejected(status_code) => Self::DownloadError(status_code.to_string()),
-            _ => Self::from_std_error(error),
-        }
+impl From<reqwest::Error> for CacheError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::download_error(&error)
     }
 }
 
-/// Completion status of a successful download request.
-#[derive(Debug)]
-pub enum DownloadStatus<T> {
-    /// The download completed successfully and the file at the path can be used.
-    Completed(T),
-    /// The requested file was not found.
-    NotFound,
-    /// Not enough permissions to download the file.
-    PermissionDenied,
+impl From<GcsError> for CacheError {
+    fn from(error: GcsError) -> Self {
+        Self::DownloadError(error.to_string())
+    }
 }
 
 /// A service which can download files from a [`SourceConfig`].
@@ -204,10 +140,10 @@ impl DownloadService {
         &self,
         source: &RemoteFile,
         temp_file: NamedTempFile,
-    ) -> Result<DownloadStatus<NamedTempFile>, DownloadError> {
+    ) -> CacheEntry<NamedTempFile> {
         let destination = temp_file.path();
 
-        let result = future_utils::retry(|| async {
+        let result = retry(|| async {
             match source {
                 RemoteFile::Sentry(inner) => {
                     self.sentry
@@ -228,21 +164,12 @@ impl DownloadService {
         });
 
         match result.await {
-            Ok(DownloadStatus::Completed(_)) => {
-                tracing::debug!("Fetched debug file from {}", source);
-                Ok(DownloadStatus::Completed(temp_file))
-            }
-            Ok(DownloadStatus::NotFound) => {
-                tracing::debug!("Debug file not found at {}", source);
-                Ok(DownloadStatus::NotFound)
-            }
-            Ok(DownloadStatus::PermissionDenied) => {
-                tracing::debug!("No permissions to fetch file from {}", source);
-                // FIXME: downstream users still expect these to be errors
-                Err(DownloadError::Permissions)
+            Ok(_) => {
+                tracing::debug!("File `{}` fetched successfully", source);
+                Ok(temp_file)
             }
             Err(err) => {
-                tracing::debug!("Failed to fetch debug file from {}: {}", source, err);
+                tracing::debug!("File `{}` fetching failed: {}", source, err);
                 Err(err)
             }
         }
@@ -259,17 +186,16 @@ impl DownloadService {
         self: Arc<Self>,
         source: RemoteFile,
         destination: NamedTempFile,
-    ) -> Result<DownloadStatus<NamedTempFile>, DownloadError> {
+    ) -> CacheEntry<NamedTempFile> {
         let slf = self.clone();
         let job = async move { slf.dispatch_download(&source, destination).await };
         let job = CancelOnDrop::new(self.runtime.spawn(job.bind_hub(::sentry::Hub::current())));
         let job = tokio::time::timeout(self.max_download_timeout, job);
         let job = measure("service.download", m::timed_result, None, job);
 
-        match job.await {
-            Ok(Ok(result)) => result,
-            _ => Err(DownloadError::Canceled),
-        }
+        job.await
+            .map_err(|_| CacheError::Timeout(self.max_download_timeout))? // Timeout
+            .map_err(|_| CacheError::InternalError)? // Spawn error
     }
 
     /// Returns all objects matching the [`ObjectId`] at the source.
@@ -278,7 +204,7 @@ impl DownloadService {
     /// download attempt should be made without any guarantee the object is actually there.
     ///
     /// If the source needs to be contacted to get matching objects this may fail and
-    /// returns a [`DownloadError`].
+    /// returns a [`CacheError`].
     ///
     /// Note that the `filetypes` argument is not more then a hint, not all source types
     /// will respect this and they may return all DIFs matching the `object_id`.  After
@@ -308,10 +234,11 @@ impl DownloadService {
             match source {
                 SourceConfig::Sentry(cfg) => {
                     let job = self.sentry.list_files(cfg.clone(), object_id, filetypes);
-                    let job = tokio::time::timeout(Duration::from_secs(30), job);
+                    let timeout = Duration::from_secs(30);
+                    let job = tokio::time::timeout(timeout, job);
                     let job = measure("service.download.list_files", m::timed_result, None, job);
 
-                    let sentry_files = job.await.map_err(|_| DownloadError::Canceled);
+                    let sentry_files = job.await.map_err(|_| CacheError::Timeout(timeout));
                     match sentry_files {
                         Ok(Ok(files)) => remote_files.extend(files),
                         Ok(Err(error)) | Err(error) => {
@@ -331,36 +258,54 @@ impl DownloadService {
     }
 }
 
+/// Try to run a future up to 3 times with 20 millisecond delays on failure.
+pub async fn retry<G, F, T>(mut task_gen: G) -> CacheEntry<T>
+where
+    G: FnMut() -> F,
+    F: Future<Output = CacheEntry<T>>,
+{
+    let mut tries = 0;
+    loop {
+        tries += 1;
+        let result = task_gen().await;
+
+        // its highly unlikely we get a different result when retrying these
+        let should_not_retry = matches!(
+            result,
+            Ok(_) | Err(CacheError::NotFound | CacheError::PermissionDenied(_))
+        );
+
+        if should_not_retry || tries >= 3 {
+            break result;
+        }
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 /// Download the source from a stream.
 ///
 /// This is common functionality used by many downloaders.
-///
-/// # Errors
-/// - [`DownloadError::BadDestination`]
-/// - [`DownloadError::Write`]
-/// - [`DownloadError::Canceled`]
 async fn download_stream(
     source: &RemoteFile,
-    stream: impl Stream<Item = Result<impl AsRef<[u8]>, DownloadError>>,
+    stream: impl Stream<Item = Result<impl AsRef<[u8]>, CacheError>>,
     destination: &Path,
     timeout: Option<Duration>,
-) -> Result<DownloadStatus<()>, DownloadError> {
+) -> CacheEntry {
     // All file I/O in this function is blocking!
     tracing::trace!("Downloading from {}", source);
     let future = async {
-        let mut file = File::create(destination)
-            .await
-            .map_err(DownloadError::BadDestination)?;
+        let mut file = File::create(destination).await?;
         futures::pin_mut!(stream);
 
         let mut throughput_recorder =
             MeasureSourceDownloadGuard::new("source.download.stream", source.source_metric_key());
-        let result: Result<_, DownloadError> = async {
+        let result: CacheEntry = async {
             while let Some(chunk) = stream.next().await {
                 let chunk = chunk?;
                 let chunk = chunk.as_ref();
                 throughput_recorder.add_bytes_transferred(chunk.len() as u64);
-                file.write_all(chunk).await.map_err(DownloadError::Write)?;
+                file.write_all(chunk).await?;
             }
             Ok(())
         }
@@ -368,15 +313,73 @@ async fn download_stream(
         throughput_recorder.done(&result);
         result?;
 
-        file.flush().await.map_err(DownloadError::Write)?;
-        Ok(DownloadStatus::Completed(()))
+        file.flush().await?;
+        Ok(())
     };
 
     match timeout {
         Some(timeout) => tokio::time::timeout(timeout, future)
             .await
-            .map_err(|_| DownloadError::Canceled)?,
+            .map_err(|_| CacheError::Timeout(timeout))?,
         None => future.await,
+    }
+}
+
+async fn download_reqwest(
+    source: &RemoteFile,
+    builder: reqwest::RequestBuilder,
+    connect_timeout: Duration,
+    streaming_timeout: Duration,
+    destination: &Path,
+) -> CacheEntry {
+    let request = builder.send();
+
+    let request = tokio::time::timeout(connect_timeout, request);
+    let request = measure_download_time(source.source_metric_key(), request);
+
+    let timeout_err = CacheError::Timeout(connect_timeout);
+    let response = request.await.map_err(|_| timeout_err)??;
+
+    let status = response.status();
+    if status.is_success() {
+        tracing::trace!("Success hitting `{}`", source);
+
+        let content_length = response
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|hv| hv.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok());
+
+        let timeout = content_length.map(|cl| content_length_timeout(cl, streaming_timeout));
+        let stream = response.bytes_stream().map_err(CacheError::from);
+
+        download_stream(source, stream, destination, timeout).await
+    } else if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
+        tracing::debug!(
+            "Insufficient permissions to download `{}`: {}",
+            source,
+            status
+        );
+
+        // TODO: figure out if we can log/return the whole response text
+        // let details = response.text().await?;
+        let details = status.to_string();
+
+        Err(CacheError::PermissionDenied(details))
+        // If it's a client error, chances are it's a 404.
+    } else if status.is_client_error() {
+        tracing::debug!(
+            "Unexpected client error status code from `{}`: {}",
+            source,
+            status
+        );
+
+        Err(CacheError::NotFound)
+    } else {
+        tracing::debug!("Unexpected status code from `{}`: {}", source, status);
+
+        let details = status.to_string();
+        Err(CacheError::DownloadError(details))
     }
 }
 
@@ -531,7 +534,7 @@ mod tests {
             .download(file_source, tempfile::NamedTempFile::new().unwrap())
             .await
         {
-            Ok(DownloadStatus::Completed(temp_file)) => {
+            Ok(temp_file) => {
                 let content = std::fs::read_to_string(temp_file.path()).unwrap();
                 assert_eq!(content, "hello world\n")
             }

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -177,7 +177,7 @@ impl CacheItemRequest for FetchPortablePdbCacheInternal {
 ///
 /// It is assumed that the `object_handle` contains a positive cache.
 #[tracing::instrument(skip_all)]
-fn write_ppdb_cache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry<()> {
+fn write_ppdb_cache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry {
     object_handle.configure_scope();
 
     let ppdb_obj = match object_handle.object() {

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -277,7 +277,7 @@ fn write_symcache(
     file: &mut File,
     object_handle: &ObjectHandle,
     secondary_sources: SecondarySymCacheSources,
-) -> CacheEntry<()> {
+) -> CacheEntry {
     object_handle.configure_scope();
 
     let symbolic_object = object_handle.object();

--- a/crates/symbolicator-service/src/utils/futures.rs
+++ b/crates/symbolicator-service/src/utils/futures.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::future::Future;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use tokio::task::JoinHandle;
 
@@ -213,23 +213,5 @@ pub mod m {
             Ok(inner) => self::result(inner),
             Err(_) => "timeout",
         }
-    }
-}
-
-/// Try to run a future up to 3 times with 20 millisecond delays on failure.
-pub async fn retry<G, F, T, E>(mut task_gen: G) -> Result<T, E>
-where
-    G: FnMut() -> F,
-    F: Future<Output = Result<T, E>>,
-{
-    let mut tries = 0;
-    loop {
-        tries += 1;
-        let result = task_gen().await;
-        if result.is_ok() || tries >= 3 {
-            break result;
-        }
-
-        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -190,7 +190,9 @@ async fn test_no_permission() {
     assert_eq!(candidates[1].source, SourceId::new("forbidden"));
     assert_eq!(
         candidates[1].download,
-        ObjectDownloadInfo::NoPerm { details: "".into() }
+        ObjectDownloadInfo::NoPerm {
+            details: "403 Forbidden".into()
+        }
     );
 
     assert_eq!(candidates[3].source, SourceId::new("invalid-gcs"));
@@ -202,7 +204,7 @@ async fn test_no_permission() {
     assert_eq!(
         candidates[3].download,
         ObjectDownloadInfo::Error {
-            details: "download failed: failed to fetch data from GCS: failed encoding JWT".into()
+            details: "download failed: failed encoding JWT".into()
         }
     );
 
@@ -213,7 +215,7 @@ async fn test_no_permission() {
     );
     assert_eq!(
         candidates[5].download,
-        ObjectDownloadInfo::NoPerm { details: "".into() }
+        ObjectDownloadInfo::NoPerm { details: "The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.".into() }
     );
 }
 

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -37,7 +37,7 @@ async fn test_download_errors() {
     };
 
     // NOTE: we run requests twice to make sure that round-trips through the cache give us the same results.
-    for _ in 0..2 {
+    for i in 0..2 {
         // NOTE: we try this 3 times on error
         let source = hitcounter.source("rejected", "/respond_statuscode/500/");
         let request = get_symbolication_request(vec![source]);
@@ -48,7 +48,7 @@ async fn test_download_errors() {
             (
                 FrameStatus::Missing,
                 ObjectFileStatus::FetchingFailed,
-                ObjectUseInfo::None, // FIXME: should this be an error?
+                ObjectUseInfo::None,
                 ObjectDownloadInfo::Error {
                     details: "download failed: 500 Internal Server Error".into()
                 }
@@ -65,7 +65,7 @@ async fn test_download_errors() {
             (
                 FrameStatus::Missing,
                 ObjectFileStatus::Timeout,
-                ObjectUseInfo::None, // FIXME: should this be an error?
+                ObjectUseInfo::None,
                 ObjectDownloadInfo::Error {
                     details: "download timed out".into()
                 }
@@ -81,7 +81,7 @@ async fn test_download_errors() {
             (
                 FrameStatus::Missing,
                 ObjectFileStatus::Missing,
-                ObjectUseInfo::None, // FIXME: should this be an error?
+                ObjectUseInfo::None,
                 ObjectDownloadInfo::NotFound
             )
         );
@@ -95,8 +95,16 @@ async fn test_download_errors() {
             (
                 FrameStatus::Missing,
                 ObjectFileStatus::FetchingFailed,
-                ObjectUseInfo::None, // FIXME: should this be an error?
-                ObjectDownloadInfo::NoPerm { details: "".into() }
+                ObjectUseInfo::None,
+                ObjectDownloadInfo::NoPerm {
+                    // FIXME: We are currently serializing `CacheError` in "legacy" mode that does
+                    // not support details
+                    details: if i == 0 {
+                        "403 Forbidden".into()
+                    } else {
+                        "".into()
+                    }
+                }
             )
         );
 


### PR DESCRIPTION
Also deduplicates a bunch of downloader code that matches on response statuses.

Fixes https://github.com/getsentry/symbolicator/issues/930.

#skip-changelog