### PR TITLE
ref: Make the cacher work with a `&mut NamedTempFile`

### DIFF
--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -56,8 +56,8 @@ impl FetchFileRequest {
     /// Downloads the file and saves it to `path`.
     ///
     /// Actual implementation of [`FetchFileRequest::compute`].
-    async fn fetch_file(self, temp_file: NamedTempFile) -> CacheEntry<NamedTempFile> {
-        let temp_file = fetch_file(self.download_svc, self.file_source, temp_file).await?;
+    async fn fetch_file(self, temp_file: &mut NamedTempFile) -> CacheEntry {
+        fetch_file(self.download_svc, self.file_source, temp_file).await?;
 
         let view = ByteView::map_file_ref(temp_file.as_file())?;
 
@@ -67,7 +67,7 @@ impl FetchFileRequest {
             return Err(CacheError::Malformed("Failed to parse il2cpp".to_string()));
         }
 
-        Ok(temp_file)
+        Ok(())
     }
 }
 
@@ -84,7 +84,7 @@ impl CacheItemRequest for FetchFileRequest {
     /// Downloads a file, writing it to `path`.
     ///
     /// Only when [`Ok`] is returned is the data written to `path` used.
-    fn compute(&self, temp_file: NamedTempFile) -> BoxFuture<'static, CacheEntry<NamedTempFile>> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         let fut = self.clone().fetch_file(temp_file).bind_hub(Hub::current());
 
         let source_name = self.file_source.source_type_name().into();

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -131,16 +131,14 @@ struct FetchSymCacheInternal {
 /// code.
 #[tracing::instrument(name = "compute_symcache", skip_all)]
 async fn fetch_difs_and_compute_symcache(
-    mut temp_file: NamedTempFile,
+    temp_file: &mut NamedTempFile,
+    objects_actor: &ObjectsActor,
     object_meta: Arc<ObjectMetaHandle>,
-    objects_actor: ObjectsActor,
     secondary_sources: SecondarySymCacheSources,
-) -> CacheEntry<NamedTempFile> {
+) -> CacheEntry {
     let object_handle = objects_actor.fetch(object_meta.clone()).await?;
 
-    write_symcache(temp_file.as_file_mut(), &object_handle, secondary_sources)?;
-
-    Ok(temp_file)
+    write_symcache(temp_file.as_file_mut(), &object_handle, secondary_sources)
 }
 
 impl CacheItemRequest for FetchSymCacheInternal {
@@ -152,11 +150,11 @@ impl CacheItemRequest for FetchSymCacheInternal {
         self.object_meta.cache_key()
     }
 
-    fn compute(&self, temp_file: NamedTempFile) -> BoxFuture<'static, CacheEntry<NamedTempFile>> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         let future = fetch_difs_and_compute_symcache(
             temp_file,
+            &self.objects_actor,
             self.object_meta.clone(),
-            self.objects_actor.clone(),
             self.secondary_sources.clone(),
         );
 

--- a/crates/symbolicator-service/src/utils/compression.rs
+++ b/crates/symbolicator-service/src/utils/compression.rs
@@ -9,9 +9,8 @@ use tempfile::NamedTempFile;
 /// Some compression methods are implemented by spawning an external tool and can only
 /// process from a named pathname, hence we need a [`NamedTempFile`] as source.
 ///
-/// On success, this will return the [`NamedTempFile`] with the decompressed file contents. This
-/// can either be the original temp file if it was already uncompressed, or a new temp file in the
-/// same directory if decompression was performed.
+/// The passed [`NamedTempFile`] might be swapped with a fresh one in case decompression happens.
+/// That new temp file will be created in the same directory as the original one.
 pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
     // Ensure that both meta data and file contents are available to the
     // subsequent reads of the file metadata and reads from other threads.

--- a/crates/symbolicator-service/src/utils/compression.rs
+++ b/crates/symbolicator-service/src/utils/compression.rs
@@ -12,7 +12,7 @@ use tempfile::NamedTempFile;
 /// On success, this will return the [`NamedTempFile`] with the decompressed file contents. This
 /// can either be the original temp file if it was already uncompressed, or a new temp file in the
 /// same directory if decompression was performed.
-pub fn maybe_decompress_file(src: NamedTempFile) -> io::Result<NamedTempFile> {
+pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
     // Ensure that both meta data and file contents are available to the
     // subsequent reads of the file metadata and reads from other threads.
     let mut file = src.as_file();
@@ -41,9 +41,10 @@ pub fn maybe_decompress_file(src: NamedTempFile) -> io::Result<NamedTempFile> {
         [0x28, 0xb5, 0x2f, 0xfd] => {
             metric!(counter("compression") += 1, "type" => "zstd");
 
-            let mut dst = tempfile_in_parent(&src)?;
+            let mut dst = tempfile_in_parent(src)?;
             zstd::stream::copy_decode(file, &mut dst)?;
-            Ok(dst)
+
+            std::mem::swap(src, &mut dst);
         }
         // Magic bytes for gzip
         // https://tools.ietf.org/html/rfc1952#section-2.3.1
@@ -52,25 +53,27 @@ pub fn maybe_decompress_file(src: NamedTempFile) -> io::Result<NamedTempFile> {
 
             // We assume MultiGzDecoder accepts a strict superset of input
             // values compared to GzDecoder.
-            let mut dst = tempfile_in_parent(&src)?;
+            let mut dst = tempfile_in_parent(src)?;
             let mut reader = MultiGzDecoder::new(file);
             io::copy(&mut reader, &mut dst)?;
-            Ok(dst)
+
+            std::mem::swap(src, &mut dst);
         }
         // Magic bytes for zlib
         [0x78, 0x01, _, _] | [0x78, 0x9c, _, _] | [0x78, 0xda, _, _] => {
             metric!(counter("compression") += 1, "type" => "zlib");
 
-            let mut dst = tempfile_in_parent(&src)?;
+            let mut dst = tempfile_in_parent(src)?;
             let mut reader = ZlibDecoder::new(file);
             io::copy(&mut reader, &mut dst)?;
-            Ok(dst)
+
+            std::mem::swap(src, &mut dst);
         }
         // Magic bytes for CAB
         [77, 83, 67, 70] => {
             metric!(counter("compression") += 1, "type" => "cab");
 
-            let dst = tempfile_in_parent(&src)?;
+            let mut dst = tempfile_in_parent(src)?;
             let status = Command::new("cabextract")
                 .arg("-sfqp")
                 .arg(src.path())
@@ -85,14 +88,15 @@ pub fn maybe_decompress_file(src: NamedTempFile) -> io::Result<NamedTempFile> {
                 ));
             }
 
-            Ok(dst)
+            std::mem::swap(src, &mut dst);
         }
         // Probably not compressed
         _ => {
             metric!(counter("compression") += 1, "type" => "none");
-            Ok(src)
         }
     }
+
+    Ok(())
 }
 
 // FIXME(swatinem): this fn needs a better place


### PR DESCRIPTION
Instead of taking and returning a `NamedTempFile`, rather take a `&mut NamedTempFile`, together with `std::mem::swap` in case we create new files. This avoids creating a new file in the hot error (not found) case.

#skip-changelog