### PR TITLE
fix: Do not error Docker build on existing /data dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN groupadd --system symbolicator --gid $SYMBOLICATOR_GID \
     && useradd --system --gid symbolicator --uid $SYMBOLICATOR_UID symbolicator
 
 VOLUME ["/data"]
-RUN mkdir /etc/symbolicator /data && \
+RUN mkdir -p /etc/symbolicator /data && \
     chown symbolicator:symbolicator /etc/symbolicator /data
 
 EXPOSE 3021


### PR DESCRIPTION
Oh the irony, https://github.com/getsentry/symbolicator/pull/928 (CC @mattgauntseo-sentry @asottile-sentry) should have added a check that prevents us from breaking our internal cloudbuild. But that very PR broke the internal cloud build, and noone noticed because the cloudbuild status is not exposed anywhere.

Can we expose the cloud build status here in github for master/release branches? Its not necessary to have it for PRs I guess, as long as master is red, people will notice.

#skip-changelog