### PR TITLE
feat(symbolicli): Add offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added offline mode to `symbolicli`. ([#967](https://github.com/getsentry/symbolicator/pull/967))
+
 ### Internal
 
 - Use a default crash DB if we have a Cache configured. ([#941](https://github.com/getsentry/symbolicator/pull/941))

--- a/crates/symbolicli/README.md
+++ b/crates/symbolicli/README.md
@@ -12,6 +12,14 @@ symbolicli -o <ORG> -p <PROJECT> --auth-token <TOKEN> <EVENT>
 * `<TOKEN>` is a Sentry authentication token that has access to the project;
 * `<EVENT>` is either a local file (minidump or event JSON) or the ID of an event from the Sentry instance.
 
+Alternatively, you can run `symbolicli` in offline mode:
+```
+symbolicli --offline <EVENT>
+```
+
+In offline mode `symbolicli` will not attempt to access a Sentry server, which means you can only
+process local events.
+
 # Configuration
 
 `symbolicli` can be configured via the `~/.symboliclirc` config file, written in the TOML format.

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use output::{print_compact, print_pretty};
 use remote::EventKey;
 
+use settings::Mode;
 use symbolicator_service::services::symbolication::SymbolicationActor;
 use symbolicator_service::types::{CompletedSymbolicationResponse, Scope};
 use symbolicator_sources::{SentrySourceConfig, SourceConfig, SourceId};
@@ -20,12 +21,9 @@ mod settings;
 async fn main() -> anyhow::Result<()> {
     let settings::Settings {
         event_id,
-        project,
-        org,
-        auth_token,
-        base_url,
         symbolicator_config,
         output_format,
+        mode,
     } = settings::Settings::get()?;
 
     tracing_subscriber::fmt::init();
@@ -36,29 +34,31 @@ async fn main() -> anyhow::Result<()> {
             .await
             .context("failed to start symbolication service")?;
 
-    let mut headers = header::HeaderMap::new();
-    headers.insert(
-        header::AUTHORIZATION,
-        header::HeaderValue::from_str(&format!("Bearer {auth_token}")).unwrap(),
-    );
+    let mut sources = vec![];
+    if let Mode::Online {
+        ref org,
+        ref project,
+        ref base_url,
+        ref auth_token,
+    } = mode
+    {
+        let project_source = SourceConfig::Sentry(Arc::new(SentrySourceConfig {
+            id: SourceId::new("sentry:project"),
+            token: auth_token.clone(),
+            url: base_url
+                .join(&format!("projects/{org}/{project}/files/dsyms/"))
+                .unwrap(),
+        }));
 
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .build()
-        .unwrap();
-
-    let project_source = SourceConfig::Sentry(Arc::new(SentrySourceConfig {
-        id: SourceId::new("sentry:project"),
-        token: auth_token,
-        url: base_url
-            .join(&format!("projects/{org}/{project}/files/dsyms/"))
-            .unwrap(),
-    }));
-    let mut sources = vec![project_source.clone()];
+        sources.push(project_source);
+    }
     sources.extend(symbolicator_config.sources.iter().cloned());
     let sources = Arc::from(sources.into_boxed_slice());
 
-    let scope = Scope::Scoped(project.clone());
+    let scope = match mode {
+        Mode::Online { ref project, .. } => Scope::Scoped(project.clone()),
+        Mode::Offline => Scope::Global,
+    };
 
     let res = match Payload::parse(&event_id)? {
         Some(local) => {
@@ -67,6 +67,21 @@ async fn main() -> anyhow::Result<()> {
         }
         None => {
             tracing::info!("event not found in local file system");
+            let Mode::Online { base_url, org, project, auth_token } = mode else {
+                anyhow::bail!("Event not found in local file system and `symbolicli` is in offline mode. Stopping.");
+            };
+
+            let mut headers = header::HeaderMap::new();
+            headers.insert(
+                header::AUTHORIZATION,
+                header::HeaderValue::from_str(&format!("Bearer {auth_token}")).unwrap(),
+            );
+
+            let client = reqwest::Client::builder()
+                .default_headers(headers)
+                .build()
+                .unwrap();
+
             let key = EventKey {
                 base_url: &base_url,
                 org: &org,

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -26,6 +26,18 @@ pub enum OutputFormat {
     Compact,
 }
 
+/// Controls whether `symbolicli` will attempt to access a Sentry server.
+#[derive(Clone, Debug)]
+pub enum Mode {
+    Offline,
+    Online {
+        org: String,
+        project: String,
+        auth_token: String,
+        base_url: reqwest::Url,
+    },
+}
+
 /// A utility that provides local symbolication of Sentry events.
 ///
 /// A valid auth token needs to be provided via the `--auth-token` option,
@@ -65,6 +77,12 @@ struct Cli {
     /// The output format.
     #[arg(long, value_enum, default_value = "json")]
     format: OutputFormat,
+
+    /// Run in offline mode, i.e., don't access the Sentry server.
+    ///
+    /// In offline mode symbolicli will still access manually configured symbol sources.
+    #[arg(long)]
+    offline: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -103,12 +121,9 @@ impl ConfigFile {
 #[derive(Clone, Debug)]
 pub struct Settings {
     pub event_id: String,
-    pub org: String,
-    pub project: String,
-    pub auth_token: String,
-    pub base_url: reqwest::Url,
     pub symbolicator_config: Config,
     pub output_format: OutputFormat,
+    pub mode: Mode,
 }
 
 impl Settings {
@@ -121,34 +136,45 @@ impl Settings {
             None => ConfigFile::default(),
         };
 
-        let Some(auth_token) = cli
-            .auth_token
-            .or_else(|| std::env::var("SENTRY_AUTH_TOKEN").ok())
-            .or_else(|| project_config_file.auth_token.take())
-            .or_else(|| global_config_file.auth_token.take()) else {
-            bail!("No auth token provided. Pass it either via the `--auth-token` option or via the `SENTRY_AUTH_TOKEN` environment variable.");
-    };
+        let mode = if cli.offline {
+            Mode::Offline
+        } else {
+            let Some(auth_token) = cli
+                .auth_token
+                .or_else(|| std::env::var("SENTRY_AUTH_TOKEN").ok())
+                .or_else(|| project_config_file.auth_token.take())
+                .or_else(|| global_config_file.auth_token.take()) else {
+                bail!("No auth token provided. Pass it either via the `--auth-token` option or via the `SENTRY_AUTH_TOKEN` environment variable.");
+            };
 
-        let sentry_url = cli
-            .url
-            .as_deref()
-            .or(project_config_file.url.as_deref())
-            .or(global_config_file.url.as_deref())
-            .unwrap_or(DEFAULT_URL);
+            let sentry_url = cli
+                .url
+                .as_deref()
+                .or(project_config_file.url.as_deref())
+                .or(global_config_file.url.as_deref())
+                .unwrap_or(DEFAULT_URL);
 
-        let sentry_url = Url::parse(sentry_url).context("Invalid sentry URL")?;
-        let url = sentry_url.join("/api/0/").unwrap();
+            let sentry_url = Url::parse(sentry_url).context("Invalid sentry URL")?;
+            let url = sentry_url.join("/api/0/").unwrap();
 
-        let Some(org) = cli.org
-            .or_else(|| project_config_file.org.take())
-            .or_else(|| global_config_file.org.take()) else {
-            bail!("No organization provided. Pass it either via the `--org` option or put it in .symboliclirc.");  
-        };
+            let Some(org) = cli.org
+                .or_else(|| project_config_file.org.take())
+                .or_else(|| global_config_file.org.take()) else {
+                bail!("No organization provided. Pass it either via the `--org` option or put it in .symboliclirc.");  
+            };
 
-        let Some(project) = cli.project
-            .or_else(|| project_config_file.project.take())
-            .or_else(|| global_config_file.project.take()) else {
-            bail!("No project provided. Pass it either via the `--project` option or put it in .symboliclirc.");  
+            let Some(project) = cli.project
+                .or_else(|| project_config_file.project.take())
+                .or_else(|| global_config_file.project.take()) else {
+                bail!("No project provided. Pass it either via the `--project` option or put it in .symboliclirc.");  
+            };
+
+            Mode::Online {
+                base_url: url,
+                org,
+                project,
+                auth_token,
+            }
         };
 
         let symbolicator_config = {
@@ -163,12 +189,9 @@ impl Settings {
 
         let args = Settings {
             event_id: cli.event,
-            org,
-            project,
-            auth_token,
-            base_url: url,
             symbolicator_config,
             output_format: cli.format,
+            mode,
         };
 
         Ok(args)


### PR DESCRIPTION
The main use case for this is debugging customer minidumps where attempting to access the Sentry server would just lead to nonstop errors.