### PR TITLE
feat: Removes an unused dependency of symbolicator-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,12 +593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,7 +1625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d39291d300fa58721578eefc8e7b462ef555452eebdbcc0ee260918aace3c9"
 dependencies = [
  "async-trait",
- "base64 0.13.1",
+ "base64",
  "dirs-next",
  "hyper",
  "hyper-rustls",
@@ -1731,7 +1725,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2125,7 +2119,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -2786,7 +2780,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64 0.13.1",
+ "base64",
 ]
 
 [[package]]
@@ -3167,7 +3161,7 @@ version = "0.11.12"
 source = "git+https://github.com/getsentry/reqwest?branch=restricted-connector#2236850c80cc430082bb098baf3e9e73af5c9789"
 dependencies = [
  "async-compression",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3291,7 +3285,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64 0.13.1",
+ "base64",
 ]
 
 [[package]]
@@ -3300,7 +3294,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.13.1",
+ "base64",
 ]
 
 [[package]]
@@ -4033,7 +4027,6 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "backtrace",
- "base64 0.20.0",
  "cadence",
  "chrono",
  "filetime",
@@ -4649,7 +4642,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "byteorder",
  "bytes",
  "http",
@@ -4758,7 +4751,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "chunked_transfer",
  "log",
  "native-tls",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -17,7 +17,6 @@ aws-types = { version = "0.52.0", features = ["hardcoded-credentials"] }
 aws-sdk-s3 = "0.22.0"
 aws-smithy-http = "0.52.0"
 backtrace = "0.3.65"
-base64 = "0.20.0"
 cadence = "0.29.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 filetime = "0.2.16"

--- a/crates/symbolicator-service/src/utils/gcs.rs
+++ b/crates/symbolicator-service/src/utils/gcs.rs
@@ -54,8 +54,6 @@ struct GcsTokenResponse {
 
 #[derive(Debug, Error)]
 pub enum GcsError {
-    #[error("failed decoding key")]
-    Base64(#[from] base64::DecodeError),
     #[error("failed to construct URL")]
     InvalidUrl,
     #[error("failed encoding JWT")]


### PR DESCRIPTION
Turns out we do not use this.

#skip-changelog