### PR TITLE
fix: Add back a `bind_hub` for concurrent CFI access

### DIFF
--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -58,12 +58,14 @@ pub enum CacheError {
 }
 
 impl From<std::io::Error> for CacheError {
+    #[track_caller]
     fn from(err: std::io::Error) -> Self {
         Self::from_std_error(err)
     }
 }
 
 impl From<serde_json::Error> for CacheError {
+    #[track_caller]
     fn from(err: serde_json::Error) -> Self {
         Self::from_std_error(err)
     }
@@ -183,6 +185,7 @@ impl CacheError {
         }
     }
 
+    #[track_caller]
     pub(crate) fn from_std_error<E: std::error::Error + 'static>(e: E) -> Self {
         let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
         tracing::error!(error = dynerr);

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -12,6 +12,7 @@ use minidump_processor::{
     FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, ProcessState,
     SymbolProvider,
 };
+use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
 use tempfile::TempPath;
 
@@ -194,6 +195,11 @@ impl SymbolicatorSymbolProvider {
                         sources,
                         scope,
                     })
+                    // NOTE: this `bind_hub` is important!
+                    // `load_cfi_module` is being called concurrently from `rust-minidump` via
+                    // `join_all`. We do need proper isolation of any async task that might
+                    // manipulate any Sentry scope.
+                    .bind_hub(Hub::new_from_top(Hub::current()))
                     .await
             })
             .await
@@ -342,7 +348,9 @@ async fn stackwalk(
                 None => ObjectFileStatus::Unused,
                 Some(cfi_module) => {
                     obj_info.features.merge(cfi_module.features);
-                    obj_info.candidates.merge(&cfi_module.candidates);
+                    // NOTE: minidump stackwalking is the first thing that happens to a request,
+                    // hence the current candidate list is empty.
+                    obj_info.candidates = cfi_module.candidates;
                     object_file_status_from_cache_entry(&cfi_module.cache)
                 }
             });


### PR DESCRIPTION
It might seem that some concurrent `Hub`/`Scope` access can potentially deadlock.

The PR that originally removed the `bind_hub` was https://github.com/getsentry/symbolicator/pull/933, and we bisected a deadlock in canary deployments to that PR. This PR here that adds back that `bind_hub` is running stably so far for longer time than it took for the non-`bind_hub` version to eventually deadlock.

Also micro-optimizes candidate merge and sprinkles some `#[track_caller]` annotations.

#skip-changelog