### PR TITLE
fix: Apply clippy lints

### DIFF
--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -425,8 +425,7 @@ mod tests {
 
         assert!(
             matches!(result, Err(CacheError::PermissionDenied(_))),
-            "{:?}",
-            result
+            "{result:?}"
         );
 
         assert!(!target_path.exists());

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -33,8 +33,10 @@ pub struct Signal(pub u32);
 /// request must match the scope of a file.
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(untagged)]
+#[derive(Default)]
 pub enum Scope {
     #[serde(rename = "global")]
+    #[default]
     Global,
     Scoped(String),
 }
@@ -45,12 +47,6 @@ impl AsRef<str> for Scope {
             Scope::Global => "global",
             Scope::Scoped(ref s) => s,
         }
-    }
-}
-
-impl Default for Scope {
-    fn default() -> Self {
-        Scope::Global
     }
 }
 
@@ -156,8 +152,10 @@ pub struct RawFrame {
 /// information.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum FrameTrust {
     /// Unknown.
+    #[default]
     None,
     /// Found by scanning the stack.
     Scan,
@@ -174,12 +172,6 @@ pub enum FrameTrust {
     /// This is only possible for the topmost, i.e. the crashing, frame as for the other
     /// frames the registers need to be reconstructed when unwinding the stack.
     Context,
-}
-
-impl Default for FrameTrust {
-    fn default() -> Self {
-        FrameTrust::None
-    }
 }
 
 impl From<minidump_processor::FrameTrust> for FrameTrust {
@@ -266,8 +258,10 @@ pub struct RawObjectInfo {
 /// Information on the symbolication status of this frame.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum FrameStatus {
     /// The frame was symbolicated successfully.
+    #[default]
     Symbolicated,
     /// The symbol (i.e. function) was not found within the debug file.
     MissingSymbol,
@@ -277,12 +271,6 @@ pub enum FrameStatus {
     Missing,
     /// The retrieved debug file could not be processed.
     Malformed,
-}
-
-impl Default for FrameStatus {
-    fn default() -> Self {
-        FrameStatus::Symbolicated
-    }
 }
 
 /// A potentially symbolicated frame in the symbolication response.
@@ -336,10 +324,12 @@ pub struct CompleteStacktrace {
 /// Information on a debug information file.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ObjectFileStatus {
     /// The file was found and successfully processed.
     Found,
     /// The image was not referenced in the stack trace and not further handled.
+    #[default]
     Unused,
     /// The file could not be found in any of the specified sources.
     Missing,
@@ -365,12 +355,6 @@ impl ObjectFileStatus {
             ObjectFileStatus::Timeout => "timeout",
             ObjectFileStatus::Other => "other",
         }
-    }
-}
-
-impl Default for ObjectFileStatus {
-    fn default() -> Self {
-        ObjectFileStatus::Unused
     }
 }
 

--- a/crates/symbolicator-service/src/utils/addr.rs
+++ b/crates/symbolicator-service/src/utils/addr.rs
@@ -7,18 +7,13 @@ use serde::ser::{Serialize, Serializer};
 use thiserror::Error;
 
 /// Defines the addressing mode.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub enum AddrMode {
     /// Declares addresses to be absolute with a shared memory space.
+    #[default]
     Abs,
     /// Declares an address to be relative to an indexed module.
     Rel(usize),
-}
-
-impl Default for AddrMode {
-    fn default() -> AddrMode {
-        AddrMode::Abs
-    }
 }
 
 impl fmt::Display for AddrMode {

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -373,13 +373,13 @@ async fn test_unreachable_bucket() {
             let source = if ty == "http" {
                 let config = source_config(DirectoryLayoutType::Symstore, vec![FileType::Pdb]);
                 hitcounter.source_with_config(
-                    &format!("broken-{}-{}", ty, code),
+                    &format!("broken-{ty}-{code}"),
                     &format!("respond_statuscode/{code}"),
                     config,
                 )
             } else {
                 SourceConfig::Sentry(Arc::new(SentrySourceConfig {
-                    id: SourceId::new(format!("broken-{}-{}", ty, code)),
+                    id: SourceId::new(format!("broken-{ty}-{code}")),
                     url: hitcounter.url(&format!("respond_statuscode/{code}")),
                     token: "123abc".into(),
                 }))
@@ -434,7 +434,7 @@ async fn test_lookup_deduplication() {
     for is_public in [true, false] {
         config.is_public = is_public;
         let source =
-            hitcounter.source_with_config(&format!("test-{}", is_public), "msdl/", config.clone());
+            hitcounter.source_with_config(&format!("test-{is_public}"), "msdl/", config.clone());
 
         let requests = (0..20).map(|_| {
             let modules = modules.iter().cloned().map(From::from).collect();

--- a/crates/symbolicator-sources/src/sources.rs
+++ b/crates/symbolicator-sources/src/sources.rs
@@ -196,17 +196,13 @@ pub enum DirectoryLayoutType {
 /// Casing of filenames on the symbol server
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum FilenameCasing {
     /// Default casing depending on layout type.
+    #[default]
     Default,
     /// Uppercase filenames.
     Uppercase,
     /// Lowercase filenames.
     Lowercase,
-}
-
-impl Default for FilenameCasing {
-    fn default() -> Self {
-        FilenameCasing::Default
-    }
 }

--- a/crates/symbolicator-sources/src/sources/s3.rs
+++ b/crates/symbolicator-sources/src/sources/s3.rs
@@ -130,17 +130,13 @@ where
 /// <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum AwsCredentialsProvider {
     /// Static Credentials
+    #[default]
     Static,
     /// Credentials derived from the container.
     Container,
-}
-
-impl Default for AwsCredentialsProvider {
-    fn default() -> Self {
-        AwsCredentialsProvider::Static
-    }
 }
 
 /// Amazon S3 authorization information.

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -41,6 +41,7 @@ impl Deref for Glob {
 /// The type of an executable object file.
 #[derive(Serialize, Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ObjectType {
     /// ELF Object.
     Elf,
@@ -53,6 +54,7 @@ pub enum ObjectType {
     /// Portable Executable containing .NET code, which has a Portable PDB companion.
     PeDotnet,
     /// Unknown Object.
+    #[default]
     Unknown,
 }
 
@@ -91,12 +93,6 @@ impl fmt::Display for ObjectType {
             ObjectType::Wasm => write!(f, "wasm"),
             ObjectType::Unknown => write!(f, "unknown"),
         }
-    }
-}
-
-impl Default for ObjectType {
-    fn default() -> ObjectType {
-        ObjectType::Unknown
     }
 }
 

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -215,7 +215,7 @@ impl Server {
             .route(
                 "/redirect/*path",
                 get(|extract::Path(path): extract::Path<String>| async move {
-                    (StatusCode::FOUND, [("Location", format!("/{}", path))])
+                    (StatusCode::FOUND, [("Location", format!("/{path}"))])
                 }),
             )
             .route(
@@ -225,14 +225,14 @@ impl Server {
                         let duration = humantime::parse_duration(&time).unwrap();
                         tokio::time::sleep(duration).await;
 
-                        (StatusCode::FOUND, [("Location", format!("/{}", path))])
+                        (StatusCode::FOUND, [("Location", format!("/{path}"))])
                     },
                 ),
             )
             .route(
                 "/msdl/*path",
                 get(|extract::Path(path): extract::Path<String>| async move {
-                    let url = format!("https://msdl.microsoft.com/download/symbols/{}", path);
+                    let url = format!("https://msdl.microsoft.com/download/symbols/{path}");
                     (StatusCode::FOUND, [("Location", url)])
                 }),
             )

--- a/crates/symbolicator/src/endpoints/requests.rs
+++ b/crates/symbolicator/src/endpoints/requests.rs
@@ -43,7 +43,7 @@ mod tests {
     fn ensure_request_id(response: SymbolicationResponse) -> RequestId {
         match response {
             SymbolicationResponse::Pending { request_id, .. } => request_id,
-            res => panic!("expected a pending response, got: {:#?}", res),
+            res => panic!("expected a pending response, got: {res:#?}"),
         }
     }
 
@@ -89,7 +89,7 @@ mod tests {
         let request_id = ensure_request_id(response.json().await.unwrap());
 
         let response = client
-            .get(server.url(&format!("/requests/{}?timeout=1", request_id)))
+            .get(server.url(&format!("/requests/{request_id}?timeout=1")))
             .send()
             .await
             .unwrap();
@@ -97,7 +97,7 @@ mod tests {
         let request_id = ensure_request_id(response.json().await.unwrap());
 
         let response = client
-            .get(server.url(&format!("/requests/{}", request_id)))
+            .get(server.url(&format!("/requests/{request_id}")))
             .send()
             .await
             .unwrap();


### PR DESCRIPTION
Clippy now has an auto-fixable lint to use `#[derive(Default)]` and use `#[default]` on enums.

#skip-changelog