### PR TITLE
ref: Add configuration for in-memory caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Added offline mode and caching to `symbolicli`. ([#967](https://github.com/getsentry/symbolicator/pull/967),[#968](https://github.com/getsentry/symbolicator/pull/968))
+- Use `moka` as an in-memory `Cacher` implementation. ([#979](https://github.com/getsentry/symbolicator/pull/979))
 
 ### Internal
 

--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -589,6 +589,13 @@ impl Cache {
             None => Ok(NamedTempFile::new()?),
         }
     }
+    pub fn in_memory_capacity(&self) -> u64 {
+        self.cache_config.in_memory_capacity()
+    }
+
+    pub fn in_memory_ttl(&self) -> Option<Duration> {
+        self.cache_config.in_memory_ttl()
+    }
 }
 
 /// Expiration strategies for cache items. These aren't named after the strategies themselves right

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -132,6 +132,16 @@ pub struct DownloadedCacheConfig {
 
     /// Maximum number of lazy re-downloads
     pub max_lazy_redownloads: isize,
+
+    /// The number of elements that may be held in the in-memory cache.
+    ///
+    /// Defautls to 100.
+    pub in_memory_capacity: u64,
+
+    /// The length of time elements will stay in the in-memory cache.
+    ///
+    /// Defaults to 1h.
+    pub in_memory_ttl: Option<Duration>,
 }
 
 impl Default for DownloadedCacheConfig {
@@ -141,6 +151,8 @@ impl Default for DownloadedCacheConfig {
             retry_misses_after: Some(Duration::from_secs(3600)),
             retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
             max_lazy_redownloads: 50,
+            in_memory_capacity: 100,
+            in_memory_ttl: Some(Duration::from_secs(3600)),
         }
     }
 }
@@ -165,6 +177,16 @@ pub struct DerivedCacheConfig {
 
     /// Maximum number of lazy re-computations
     pub max_lazy_recomputations: isize,
+
+    /// The number of elements that may be held in the in-memory cache.
+    ///
+    /// Defautls to 100.
+    pub in_memory_capacity: u64,
+
+    /// The length of time elements will stay in the in-memory cache.
+    ///
+    /// Defaults to 1h.
+    pub in_memory_ttl: Option<Duration>,
 }
 
 impl Default for DerivedCacheConfig {
@@ -174,6 +196,8 @@ impl Default for DerivedCacheConfig {
             retry_misses_after: Some(Duration::from_secs(3600)),
             retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
             max_lazy_recomputations: 20,
+            in_memory_capacity: 100,
+            in_memory_ttl: Some(Duration::from_secs(3600)),
         }
     }
 }
@@ -225,6 +249,22 @@ impl CacheConfig {
             Self::Downloaded(cfg) => cfg.retry_malformed_after,
             Self::Derived(cfg) => cfg.retry_malformed_after,
             Self::Diagnostics(_cfg) => None,
+        }
+    }
+
+    pub fn in_memory_capacity(&self) -> u64 {
+        match self {
+            CacheConfig::Downloaded(cfg) => cfg.in_memory_capacity,
+            CacheConfig::Derived(cfg) => cfg.in_memory_capacity,
+            CacheConfig::Diagnostics(_) => 0,
+        }
+    }
+
+    pub fn in_memory_ttl(&self) -> Option<Duration> {
+        match self {
+            CacheConfig::Downloaded(cfg) => cfg.in_memory_ttl,
+            CacheConfig::Derived(cfg) => cfg.in_memory_ttl,
+            CacheConfig::Diagnostics(_) => None,
         }
     }
 }

--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -98,7 +98,7 @@ impl SentryDownloader {
     /// If there are cached search results this skips the actual search.
     async fn cached_sentry_search(&self, query: SearchQuery) -> CacheEntry<Vec<SearchResult>> {
         let query_ = query.clone();
-        let init_future = async {
+        let init_future = Box::pin(async {
             tracing::debug!(
                 "Fetching list of Sentry debug files from {}",
                 &query_.index_url
@@ -112,7 +112,7 @@ impl SentryDownloader {
                 CancelOnDrop::new(self.runtime.spawn(future.bind_hub(sentry::Hub::current())));
 
             future.await.map_err(|_| CacheError::InternalError)?
-        };
+        });
         self.index_cache
             .get_with_if(query, init_future, |entry| entry.is_err())
             .await

--- a/crates/symbolicator-service/src/services/fetch_file.rs
+++ b/crates/symbolicator-service/src/services/fetch_file.rs
@@ -14,7 +14,7 @@ use crate::utils::compression::maybe_decompress_file;
 /// [`NamedTempFile`] back to the caller. This is either the original in case no decompression
 /// needs to happen, or a new one in case the downloaded file needs to be decompressed. In that case,
 /// a new [`NamedTempFile`] in the same directory will be created and returned.
-#[tracing::instrument(skip(downloader, temp_file))]
+#[tracing::instrument(skip(downloader, temp_file), fields(%file_id))]
 pub async fn fetch_file(
     downloader: Arc<DownloadService>,
     file_id: RemoteFile,

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -268,7 +268,7 @@ mod tests {
     use symbolic::common::DebugId;
     use tempfile::TempDir;
 
-    async fn objects_actor(tempdir: &TempDir) -> ObjectsActor {
+    async fn make_objects_actor(tempdir: &TempDir) -> ObjectsActor {
         let meta_cache = Cache::from_config(
             CacheName::ObjectMeta,
             Some(tempdir.path().join("meta")),
@@ -305,7 +305,7 @@ mod tests {
 
         let hitcounter = test::Server::new();
         let cachedir = tempdir();
-        let objects_actor = objects_actor(&cachedir).await;
+        let objects_actor = make_objects_actor(&cachedir).await;
 
         let find_object = FindObject {
             filetypes: &[FileType::MachCode],
@@ -337,6 +337,9 @@ mod tests {
             CacheError::DownloadError("500 Internal Server Error".into())
         );
         assert_eq!(hitcounter.accesses(), 3); // up to 3 tries on failure
+
+        // NOTE: creating a fresh instance to avoid in-memory cache
+        let objects_actor = make_objects_actor(&cachedir).await;
         let result = objects_actor
             .find(find_object.clone())
             .await
@@ -357,7 +360,7 @@ mod tests {
 
         let hitcounter = test::Server::new();
         let cachedir = tempdir();
-        let objects_actor = objects_actor(&cachedir).await;
+        let objects_actor = make_objects_actor(&cachedir).await;
 
         let find_object = FindObject {
             filetypes: &[FileType::MachCode],
@@ -386,6 +389,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(result, CacheError::NotFound);
         assert_eq!(hitcounter.accesses(), 1);
+
+        // NOTE: creating a fresh instance to avoid in-memory cache
+        let objects_actor = make_objects_actor(&cachedir).await;
         let result = objects_actor
             .find(find_object.clone())
             .await
@@ -403,7 +409,7 @@ mod tests {
 
         let hitcounter = test::Server::new();
         let cachedir = tempdir();
-        let objects_actor = objects_actor(&cachedir).await;
+        let objects_actor = make_objects_actor(&cachedir).await;
 
         let find_object = FindObject {
             filetypes: &[FileType::MachCode],
@@ -434,6 +440,9 @@ mod tests {
         assert_eq!(result, err);
         // XXX: why are we not trying this 3 times?
         assert_eq!(hitcounter.accesses(), 1);
+
+        // NOTE: creating a fresh instance to avoid in-memory cache
+        let objects_actor = make_objects_actor(&cachedir).await;
         let result = objects_actor
             .find(find_object.clone())
             .await
@@ -452,7 +461,7 @@ mod tests {
 
         let hitcounter = test::Server::new();
         let cachedir = tempdir();
-        let objects_actor = objects_actor(&cachedir).await;
+        let objects_actor = make_objects_actor(&cachedir).await;
 
         let find_object = FindObject {
             filetypes: &[FileType::MachCode],
@@ -482,6 +491,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(result, err);
         assert_eq!(hitcounter.accesses(), 1);
+
+        // NOTE: creating a fresh instance to avoid in-memory cache
+        let objects_actor = make_objects_actor(&cachedir).await;
         let result = objects_actor
             .find(find_object.clone())
             .await

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -521,6 +521,7 @@ fn normalize_minidump_os_name(os: Os) -> &'static str {
 #[cfg(test)]
 mod tests {
     use crate::services::create_service;
+    use crate::services::objects::{FindObject, ObjectPurpose};
     use crate::services::ppdb_caches::FetchPortablePdbCache;
     use crate::services::symcaches::FetchSymCache;
 
@@ -531,7 +532,7 @@ mod tests {
     /// The size assertion will naturally change with compiler, dependency and code changes.
     #[tokio::test]
     async fn future_size() {
-        let (sym, _) = create_service(&Default::default(), tokio::runtime::Handle::current())
+        let (sym, obj) = create_service(&Default::default(), tokio::runtime::Handle::current())
             .await
             .unwrap();
 
@@ -546,6 +547,16 @@ mod tests {
         let fut = provider.load_cfi_module(&module);
         assert_eq!(std::mem::size_of_val(&fut), 880);
 
+        let req = FindObject {
+            filetypes: &[],
+            purpose: ObjectPurpose::Debug,
+            identifier: Default::default(),
+            sources: Arc::from_iter([]),
+            scope: Scope::Global,
+        };
+        let fut = obj.find(req);
+        assert_eq!(std::mem::size_of_val(&fut), 4864);
+
         let req = FetchCfiCache {
             object_type: Default::default(),
             identifier: Default::default(),
@@ -553,7 +564,7 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.cficaches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 3456);
+        assert_eq!(std::mem::size_of_val(&fut), 5248);
 
         let req = FetchPortablePdbCache {
             identifier: Default::default(),
@@ -561,7 +572,7 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.ppdb_caches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 3456);
+        assert_eq!(std::mem::size_of_val(&fut), 5248);
 
         let req = FetchSymCache {
             object_type: Default::default(),
@@ -570,6 +581,6 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.symcaches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 7680);
+        assert_eq!(std::mem::size_of_val(&fut), 11264);
     }
 }

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -545,7 +545,7 @@ mod tests {
 
         let module = ("foo", DebugId::nil());
         let fut = provider.load_cfi_module(&module);
-        assert_eq!(std::mem::size_of_val(&fut), 880);
+        assert_eq!(std::mem::size_of_val(&fut), 872);
 
         let req = FindObject {
             filetypes: &[],
@@ -555,7 +555,7 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = obj.find(req);
-        assert_eq!(std::mem::size_of_val(&fut), 4864);
+        assert_eq!(std::mem::size_of_val(&fut), 4608);
 
         let req = FetchCfiCache {
             object_type: Default::default(),
@@ -564,7 +564,7 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.cficaches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 5248);
+        assert_eq!(std::mem::size_of_val(&fut), 4992);
 
         let req = FetchPortablePdbCache {
             identifier: Default::default(),
@@ -572,7 +572,7 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.ppdb_caches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 5248);
+        assert_eq!(std::mem::size_of_val(&fut), 4992);
 
         let req = FetchSymCache {
             object_type: Default::default(),
@@ -581,6 +581,6 @@ mod tests {
             scope: Scope::Global,
         };
         let fut = sym.symcaches.fetch(req);
-        assert_eq!(std::mem::size_of_val(&fut), 11264);
+        assert_eq!(std::mem::size_of_val(&fut), 10752);
     }
 }

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -362,6 +362,8 @@ mod tests {
     /// and timeout for download cache misses.
     async fn symcache_actor(cache_dir: PathBuf, timeout: Duration) -> SymCacheActor {
         let mut cache_config = CacheConfigs::default();
+        cache_config.downloaded.in_memory_ttl = Some(Duration::from_millis(500));
+        cache_config.derived.in_memory_ttl = Some(Duration::from_millis(500));
         cache_config.downloaded.retry_misses_after = Some(timeout);
 
         let config = Config {

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -447,20 +447,19 @@ mod tests {
 
         // Create the symcache for the first time. Since the bcsymbolmap is not available, names in the
         // symcache will be obfuscated.
-        let owned_symcache = symcache_actor
+        let symcache = symcache_actor
             .fetch(fetch_symcache.clone())
             .await
             .cache
-            .ok()
             .unwrap();
 
-        let symcache = owned_symcache.get();
-        let sl = symcache.lookup(0x5a75).next().unwrap();
+        let sl = symcache.get().lookup(0x5a75).next().unwrap();
         assert_eq!(
             sl.file().unwrap().full_path(),
             "__hidden#41_/__hidden#41_/__hidden#42_"
         );
         assert_eq!(sl.function().name(), "__hidden#0_");
+        drop(symcache);
 
         // Copy the plist and bcsymbolmap to the temporary symbol directory so that the SymCacheActor can find them.
         fs::copy(
@@ -476,37 +475,30 @@ mod tests {
         .unwrap();
 
         // Create the symcache for the second time. Even though the bcsymbolmap is now available, its absence should
-        // still be cached and the SymcacheActor should make no attempt to download it. Therefore, the names should
+        // still be cached and the SymCacheActor should make no attempt to download it. Therefore, the names should
         // be obfuscated like before.
-        let owned_symcache = symcache_actor
+        let symcache = symcache_actor
             .fetch(fetch_symcache.clone())
             .await
             .cache
-            .ok()
             .unwrap();
 
-        let symcache = owned_symcache.get();
-        let sl = symcache.lookup(0x5a75).next().unwrap();
+        let sl = symcache.get().lookup(0x5a75).next().unwrap();
         assert_eq!(
             sl.file().unwrap().full_path(),
             "__hidden#41_/__hidden#41_/__hidden#42_"
         );
         assert_eq!(sl.function().name(), "__hidden#0_");
+        drop(symcache);
 
         // Sleep long enough for the negative cache entry to become invalid.
         std::thread::sleep(TIMEOUT);
 
         // Create the symcache for the third time. This time, the bcsymbolmap is downloaded and the names in the
         // symcache are unobfuscated.
-        let owned_symcache = symcache_actor
-            .fetch(fetch_symcache.clone())
-            .await
-            .cache
-            .ok()
-            .unwrap();
+        let symcache = symcache_actor.fetch(fetch_symcache).await.cache.unwrap();
 
-        let symcache = owned_symcache.get();
-        let sl = symcache.lookup(0x5a75).next().unwrap();
+        let sl = symcache.get().lookup(0x5a75).next().unwrap();
         assert_eq!(
             sl.file().unwrap().full_path(),
             "/Users/philipphofmann/git-repos/sentry-cocoa/Sources/Sentry/SentryMessage.m"

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -31,7 +31,7 @@ pub struct Signal(pub u32);
 /// Based on scopes, access to debug files that have been cached is determined. If a file comes from
 /// a public source, it can be used for any symbolication request. Otherwise, the symbolication
 /// request must match the scope of a file.
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, Ord, PartialEq, PartialOrd, Hash)]
 #[serde(untagged)]
 #[derive(Default)]
 pub enum Scope {

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -561,6 +561,7 @@ async fn test_basic_windows() {
                     } else {
                         // we are downloading twice: once for the objects_meta request, and once
                         // again for the objects/symcache request
+                        // well with in-memory caching, we are only requesting once
                         (2, 1)
                     };
 

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -561,8 +561,8 @@ async fn test_basic_windows() {
                     } else {
                         // we are downloading twice: once for the objects_meta request, and once
                         // again for the objects/symcache request
-                        // well with in-memory caching, we are only requesting once
-                        (2, 1)
+                        // FIXME: well with in-memory caching, we are only requesting once
+                        (1, 1)
                     };
 
                     assert_eq!(&hits, &[

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -495,6 +495,7 @@ fn get_files(path: impl AsRef<Path>) -> Vec<(String, u64)> {
 }
 
 /// Tests caching side-effects, like cache files written and hits to the symbol source.
+#[allow(clippy::if_same_then_else)]
 #[tokio::test]
 async fn test_basic_windows() {
     let (modules, stacktraces) = request_fixture();

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -37,7 +37,7 @@ async fn test_download_errors() {
     };
 
     // NOTE: we run requests twice to make sure that round-trips through the cache give us the same results.
-    for i in 0..2 {
+    for _i in 0..2 {
         // NOTE: we try this 3 times on error
         let source = hitcounter.source("rejected", "/respond_statuscode/500/");
         let request = get_symbolication_request(vec![source]);
@@ -100,11 +100,7 @@ async fn test_download_errors() {
                     // FIXME: We are currently serializing `CacheError` in "legacy" mode that does
                     // not support details
                     // FIXME: However, adding an in-memory cache means we still get the proper values
-                    details: if i == 0 {
-                        "403 Forbidden".into()
-                    } else {
-                        "403 Forbidden".into()
-                    }
+                    details: "403 Forbidden".into()
                 }
             )
         );

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -10,11 +10,6 @@ use crate::symbolication::{get_symbolication_request, setup_service};
 
 #[tokio::test]
 async fn test_download_errors() {
-    let (symbolication, _cache_dir) = setup_service(|config| {
-        config.max_download_timeout = Duration::from_millis(200);
-    })
-    .await;
-
     let hitcounter = Server::new();
 
     // This returns frame and module statuses:
@@ -38,6 +33,11 @@ async fn test_download_errors() {
 
     // NOTE: we run requests twice to make sure that round-trips through the cache give us the same results.
     for i in 0..2 {
+        let (symbolication, _cache_dir) = setup_service(|config| {
+            config.max_download_timeout = Duration::from_millis(200);
+        })
+        .await;
+
         // NOTE: we try this 3 times on error
         let source = hitcounter.source("rejected", "/respond_statuscode/500/");
         let request = get_symbolication_request(vec![source]);

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -10,6 +10,11 @@ use crate::symbolication::{get_symbolication_request, setup_service};
 
 #[tokio::test]
 async fn test_download_errors() {
+    let (symbolication, _cache_dir) = setup_service(|config| {
+        config.max_download_timeout = Duration::from_millis(200);
+    })
+    .await;
+
     let hitcounter = Server::new();
 
     // This returns frame and module statuses:
@@ -33,11 +38,6 @@ async fn test_download_errors() {
 
     // NOTE: we run requests twice to make sure that round-trips through the cache give us the same results.
     for i in 0..2 {
-        let (symbolication, _cache_dir) = setup_service(|config| {
-            config.max_download_timeout = Duration::from_millis(200);
-        })
-        .await;
-
         // NOTE: we try this 3 times on error
         let source = hitcounter.source("rejected", "/respond_statuscode/500/");
         let request = get_symbolication_request(vec![source]);
@@ -99,10 +99,11 @@ async fn test_download_errors() {
                 ObjectDownloadInfo::NoPerm {
                     // FIXME: We are currently serializing `CacheError` in "legacy" mode that does
                     // not support details
+                    // FIXME: However, adding an in-memory cache means we still get the proper values
                     details: if i == 0 {
                         "403 Forbidden".into()
                     } else {
-                        "".into()
+                        "403 Forbidden".into()
                     }
                 }
             )

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -43,7 +43,7 @@ pub use tempfile::TempDir;
 ///    other logs (such as actix or symbolic).
 pub fn setup() {
     fmt()
-        .with_env_filter(EnvFilter::new("symbolicator-service=trace"))
+        .with_env_filter(EnvFilter::new("symbolicator_service=trace"))
         .with_target(false)
         .pretty()
         .with_test_writer()


### PR DESCRIPTION
This also renames the `config` and `cache` fields of `Cacher` to `on_disk` and `in_memory`, respectively.

I am actually unsure about a number of points.

* Should the in-memory caches have a time-to-idle rather than a time-to-live?
* Do we actually need/want different capacity/ttl values for downloaded and derived caches?
* Are the default values sane?

In general I think the cache configuration machinery is getting a bit convoluted and we should think about restructuring it a bit.