### PR TITLE
fix: Correctly treat `NotFound` in terms of cache fallback

### DIFF
--- a/crates/symbolicator-service/src/cache.rs
+++ b/crates/symbolicator-service/src/cache.rs
@@ -605,6 +605,7 @@ pub enum ExpirationStrategy {
 }
 
 /// This gives the time at which different cache items need to be refreshed or touched.
+#[derive(Debug)]
 pub enum ExpirationTime {
     /// The [`Duration`] after which [`Negative`](ExpirationStrategy::Negative) or
     /// [`Malformed`](ExpirationStrategy::Malformed) cache entries expire and need

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -43,7 +43,7 @@ pub use tempfile::TempDir;
 ///    other logs (such as actix or symbolic).
 pub fn setup() {
     fmt()
-        .with_env_filter(EnvFilter::new("symbolicator-service=trace"))
+        .with_env_filter(EnvFilter::new("symbolicator_service=trace"))
         .with_target(false)
         .pretty()
         .with_test_writer()


### PR DESCRIPTION
We have a steady stream of cache fallbacks since a while which has been baffling me.

I suspect these happen because:
- we have an older cache version to use
- when regenerating the cache, the file can not be found anymore and a `NotFound` marker is written
- the `NotFound` marker was previously always skipped, falling back to the old cache version

Apart from fixing and testing this edge case, this also simplifies the cache versioning code a bit.

#skip-changelog