### PR TITLE
fix: Use unique Cache files for symcaches with markers

### DIFF
--- a/crates/symbolicator-service/src/services/symcaches/markers.rs
+++ b/crates/symbolicator-service/src/services/symcaches/markers.rs
@@ -1,5 +1,7 @@
+use std::fmt::Write;
 use std::io::SeekFrom;
 
+use crate::services::cacher::CacheKey;
 use crate::services::{bitcode::BcSymbolMapHandle, il2cpp::Il2cppHandle};
 
 /// This is the legacy marker that was used previously to flag a SymCache that was created
@@ -36,6 +38,15 @@ impl SymCacheMarkers {
             markers |= MARKER_IL2CPP;
         }
         Self { markers }
+    }
+
+    /// Appends the marker state to the [`CacheKey`] in order to have unique cache files depending
+    /// on the applied sources.
+    pub fn append_to_key(&self, mut key: CacheKey) -> CacheKey {
+        if self.markers > 0 {
+            write!(&mut key.cache_key, "_{}", self.markers).unwrap();
+        }
+        key
     }
 
     /// Extracts the markers embedded in the given `data`.


### PR DESCRIPTION
This gives symcaches a unique cache key depending on the `secondary_sources` and the same cache file is not being reused with different sets of `secondary_sources`.

It also paves the way to avoid appending markers to files and thus getting rid of the `should_load` check in the future.

This still does not solve the edge-case when any of the `secondary_sources` itself changes. But that is the same edge-case we currently have if files on external symbol sources are overwritten. As long as we have that file cached, we will never try to re-download that file.
Cache files are considered to be immutable.

#skip-changelog