### PR TITLE
ref: Use a OnceCell instead of async RwLock in Shared Cache

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -23,7 +23,7 @@ use crate::types::Scope;
 use crate::utils::futures::{m, measure};
 
 use super::fetch_file;
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 /// Handle to a valid BCSymbolMap.
 ///
@@ -163,11 +163,11 @@ pub struct BitcodeService {
 impl BitcodeService {
     pub fn new(
         difs_cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
+        shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
     ) -> Self {
         Self {
-            cache: Arc::new(Cacher::new(difs_cache, shared_cache_svc)),
+            cache: Arc::new(Cacher::new(difs_cache, shared_cache)),
             download_svc,
         }
     }

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -21,7 +21,7 @@ use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
 use super::derived::{derive_from_object_handle, DerivedCache};
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 /// The supported cficache versions.
 ///
@@ -74,13 +74,9 @@ pub struct CfiCacheActor {
 }
 
 impl CfiCacheActor {
-    pub fn new(
-        cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
-        objects: ObjectsActor,
-    ) -> Self {
+    pub fn new(cache: Cache, shared_cache: SharedCacheRef, objects: ObjectsActor) -> Self {
         CfiCacheActor {
-            cficaches: Arc::new(Cacher::new(cache, shared_cache_svc)),
+            cficaches: Arc::new(Cacher::new(cache, shared_cache)),
             objects,
         }
     }

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -21,7 +21,7 @@ use crate::types::Scope;
 use crate::utils::futures::{m, measure};
 
 use super::fetch_file;
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 /// Handle to a valid [`LineMapping`].
 ///
@@ -114,11 +114,11 @@ pub struct Il2cppService {
 impl Il2cppService {
     pub fn new(
         difs_cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
+        shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
     ) -> Self {
         Self {
-            cache: Arc::new(Cacher::new(difs_cache, shared_cache_svc)),
+            cache: Arc::new(Cacher::new(difs_cache, shared_cache)),
             download_svc,
         }
     }

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -9,8 +9,6 @@
 //! The internal services require a separate asynchronous runtimes dedicated for I/O-intensive work,
 //! such as downloads and access to the shared cache.
 
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 
 use crate::cache::Caches;
@@ -41,7 +39,7 @@ use self::symbolication::SymbolicationActor;
 use self::symcaches::SymCacheActor;
 pub use fetch_file::fetch_file;
 
-pub async fn create_service(
+pub fn create_service(
     config: &Config,
     io_pool: tokio::runtime::Handle,
 ) -> Result<(SymbolicationActor, ObjectsActor)> {
@@ -52,8 +50,7 @@ pub async fn create_service(
 
     let downloader = DownloadService::new(config, io_pool.clone());
 
-    let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool.clone()).await;
-    let shared_cache = Arc::new(shared_cache);
+    let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool.clone());
 
     let objects = ObjectsActor::new(
         caches.object_meta,

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -50,7 +50,7 @@ pub fn create_service(
 
     let downloader = DownloadService::new(config, io_pool.clone());
 
-    let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool.clone());
+    let shared_cache = SharedCacheService::new(config.shared_cache.clone(), io_pool);
 
     let objects = ObjectsActor::new(
         caches.object_meta,

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -262,7 +262,6 @@ mod tests {
     use crate::services::download::DownloadService;
     use crate::services::objects::data_cache::Scope;
     use crate::services::objects::{FindObject, ObjectPurpose, ObjectsActor};
-    use crate::services::shared_cache::SharedCacheService;
     use crate::test::{self, tempdir};
 
     use symbolic::common::DebugId;
@@ -295,8 +294,7 @@ mod tests {
 
         let runtime = tokio::runtime::Handle::current();
         let download_svc = DownloadService::new(&config, runtime.clone());
-        let shared_cache_svc = Arc::new(SharedCacheService::new(None, runtime).await);
-        ObjectsActor::new(meta_cache, data_cache, shared_cache_svc, download_svc)
+        ObjectsActor::new(meta_cache, data_cache, Default::default(), download_svc)
     }
 
     #[tokio::test]

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -292,8 +292,7 @@ mod tests {
             ..Config::default()
         };
 
-        let runtime = tokio::runtime::Handle::current();
-        let download_svc = DownloadService::new(&config, runtime.clone());
+        let download_svc = DownloadService::new(&config, tokio::runtime::Handle::current());
         ObjectsActor::new(meta_cache, data_cache, Default::default(), download_svc)
     }
 

--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -17,7 +17,7 @@ use meta_cache::FetchFileMetaRequest;
 pub use data_cache::ObjectHandle;
 pub use meta_cache::ObjectMetaHandle;
 
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 mod data_cache;
 mod meta_cache;
@@ -86,12 +86,12 @@ impl ObjectsActor {
     pub fn new(
         meta_cache: Cache,
         data_cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
+        shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
     ) -> Self {
         ObjectsActor {
-            meta_cache: Arc::new(Cacher::new(meta_cache, Arc::clone(&shared_cache_svc))),
-            data_cache: Arc::new(Cacher::new(data_cache, shared_cache_svc)),
+            meta_cache: Arc::new(Cacher::new(meta_cache, Arc::clone(&shared_cache))),
+            data_cache: Arc::new(Cacher::new(data_cache, shared_cache)),
             download_svc,
         }
     }

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -19,7 +19,7 @@ use crate::utils::sentry::ConfigureScope;
 use super::cacher::{CacheItemRequest, CacheKey, CacheVersions, Cacher};
 use super::derived::{derive_from_object_handle, DerivedCache};
 use super::objects::{FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor};
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 /// The supported ppdb_cache versions.
 ///
@@ -64,13 +64,9 @@ pub struct PortablePdbCacheActor {
 }
 
 impl PortablePdbCacheActor {
-    pub fn new(
-        cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
-        objects: ObjectsActor,
-    ) -> Self {
+    pub fn new(cache: Cache, shared_cache: SharedCacheRef, objects: ObjectsActor) -> Self {
         Self {
-            ppdb_caches: Arc::new(Cacher::new(cache, shared_cache_svc)),
+            ppdb_caches: Arc::new(Cacher::new(cache, shared_cache)),
             objects,
         }
     }

--- a/crates/symbolicator-service/src/services/shared_cache.rs
+++ b/crates/symbolicator-service/src/services/shared_cache.rs
@@ -527,7 +527,7 @@ impl SharedCacheBackend {
     }
 }
 
-/// Message to send upload tasks across the [`InnerSharedCacheService::upload_queue_tx`].
+/// Message to send upload tasks across the [`SharedCacheService::upload_queue_tx`].
 #[derive(Debug)]
 struct UploadMessage {
     /// The cache key to store the data at.

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -372,10 +372,9 @@ mod tests {
             ..Default::default()
         };
 
-        let runtime = tokio::runtime::Handle::current();
         let caches = Caches::from_config(&config).unwrap();
         caches.clear_tmp(&config).unwrap();
-        let downloader = DownloadService::new(&config, runtime.clone());
+        let downloader = DownloadService::new(&config, tokio::runtime::Handle::current());
         let shared_cache = SharedCacheRef::default();
         let objects = ObjectsActor::new(
             caches.object_meta,

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -24,7 +24,7 @@ use self::markers::{SecondarySymCacheSources, SymCacheMarkers};
 
 use super::derived::{derive_from_object_handle, DerivedCache};
 use super::il2cpp::Il2cppService;
-use super::shared_cache::SharedCacheService;
+use super::shared_cache::SharedCacheRef;
 
 mod markers;
 
@@ -91,13 +91,13 @@ pub struct SymCacheActor {
 impl SymCacheActor {
     pub fn new(
         cache: Cache,
-        shared_cache_svc: Arc<SharedCacheService>,
+        shared_cache: SharedCacheRef,
         objects: ObjectsActor,
         bitcode_svc: BitcodeService,
         il2cpp_svc: Il2cppService,
     ) -> Self {
         SymCacheActor {
-            symcaches: Arc::new(Cacher::new(cache, shared_cache_svc)),
+            symcaches: Arc::new(Cacher::new(cache, shared_cache)),
             objects,
             bitcode_svc,
             il2cpp_svc,
@@ -352,6 +352,7 @@ mod tests {
     use crate::cache::Caches;
     use crate::config::{CacheConfigs, Config};
     use crate::services::bitcode::BitcodeService;
+    use crate::services::shared_cache::SharedCacheRef;
     use crate::services::DownloadService;
     use crate::test::{self, fixture};
     use symbolicator_sources::{
@@ -375,7 +376,7 @@ mod tests {
         let caches = Caches::from_config(&config).unwrap();
         caches.clear_tmp(&config).unwrap();
         let downloader = DownloadService::new(&config, runtime.clone());
-        let shared_cache = Arc::new(SharedCacheService::new(None, runtime.clone()).await);
+        let shared_cache = SharedCacheRef::default();
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -41,7 +41,7 @@ fn request_fixture() -> (Vec<RawObjectInfo>, Vec<RawStacktrace>) {
 /// tests that nothing happens when no source is supplied
 #[tokio::test]
 async fn test_no_sources() {
-    let (symbolication, cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -65,7 +65,7 @@ async fn test_no_sources() {
 /// Tests that source file types are correctly filtered
 #[tokio::test]
 async fn test_sources_filetypes() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -91,7 +91,7 @@ async fn test_sources_filetypes() {
 /// tests that sourcce `path_patterns` work as expected
 #[tokio::test]
 async fn test_path_patterns() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -149,7 +149,7 @@ async fn test_path_patterns() {
 /// Tests permission errors for http, s3 and gcs sources
 #[tokio::test]
 async fn test_no_permission() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let hitcounter = Server::new();
 
@@ -257,7 +257,7 @@ async fn test_reserved_ip_addresses() {
 
     let request = get_symbolication_request(sources);
 
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let mut response = symbolication.symbolicate(request.clone()).await.unwrap();
     let candidates = response.modules.pop().unwrap().candidates.0;
 
@@ -291,8 +291,7 @@ async fn test_reserved_ip_addresses() {
 
     let (symbolication, _cache_dir) = setup_service(|cfg| {
         cfg.connect_to_reserved_ips = false;
-    })
-    .await;
+    });
     let mut response = symbolication.symbolicate(request.clone()).await.unwrap();
     let candidates = response.modules.pop().unwrap().candidates.0;
 
@@ -329,7 +328,7 @@ async fn test_reserved_ip_addresses() {
 /// Tests that symbolicator correctly follows redirects
 #[tokio::test]
 async fn test_redirects() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -359,7 +358,7 @@ async fn test_redirects() {
 /// Tests what candidate info we get for different response codes
 #[tokio::test]
 async fn test_unreachable_bucket() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -423,7 +422,7 @@ async fn test_unreachable_bucket() {
 /// Tests request coalescing and effect of caches
 #[tokio::test]
 async fn test_lookup_deduplication() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
 
     let (modules, stacktraces) = request_fixture();
 
@@ -512,8 +511,7 @@ async fn test_basic_windows() {
                 if !with_cache {
                     cfg.cache_dir = None;
                 }
-            })
-            .await;
+            });
 
             let request = SymbolicateStacktraces {
                 modules: modules.iter().cloned().map(From::from).collect(),

--- a/crates/symbolicator-service/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-service/tests/integration/process_minidump.rs
@@ -13,7 +13,7 @@ use crate::symbolication::setup_service;
 macro_rules! stackwalk_minidump {
     ($path:expr) => {
         async {
-            let (symbolication, cache_dir) = setup_service(|_| ()).await;
+            let (symbolication, cache_dir) = setup_service(|_| ());
             let (_symsrv, source) = test::symbol_server();
 
             let minidump = test::read_fixture($path);

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -12,8 +12,7 @@ use crate::symbolication::{get_symbolication_request, setup_service};
 async fn test_download_errors() {
     let (symbolication, _cache_dir) = setup_service(|config| {
         config.max_download_timeout = Duration::from_millis(200);
-    })
-    .await;
+    });
 
     let hitcounter = Server::new();
 

--- a/crates/symbolicator-service/tests/integration/symbolication.rs
+++ b/crates/symbolicator-service/tests/integration/symbolication.rs
@@ -21,7 +21,7 @@ use symbolicator_test::{assert_snapshot, fixture};
 ///
 /// The service is configured with `connect_to_reserved_ips = True`. This allows to use a local
 /// symbol server to test object file downloads.
-pub async fn setup_service(
+pub fn setup_service(
     update_config: impl FnOnce(&mut Config),
 ) -> (SymbolicationActor, test::TempDir) {
     test::setup();
@@ -36,7 +36,7 @@ pub async fn setup_service(
     update_config(&mut config);
 
     let handle = tokio::runtime::Handle::current();
-    let (symbolication, _objects) = create_service(&config, handle).await.unwrap();
+    let (symbolication, _objects) = create_service(&config, handle).unwrap();
 
     (symbolication, cache_dir)
 }
@@ -72,7 +72,7 @@ async fn test_remove_bucket() {
     // Test with sources first, and then without. This test should verify that we do not leak
     // cached debug files to requests that no longer specify a source.
 
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_symsrv, source) = test::symbol_server();
 
     let request = get_symbolication_request(vec![source]);
@@ -91,7 +91,7 @@ async fn test_add_bucket() {
     // Test without sources first, then with. This test should verify that we apply a new source
     // to requests immediately.
 
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_symsrv, source) = test::symbol_server();
 
     let request = get_symbolication_request(vec![]);
@@ -107,7 +107,7 @@ async fn test_add_bucket() {
 
 #[tokio::test]
 async fn test_apple_crash_report() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_symsrv, source) = test::symbol_server();
 
     let report_file = std::fs::File::open(fixture("apple_crash_report.txt")).unwrap();
@@ -121,7 +121,7 @@ async fn test_apple_crash_report() {
 
 #[tokio::test]
 async fn test_wasm_payload() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_symsrv, source) = test::symbol_server();
 
     let modules: Vec<RawObjectInfo> = serde_json::from_str(
@@ -160,7 +160,7 @@ async fn test_wasm_payload() {
 
 #[tokio::test]
 async fn test_source_candidates() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_symsrv, source) = test::symbol_server();
 
     // its not wasm, but that is the easiest to write tests because of relative
@@ -200,7 +200,7 @@ async fn test_source_candidates() {
 
 #[tokio::test]
 async fn test_dotnet_integration() {
-    let (symbolication, _cache_dir) = setup_service(|_| ()).await;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
     let (_srv, source) = test::symbol_server();
 
     let modules: Vec<RawObjectInfo> = serde_json::from_str(

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -92,7 +92,6 @@ async fn main() -> Result<()> {
     let runtime = tokio::runtime::Handle::current();
     let (symbolication, _objects) =
         symbolicator_service::services::create_service(&service_config, runtime)
-            .await
             .context("failed starting symbolication service")?;
     let symbolication = Arc::new(symbolication);
 

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -63,7 +63,7 @@ mod tests {
     async fn test_basic() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let file_contents = test::read_fixture("apple_crash_report.txt");
         let file_part = multipart::Part::bytes(file_contents).file_name("apple_crash_report.txt");
@@ -90,7 +90,7 @@ mod tests {
     async fn test_unknown_field() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let file_contents = test::read_fixture("apple_crash_report.txt");
         let file_part = multipart::Part::bytes(file_contents).file_name("apple_crash_report.txt");

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -84,7 +84,7 @@ mod tests {
     async fn test_basic() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let file_contents = test::read_fixture("windows.dmp");
         let file_part = multipart::Part::bytes(file_contents).file_name("windows.dmp");
@@ -110,7 +110,7 @@ mod tests {
     async fn test_integration_microsoft() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
         let source = test::microsoft_symsrv();
 
         let file_contents = test::read_fixture("windows.dmp");
@@ -138,7 +138,7 @@ mod tests {
     async fn test_unknown_field() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let file_contents = test::read_fixture("windows.dmp");
         let file_part = multipart::Part::bytes(file_contents).file_name("windows.dmp");
@@ -162,7 +162,7 @@ mod tests {
     async fn test_body_limit() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let len = 96 * 1024 * 1024;
         let mut buf = vec![b'.'; len];

--- a/crates/symbolicator/src/endpoints/requests.rs
+++ b/crates/symbolicator/src/endpoints/requests.rs
@@ -54,7 +54,7 @@ mod tests {
         test::setup();
 
         let client = Client::new();
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
         let hitcounter = test::Server::new();
 
         let payload = r##"{

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -92,7 +92,7 @@ mod tests {
     async fn test_body_limit() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let mut buf = vec![b'.'; 4 * 1024 * 1024];
         buf[0] = b'"';
@@ -128,7 +128,7 @@ mod tests {
     async fn test_unknown_field() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let payload = r##"{
             "stacktraces": [],
@@ -153,7 +153,7 @@ mod tests {
     async fn test_no_dif_candidates() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let payload = r##"{
             "stacktraces": [{
@@ -194,7 +194,7 @@ mod tests {
     async fn test_unknown_source_config() {
         test::setup();
 
-        let server = test::server_with_default_service().await;
+        let server = test::server_with_default_service();
 
         let payload = r##"{
             "stacktraces": [{

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -35,15 +35,13 @@ mod test {
 
     use crate::endpoints;
 
-    pub async fn server_with_default_service() -> Server {
+    pub fn server_with_default_service() -> Server {
         let handle = tokio::runtime::Handle::current();
         let config = Config {
             connect_to_reserved_ips: true,
             ..Config::default()
         };
-        let service = RequestService::create(config, handle.clone(), handle.clone())
-            .await
-            .unwrap();
+        let service = RequestService::create(config, handle.clone(), handle.clone()).unwrap();
 
         Server::with_router(endpoints::create_app(service))
     }

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -41,7 +41,7 @@ mod test {
             connect_to_reserved_ips: true,
             ..Config::default()
         };
-        let service = RequestService::create(config, handle.clone(), handle.clone()).unwrap();
+        let service = RequestService::create(config, handle.clone(), handle).unwrap();
 
         Server::with_router(endpoints::create_app(service))
     }

--- a/crates/symbolicator/src/server.rs
+++ b/crates/symbolicator/src/server.rs
@@ -30,30 +30,29 @@ pub fn run(config: Config) -> Result<()> {
 
     let megs = 1024 * 1024;
     let io_pool = tokio::runtime::Builder::new_multi_thread()
-        .thread_name("symbolicator-io")
+        .thread_name("sym-io")
         .enable_all()
         .thread_stack_size(8 * megs)
         .build()?;
     let cpu_pool = tokio::runtime::Builder::new_multi_thread()
-        .thread_name("symbolicator-cpu")
+        .thread_name("sym-cpu")
         .enable_all()
         .thread_stack_size(8 * megs)
         .build()?;
     let web_pool = tokio::runtime::Builder::new_multi_thread()
-        .thread_name("symbolicator-web")
+        .thread_name("sym-web")
         .enable_all()
         .thread_stack_size(8 * megs)
         .build()?;
 
     let mut servers: Vec<BoxFuture<_>> = vec![];
 
-    let service = web_pool
-        .block_on(RequestService::create(
-            config.clone(),
-            io_pool.handle().to_owned(),
-            cpu_pool.handle().to_owned(),
-        ))
-        .context("failed to create service state")?;
+    let service = RequestService::create(
+        config.clone(),
+        io_pool.handle().to_owned(),
+        cpu_pool.handle().to_owned(),
+    )
+    .context("failed to create service state")?;
 
     let svc = endpoints::create_app(service).into_make_service();
 

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -173,7 +173,7 @@ struct RequestServiceInner {
 
 impl RequestService {
     /// Creates a new [`RequestService`].
-    pub async fn create(
+    pub fn create(
         mut config: Config,
         io_pool: tokio::runtime::Handle,
         cpu_pool: tokio::runtime::Handle,
@@ -186,7 +186,7 @@ impl RequestService {
         }
 
         let (symbolication, objects) =
-            symbolicator_service::services::create_service(&config, io_pool.clone()).await?;
+            symbolicator_service::services::create_service(&config, io_pool.clone())?;
 
         let symbolication_taskmon = tokio_metrics::TaskMonitor::new();
         {
@@ -538,9 +538,7 @@ mod tests {
         // Make sure we can repeatedly poll for the response
         let config = Config::default();
         let handle = tokio::runtime::Handle::current();
-        let service = RequestService::create(config, handle.clone(), handle)
-            .await
-            .unwrap();
+        let service = RequestService::create(config, handle.clone(), handle).unwrap();
 
         let stacktraces = serde_json::from_str(
             r#"[
@@ -619,9 +617,7 @@ mod tests {
         };
 
         let handle = tokio::runtime::Handle::current();
-        let service = RequestService::create(config, handle.clone(), handle)
-            .await
-            .unwrap();
+        let service = RequestService::create(config, handle.clone(), handle).unwrap();
 
         let hitcounter = test::Server::new();
         let source = hitcounter.source("pending", "/delay/1h/");

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -31,7 +31,6 @@ async fn main() -> anyhow::Result<()> {
     let runtime = tokio::runtime::Handle::current();
     let (symbolication, _objects) =
         symbolicator_service::services::create_service(&symbolicator_config, runtime)
-            .await
             .context("failed to start symbolication service")?;
 
     let mut sources = vec![];


### PR DESCRIPTION
This avoids some internal indirection and locking, and makes a couple of function non-async, such as the service startup path.

#skip-changelog