### PR TITLE
Add codecov.yml and update action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,6 @@ jobs:
 
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
-      - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
+      - uses: codecov/codecov-action@v3
         with:
           files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        env:
+          SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_CLIENT_EMAIL }}
+          SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_GCS_PRIVATE_KEY }}
+          SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_ACCESS_KEY_ID }}
+          SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.SENTRY_SYMBOLICATOR_TEST_AWS_SECRET_ACCESS_KEY }}
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Looks like I never committed the `.codecov.yml` file that makes codecov a lot less annoying :-)
This copies that file from other repos that have the same config, as well as updating the action to the latest version.

#skip-changelog