### PR TITLE
ref: Move `CacheKey` into its own file

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -121,10 +121,7 @@ impl CacheItemRequest for FetchFileRequest {
     type Item = Arc<CacheHandle>;
 
     fn get_cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.file_source.cache_key(),
-            scope: self.scope.clone(),
-        }
+        CacheKey::from_scoped_file(&self.scope, &self.file_source)
     }
 
     /// Downloads a file, writing it to `path`.

--- a/crates/symbolicator-service/src/services/cache_key.rs
+++ b/crates/symbolicator-service/src/services/cache_key.rs
@@ -8,29 +8,27 @@ use crate::types::Scope;
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct CacheKey {
     pub cache_key: String,
-    pub scope: Scope,
 }
 
 impl fmt::Display for CacheKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} (scope {})", self.cache_key, self.scope)
+        write!(f, "{}", self.cache_key)
     }
 }
 
 impl CacheKey {
     /// Creates a [`CacheKey`] for the given [`RemoteFile`] tied to [`Scope`].
     pub fn from_scoped_file(scope: &Scope, file: &RemoteFile) -> Self {
-        Self {
-            cache_key: file.cache_key(),
-            scope: scope.clone(),
-        }
+        let scope = safe_path_segment(scope.as_ref());
+        let cache_key = safe_path_segment(&file.cache_key());
+        let cache_key = format!("{scope}/{cache_key}");
+        Self { cache_key }
     }
 
     /// Returns the relative path inside the cache for this cache key.
     pub fn relative_path(&self) -> PathBuf {
         let mut path = PathBuf::new();
-        path.push(safe_path_segment(self.scope.as_ref()));
-        path.push(safe_path_segment(&self.cache_key));
+        path.push(&self.cache_key);
         path
     }
 
@@ -40,7 +38,7 @@ impl CacheKey {
         if version != 0 {
             path.push(version.to_string());
         }
-        path.push(self.relative_path());
+        path.push(&self.cache_key);
         path
     }
 }
@@ -50,5 +48,5 @@ impl CacheKey {
 /// * absolute paths
 /// * ":" (not a threat on POSIX filesystems, but confuses OS X Finder)
 fn safe_path_segment(s: &str) -> String {
-    s.replace(['.', '/', ':'], "_")
+    s.replace(['.', '/', '\\', ':'], "_")
 }

--- a/crates/symbolicator-service/src/services/cache_key.rs
+++ b/crates/symbolicator-service/src/services/cache_key.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use symbolicator_sources::RemoteFile;
+
+use crate::types::Scope;
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CacheKey {
+    pub cache_key: String,
+    pub scope: Scope,
+}
+
+impl fmt::Display for CacheKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (scope {})", self.cache_key, self.scope)
+    }
+}
+
+impl CacheKey {
+    /// Creates a [`CacheKey`] for the given [`RemoteFile`] tied to [`Scope`].
+    pub fn from_scoped_file(scope: &Scope, file: &RemoteFile) -> Self {
+        Self {
+            cache_key: file.cache_key(),
+            scope: scope.clone(),
+        }
+    }
+
+    /// Returns the relative path inside the cache for this cache key.
+    pub fn relative_path(&self) -> PathBuf {
+        let mut path = PathBuf::new();
+        path.push(safe_path_segment(self.scope.as_ref()));
+        path.push(safe_path_segment(&self.cache_key));
+        path
+    }
+
+    /// Returns the full cache path for this key inside the provided cache directory.
+    pub fn cache_path(&self, cache_dir: &Path, version: u32) -> PathBuf {
+        let mut path = PathBuf::from(cache_dir);
+        if version != 0 {
+            path.push(version.to_string());
+        }
+        path.push(self.relative_path());
+        path
+    }
+}
+
+/// Protect against:
+/// * ".."
+/// * absolute paths
+/// * ":" (not a threat on POSIX filesystems, but confuses OS X Finder)
+fn safe_path_segment(s: &str) -> String {
+    s.replace(['.', '/', ':'], "_")
+}

--- a/crates/symbolicator-service/src/services/cache_key.rs
+++ b/crates/symbolicator-service/src/services/cache_key.rs
@@ -26,10 +26,8 @@ impl CacheKey {
     }
 
     /// Returns the relative path inside the cache for this cache key.
-    pub fn relative_path(&self) -> PathBuf {
-        let mut path = PathBuf::new();
-        path.push(&self.cache_key);
-        path
+    pub fn relative_path(&self) -> &str {
+        &self.cache_key
     }
 
     /// Returns the full cache path for this key inside the provided cache directory.

--- a/crates/symbolicator-service/src/services/cacher.rs
+++ b/crates/symbolicator-service/src/services/cacher.rs
@@ -533,7 +533,6 @@ mod tests {
     use crate::cache::CacheName;
     use crate::config::{CacheConfig, CacheConfigs};
     use crate::test;
-    use crate::types::Scope;
 
     use super::*;
 
@@ -563,7 +562,6 @@ mod tests {
         fn get_cache_key(&self) -> CacheKey {
             CacheKey {
                 cache_key: String::from(self.key),
-                scope: Scope::Global,
             }
         }
 

--- a/crates/symbolicator-service/src/services/cacher.rs
+++ b/crates/symbolicator-service/src/services/cacher.rs
@@ -609,7 +609,7 @@ mod tests {
         .unwrap();
         let cacher = Cacher::new(cache, Default::default());
 
-        let request = TestCacheItem::new("some_cache_key");
+        let request = TestCacheItem::new("global/some_cache_key");
 
         let first_result = cacher.compute_memoized(request.clone()).await;
         assert_eq!(first_result.unwrap().as_str(), "some old cached contents");
@@ -651,7 +651,7 @@ mod tests {
         .unwrap();
         let cacher = Cacher::new(cache, Default::default());
 
-        let request = TestCacheItem::new("some_cache_key");
+        let request = TestCacheItem::new("global/some_cache_key");
 
         let first_result = cacher.compute_memoized(request.clone()).await;
         assert_eq!(first_result, Err(CacheError::NotFound));
@@ -665,13 +665,12 @@ mod tests {
     async fn test_lazy_computation_limit() {
         test::setup();
 
-        let keys = &["1", "2", "3"];
+        let keys = &["global/1", "global/2", "global/3"];
 
         let cache_dir = test::tempdir().path().join("test");
         std::fs::create_dir_all(cache_dir.join("global")).unwrap();
         for key in keys {
-            let mut path = cache_dir.join("global");
-            path.push(key);
+            let path = cache_dir.join(key);
             std::fs::write(path, "some old cached contents").unwrap();
         }
 

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -75,10 +75,7 @@ impl CacheItemRequest for FetchFileRequest {
     type Item = Il2cppHandle;
 
     fn get_cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.file_source.cache_key(),
-            scope: self.scope.clone(),
-        }
+        CacheKey::from_scoped_file(&self.scope, &self.file_source)
     }
 
     /// Downloads a file, writing it to `path`.

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -15,6 +15,7 @@ use crate::cache::Caches;
 use crate::config::Config;
 
 pub mod bitcode;
+mod cache_key;
 pub mod cacher;
 pub mod cficaches;
 pub mod derived;

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -52,10 +52,7 @@ pub struct ObjectMetaHandle {
 
 impl ObjectMetaHandle {
     pub fn cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.file_source.cache_key(),
-            scope: self.scope.clone(),
-        }
+        CacheKey::from_scoped_file(&self.scope, &self.file_source)
     }
 
     pub fn features(&self) -> ObjectFeatures {
@@ -120,10 +117,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
     type Item = Arc<ObjectMetaHandle>;
 
     fn get_cache_key(&self) -> CacheKey {
-        CacheKey {
-            cache_key: self.file_source.cache_key(),
-            scope: self.scope.clone(),
-        }
+        CacheKey::from_scoped_file(&self.scope, &self.file_source)
     }
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {

--- a/crates/symbolicator-service/src/services/shared_cache.rs
+++ b/crates/symbolicator-service/src/services/shared_cache.rs
@@ -846,8 +846,6 @@ mod tests {
 
     use symbolicator_test::TestGcsCredentials;
 
-    use crate::types::Scope;
-
     use super::*;
 
     impl From<TestGcsCredentials> for GcsSharedCacheConfig {
@@ -882,8 +880,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Global,
+                cache_key: "global/some_item".to_string(),
             },
         };
         let cache_path = dir.path().join(key.relative_path());
@@ -922,8 +919,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Global,
+                cache_key: "global/some_item".to_string(),
             },
         };
 
@@ -956,8 +952,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Global,
+                cache_key: "global/some_item".to_string(),
             },
         };
         let cache_path = dir.path().join(key.relative_path());
@@ -996,8 +991,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Scoped(Uuid::new_v4().to_string()),
+                cache_key: format!("{}/some_item", Uuid::new_v4()),
             },
         };
 
@@ -1029,8 +1023,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Scoped(Uuid::new_v4().to_string()),
+                cache_key: format!("{}/some_item", Uuid::new_v4()),
             },
         };
 
@@ -1055,8 +1048,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Scoped(Uuid::new_v4().to_string()),
+                cache_key: format!("{}/some_item", Uuid::new_v4()),
             },
         };
 
@@ -1096,8 +1088,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Scoped(Uuid::new_v4().to_string()),
+                cache_key: format!("{}/some_item", Uuid::new_v4()),
             },
         };
 
@@ -1140,8 +1131,7 @@ mod tests {
             name: CacheName::Objects,
             version: 0,
             local_key: CacheKey {
-                cache_key: "some_item".to_string(),
-                scope: Scope::Scoped(Uuid::new_v4().to_string()),
+                cache_key: format!("{}/some_item", Uuid::new_v4()),
             },
         };
 

--- a/crates/symbolicator-service/src/services/shared_cache.rs
+++ b/crates/symbolicator-service/src/services/shared_cache.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -175,11 +174,11 @@ impl GcsState {
         sentry::configure_scope(|scope| {
             let mut map = BTreeMap::new();
             map.insert("bucket".to_string(), self.config.bucket.clone().into());
-            map.insert("key".to_string(), key.gcs_bucket_key().into());
+            map.insert("key".to_string(), key.relative_path().into());
             scope.set_context("GCS Shared Cache", Context::Other(map));
         });
         let token = self.get_token().await?;
-        let url = gcs::download_url(&self.config.bucket, key.gcs_bucket_key().as_ref())
+        let url = gcs::download_url(&self.config.bucket, key.relative_path().as_ref())
             .context("URL construction failed")?;
         let request = self.client.get(url).bearer_auth(token.as_str()).send();
         let request = tokio::time::timeout(CONNECT_TIMEOUT, request);
@@ -190,10 +189,7 @@ impl GcsState {
                 let status = response.status();
                 match status {
                     _ if status.is_success() => {
-                        tracing::trace!(
-                            "Success hitting shared_cache GCS {}",
-                            key.gcs_bucket_key()
-                        );
+                        tracing::trace!("Success hitting shared_cache GCS {}", key.relative_path());
                         let stream = response
                             .bytes_stream()
                             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
@@ -217,7 +213,7 @@ impl GcsState {
             Ok(Err(e)) => {
                 tracing::trace!(
                     "Error in shared_cache GCS response for {}",
-                    key.gcs_bucket_key()
+                    key.relative_path()
                 );
                 Err(e).context("Bad GCS response for shared_cache")?
             }
@@ -227,7 +223,7 @@ impl GcsState {
 
     async fn exists(&self, key: &SharedCacheKey) -> Result<bool, CacheError> {
         let token = self.get_token().await?;
-        let url = gcs::object_url(&self.config.bucket, key.gcs_bucket_key().as_ref())
+        let url = gcs::object_url(&self.config.bucket, &key.relative_path())
             .context("failed to build object url")?;
         let request = self.client.get(url).bearer_auth(token.as_str()).send();
         let request = tokio::time::timeout(CONNECT_TIMEOUT, request);
@@ -276,7 +272,7 @@ impl GcsState {
         sentry::configure_scope(|scope| {
             let mut map = BTreeMap::new();
             map.insert("bucket".to_string(), self.config.bucket.clone().into());
-            map.insert("key".to_string(), key.gcs_bucket_key().into());
+            map.insert("key".to_string(), key.relative_path().into());
             scope.set_context("GCS Shared Cache", Context::Other(map));
         });
         if reason == CacheStoreReason::Refresh {
@@ -308,7 +304,7 @@ impl GcsState {
             .context("failed to build url")?
             .extend(&[&self.config.bucket, "o"]);
         url.query_pairs_mut()
-            .append_pair("name", &key.gcs_bucket_key())
+            .append_pair("name", &key.relative_path())
             // Upload only if it's not already there
             .append_pair("ifGenerationMatch", "0");
 
@@ -328,10 +324,7 @@ impl GcsState {
                 let status = response.status();
                 match status {
                     successful if successful.is_success() => {
-                        tracing::trace!(
-                            "Success hitting shared_cache GCS {}",
-                            key.gcs_bucket_key()
-                        );
+                        tracing::trace!("Success hitting shared_cache GCS {}", key.relative_path());
                         Ok(SharedCacheStoreResult::Written(total_bytes))
                     }
                     StatusCode::PRECONDITION_FAILED => Ok(SharedCacheStoreResult::Skipped),
@@ -347,7 +340,7 @@ impl GcsState {
             Ok(Err(err)) => {
                 tracing::trace!(
                     "Error in shared_cache GCS response for {}",
-                    key.gcs_bucket_key()
+                    key.relative_path()
                 );
                 Err(err).context("Bad GCS response for shared_cache")?
             }
@@ -458,29 +451,15 @@ pub struct SharedCacheKey {
 
 impl SharedCacheKey {
     /// The relative path of this cache key within a shared cache.
-    fn relative_path(&self) -> PathBuf {
+    fn relative_path(&self) -> String {
         // Note that this always pushes the version into the path, this is fine since we do
         // not need any backwards compatibility with existing caches for the shared cache.
-        let mut path = PathBuf::new();
-        path.push(self.name.to_string());
-        path.push(self.version.to_string());
-        path.push(self.local_key.relative_path());
-        path
-    }
-
-    /// The [`SharedCacheKey::relative_path`] as a GCS bucket key.
-    fn gcs_bucket_key(&self) -> String {
-        // All our paths should be UTF-8, we don't construct non-UTF-8 paths.
-        match self.relative_path().to_str() {
-            Some(s) => s.to_owned(),
-            None => {
-                tracing::error!(
-                    "Non UTF-8 path in SharedCacheKey: {}",
-                    self.relative_path().display()
-                );
-                self.relative_path().to_string_lossy().into_owned()
-            }
-        }
+        format!(
+            "{}/{}/{}",
+            self.name,
+            self.version,
+            self.local_key.relative_path()
+        )
     }
 }
 
@@ -647,10 +626,7 @@ impl SharedCacheService {
             let mut map = BTreeMap::new();
             map.insert("backend".to_string(), backend.name().into());
             map.insert("cache".to_string(), key.name.as_ref().into());
-            map.insert(
-                "path".to_string(),
-                key.relative_path().to_string_lossy().into(),
-            );
+            map.insert("path".to_string(), key.relative_path().into());
             scope.set_context("Shared Cache", Context::Other(map));
         });
 
@@ -733,10 +709,7 @@ impl SharedCacheService {
             let mut map = BTreeMap::new();
             map.insert("backend".to_string(), backend_name.into());
             map.insert("cache".to_string(), key.name.as_ref().into());
-            map.insert(
-                "path".to_string(),
-                key.relative_path().to_string_lossy().into(),
-            );
+            map.insert("path".to_string(), key.relative_path().into());
             scope.set_context("Shared Cache", Context::Other(map));
         });
         let res = match self.backend.as_ref() {


### PR DESCRIPTION
This is a preliminary refactor moving us a bit closer towards #983:

Adds a different constructor to `CacheKey` and makes it use `String` internally instead of `PathBuf`.

The goal here is that it should make it simpler to move us towards to just use opaque paths/strings for these cache files.

The problem is also that we have different permutations of names:
- For the `Cacher`, the `cache_dir` already includes the `CacheName`, so the `cache_path` added on top does not need it.
- However for the `SharedCache`, the `CacheName` needs to be prepended directly. The shared cache needs the `CacheName` parameter anyway for reasons, so we might as well reuse the same cache key and just prepend the cache name in the shared cache abstraction?

So we end up with the different cases (where `key` = `{scope}/{file_key}`:
- `$cache_dir` + `/{version}/{key}` for versioned caches
- `$cache_dir` + `/{key}` for unversioned caches
- `{cache_name}/{version}/{key}` for the shared cache

If we want to migrate the keys to hashes, we would then have additionally:
- `$cache_dir` + `/{version}/{hashed_key}` these would always be versioned
- `{cache_name}/{version}/{hashed_key}` for the shared cache

#skip-changelog