### PR TITLE
fix: Properly support NuGet symbols with SymbolChecksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   frame's instruction address needs to be adjusted for symbolication. ([#948](https://github.com/getsentry/symbolicator/pull/948))
 - Added offline mode and caching to `symbolicli`. ([#967](https://github.com/getsentry/symbolicator/pull/967),[#968](https://github.com/getsentry/symbolicator/pull/968))
 - Support PortablePDB embedded sources. ([#996](https://github.com/getsentry/symbolicator/pull/996))
+- Properly support NuGet symbols with SymbolChecksum. ([#993](https://github.com/getsentry/symbolicator/pull/993))
 
 ### Internal
 

--- a/crates/symbolicator-service/src/services/download/http.rs
+++ b/crates/symbolicator-service/src/services/download/http.rs
@@ -39,14 +39,20 @@ impl HttpDownloader {
         tracing::debug!("Fetching debug file from {}", download_url);
         let mut builder = self.client.get(download_url.clone());
 
-        for (key, value) in file_source.source.headers.iter() {
+        let headers = file_source
+            .source
+            .headers
+            .iter()
+            .chain(file_source.headers.iter());
+        for (key, value) in headers {
             if let Ok(key) = header::HeaderName::from_bytes(key.as_bytes()) {
                 builder = builder.header(key, value.as_str());
             }
         }
-        let source = RemoteFile::from(file_source);
+
         let request = builder.header(header::USER_AGENT, USER_AGENT);
 
+        let source = RemoteFile::from(file_source);
         super::download_reqwest(
             &source,
             request,

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -173,12 +173,12 @@ fn map_apple_binary_image(image: apple_crash_report_parser::BinaryImage) -> Comp
         code_file: Some(image.path.clone()),
         debug_id: Some(debug_id.to_string()),
         debug_file: Some(image.path),
+        debug_checksum: None,
         image_addr: HexValue(image.addr.0),
         image_size: match image.size {
             0 => None,
             size => Some(size),
         },
-        checksum: None,
     };
 
     raw_info.into()

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -38,6 +38,7 @@ fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
         },
         debug_file: object_info.debug_file.clone(),
         code_file: object_info.code_file.clone(),
+        debug_checksum: object_info.debug_checksum.clone(),
         object_type: object_info.ty,
     }
 }

--- a/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
+++ b/crates/symbolicator-service/src/services/symbolication/module_lookup.rs
@@ -525,9 +525,9 @@ mod tests {
             debug_id: None,
             code_file: None,
             debug_file: None,
+            debug_checksum: None,
             image_addr: HexValue(42),
             image_size: Some(0),
-            checksum: None,
         });
 
         let lookup = ModuleLookup::new(Scope::Global, Arc::new([]), std::iter::once(info.clone()));

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -185,6 +185,7 @@ impl SymbolicatorSymbolProvider {
                     debug_file: module
                         .debug_file()
                         .map(|debug_file| debug_file.into_owned()),
+                    debug_checksum: None,
                     object_type: self.object_type,
                 };
 
@@ -260,12 +261,12 @@ fn object_info_from_minidump_module(ty: ObjectType, module: &MinidumpModule) -> 
         code_file,
         debug_id: module.debug_identifier().map(|c| c.breakpad().to_string()),
         debug_file: module.debug_file().map(|c| c.into_owned()),
+        debug_checksum: None,
         image_addr: HexValue(module.base_address()),
         image_size: match module.size() {
             0 => None,
             size => Some(size),
         },
-        checksum: None,
     })
 }
 

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -249,6 +249,10 @@ pub struct RawObjectInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debug_file: Option<String>,
 
+    /// Checksum of the file's contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debug_checksum: Option<String>,
+
     /// Absolute address at which the image was mounted into virtual memory.
     ///
     /// We do allow the `image_addr` to be skipped if it is zero. This is because systems like WASM
@@ -262,10 +266,6 @@ pub struct RawObjectInfo {
     /// The size is infered from the module list if not specified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_size: Option<u64>,
-
-    /// Checksum of the file's contents.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checksum: Option<String>,
 }
 
 /// Information on the symbolication status of this frame.

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__nuget_file.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__nuget_file.snap
@@ -1,0 +1,45 @@
+---
+source: crates/symbolicator-service/tests/integration/symbolication.rs
+assertion_line: 313
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        original_index: 0
+        addr_mode: "rel:0"
+        instruction_addr: "0x21"
+        function_id: "0xc"
+        package: "./TimeZoneConverter.dll"
+        lang: csharp
+        filename: TZConvert.cs
+        abs_path: /_/src/TimeZoneConverter/TZConvert.cs
+        lineno: 115
+modules:
+  - debug_status: found
+    features:
+      has_debug_info: true
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: true
+    arch: unknown
+    type: pe_dotnet
+    code_id: efc9a199e000
+    code_file: "./TimeZoneConverter.dll"
+    debug_id: 4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc
+    debug_file: "./TimeZoneConverter.pdb"
+    debug_checksum: "SHA256:87a82c4e5e82f386968f25b41ae1b5f3cc3f6d9e79cfb4464f8240400fc47dcd"
+    image_addr: "0x0"
+    candidates:
+      - source: nuget
+        location: "https://symbols.nuget.org/download/symbols/TimeZoneConverter.pdb/4E2CA887825E46F3968F25B41AE1B5F3ffffffff/TimeZoneConverter.pdb"
+        download:
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: false
+            has_symbols: false
+            has_sources: true
+        debug:
+          status: ok
+

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -484,6 +484,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: Some(leading_fn.into()),
                 debug_id: None,
                 debug_file: None,
+                debug_checksum: None,
                 object_type: ObjectType::Elf,
             },
         ))
@@ -495,6 +496,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: Some(leading_fn.into()),
                 debug_id: None,
                 debug_file: None,
+                debug_checksum: None,
                 object_type: ObjectType::Elf,
             },
         ))
@@ -507,6 +509,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: Some(leading_fn.into()),
                 debug_id: None,
                 debug_file: None,
+                debug_checksum: None,
                 object_type: ObjectType::Macho,
             },
         ))
@@ -518,6 +521,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: Some(leading_fn.into()),
                 debug_id: None,
                 debug_file: None,
+                debug_checksum: None,
                 object_type: ObjectType::Macho,
             },
         ))
@@ -529,6 +533,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: None,
                 debug_id: Some(DebugId::from_breakpad(signature).ok()?),
                 debug_file: Some(leading_fn.into()),
+                debug_checksum: None,
                 object_type: ObjectType::Pe,
             },
         ))
@@ -540,6 +545,7 @@ pub fn parse_symstore_path(path: &str) -> Option<(&'static [FileType], ObjectId)
                 code_file: Some(leading_fn.into()),
                 debug_id: None,
                 debug_file: None,
+                debug_checksum: None,
                 object_type: ObjectType::Pe,
             },
         ))
@@ -583,6 +589,7 @@ mod tests {
             code_file: Some("C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe".into()),
             debug_id: Some("3249d99d-0c40-4931-8610-f4e4fb0b6936-1".parse().unwrap()),
             debug_file: Some("C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb".into()),
+                debug_checksum: None,
             object_type: ObjectType::Pe,
         };
         static ref MACHO_OBJECT_ID: ObjectId = ObjectId {
@@ -590,6 +597,7 @@ mod tests {
             code_file: Some("/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash".into()),
             debug_id: Some("67e9247c-814e-392b-a027-dbde6748fcbf".parse().unwrap()),
             debug_file: Some("crash".into()),
+                debug_checksum: None,
             object_type: ObjectType::Macho,
         };
         static ref ELF_OBJECT_ID: ObjectId = ObjectId {
@@ -597,6 +605,7 @@ mod tests {
             code_file: Some("/lib/x86_64-linux-gnu/libm-2.23.so".into()),
             debug_id: Some("e45db8df-af2d-09fd-640c-8fe377d572de".parse().unwrap()),
             debug_file: Some("/lib/x86_64-linux-gnu/libm-2.23.so".into()),
+                debug_checksum: None,
             object_type: ObjectType::Elf,
         };
         static ref WASM_OBJECT_ID: ObjectId = ObjectId {
@@ -604,6 +613,7 @@ mod tests {
             code_file: None,
             debug_id: Some("67e9247c-814e-392b-a027-dbde6748fcbf".parse().unwrap()),
             debug_file: Some("file://foo.invalid/demo.wasm".into()),
+                debug_checksum: None,
             object_type: ObjectType::Wasm,
         };
     }

--- a/crates/symbolicator-sources/src/sources/http.rs
+++ b/crates/symbolicator-sources/src/sources/http.rs
@@ -30,6 +30,8 @@ pub struct HttpRemoteFile {
     /// The underlying [`HttpSourceConfig`].
     pub source: Arc<HttpSourceConfig>,
     pub(crate) location: SourceLocation,
+    /// Additional HTTP headers to send with a symbol request.
+    pub headers: BTreeMap<String, String>,
 }
 
 impl From<HttpRemoteFile> for RemoteFile {
@@ -41,7 +43,11 @@ impl From<HttpRemoteFile> for RemoteFile {
 impl HttpRemoteFile {
     /// Creates a new [`HttpRemoteFile`].
     pub fn new(source: Arc<HttpSourceConfig>, location: SourceLocation) -> Self {
-        Self { source, location }
+        Self {
+            source,
+            location,
+            headers: Default::default(),
+        }
     }
 
     pub(crate) fn uri(&self) -> RemoteFileUri {

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -111,6 +111,9 @@ pub struct ObjectId {
     /// Path to the debug file.
     pub debug_file: Option<String>,
 
+    /// Checksum of the debug file's contents.
+    pub debug_checksum: Option<String>,
+
     /// Hint to what we believe the file type should be.
     pub object_type: ObjectType,
 }

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -124,6 +124,20 @@ pub fn microsoft_symsrv() -> SourceConfig {
     }))
 }
 
+pub fn nuget_source() -> SourceConfig {
+    SourceConfig::Http(Arc::new(HttpSourceConfig {
+        id: SourceId::new("nuget"),
+        url: "https://symbols.nuget.org/download/symbols/"
+            .parse()
+            .unwrap(),
+        headers: Default::default(),
+        files: source_config(
+            symbolicator_sources::DirectoryLayoutType::Symstore,
+            vec![FileType::Pe, FileType::Pdb, FileType::PortablePdb],
+        ),
+    }))
+}
+
 /// Gives a [`CommonSourceConfig`] with the given layout type and file types filter.
 pub fn source_config(ty: DirectoryLayoutType, filetypes: Vec<FileType>) -> CommonSourceConfig {
     CommonSourceConfig {

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -598,7 +598,7 @@ mod tests {
                 image_size: Some(4096),
                 code_file: None,
                 debug_file: None,
-                checksum: None,
+                debug_checksum: None,
             })],
         }
     }


### PR DESCRIPTION
Adds the `SymbolChecksum` header to HTTP sources if the `ObjectId` has a `debug_checksum` field. Also properly passes through that `debug_checksum` field from the incoming modules definition.

This is still lacking proper tests, for which we would need an event that uses some .NET library that has symbols available on nuget. I suggest we do a proper integration test fetching things from upstream, as the upstream server at least checks for the presence of the header (even though it does not *yet* check the actual checksum, lol).

Apart from this, we should also make sure that the `debug_checksum` field is correctly passed through from sentry itself, and maybe also add the NuGet server as a builtin source in sentry, because why not…