### PR TITLE
ref: Improve Integration Tests a bit

### DIFF
--- a/crates/symbolicator-service/tests/integration/main.rs
+++ b/crates/symbolicator-service/tests/integration/main.rs
@@ -2,5 +2,9 @@
 
 pub mod e2e;
 pub mod process_minidump;
+pub mod public_sources;
 pub mod source_errors;
 pub mod symbolication;
+pub mod utils;
+
+pub use utils::*;

--- a/crates/symbolicator-service/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-service/tests/integration/process_minidump.rs
@@ -5,18 +5,16 @@ use std::sync::Arc;
 use tempfile::NamedTempFile;
 
 use symbolicator_service::types::Scope;
-use symbolicator_test as test;
-use symbolicator_test::assert_snapshot;
 
-use crate::symbolication::setup_service;
+use crate::{assert_snapshot, read_fixture, setup_service, symbol_server};
 
 macro_rules! stackwalk_minidump {
     ($path:expr) => {
         async {
             let (symbolication, cache_dir) = setup_service(|_| ());
-            let (_symsrv, source) = test::symbol_server();
+            let (_symsrv, source) = symbol_server();
 
-            let minidump = test::read_fixture($path);
+            let minidump = read_fixture($path);
             let mut minidump_file = NamedTempFile::new().unwrap();
             minidump_file.write_all(&minidump).unwrap();
             let response = symbolication

--- a/crates/symbolicator-service/tests/integration/public_sources.rs
+++ b/crates/symbolicator-service/tests/integration/public_sources.rs
@@ -22,10 +22,7 @@ async fn test_nuget_source() {
             .parse()
             .unwrap(),
         headers: Default::default(),
-        files: source_config(
-            DirectoryLayoutType::Symstore,
-            vec![FileType::Pe, FileType::Pdb, FileType::PortablePdb],
-        ),
+        files: source_config(DirectoryLayoutType::Symstore, vec![FileType::PortablePdb]),
     }));
 
     let request = make_symbolication_request(

--- a/crates/symbolicator-service/tests/integration/public_sources.rs
+++ b/crates/symbolicator-service/tests/integration/public_sources.rs
@@ -1,0 +1,52 @@
+//! Integration tests for some public symbol servers that we want to explicitly fetch from.
+//!
+//! Ideally we should only test each public symbol server we care about only once, as fetching "real"
+//! symbols from the web can be slow and presents a source of flakiness.
+//! FIXME: We currently use the microsoft symbol server all over the place for a couple of tests,
+//! which we should migrate over to use our internal fixtures instead.
+
+use std::sync::Arc;
+
+use symbolicator_sources::{
+    DirectoryLayoutType, FileType, HttpSourceConfig, SourceConfig, SourceId,
+};
+
+use crate::{assert_snapshot, make_symbolication_request, setup_service, source_config};
+
+#[tokio::test]
+async fn test_nuget_source() {
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let source = SourceConfig::Http(Arc::new(HttpSourceConfig {
+        id: SourceId::new("nuget"),
+        url: "https://symbols.nuget.org/download/symbols/"
+            .parse()
+            .unwrap(),
+        headers: Default::default(),
+        files: source_config(
+            DirectoryLayoutType::Symstore,
+            vec![FileType::Pe, FileType::Pdb, FileType::PortablePdb],
+        ),
+    }));
+
+    let request = make_symbolication_request(
+        vec![source],
+        r#"[{
+          "type":"pe_dotnet",
+          "code_id": "efc9a199e000",
+          "code_file": "./TimeZoneConverter.dll",
+          "debug_id": "4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc",
+          "debug_file": "./TimeZoneConverter.pdb",
+          "debug_checksum": "SHA256:87a82c4e5e82f386968f25b41ae1b5f3cc3f6d9e79cfb4464f8240400fc47dcd"
+        }]"#,
+        r#"[{
+          "frames":[{
+            "instruction_addr": "0x21",
+            "function_id": "0xc",
+            "addr_mode":"rel:0"
+          }]
+        }]"#,
+    );
+    let response = symbolication.symbolicate(request).await;
+
+    assert_snapshot!(response.unwrap());
+}

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__public_sources__nuget_source.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__public_sources__nuget_source.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/symbolicator-service/tests/integration/symbolication.rs
-assertion_line: 313
+source: crates/symbolicator-service/tests/integration/public_sources.rs
+assertion_line: 45
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__public_sources__ubuntu_source.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__public_sources__ubuntu_source.snap
@@ -1,0 +1,64 @@
+---
+source: crates/symbolicator-service/tests/integration/public_sources.rs
+assertion_line: 83
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        original_index: 0
+        instruction_addr: "0x7fa923b1df1a"
+        package: /usr/lib/x86_64-linux-gnu/libc.so.6
+        lang: c
+        symbol: __pthread_cond_wait_common
+        function: __pthread_cond_wait_common
+        filename: pthread_cond_wait.c
+        abs_path: nptl/nptl/pthread_cond_wait.c
+        lineno: 503
+      - status: symbolicated
+        original_index: 0
+        instruction_addr: "0x7fa923b1df1a"
+        package: /usr/lib/x86_64-linux-gnu/libc.so.6
+        lang: c
+        symbol: __GI___pthread_cond_timedwait
+        sym_addr: "0x7fa923b1dce0"
+        function: __GI___pthread_cond_timedwait
+        filename: pthread_cond_wait.c
+        abs_path: nptl/nptl/pthread_cond_wait.c
+        lineno: 652
+modules:
+  - debug_status: found
+    features:
+      has_debug_info: true
+      has_unwind_info: false
+      has_symbols: true
+      has_sources: false
+    arch: x86_64
+    type: elf
+    code_id: 69389d485a9793dbe873f0ea2c93e02efaa9aa3d
+    code_file: /usr/lib/x86_64-linux-gnu/libc.so.6
+    debug_id: 489d3869-975a-db93-e873-f0ea2c93e02e
+    debug_file: /usr/lib/x86_64-linux-gnu/libc.so.6
+    image_addr: "0x7fa923a8a000"
+    image_size: 1822720
+    candidates:
+      - source: ubuntu
+        location: No object files listed on this source
+        download:
+          status: notfound
+      - source: ubuntu
+        location: "https://debuginfod.ubuntu.com/buildid/69389d485a9793dbe873f0ea2c93e02efaa9aa3d/debuginfo"
+        download:
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: false
+            has_symbols: true
+            has_sources: false
+        debug:
+          status: ok
+      - source: ubuntu
+        location: "https://debuginfod.ubuntu.com/buildid/69389d485a9793dbe873f0ea2c93e02efaa9aa3d/executable"
+        download:
+          status: notfound
+

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -4,9 +4,8 @@ use symbolicator_service::types::{
     CompletedSymbolicationResponse, FrameStatus, ObjectDownloadInfo, ObjectFileStatus,
     ObjectUseInfo,
 };
-use symbolicator_test::Server;
 
-use crate::symbolication::{get_symbolication_request, setup_service};
+use crate::{example_request, setup_service, Server};
 
 #[tokio::test]
 async fn test_download_errors() {
@@ -39,7 +38,7 @@ async fn test_download_errors() {
     for _ in 0..2 {
         // NOTE: we try this 3 times on error
         let source = hitcounter.source("rejected", "/respond_statuscode/500/");
-        let request = get_symbolication_request(vec![source]);
+        let request = example_request(vec![source]);
         let response = symbolication.symbolicate(request).await.unwrap();
 
         assert_eq!(
@@ -56,7 +55,7 @@ async fn test_download_errors() {
 
         // NOTE: we should probably try this 3 times?
         let source = hitcounter.source("pending", "/delay/1h/");
-        let request = get_symbolication_request(vec![source]);
+        let request = example_request(vec![source]);
         let response = symbolication.symbolicate(request).await.unwrap();
 
         assert_eq!(
@@ -72,7 +71,7 @@ async fn test_download_errors() {
         );
 
         let source = hitcounter.source("notfound", "/respond_statuscode/404/");
-        let request = get_symbolication_request(vec![source]);
+        let request = example_request(vec![source]);
         let response = symbolication.symbolicate(request).await.unwrap();
 
         assert_eq!(
@@ -86,7 +85,7 @@ async fn test_download_errors() {
         );
 
         let source = hitcounter.source("permissiondenied", "/respond_statuscode/403/");
-        let request = get_symbolication_request(vec![source]);
+        let request = example_request(vec![source]);
         let response = symbolication.symbolicate(request).await.unwrap();
 
         assert_eq!(
@@ -102,7 +101,7 @@ async fn test_download_errors() {
         );
 
         let source = hitcounter.source("invalid", "/garbage_data/invalid");
-        let request = get_symbolication_request(vec![source]);
+        let request = example_request(vec![source]);
         let response = symbolication.symbolicate(request).await.unwrap();
 
         assert_eq!(

--- a/crates/symbolicator-service/tests/integration/symbolication.rs
+++ b/crates/symbolicator-service/tests/integration/symbolication.rs
@@ -1,86 +1,11 @@
 use std::sync::Arc;
 
-use symbolicator_service::config::Config;
-use symbolicator_service::services::create_service;
-use symbolicator_service::services::symbolication::{
-    StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor,
+use symbolicator_service::types::Scope;
+
+use crate::{
+    assert_snapshot, example_request, fixture, make_symbolication_request, setup_service,
+    symbol_server,
 };
-use symbolicator_service::types::{
-    CompleteObjectInfo, RawFrame, RawObjectInfo, RawStacktrace, Scope,
-};
-use symbolicator_service::utils::hex::HexValue;
-use symbolicator_sources::{ObjectType, SourceConfig};
-use symbolicator_test as test;
-use symbolicator_test::{assert_snapshot, fixture};
-
-/// Setup tests and create a test service.
-///
-/// This function returns a tuple containing the service to test, and a temporary cache
-/// directory. The directory is cleaned up when the [`TempDir`] instance is dropped. Keep it as
-/// guard until the test has finished.
-///
-/// The service is configured with `connect_to_reserved_ips = True`. This allows to use a local
-/// symbol server to test object file downloads.
-pub fn setup_service(
-    update_config: impl FnOnce(&mut Config),
-) -> (SymbolicationActor, test::TempDir) {
-    test::setup();
-
-    let cache_dir = test::tempdir();
-
-    let mut config = Config {
-        cache_dir: Some(cache_dir.path().to_owned()),
-        connect_to_reserved_ips: true,
-        ..Default::default()
-    };
-    update_config(&mut config);
-
-    let handle = tokio::runtime::Handle::current();
-    let (symbolication, _objects) = create_service(&config, handle).unwrap();
-
-    (symbolication, cache_dir)
-}
-
-pub fn get_symbolication_request(sources: Vec<SourceConfig>) -> SymbolicateStacktraces {
-    SymbolicateStacktraces {
-        scope: Scope::Global,
-        signal: None,
-        sources: Arc::from(sources),
-        origin: StacktraceOrigin::Symbolicate,
-        stacktraces: vec![RawStacktrace {
-            frames: vec![RawFrame {
-                instruction_addr: HexValue(0x1_0000_0fa0),
-                ..RawFrame::default()
-            }],
-            ..RawStacktrace::default()
-        }],
-        modules: vec![CompleteObjectInfo::from(RawObjectInfo {
-            ty: ObjectType::Macho,
-            code_id: Some("502fc0a51ec13e479998684fa139dca7".to_owned().to_lowercase()),
-            debug_id: Some("502fc0a5-1ec1-3e47-9998-684fa139dca7".to_owned()),
-            image_addr: HexValue(0x1_0000_0000),
-            image_size: Some(4096),
-            code_file: None,
-            debug_file: None,
-            debug_checksum: None,
-        })],
-    }
-}
-
-pub fn make_symbolication_request(
-    modules: Vec<RawObjectInfo>,
-    stacktraces: Vec<RawStacktrace>,
-    sources: Vec<SourceConfig>,
-) -> SymbolicateStacktraces {
-    SymbolicateStacktraces {
-        modules: modules.into_iter().map(From::from).collect(),
-        stacktraces,
-        signal: None,
-        origin: StacktraceOrigin::Symbolicate,
-        sources: Arc::from(sources),
-        scope: Default::default(),
-    }
-}
 
 #[tokio::test]
 async fn test_remove_bucket() {
@@ -88,14 +13,14 @@ async fn test_remove_bucket() {
     // cached debug files to requests that no longer specify a source.
 
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_symsrv, source) = test::symbol_server();
+    let (_symsrv, source) = symbol_server();
 
-    let request = get_symbolication_request(vec![source]);
+    let request = example_request(vec![source]);
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
 
-    let request = get_symbolication_request(vec![]);
+    let request = example_request(vec![]);
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
@@ -107,14 +32,14 @@ async fn test_add_bucket() {
     // to requests immediately.
 
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_symsrv, source) = test::symbol_server();
+    let (_symsrv, source) = symbol_server();
 
-    let request = get_symbolication_request(vec![]);
+    let request = example_request(vec![]);
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
 
-    let request = get_symbolication_request(vec![source]);
+    let request = example_request(vec![source]);
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
@@ -123,7 +48,7 @@ async fn test_add_bucket() {
 #[tokio::test]
 async fn test_apple_crash_report() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_symsrv, source) = test::symbol_server();
+    let (_symsrv, source) = symbol_server();
 
     let report_file = std::fs::File::open(fixture("apple_crash_report.txt")).unwrap();
 
@@ -137,29 +62,23 @@ async fn test_apple_crash_report() {
 #[tokio::test]
 async fn test_wasm_payload() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_symsrv, source) = test::symbol_server();
+    let (_symsrv, source) = symbol_server();
 
-    let modules = serde_json::from_str(
+    let request = make_symbolication_request(
+        vec![source],
         r#"[{
           "type":"wasm",
           "debug_id":"bda18fd8-5d4a-4eb8-9302-2d6bfad846b1",
           "code_id":"bda18fd85d4a4eb893022d6bfad846b1",
           "debug_file":"file://foo.invalid/demo.wasm"
         }]"#,
-    )
-    .unwrap();
-
-    let stacktraces = serde_json::from_str(
         r#"[{
           "frames":[{
             "instruction_addr":"0x8c",
             "addr_mode":"rel:0"
           }]
         }]"#,
-    )
-    .unwrap();
-
-    let request = make_symbolication_request(modules, stacktraces, vec![source]);
+    );
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
@@ -168,30 +87,24 @@ async fn test_wasm_payload() {
 #[tokio::test]
 async fn test_source_candidates() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_symsrv, source) = test::symbol_server();
+    let (_symsrv, source) = symbol_server();
 
     // its not wasm, but that is the easiest to write tests because of relative
     // addressing ;-)
-    let modules = serde_json::from_str(
+    let request = make_symbolication_request(
+        vec![source],
         r#"[{
           "type":"wasm",
           "debug_id":"7f883fcd-c553-36d0-a809-b0150f09500b",
           "code_id":"7f883fcdc55336d0a809b0150f09500b"
         }]"#,
-    )
-    .unwrap();
-
-    let stacktraces = serde_json::from_str(
         r#"[{
           "frames":[{
             "instruction_addr":"0x3880",
             "addr_mode":"rel:0"
           }]
         }]"#,
-    )
-    .unwrap();
-
-    let request = make_symbolication_request(modules, stacktraces, vec![source]);
+    );
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
@@ -200,18 +113,15 @@ async fn test_source_candidates() {
 #[tokio::test]
 async fn test_dotnet_integration() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_srv, source) = test::symbol_server();
+    let (_srv, source) = symbol_server();
 
-    let modules = serde_json::from_str(
+    let request = make_symbolication_request(
+        vec![source],
         r#"[{
           "type":"pe_dotnet",
           "debug_file":"integration.pdb",
           "debug_id":"0c1033f78632492e91c6c314b72e1920e60b819d"
         }]"#,
-    )
-    .unwrap();
-
-    let stacktraces = serde_json::from_str(
         r#"[{
           "frames":[{
             "instruction_addr": 10,
@@ -239,10 +149,7 @@ async fn test_dotnet_integration() {
             "addr_mode": "rel:0"
           }]
         }]"#,
-    )
-    .unwrap();
-
-    let request = make_symbolication_request(modules, stacktraces, vec![source]);
+    );
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());
@@ -251,18 +158,15 @@ async fn test_dotnet_integration() {
 #[tokio::test]
 async fn test_dotnet_embedded_sources() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
-    let (_srv, source) = test::symbol_server();
+    let (_srv, source) = symbol_server();
 
-    let modules = serde_json::from_str(
+    let request = make_symbolication_request(
+        vec![source],
         r#"[{
           "type":"pe_dotnet",
           "debug_file":"portable-embedded.pdb",
           "debug_id":"b6919861-510c-4887-9994-943f64f70c37-870b9ef9"
         }]"#,
-    )
-    .unwrap();
-
-    let stacktraces = serde_json::from_str(
         r#"[{
           "frames":[{
             "instruction_addr": 47,
@@ -270,44 +174,7 @@ async fn test_dotnet_embedded_sources() {
             "addr_mode":"rel:0"
           }]
         }]"#,
-    )
-    .unwrap();
-
-    let request = make_symbolication_request(modules, stacktraces, vec![source]);
-    let response = symbolication.symbolicate(request).await;
-
-    assert_snapshot!(response.unwrap());
-}
-
-#[tokio::test]
-async fn test_nuget_file() {
-    let (symbolication, _cache_dir) = setup_service(|_| ());
-    let source = test::nuget_source();
-
-    let modules = serde_json::from_str(
-        r#"[{
-          "type":"pe_dotnet",
-          "code_id": "efc9a199e000",
-          "code_file": "./TimeZoneConverter.dll",
-          "debug_id": "4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc",
-          "debug_file": "./TimeZoneConverter.pdb",
-          "debug_checksum": "SHA256:87a82c4e5e82f386968f25b41ae1b5f3cc3f6d9e79cfb4464f8240400fc47dcd"
-        }]"#,
-    )
-    .unwrap();
-
-    let stacktraces = serde_json::from_str(
-        r#"[{
-          "frames":[{
-            "instruction_addr": "0x21",
-            "function_id": "0xc",
-            "addr_mode":"rel:0"
-          }]
-        }]"#,
-    )
-    .unwrap();
-
-    let request = make_symbolication_request(modules, stacktraces, vec![source]);
+    );
     let response = symbolication.symbolicate(request).await;
 
     assert_snapshot!(response.unwrap());

--- a/crates/symbolicator-service/tests/integration/utils.rs
+++ b/crates/symbolicator-service/tests/integration/utils.rs
@@ -1,1 +1,82 @@
+use std::sync::Arc;
 
+use symbolicator_service::config::Config;
+use symbolicator_service::services::create_service;
+use symbolicator_service::services::symbolication::{
+    StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor,
+};
+use symbolicator_service::types::RawObjectInfo;
+use symbolicator_sources::SourceConfig;
+use symbolicator_test as test;
+
+pub use test::{assert_snapshot, fixture, read_fixture, source_config, symbol_server, Server};
+
+/// Setup tests and create a test service.
+///
+/// This function returns a tuple containing the service to test, and a temporary cache
+/// directory. The directory is cleaned up when the [`TempDir`] instance is dropped. Keep it as
+/// guard until the test has finished.
+///
+/// The service is configured with `connect_to_reserved_ips = True`. This allows to use a local
+/// symbol server to test object file downloads.
+/// The `update_config` closure can modify any default configuration if needed before the server is
+/// started.
+pub fn setup_service(
+    update_config: impl FnOnce(&mut Config),
+) -> (SymbolicationActor, test::TempDir) {
+    test::setup();
+
+    let cache_dir = test::tempdir();
+
+    let mut config = Config {
+        cache_dir: Some(cache_dir.path().to_owned()),
+        connect_to_reserved_ips: true,
+        ..Default::default()
+    };
+    update_config(&mut config);
+
+    let handle = tokio::runtime::Handle::current();
+    let (symbolication, _objects) = create_service(&config, handle).unwrap();
+
+    (symbolication, cache_dir)
+}
+
+/// Creates a new Symbolication request with the given modules and stack traces,
+/// which are being parsed from JSON.
+pub fn make_symbolication_request(
+    sources: Vec<SourceConfig>,
+    modules: &str,
+    stacktraces: &str,
+) -> SymbolicateStacktraces {
+    let modules: Vec<RawObjectInfo> = serde_json::from_str(modules).unwrap();
+    let stacktraces = serde_json::from_str(stacktraces).unwrap();
+    SymbolicateStacktraces {
+        modules: modules.into_iter().map(From::from).collect(),
+        stacktraces,
+        signal: None,
+        origin: StacktraceOrigin::Symbolicate,
+        sources: Arc::from(sources),
+        scope: Default::default(),
+    }
+}
+
+/// Creates an example Symbolication request with the given sources.
+/// The stack trace contains a single frame referencing the one module, which is available in the
+/// fixtures that are being served by [`symbol_server`].
+pub fn example_request(sources: Vec<SourceConfig>) -> SymbolicateStacktraces {
+    make_symbolication_request(
+        sources,
+        r#"[{
+          "type":"macho",
+          "debug_id":"502fc0a5-1ec1-3e47-9998-684fa139dca7",
+          "code_id":"502fc0a51ec13e479998684fa139dca7",
+          "image_addr": "0x100000000",
+          "image_size": 4096
+        }]"#,
+        r#"[{
+          "frames":[{
+            "instruction_addr":"0x100000fa0"
+          }]
+        }]"#,
+    )
+}

--- a/crates/symbolicator-service/tests/integration/utils.rs
+++ b/crates/symbolicator-service/tests/integration/utils.rs
@@ -43,6 +43,7 @@ pub fn setup_service(
 
 /// Creates a new Symbolication request with the given modules and stack traces,
 /// which are being parsed from JSON.
+#[track_caller]
 pub fn make_symbolication_request(
     sources: Vec<SourceConfig>,
     modules: &str,

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -107,6 +107,8 @@ pub fn local_source() -> SourceConfig {
 }
 
 /// Get bucket configuration for the microsoft symbol server.
+// FIXME(swatinem): this is used for a couple of http endpoint tests, which we could migrate to our
+// local source as well.
 pub fn microsoft_symsrv() -> SourceConfig {
     SourceConfig::Http(Arc::new(HttpSourceConfig {
         id: SourceId::new("microsoft"),
@@ -121,20 +123,6 @@ pub fn microsoft_symsrv() -> SourceConfig {
             },
             ..Default::default()
         },
-    }))
-}
-
-pub fn nuget_source() -> SourceConfig {
-    SourceConfig::Http(Arc::new(HttpSourceConfig {
-        id: SourceId::new("nuget"),
-        url: "https://symbols.nuget.org/download/symbols/"
-            .parse()
-            .unwrap(),
-        headers: Default::default(),
-        files: source_config(
-            symbolicator_sources::DirectoryLayoutType::Symstore,
-            vec![FileType::Pe, FileType::Pdb, FileType::PortablePdb],
-        ),
     }))
 }
 
@@ -332,7 +320,7 @@ impl Default for Server {
 /// Spawn an actual HTTP symbol server for local fixtures.
 ///
 /// The symbol server serves static files from the local symbols fixture location under the
-/// `/download` prefix. The layout of this folder is `DirectoryLayoutType::Native`. This function
+/// `/symbols` prefix. The layout of this folder is `DirectoryLayoutType::Native`. This function
 /// returns the test server as well as a source configuration, which can be used to access the
 /// symbol server in symbolication requests.
 ///


### PR DESCRIPTION
- Creates a `utils` module that re-exports relevant things from `symbolicator_test`, and is itself re-exported from the root.
- Simplifies creating symbolication requests a bit.
- Moves tests for external public symbol servers to its dedicated file.

#skip-changelog