### PR TITLE
doc: Correct supported formats for debuginfod

### DIFF
--- a/docs/advanced/symbol-server-compatibility.md
+++ b/docs/advanced/symbol-server-compatibility.md
@@ -284,8 +284,7 @@ The following layout types support this lookup:
 ### debuginfod
 
 Symbolicator also supports talking to
-[debuginfod](https://debuginfod.elfutils.org/) compatible servers for ELF and
-Macho.
+[debuginfod](https://debuginfod.elfutils.org/) compatible servers for ELF.
 
 **Schema**:
 


### PR DESCRIPTION
The docs claim that we support fetching Macho files from `debuginfod` symbol sources, but given https://github.com/getsentry/symbolicator/blob/ddf55813bb3ce01a5285a58539cfb9b1c5a138de/crates/symbolicator-sources/src/paths.rs#L316 this is clearly not the case.

#skip-changelog