### PR TITLE
ref: Box::pin all the moka init Futures

### DIFF
--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -98,7 +98,7 @@ impl SentryDownloader {
     /// If there are cached search results this skips the actual search.
     async fn cached_sentry_search(&self, query: SearchQuery) -> CacheEntry<Vec<SearchResult>> {
         let query_ = query.clone();
-        let init_future = async {
+        let init = Box::pin(async {
             tracing::debug!(
                 "Fetching list of Sentry debug files from {}",
                 &query_.index_url
@@ -112,9 +112,9 @@ impl SentryDownloader {
                 CancelOnDrop::new(self.runtime.spawn(future.bind_hub(sentry::Hub::current())));
 
             future.await.map_err(|_| CacheError::InternalError)?
-        };
+        });
         self.index_cache
-            .get_with_if(query, init_future, |entry| entry.is_err())
+            .get_with_if(query, init, |entry| entry.is_err())
             .await
     }
 

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -173,7 +173,7 @@ impl SymbolicatorSymbolProvider {
     /// Fetches CFI for the given module, parses it into a `SymbolFile`, and stores it internally.
     async fn load_cfi_module(&self, module: &(dyn Module + Sync)) -> FetchedCfiCache {
         let key = LookupKey::new(module);
-        let load = Box::pin(async {
+        let init = Box::pin(async {
             let sources = self.sources.clone();
             let scope = self.scope.clone();
 
@@ -202,7 +202,7 @@ impl SymbolicatorSymbolProvider {
                 .bind_hub(Hub::new_from_top(Hub::current()))
                 .await
         });
-        self.cficaches.get_with_by_ref(&key, load).await
+        self.cficaches.get_with_by_ref(&key, init).await
     }
 }
 

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -173,37 +173,36 @@ impl SymbolicatorSymbolProvider {
     /// Fetches CFI for the given module, parses it into a `SymbolFile`, and stores it internally.
     async fn load_cfi_module(&self, module: &(dyn Module + Sync)) -> FetchedCfiCache {
         let key = LookupKey::new(module);
-        self.cficaches
-            .get_with_by_ref(&key, async {
-                let sources = self.sources.clone();
-                let scope = self.scope.clone();
+        let load = Box::pin(async {
+            let sources = self.sources.clone();
+            let scope = self.scope.clone();
 
-                let identifier = ObjectId {
-                    code_id: key.code_id.clone(),
-                    code_file: Some(module.code_file().into_owned()),
-                    debug_id: key.debug_id,
-                    debug_file: module
-                        .debug_file()
-                        .map(|debug_file| debug_file.into_owned()),
-                    debug_checksum: None,
+            let identifier = ObjectId {
+                code_id: key.code_id.clone(),
+                code_file: Some(module.code_file().into_owned()),
+                debug_id: key.debug_id,
+                debug_file: module
+                    .debug_file()
+                    .map(|debug_file| debug_file.into_owned()),
+                debug_checksum: None,
+                object_type: self.object_type,
+            };
+
+            self.cficache_actor
+                .fetch(FetchCfiCache {
                     object_type: self.object_type,
-                };
-
-                self.cficache_actor
-                    .fetch(FetchCfiCache {
-                        object_type: self.object_type,
-                        identifier,
-                        sources,
-                        scope,
-                    })
-                    // NOTE: this `bind_hub` is important!
-                    // `load_cfi_module` is being called concurrently from `rust-minidump` via
-                    // `join_all`. We do need proper isolation of any async task that might
-                    // manipulate any Sentry scope.
-                    .bind_hub(Hub::new_from_top(Hub::current()))
-                    .await
-            })
-            .await
+                    identifier,
+                    sources,
+                    scope,
+                })
+                // NOTE: this `bind_hub` is important!
+                // `load_cfi_module` is being called concurrently from `rust-minidump` via
+                // `join_all`. We do need proper isolation of any async task that might
+                // manipulate any Sentry scope.
+                .bind_hub(Hub::new_from_top(Hub::current()))
+                .await
+        });
+        self.cficaches.get_with_by_ref(&key, load).await
     }
 }
 


### PR DESCRIPTION
We can extract this from #1010, and this should help with https://github.com/moka-rs/moka/issues/212 even if we do not (yet) switch to more widespread moka usage.

#skip-changelog