### PR TITLE
ref: Reduce cardinality of `futures::measure` metrics

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -126,16 +126,9 @@ impl CacheItemRequest for FetchFileRequest {
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         let fut = self.fetch_file(temp_file).bind_hub(Hub::current());
 
-        let source_name = self.file_source.source_type_name().into();
-
         let timeout = Duration::from_secs(1200);
         let future = tokio::time::timeout(timeout, fut);
-        let future = measure(
-            "auxdifs",
-            m::timed_result,
-            Some(("source_type", source_name)),
-            future,
-        );
+        let future = measure("auxdifs", m::timed_result, future);
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -80,16 +80,9 @@ impl CacheItemRequest for FetchFileRequest {
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         let fut = self.clone().fetch_file(temp_file).bind_hub(Hub::current());
 
-        let source_name = self.file_source.source_type_name().into();
-
         let timeout = Duration::from_secs(1200);
         let future = tokio::time::timeout(timeout, fut);
-        let future = measure(
-            "il2cpp",
-            m::timed_result,
-            Some(("source_type", source_name)),
-            future,
-        );
+        let future = measure("il2cpp", m::timed_result, future);
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -214,16 +214,9 @@ impl CacheItemRequest for FetchFileDataRequest {
         )
         .bind_hub(Hub::current());
 
-        let type_name = self.0.file_source.source_type_name().into();
-
         let timeout = Duration::from_secs(600);
         let future = tokio::time::timeout(timeout, future);
-        let future = measure(
-            "objects",
-            m::timed_result,
-            Some(("source_type", type_name)),
-            future,
-        );
+        let future = measure("objects", m::timed_result, future);
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 

--- a/crates/symbolicator-sources/src/remotefile.rs
+++ b/crates/symbolicator-sources/src/remotefile.rs
@@ -225,17 +225,6 @@ impl RemoteFile {
         }
     }
 
-    /// A short name for the source type.
-    pub fn source_type_name(&self) -> &'static str {
-        match *self {
-            Self::Sentry(..) => "sentry",
-            Self::S3(..) => "s3",
-            Self::Gcs(..) => "gcs",
-            Self::Http(..) => "http",
-            Self::Filesystem(..) => "filesystem",
-        }
-    }
-
     /// Returns a key that uniquely identifies the source for metrics.
     ///
     /// If this is a built-in source the source_id is returned, otherwise this falls
@@ -247,9 +236,14 @@ impl RemoteFile {
         // source, then the source_id is a random string which inflates the cardinality of this
         // metric as the tag values will greatly vary.
         if id.starts_with("sentry:") {
-            id
-        } else {
-            self.source_type_name()
+            return id;
+        }
+        match self {
+            Self::Sentry(..) => "sentry",
+            Self::S3(..) => "s3",
+            Self::Gcs(..) => "gcs",
+            Self::Http(..) => "http",
+            Self::Filesystem(..) => "filesystem",
         }
     }
 

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -401,7 +401,7 @@ impl RequestService {
             metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
 
             let f = tokio::time::timeout(Duration::from_secs(3600), f);
-            let f = measure(task_name, m::timed_result, None, f);
+            let f = measure(task_name, m::timed_result, f);
 
             // This flattens the `Result<Result<_, Error>, Timeout>` into a
             // `Result<_, SymbolicationError>` so we can match on it more easily.


### PR DESCRIPTION
This removes a couple of tags that I don’t believe anyone has every looked at (certainly I haven’t), and which are also not used anywhere in DD.

The `source.download.X` metrics are tagged with the source type (or rather `source_metric_key`) already and are being displayed in a dashboard which should be the source of truth for download related metrics.

I also question the usefulness of the `futures::measure` metrics in general. We use sentry performance monitoring for these as well through `tracing::instrument` which might be a much better way to look at these things in general.

#skip-changelog