### PR TITLE
fix: Remove version numbers from symbolicli deps

### DIFF
--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -15,8 +15,8 @@ serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
 symbolic = "11.0.0"
-symbolicator-service = { version = "0.6.0", path = "../symbolicator-service" }
-symbolicator-sources = { version = "0.6.0", path = "../symbolicator-sources" }
+symbolicator-service = { path = "../symbolicator-service" }
+symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.3.0"
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
 toml = "0.5.9"


### PR DESCRIPTION
So we can release.

#skip-changelog