### PR TITLE
ref: Remove `ExpirationTime` from `Item::load`

### DIFF
--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -882,7 +882,7 @@ impl CacheItemRequest for TestCacheItem {
         })
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         Ok(std::str::from_utf8(data.as_slice()).unwrap().to_owned())
     }
 }

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -17,8 +17,7 @@ use symbolicator_sources::{FileType, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use crate::services::download::DownloadService;
 use crate::types::Scope;
@@ -132,7 +131,7 @@ impl CacheItemRequest for FetchFileRequest {
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         Ok(Arc::new(CacheHandle {
             uuid: self.uuid,
             data,

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -12,8 +12,7 @@ use symbolic::common::ByteView;
 use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
 };
 use crate::services::objects::{
     FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,
@@ -124,7 +123,7 @@ impl CacheItemRequest for FetchCfiCacheInternal {
         CfiCache::from_bytes(ByteView::from_slice(data)).is_ok()
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         parse_cfi_cache(data)
     }
 }

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -15,8 +15,7 @@ use symbolicator_sources::{FileType, ObjectId, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use crate::services::download::DownloadService;
 use crate::types::Scope;
@@ -86,7 +85,7 @@ impl CacheItemRequest for FetchFileRequest {
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         Ok(Il2cppHandle { data })
     }
 }

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -21,7 +21,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
-use crate::caching::{CacheEntry, CacheError, CacheItemRequest, CacheKey, ExpirationTime};
+use crate::caching::{CacheEntry, CacheError, CacheItemRequest, CacheKey};
 use crate::services::download::DownloadService;
 use crate::services::fetch_file;
 use crate::types::Scope;
@@ -220,7 +220,7 @@ impl CacheItemRequest for FetchFileDataRequest {
         Box::pin(async move { future.await.map_err(|_| CacheError::Timeout(timeout))? })
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         let object = OwnedObject::parse(data)?;
         let object_handle = ObjectHandle {
             object_id: self.0.object_id.clone(),

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -15,7 +15,7 @@ use symbolic::common::ByteView;
 use symbolicator_sources::{ObjectId, RemoteFile, RemoteFileUri, SourceId};
 use tempfile::NamedTempFile;
 
-use crate::caching::{CacheEntry, CacheItemRequest, CacheKey, Cacher, ExpirationTime};
+use crate::caching::{CacheEntry, CacheItemRequest, CacheKey, Cacher};
 use crate::types::{ObjectFeatures, Scope};
 
 use super::FetchFileDataRequest;
@@ -124,7 +124,7 @@ impl CacheItemRequest for FetchFileMetaRequest {
     }
 
     /// Returns the [`ObjectMetaHandle`] at the given cache key.
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         // When CacheStatus::Negative we get called with an empty ByteView, for Malformed we
         // get the malformed marker.
         let features = serde_json::from_slice(&data)?;

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -12,8 +12,7 @@ use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, SourceConfig};
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
 };
 use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
@@ -149,7 +148,7 @@ impl CacheItemRequest for FetchPortablePdbCacheInternal {
         true
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         parse_ppdb_cache_owned(data)
     }
 }

--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::future::BoxFuture;
 use symbolic::common::{ByteView, SelfCell};
@@ -13,8 +12,7 @@ use symbolicator_sources::{SentryFileId, SentryFileType, SentryRemoteFile, Sentr
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
 };
 use crate::services::download::sentry::SearchArtifactResult;
 use crate::services::download::DownloadService;
@@ -106,7 +104,7 @@ impl SourceMapService {
         req.compute(&mut temp_file).await?;
 
         let temp_bv = ByteView::map_file_ref(temp_file.as_file())?;
-        req.load(temp_bv, ExpirationTime::TouchIn(Duration::ZERO))
+        req.load(temp_bv)
     }
 }
 
@@ -135,7 +133,7 @@ impl CacheItemRequest for FetchSourceMapCacheInternal {
         true
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         parse_sourcemap_cache_owned(data)
     }
 }

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -11,8 +11,7 @@ use symbolic::symcache::{SymCache, SymCacheConverter};
 use symbolicator_sources::{FileType, ObjectId, ObjectType, SourceConfig};
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, ExpirationTime,
-    SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
 };
 use crate::services::bitcode::BitcodeService;
 use crate::services::objects::{
@@ -170,7 +169,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
             .unwrap_or(false)
     }
 
-    fn load(&self, data: ByteView<'static>, _expiration: ExpirationTime) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         parse_symcache_owned(data)
     }
 }


### PR DESCRIPTION
This was originally intended to define a per-item TTL for an in-memory cache. Though this should be just handled internally in the `Cacher`. We will revisit this once we properly implement in-memory caching.