### PR TITLE
ref: Document cache metrics

### DIFF
--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -368,7 +368,9 @@ impl<T: CacheItemRequest> Cacher<T> {
         });
 
         let res = self.cache.get_with_by_ref(&cache_key, compute).await;
-        metric!(counter("caches.memory.hit") += 1, "cache" => name.as_ref());
+        if was_memory_hit {
+            metric!(counter("caches.memory.hit") += 1, "cache" => name.as_ref());
+        }
         res
     }
 

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -202,9 +202,10 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// This method does not take care of ensuring the computation only happens once even
     /// for concurrent requests, see the public [`Cacher::compute_memoized`] for this.
     async fn compute(&self, request: T, key: &CacheKey, is_refresh: bool) -> CacheEntry<T::Item> {
+        let name = self.config.name();
         let mut temp_file = self.tempfile()?;
         let shared_cache_key = SharedCacheKey {
-            name: self.config.name(),
+            name,
             version: T::VERSIONS.current,
             local_key: key.clone(),
         };
@@ -229,6 +230,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         }
 
         if entry.is_err() {
+            metric!(counter("caches.computation") += 1, "cache" => name.as_ref());
             match request.compute(&mut temp_file).await {
                 Ok(()) => {
                     // Now we have written the data to the tempfile we can mmap it, persisting it later
@@ -246,13 +248,12 @@ impl<T: CacheItemRequest> Cacher<T> {
         }
 
         if let Some(cache_dir) = self.config.cache_dir() {
-            let name = self.config.name();
             // Cache is enabled, write it!
             let cache_path = key.cache_path(cache_dir, T::VERSIONS.current);
 
             sentry::configure_scope(|scope| {
                 scope.set_extra(
-                    &format!("cache.{}.cache_path", self.config.name()),
+                    &format!("cache.{name}.cache_path"),
                     cache_path.to_string_lossy().into(),
                 );
             });
@@ -273,15 +274,11 @@ impl<T: CacheItemRequest> Cacher<T> {
                     time_raw("caches.file.size") = byte_view.len() as u64,
                     "hit" => "false",
                     "is_refresh" => &is_refresh.to_string(),
-                    "cache" => self.config.name().as_ref(),
+                    "cache" => name.as_ref(),
                 );
             }
 
-            tracing::trace!(
-                "Creating {} at path {:?}",
-                self.config.name(),
-                cache_path.display()
-            );
+            tracing::trace!("Creating {name} at path {:?}", cache_path.display());
 
             persist_tempfile(temp_file, cache_path).await?;
         };
@@ -324,7 +321,10 @@ impl<T: CacheItemRequest> Cacher<T> {
         let name = self.config.name();
         metric!(counter("caches.access") += 1, "cache" => name.as_ref());
 
+        let mut was_memory_hit = true;
         let compute = Box::pin(async {
+            was_memory_hit = false;
+
             // cache_path is None when caching is disabled.
             if let Some(cache_dir) = self.config.cache_dir() {
                 let versions = std::iter::once(T::VERSIONS.current)
@@ -367,7 +367,9 @@ impl<T: CacheItemRequest> Cacher<T> {
                 .await
         });
 
-        self.cache.get_with_by_ref(&cache_key, compute).await
+        let res = self.cache.get_with_by_ref(&cache_key, compute).await;
+        metric!(counter("caches.memory.hit") += 1, "cache" => name.as_ref());
+        res
     }
 
     fn spawn_refresh(&self, cache_dir: &Path, cache_key: CacheKey, request: T) {

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -29,7 +29,25 @@
 //!
 //! ### Metrics
 //!
-//! TODO
+//! We collect a couple of metrics, each of those is tagged with a `cache` field that corresponds to
+//! the cache item type. Here is a list of metrics that are collected:
+//!
+//! - `caches.access`: All accesses.
+//! - `caches.memory.hit`: Accesses served by the in-memory layer. (FIXME: currently only used for request coalescing)
+//! - `caches.file.hit`: Accesses served by the file-system layer.
+//! - `services.shared_cache.fetch(hit:true)`: Accesses served by the shared-cache layer.
+//! - `caches.computation`: Actual computations being run, and not served by any of the caching layers.
+//!
+//! NOTE: The sum of shared-cache hits and computations can exceed the number of cache misses of
+//! previous layers in case of lazy cache recomputation.
+//!
+//! Various other metrics are being collected as well, including:
+//! - `caches.file.size`: A histogram for the size (in bytes) of the successfully loaded / written cache files.
+//! - FIXME: `caches.file.discarded` and `shared_cache.file.discarded` is still being used in the
+//!   edge-case of mutable cache files. This will go away once cache files are truly immutable.
+//! - `caches.file.write`: The number of caches being written to disk.
+//!   This should match `caches.computation` if the file-system layer is enabled.
+//! - TODO: list all the other metrics that are missing here :-)
 //!
 //! ### Configuration
 //!


### PR DESCRIPTION
This also adds explicit cache metrics for things that could in theory be derived from other metrics, but would then depend on the presence of optional services.

#skip-changelog