### PR TITLE
ref: Error handling in JS symbolication

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -176,7 +176,6 @@ impl SourceMapService {
                 CacheError::DownloadError("Could not download sourcemap file".to_string())
             })?;
 
-        // TODO(sourcemap): Do we just pass on the error from fetch_cache?
         self.fetch_cache(&sourcemap_file, &sourcemap_file).await
     }
 }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -565,6 +565,22 @@ pub struct CompletedSymbolicationResponse {
     pub modules: Vec<CompleteObjectInfo>,
 }
 
+/// Information on the symbolication status of this JavaScript frame.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum JsProcessingFrameStatus {
+    /// The frame was symbolicated successfully.
+    #[default]
+    Symbolicated,
+    /// The frame's line and column could not be found in the sourcemap.
+    InvalidSourceMapLocation,
+    /// No sourcemap was found for the frame.
+    MissingSourcemap,
+    /// The retrieved sourcemap could not be processed.
+    MalformedSourcemap,
+}
+
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingCompletedSymbolicationResponse {
     pub stacktraces: Vec<CompleteJsStacktrace>,
@@ -623,7 +639,7 @@ pub struct JsProcessingRawStacktrace {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingSymbolicatedFrame {
-    pub status: FrameStatus,
+    pub status: JsProcessingFrameStatus,
 
     #[serde(flatten)]
     pub raw: JsProcessingRawFrame,


### PR DESCRIPTION
First of all, this moves the `collect_stacktrace_artifacts` function and assorted helper functions into the `SourceMapService`.

Second of all, it introduces a new enum `JsProcessingFrameStatus` that is analogous to `FrameStatus` but for Javascript frames. The variants of `FrameStatus` don't really map too well to the problems that can occur during JS symbolication.

Third of all, it makes `js_processing_symbolicate_frame` return the new enum in the error case.

#skip-changelog