### PR TITLE
feat: Add support for in-memory caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Consolidate `CacheVersions` and bump to refresh `CacheKey` usage. ([#1041](https://github.com/getsentry/symbolicator/pull/1041), [#1042](https://github.com/getsentry/symbolicator/pull/1042))
 - Automatically block downloads from unreliable hosts. ([#1039](https://github.com/getsentry/symbolicator/pull/1039))
 - Fully migrate `CacheKey` usage and remove legacy markers. ([#1043](https://github.com/getsentry/symbolicator/pull/1043))
+- Add support for in-memory caching. ([#1028](https://github.com/getsentry/symbolicator/pull/1028))
 
 ## 0.7.0
 

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -65,7 +65,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             .weigher(|_k, v| {
                 let value_size =
                     v.1.as_ref()
-                        .map_or(0, |item| T::weight(item))
+                        .map_or(0, T::weight)
                         .max(std::mem::size_of::<CacheError>() as u32);
                 std::mem::size_of::<(CacheKey, Instant)>() as u32 + value_size
             })

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -178,6 +178,13 @@ impl Caches {
             config.caches.derived.max_lazy_recomputations.max(1),
         ));
 
+        // NOTE: We default all the caches to ~100 KiB.
+        // A cache item with all its structures is at least ~100 bytes, so this gives us an
+        // estimate of the number of items in memory around ~1_000.
+        // Most items are a lot larger in reality, but giving concrete numbers here is hard to do.
+        let default_cap = 100 * 1024;
+        let in_memory = &config.caches.in_memory;
+
         let tmp_dir = config.cache_dir("tmp");
         Ok(Self {
             objects: {
@@ -188,6 +195,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
                     max_lazy_redownloads.clone(),
+                    default_cap,
                 )?
             },
             object_meta: {
@@ -198,6 +206,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
+                    in_memory.object_meta_capacity,
                 )?
             },
             auxdifs: {
@@ -208,6 +217,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
                     max_lazy_redownloads.clone(),
+                    default_cap,
                 )?
             },
             il2cpp: {
@@ -218,6 +228,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.downloaded.into(),
                     max_lazy_redownloads,
+                    default_cap,
                 )?
             },
             symcaches: {
@@ -228,6 +239,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
+                    default_cap,
                 )?
             },
             cficaches: {
@@ -238,6 +250,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
+                    in_memory.cficaches_capacity,
                 )?
             },
             ppdb_caches: {
@@ -248,6 +261,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations.clone(),
+                    default_cap,
                 )?
             },
             sourcemap_caches: {
@@ -258,6 +272,7 @@ impl Caches {
                     tmp_dir.clone(),
                     config.caches.derived.into(),
                     max_lazy_recomputations,
+                    default_cap,
                 )?
             },
             diagnostics: {
@@ -268,6 +283,7 @@ impl Caches {
                     tmp_dir,
                     config.caches.diagnostics.into(),
                     Default::default(),
+                    default_cap,
                 )?
             },
         })

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -37,6 +37,7 @@ fn test_cache_dir_created() {
         None,
         CacheConfig::Downloaded(Default::default()),
         Default::default(),
+        1024,
     );
     let fsinfo = fs::metadata(cachedir).unwrap();
     assert!(fsinfo.is_dir());
@@ -96,6 +97,7 @@ fn test_max_unused_for() -> Result<()> {
             ..Default::default()
         }),
         Default::default(),
+        1024,
     )?;
 
     File::create(tempdir.path().join("foo/killthis"))?.write_all(b"hi")?;
@@ -130,6 +132,7 @@ fn test_retry_misses_after() -> Result<()> {
             ..Default::default()
         }),
         Default::default(),
+        1024,
     )?;
 
     File::create(tempdir.path().join("foo/keepthis"))?.write_all(b"hi")?;
@@ -176,6 +179,7 @@ fn test_cleanup_malformed() -> Result<()> {
             ..Default::default()
         }),
         Default::default(),
+        1024,
     )?;
 
     cache.cleanup()?;
@@ -216,6 +220,7 @@ fn test_cleanup_cache_specific_error_derived() -> Result<()> {
             ..Default::default()
         }),
         Default::default(),
+        1024,
     )?;
 
     sleep(Duration::from_millis(30));
@@ -256,6 +261,7 @@ fn test_cleanup_cache_specific_error_download() -> Result<()> {
             ..Default::default()
         }),
         Default::default(),
+        1024,
     )?;
 
     sleep(Duration::from_millis(30));
@@ -465,6 +471,7 @@ fn test_open_cachefile() -> Result<()> {
         None,
         CacheConfig::Downloaded(Default::default()),
         Default::default(),
+        1024,
     )?;
 
     // Create a file in the cache, with mtime of 1h 15s ago since it only gets touched
@@ -891,6 +898,7 @@ async fn test_cache_fallback() {
         None,
         CacheConfig::from(CacheConfigs::default().derived),
         Arc::new(AtomicIsize::new(1)),
+        1024,
     )
     .unwrap();
     let cacher = Cacher::new(cache, Default::default());
@@ -933,6 +941,7 @@ async fn test_cache_fallback_notfound() {
         None,
         CacheConfig::from(CacheConfigs::default().derived),
         Arc::new(AtomicIsize::new(1)),
+        1024,
     )
     .unwrap();
     let cacher = Cacher::new(cache, Default::default());
@@ -958,9 +967,10 @@ async fn test_lazy_computation_limit() {
         None,
         CacheConfig::from(CacheConfigs::default().derived),
         Arc::new(AtomicIsize::new(1)),
+        1024,
     )
     .unwrap();
-    let cacher = Cacher::new(cache, Default::default());
+    let cacher = Cacher::new(cache.clone(), Default::default());
 
     let request = TestCacheItem::new();
 

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -293,15 +293,28 @@ pub struct InMemoryCacheConfig {
     ///
     /// Defaults to `100`.
     pub s3_client_capacity: u64,
+
+    /// Capacity (in bytes) for the in-memory `object_meta` Cache.
+    ///
+    /// Defaults to `100 MiB (= 104_857_600)`.
+    pub object_meta_capacity: u64,
+
+    /// Capacity (in bytes) for the in-memory `cficaches` Cache.
+    ///
+    /// Defaults to `400 MiB (= 419_430_400)`.
+    pub cficaches_capacity: u64,
 }
 
 impl Default for InMemoryCacheConfig {
     fn default() -> Self {
+        let meg = 1024 * 1024;
         Self {
             sentry_index_capacity: 100_000.try_into().unwrap(),
             sentry_index_ttl: Duration::from_secs(3600),
             gcs_token_capacity: 100.try_into().unwrap(),
             s3_client_capacity: 100,
+            object_meta_capacity: 100 * meg,
+            cficaches_capacity: 400 * meg,
         }
     }
 }

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -24,18 +24,24 @@ use crate::utils::sentry::ConfigureScope;
 use super::caches::versions::CFICACHE_VERSIONS;
 use super::derived::{derive_from_object_handle, DerivedCache};
 
+type CfiItem = (u32, Option<Arc<SymbolFile>>);
+
 #[tracing::instrument(skip_all)]
-fn parse_cfi_cache(bytes: ByteView<'static>) -> CacheEntry<Option<Arc<SymbolFile>>> {
+fn parse_cfi_cache(bytes: ByteView<'static>) -> CacheEntry<CfiItem> {
+    let weight = bytes.len().try_into().unwrap_or(u32::MAX);
+    // NOTE: we estimate the in-memory structures to be ~8x as heavy in memory as on disk
+    let weight = weight.saturating_mul(8);
+
     let cfi_cache = CfiCache::from_bytes(bytes).map_err(CacheError::from_std_error)?;
 
     if cfi_cache.as_slice().is_empty() {
-        return Ok(None);
+        return Ok((weight, None));
     }
 
     let symbol_file =
         SymbolFile::from_bytes(cfi_cache.as_slice()).map_err(CacheError::from_std_error)?;
 
-    Ok(Some(Arc::new(symbol_file)))
+    Ok((weight, Some(Arc::new(symbol_file))))
 }
 
 #[derive(Clone, Debug)]
@@ -75,7 +81,7 @@ async fn compute_cficache(
 }
 
 impl CacheItemRequest for FetchCfiCacheInternal {
-    type Item = Option<Arc<SymbolFile>>;
+    type Item = CfiItem;
 
     const VERSIONS: CacheVersions = CFICACHE_VERSIONS;
 
@@ -90,6 +96,10 @@ impl CacheItemRequest for FetchCfiCacheInternal {
 
     fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         parse_cfi_cache(data)
+    }
+
+    fn weight(item: &Self::Item) -> u32 {
+        item.0.max(std::mem::size_of::<Self::Item>() as u32)
     }
 }
 
@@ -129,7 +139,11 @@ impl CfiCacheActor {
                 objects_actor: self.objects.clone(),
                 meta_handle,
             };
-            self.cficaches.compute_memoized(request, cache_key)
+            async {
+                let entry = self.cficaches.compute_memoized(request, cache_key).await;
+
+                entry.map(|item| item.1)
+            }
         })
         .await
     }

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -268,6 +268,7 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().derived),
             Default::default(),
+            1024,
         )
         .unwrap();
 
@@ -277,6 +278,7 @@ mod tests {
             None,
             CacheConfig::from(CacheConfigs::default().downloaded),
             Default::default(),
+            1024,
         )
         .unwrap();
 

--- a/crates/symbolicator-service/src/services/symcaches.rs
+++ b/crates/symbolicator-service/src/services/symcaches.rs
@@ -352,7 +352,7 @@ mod tests {
     async fn test_symcache_refresh() {
         test::setup();
 
-        const TIMEOUT: Duration = Duration::from_secs(5);
+        const TIMEOUT: Duration = Duration::from_secs(2);
 
         let cache_dir = test::tempdir();
         let symbol_dir = test::tempdir();

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -508,21 +508,14 @@ async fn test_basic_windows() {
                     assert_eq!(metadata, expected_metadata);
                 }
 
-                if i > 0 && with_cache {
+                // our use of in-memory caching should make sure we only ever request each file once
+                if i > 0 {
                     assert_eq!(hitcounter.accesses(), 0);
                 } else {
                     let hits = hitcounter.all_hits();
-                    let (hit_count, miss_count) = if with_cache {
-                        (1, 1)
-                    } else {
-                        // we are downloading twice: once for the objects_meta request, and once
-                        // again for the objects/symcache request
-                        (2, 1)
-                    };
-
                     assert_eq!(&hits, &[
-                        ("/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pd_".into(), miss_count),
-                        ("/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pdb".into(), hit_count),
+                        ("/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pd_".into(), 1),
+                        ("/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pdb".into(), 1),
                     ]);
                 }
             }

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -124,6 +124,10 @@ async fn test_download_errors() {
 async fn test_deny_list() {
     let (symbolication, _cache_dir) = setup_service(|config| {
         config.cache_dir = None;
+        config.caches.downloaded.retry_misses_after = Some(Duration::ZERO);
+        config.caches.derived.retry_misses_after = Some(Duration::ZERO);
+        // FIXME: `object_meta` caches treat download errors as `malformed`
+        config.caches.derived.retry_malformed_after = Some(Duration::ZERO);
         config.max_download_timeout = Duration::from_millis(100);
         config.deny_list_time_window = Duration::from_millis(500);
         config.deny_list_bucket_size = Duration::from_millis(100);
@@ -171,7 +175,7 @@ async fn test_deny_list() {
         );
     }
 
-    // For the third time the host shuold be blocked
+    // For the third time the host should be blocked
     let response = symbolication.symbolicate(request.clone()).await.unwrap();
     assert_eq!(
         get_statuses(response),
@@ -206,7 +210,7 @@ async fn test_deny_list() {
         );
     }
 
-    // For the third time the host shuold be blocked
+    // For the third time the host should be blocked
     let response = symbolication.symbolicate(request.clone()).await.unwrap();
     assert_eq!(
         get_statuses(response),


### PR DESCRIPTION
Fixes https://github.com/getsentry/symbolicator/issues/994 by adding the infrastructure and defaults for in-memory caching.

This implements weighing of cache items (based on a bunch of `size_of`s),
and per-item TTL based on the `ExpirationTime`.

Each cache defaults to ~100k in-memory size, which should be roughly ~1k items.
Except for `object_meta` which defaults to ~100M in-memory and is very hot,
and `cficaches` which defaults to ~400M and are expensive to parse, with variable per-item weight.