### PR TITLE
ref: Add human-readable metadata to `CacheKey`

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -31,6 +31,7 @@ use super::fetch_file;
 /// only have this handle if a positive cache existed.
 #[derive(Debug, Clone)]
 pub struct BcSymbolMapHandle {
+    pub file: RemoteFile,
     pub uuid: DebugId,
     pub data: ByteView<'static>,
 }
@@ -49,6 +50,7 @@ impl BcSymbolMapHandle {
 /// [`BcSymbolMapHandle`] for that.
 #[derive(Debug, Clone)]
 struct CacheHandle {
+    file: RemoteFile,
     uuid: DebugId,
     data: ByteView<'static>,
 }
@@ -133,6 +135,7 @@ impl CacheItemRequest for FetchFileRequest {
 
     fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
         Ok(Arc::new(CacheHandle {
+            file: self.file_source.clone(),
             uuid: self.uuid,
             data,
         }))
@@ -189,6 +192,7 @@ impl BitcodeService {
             .await?;
 
         Some(BcSymbolMapHandle {
+            file: symbolmap_handle.file.clone(),
             uuid: symbolmap_handle.uuid,
             data: symbolmap_handle.data.clone(),
         })

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -32,6 +32,7 @@ use super::fetch_file;
 // to a symcache, so we need to actually parse the `LineMapping` at the very end when applying it.
 #[derive(Debug, Clone)]
 pub struct Il2cppHandle {
+    pub file: RemoteFile,
     pub data: ByteView<'static>,
 }
 
@@ -86,7 +87,10 @@ impl CacheItemRequest for FetchFileRequest {
     }
 
     fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
-        Ok(Il2cppHandle { data })
+        Ok(Il2cppHandle {
+            file: self.file_source.clone(),
+            data,
+        })
     }
 }
 

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -55,7 +55,7 @@ impl ObjectMetaHandle {
     }
 
     pub fn cache_key_builder(&self) -> CacheKeyBuilder {
-        CacheKey::builder(&self.scope, &self.file_source)
+        CacheKey::legacy_builder(&self.scope, &self.file_source)
     }
 
     pub fn features(&self) -> ObjectFeatures {

--- a/crates/symbolicator-service/src/services/symcaches/markers.rs
+++ b/crates/symbolicator-service/src/services/symcaches/markers.rs
@@ -83,8 +83,13 @@ impl SymCacheMarkers {
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
     use symbolic::common::ByteView;
+    use symbolicator_sources::{
+        FilesystemRemoteFile, FilesystemSourceConfig, RemoteFile, SourceId, SourceLocation,
+    };
 
     use super::*;
 
@@ -98,11 +103,21 @@ mod tests {
 
     #[test]
     fn test_marker_roundtrip() {
+        let source = Arc::new(FilesystemSourceConfig {
+            id: SourceId::new("foo"),
+            path: PathBuf::new(),
+            files: Default::default(),
+        });
+        let location = SourceLocation::new("bar.baz");
+        let file: RemoteFile = FilesystemRemoteFile::new(source, location).into();
+
         let bcsymbolmap = BcSymbolMapHandle {
+            file: file.clone(),
             uuid: Default::default(),
             data: ByteView::from_vec(vec![]),
         };
         let il2cpp = Il2cppHandle {
+            file,
             data: ByteView::from_vec(vec![]),
         };
         let sources = SecondarySymCacheSources {

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::sync::Arc;
@@ -236,13 +237,13 @@ impl SymCacheActor {
 
             // TODO: The new symcache key needs to be a combination of *all* the sources
             let mut builder = handle.cache_key_builder();
-            if let Some(_handle) = &bcsymbolmap_handle {
-                builder.update("bcsymbolmap:");
-                // TODO: builder.update(handle.cache_key);
+            if let Some(handle) = &bcsymbolmap_handle {
+                builder.write_str("\nbcsymbolmap:\n").unwrap();
+                builder.write_file_meta(&handle.file).unwrap();
             }
-            if let Some(_handle) = &il2cpp_handle {
-                builder.update("il2cpp:");
-                // TODO: builder.update(handle.cache_key);
+            if let Some(handle) = &il2cpp_handle {
+                builder.write_str("\nil2cpp:\n").unwrap();
+                builder.write_file_meta(&handle.file).unwrap();
             }
 
             let cache_key = builder.build();


### PR DESCRIPTION
This metadata forms the basis for the `CacheKey` hash, and can be written to disk later on as well.