### PR TITLE
ref: Consolidate `CacheVersions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Introduce a `CacheKeyBuilder` and human-readable `CacheKey` metadata. ([#1033](https://github.com/getsentry/symbolicator/pull/1033), [#1036](https://github.com/getsentry/symbolicator/pull/1036))
 - Use new `CacheKey` for writes and shared-cache. ([#1038](https://github.com/getsentry/symbolicator/pull/1038))
+- Consolidate `CacheVersions` and bump half the caches to refresh `CacheKey` usage. ([#1041](https://github.com/getsentry/symbolicator/pull/1041))
 
 ## 0.7.0
 

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -99,12 +99,7 @@ pub trait CacheItemRequest: 'static + Send + Sync + Clone {
     type Item: 'static + Send + Sync + Clone;
 
     /// The cache versioning scheme that is used for this type of request.
-    ///
-    /// Defaults to a scheme that does not use versioned cache files.
-    const VERSIONS: CacheVersions = CacheVersions {
-        current: 0,
-        fallbacks: &[],
-    };
+    const VERSIONS: CacheVersions;
 
     /// Invoked to compute an instance of this item and put it at the given location in the file
     /// system. This is used to populate the cache for a previously missing element.

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -17,12 +17,14 @@ use symbolicator_sources::{FileType, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    SharedCacheRef,
 };
 use crate::services::download::DownloadService;
 use crate::types::Scope;
 use crate::utils::futures::{m, measure};
 
+use super::caches::versions::BITCODE_CACHE_VERSIONS;
 use super::fetch_file;
 
 /// Handle to a valid BCSymbolMap.
@@ -120,6 +122,8 @@ impl FetchFileRequest {
 
 impl CacheItemRequest for FetchFileRequest {
     type Item = Arc<CacheHandle>;
+
+    const VERSIONS: CacheVersions = BITCODE_CACHE_VERSIONS;
 
     /// Downloads a file, writing it to `path`.
     ///

--- a/crates/symbolicator-service/src/services/caches/mod.rs
+++ b/crates/symbolicator-service/src/services/caches/mod.rs
@@ -1,0 +1,3 @@
+//! The various caches used by the core Symbolication Service are placed here.
+
+pub mod versions;

--- a/crates/symbolicator-service/src/services/caches/versions.rs
+++ b/crates/symbolicator-service/src/services/caches/versions.rs
@@ -1,0 +1,114 @@
+//! This module defines the various [`CacheVersions`] of the various caches that Symbolicator uses.
+//!
+//! # How to version
+//!
+//! The initial "unversioned" version is `0`.
+//! Whenever we want to increase the version in order to re-generate stale/broken cache files,
+//! we need to:
+//!
+//! * increase the `current` version.
+//! * prepend the `current` version to the `fallbacks`.
+//! * it is also possible to skip a version, in case a broken deploy needed to
+//!   be reverted which left behind broken cache files.
+//!
+//! Some of the versioned caches are also tied to format versions defined in [`symbolic`].
+//! For those cases, there are static assertions that are a reminder to also bump the cache version.
+
+use crate::caching::CacheVersions;
+
+/// CFI cache, with the following versions:
+///
+/// - `3`: Proactive bump, as a bug in shared cache could have potentially
+///   uploaded `v1` cache files as `v2` erroneously.
+///
+/// - `2`: Allow underflow in Win-x64 CFI which allows loading registers from outside the stack frame.
+///
+/// - `1`: Generate higher fidelity CFI for Win-x64 binaries.
+///
+/// - `0`: Initial version.
+pub const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 3,
+    fallbacks: &[],
+};
+static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
+
+/// SymCache, with the following versions:
+///
+/// - `5`: Proactive bump, as a bug in shared cache could have potentially
+///   uploaded `v2` cache files as `v3` (and later `v4`) erroneously.
+///
+/// - `4`: An updated symbolic symcache that uses a LEB128 prefixed string table.
+///
+/// - `3`: Another round of fixes in symcache generation:
+///        - fixes problems with split inlinees and inlinees appearing twice in the call chain
+///        - undecorate Windows C-decorated symbols in symcaches
+///
+/// - `2`: Tons of fixes/improvements in symcache generation:
+///        - fixed problems with DWARF functions that have the
+///          same line records for different inline hierarchy
+///        - fixed problems with PDB where functions have line records that don't belong to them
+///        - fixed problems with PDB/DWARF when parent functions don't have matching line records
+///        - using a new TypeFormatter for PDB that can pretty-print function arguments
+///
+/// - `1`: New binary format based on instruction addr lookup.
+///
+/// - `0`: Initial version.
+pub const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 5,
+    fallbacks: &[],
+};
+static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
+
+/// Data / Objects cache, with the following versions:
+///
+/// - `1`: Recomputation to use new `CacheKey` format.
+///
+/// - `0`: Initial version.
+pub const OBJECTS_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 1,
+    fallbacks: &[0],
+};
+
+/// Objects Meta cache, with the following versions:
+///
+/// - `0`: Initial version.
+pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 0,
+    fallbacks: &[],
+};
+
+/// Portable PDB cache, with the following versions:
+///
+/// - `1`: Initial version.
+pub const PPDB_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 1,
+    fallbacks: &[],
+};
+
+/// SourceMapCache, with the following versions:
+///
+/// - `1`: Initial version.
+pub const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 1,
+    fallbacks: &[],
+};
+
+/// Il2cpp cache, with the following versions:
+///
+/// - `1`: Recomputation to use new `CacheKey` format.
+///
+/// - `0`: Initial version.
+pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 1,
+    fallbacks: &[0],
+};
+
+/// Bitcode / Auxdif (plist / bcsymbolmap) cache, with the following versions:
+///
+/// - `1`: Recomputation to use new `CacheKey` format.
+///
+/// - `0`: Initial version.
+pub const BITCODE_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: 1,
+    fallbacks: &[0],
+};

--- a/crates/symbolicator-service/src/services/cficaches.rs
+++ b/crates/symbolicator-service/src/services/cficaches.rs
@@ -21,37 +21,8 @@ use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
+use super::caches::versions::CFICACHE_VERSIONS;
 use super::derived::{derive_from_object_handle, DerivedCache};
-
-/// The supported cficache versions.
-///
-/// # How to version
-///
-/// The initial "unversioned" version is `0`.
-/// Whenever we want to increase the version in order to re-generate stale/broken
-/// cficaches, we need to:
-///
-/// * increase the `current` version.
-/// * prepend the `current` version to the `fallbacks`.
-/// * it is also possible to skip a version, in case a broken deploy needed to
-///   be reverted which left behind broken cficaches.
-///
-/// In case a symbolic update increased its own internal format version, bump the
-/// cficache file version as described above, and update the static assertion.
-///
-/// # Version History
-///
-/// - `3`: Proactive bump, as a bug in shared cache could have potentially
-///   uploaded `v1` cache files as `v2` erroneously.
-///
-/// - `2`: Allow underflow in Win-x64 CFI which allows loading registers from outside the stack frame.
-///
-/// - `1`: Generate higher fidelity CFI for Win-x64 binaries.
-const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 3,
-    fallbacks: &[],
-};
-static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
 #[tracing::instrument(skip_all)]
 fn parse_cfi_cache(bytes: ByteView<'static>) -> CacheEntry<Option<Arc<SymbolFile>>> {

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -15,12 +15,14 @@ use symbolicator_sources::{FileType, ObjectId, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    SharedCacheRef,
 };
 use crate::services::download::DownloadService;
 use crate::types::Scope;
 use crate::utils::futures::{m, measure};
 
+use super::caches::versions::IL2CPP_CACHE_VERSIONS;
 use super::fetch_file;
 
 /// Handle to a valid [`LineMapping`].
@@ -73,6 +75,8 @@ impl FetchFileRequest {
 
 impl CacheItemRequest for FetchFileRequest {
     type Item = Il2cppHandle;
+
+    const VERSIONS: CacheVersions = IL2CPP_CACHE_VERSIONS;
 
     /// Downloads a file, writing it to `path`.
     ///

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -15,6 +15,7 @@ use crate::caching::{Caches, SharedCacheService};
 use crate::config::Config;
 
 pub mod bitcode;
+pub mod caches;
 pub mod cficaches;
 pub mod derived;
 pub mod download;

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -21,7 +21,9 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
+use crate::caching::CacheVersions;
 use crate::caching::{CacheEntry, CacheError, CacheItemRequest, CacheKey};
+use crate::services::caches::versions::OBJECTS_CACHE_VERSIONS;
 use crate::services::download::DownloadService;
 use crate::services::fetch_file;
 use crate::types::Scope;
@@ -202,6 +204,8 @@ fn object_matches_id(object: &Object<'_>, id: &ObjectId) -> bool {
 
 impl CacheItemRequest for FetchFileDataRequest {
     type Item = Arc<ObjectHandle>;
+
+    const VERSIONS: CacheVersions = OBJECTS_CACHE_VERSIONS;
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         let cache_key = CacheKey::from_scoped_file(&self.0.scope, &self.0.file_source);

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -15,7 +15,10 @@ use symbolic::common::ByteView;
 use symbolicator_sources::{ObjectId, RemoteFile};
 use tempfile::NamedTempFile;
 
-use crate::caching::{CacheEntry, CacheItemRequest, CacheKey, CacheKeyBuilder, Cacher};
+use crate::caching::{
+    CacheEntry, CacheItemRequest, CacheKey, CacheKeyBuilder, CacheVersions, Cacher,
+};
+use crate::services::caches::versions::META_CACHE_VERSIONS;
 use crate::types::{ObjectFeatures, Scope};
 
 use super::FetchFileDataRequest;
@@ -110,6 +113,8 @@ impl FetchFileMetaRequest {
 
 impl CacheItemRequest for FetchFileMetaRequest {
     type Item = Arc<ObjectMetaHandle>;
+
+    const VERSIONS: CacheVersions = META_CACHE_VERSIONS;
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
         Box::pin(self.compute_file_meta(temp_file))

--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -167,10 +167,8 @@ impl ObjectsActor {
                 download_svc: self.download_svc.clone(),
             };
 
-            let meta_cache = self.meta_cache.clone();
-
             async move {
-                let handle = meta_cache.compute_memoized(request, cache_key).await;
+                let handle = self.meta_cache.compute_memoized(request, cache_key).await;
                 FoundMeta {
                     file_source,
                     handle,

--- a/crates/symbolicator-service/src/services/ppdb_caches.rs
+++ b/crates/symbolicator-service/src/services/ppdb_caches.rs
@@ -18,28 +18,9 @@ use crate::types::{CandidateStatus, Scope};
 use crate::utils::futures::{m, measure};
 use crate::utils::sentry::ConfigureScope;
 
+use super::caches::versions::PPDB_CACHE_VERSIONS;
 use super::derived::{derive_from_object_handle, DerivedCache};
 use super::objects::{FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor};
-
-/// The supported ppdb_cache versions.
-///
-/// # How to version
-///
-/// The initial version is `1`.
-/// Whenever we want to increase the version in order to re-generate stale/broken
-/// ppdb_caches, we need to:
-///
-/// * increase the `current` version.
-/// * prepend the `current` version to the `fallbacks`.
-/// * it is also possible to skip a version, in case a broken deploy needed to
-///   be reverted which left behind broken ppdb_caches.
-///
-/// In case a symbolic update increased its own internal format version, bump the
-/// ppdb_cache file version as described above, and update the static assertion.
-const PPDB_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
-};
 
 pub type OwnedPortablePdbCache = SelfCell<ByteView<'static>, PortablePdbCache<'static>>;
 

--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -21,30 +21,11 @@ use crate::caching::{
 use crate::services::download::sentry::SearchArtifactResult;
 use crate::services::download::DownloadService;
 
+use super::caches::versions::SOURCEMAP_CACHE_VERSIONS;
 use super::fetch_file;
 use super::symbolication::JsProcessingSymbolicateStacktraces;
 
 pub type OwnedSourceMapCache = SelfCell<ByteView<'static>, SourceMapCache<'static>>;
-
-/// The supported SourceMapCache versions.
-///
-/// # How to version
-///
-/// The initial version is `1`.
-/// Whenever we want to increase the version in order to re-generate stale/broken
-/// sourcemap_caches, we need to:
-///
-/// * increase the `current` version.
-/// * prepend the `current` version to the `fallbacks`.
-/// * it is also possible to skip a version, in case a broken deploy needed to
-///   be reverted which left behind broken sourcemap_caches.
-///
-/// In case a symbolic update increased its own internal format version, bump the
-/// SourceMapCache file version as described above, and update the static assertion.
-const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
-};
 
 /// A URL to a sourcemap file.
 ///

--- a/crates/symbolicator-service/src/services/symcaches/mod.rs
+++ b/crates/symbolicator-service/src/services/symcaches/mod.rs
@@ -24,51 +24,11 @@ use crate::utils::sentry::ConfigureScope;
 
 use self::markers::{SecondarySymCacheSources, SymCacheMarkers};
 
+use super::caches::versions::SYMCACHE_VERSIONS;
 use super::derived::{derive_from_object_handle, DerivedCache};
 use super::il2cpp::Il2cppService;
 
 mod markers;
-
-/// The supported symcache versions.
-///
-/// # How to version
-///
-/// The initial "unversioned" version is `0`.
-/// Whenever we want to increase the version in order to re-generate stale/broken
-/// symcaches, we need to:
-///
-/// * increase the `current` version.
-/// * prepend the `current` version to the `fallbacks`.
-/// * it is also possible to skip a version, in case a broken deploy needed to
-///   be reverted which left behind broken symcaches.
-///
-/// In case a symbolic update increased its own internal format version, bump the
-/// symcache file version as described above, and update the static assertion.
-///
-/// # Version History
-///
-/// - `5`: Proactive bump, as a bug in shared cache could have potentially
-///   uploaded `v2` cache files as `v3` (and later `v4`) erroneously.
-///
-/// - `4`: An updated symbolic symcache that uses a LEB128 prefixed string table.
-///
-/// - `3`: Another round of fixes in symcache generation:
-///        - fixes problems with split inlinees and inlinees appearing twice in the call chain
-///        - undecorate Windows C-decorated symbols in symcaches
-///
-/// - `2`: Tons of fixes/improvements in symcache generation:
-///        - fixed problems with DWARF functions that have the
-///          same line records for different inline hierarchy
-///        - fixed problems with PDB where functions have line records that don't belong to them
-///        - fixed problems with PDB/DWARF when parent functions don't have matching line records
-///        - using a new TypeFormatter for PDB that can pretty-print function arguments
-///
-/// - `1`: New binary format based on instruction addr lookup.
-const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 5,
-    fallbacks: &[],
-};
-static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 
 pub type OwnedSymCache = SelfCell<ByteView<'static>, SymCache<'static>>;
 

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -467,7 +467,7 @@ async fn test_basic_windows() {
                 );
 
                 if with_cache {
-                    let objects_dir = cache_dir.path().join("objects").join("v0");
+                    let objects_dir = cache_dir.path().join("objects");
                     let mut cached_objects = get_cache_files(&objects_dir);
 
                     // NOTE: the cache key depends on the exact location of the file, which is
@@ -494,8 +494,7 @@ async fn test_basic_windows() {
                         "{metadata:?} == {expected_metadata:?}"
                     );
 
-                    // NOTE: this needs to be updated when bumping symcaches
-                    let symcaches_dir = cache_dir.path().join("symcaches").join("v5");
+                    let symcaches_dir = cache_dir.path().join("symcaches");
                     let mut cached_symcaches = get_cache_files(&symcaches_dir);
 
                     cached_symcaches.sort_by_key(|(_, size)| *size);
@@ -504,7 +503,7 @@ async fn test_basic_windows() {
 
                     let metadata_file = &cached_symcaches[0].0;
                     let metadata =
-                        std::fs::read_to_string(objects_dir.join(metadata_file)).unwrap();
+                        std::fs::read_to_string(symcaches_dir.join(metadata_file)).unwrap();
                     expected_metadata.push_str("b\n"); // this truely ends in `.pdb` now
                     assert_eq!(metadata, expected_metadata);
                 }


### PR DESCRIPTION
Moves all the places that define `CacheVersions` into a central place, and makes it mandatory to specify explicit versions.

It also bumps some cache versions, to start lazy recomputation of some of our caches to the new `CacheKey` format, specifically: Bitcode, Il2cpp, PortablePDB, and Objects.
CFI, SymCache and Meta caches in turn depend on other categories, and will be bumped once the first categories have been migrated.