### PR TITLE
ref: Bump derived `CacheVersions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Introduce a `CacheKeyBuilder` and human-readable `CacheKey` metadata. ([#1033](https://github.com/getsentry/symbolicator/pull/1033), [#1036](https://github.com/getsentry/symbolicator/pull/1036))
 - Use new `CacheKey` for writes and shared-cache. ([#1038](https://github.com/getsentry/symbolicator/pull/1038))
-- Consolidate `CacheVersions` and bump half the caches to refresh `CacheKey` usage. ([#1041](https://github.com/getsentry/symbolicator/pull/1041))
+- Consolidate `CacheVersions` and bump to refresh `CacheKey` usage. ([#1041](https://github.com/getsentry/symbolicator/pull/1041), [#1042](https://github.com/getsentry/symbolicator/pull/1042))
 
 ## 0.7.0
 

--- a/crates/symbolicator-service/src/services/caches/versions.rs
+++ b/crates/symbolicator-service/src/services/caches/versions.rs
@@ -18,6 +18,8 @@ use crate::caching::CacheVersions;
 
 /// CFI cache, with the following versions:
 ///
+/// - `4`: Recomputation to use new `CacheKey` format.
+///
 /// - `3`: Proactive bump, as a bug in shared cache could have potentially
 ///   uploaded `v1` cache files as `v2` erroneously.
 ///
@@ -27,12 +29,14 @@ use crate::caching::CacheVersions;
 ///
 /// - `0`: Initial version.
 pub const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 3,
-    fallbacks: &[],
+    current: 4,
+    fallbacks: &[3],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
 /// SymCache, with the following versions:
+///
+/// - `6`: Recomputation to use new `CacheKey` format.
 ///
 /// - `5`: Proactive bump, as a bug in shared cache could have potentially
 ///   uploaded `v2` cache files as `v3` (and later `v4`) erroneously.
@@ -54,8 +58,8 @@ static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 ///
 /// - `0`: Initial version.
 pub const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 5,
-    fallbacks: &[],
+    current: 6,
+    fallbacks: &[5],
 };
 static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 
@@ -66,23 +70,27 @@ static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 /// - `0`: Initial version.
 pub const OBJECTS_CACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 1,
-    fallbacks: &[0],
+    fallbacks: &[],
 };
 
 /// Objects Meta cache, with the following versions:
 ///
+/// - `1`: Recomputation to use new `CacheKey` format.
+///
 /// - `0`: Initial version.
 pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 0,
-    fallbacks: &[],
+    current: 1,
+    fallbacks: &[0],
 };
 
 /// Portable PDB cache, with the following versions:
 ///
+/// - `2`: Recomputation to use new `CacheKey` format.
+///
 /// - `1`: Initial version.
 pub const PPDB_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// SourceMapCache, with the following versions:
@@ -100,7 +108,7 @@ pub const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
 /// - `0`: Initial version.
 pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 1,
-    fallbacks: &[0],
+    fallbacks: &[],
 };
 
 /// Bitcode / Auxdif (plist / bcsymbolmap) cache, with the following versions:
@@ -110,5 +118,5 @@ pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
 /// - `0`: Initial version.
 pub const BITCODE_CACHE_VERSIONS: CacheVersions = CacheVersions {
     current: 1,
-    fallbacks: &[0],
+    fallbacks: &[],
 };


### PR DESCRIPTION
Bumps the versions of all the derived caches to trigger lazy recomputation. That recomputation will then make sure newly written caches use the "new" `CacheKey`s.

lets wait till tomorrow morning to land this :-)