### PR TITLE
feat: Add logging to deny list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,6 +4432,7 @@ dependencies = [
  "flate2",
  "futures",
  "gcp_auth",
+ "humantime",
  "humantime-serde",
  "insta",
  "ipnetwork",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -50,6 +50,7 @@ url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 zstd = "0.12.1"
 data-encoding = "2.3.3"
+humantime = "2.1.0"
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -105,6 +105,7 @@ struct HostDenyList {
     time_window_millis: u64,
     bucket_size_millis: u64,
     failure_threshold: usize,
+    block_time: Duration,
     failures: moka::sync::Cache<String, CountedFailures>,
     blocked_hosts: moka::sync::Cache<String, ()>,
 }
@@ -123,11 +124,13 @@ impl HostDenyList {
             time_window_millis,
             bucket_size_millis,
             failure_threshold,
+            block_time,
             failures: moka::sync::Cache::builder()
                 .time_to_idle(time_window)
                 .build(),
             blocked_hosts: moka::sync::Cache::builder()
                 .time_to_live(block_time)
+                .eviction_listener(|host, _, _| tracing::info!(%host, "Unblocking host"))
                 .build(),
         }
     }
@@ -150,7 +153,15 @@ impl HostDenyList {
     /// If that puts the host over the threshold, it is added
     /// to the blocked servers.
     fn register_failure(&self, host: String) {
-        let current_ts = SystemTime::now()
+        let current_ts = SystemTime::now();
+
+        tracing::trace!(
+            host = %host,
+            time = %humantime::format_rfc3339(current_ts),
+            "Registering download failure"
+        );
+
+        let current_ts = current_ts
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
 
@@ -182,6 +193,11 @@ impl HostDenyList {
             .sum();
 
         if total_failures >= self.failure_threshold {
+            tracing::info!(
+                %host,
+                block_time = %humantime::format_duration(self.block_time),
+                "Blocking host due to too many download failures"
+            );
             self.blocked_hosts.insert(host, ());
         }
     }


### PR DESCRIPTION
This adds logging for when a download failure is registered for a host, as well when a host is added to or removed from the deny list. Currently the former is at `trace`, while the latter two are at `info`. Do these levels make sense? I think the adding one could be increased to `warn`.

#skip-changelog