### PR TITLE
fix: Reject minidumps with invalid file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Automatically block downloads from unreliable hosts. ([#1039](https://github.com/getsentry/symbolicator/pull/1039))
 - Fully migrate `CacheKey` usage and remove legacy markers. ([#1043](https://github.com/getsentry/symbolicator/pull/1043))
 
+### Fixes
+
+- Reject minidumps containing invalid file names. ([#1047](https://github.com/getsentry/symbolicator/pull/1047))
+
 ## 0.7.0
 
 ### Features

--- a/crates/symbolicator-service/src/services/minidump.rs
+++ b/crates/symbolicator-service/src/services/minidump.rs
@@ -96,6 +96,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 
+use symbolic::common::ByteView;
 use thiserror::Error;
 
 use crate::types::{self, FrameTrust};
@@ -104,11 +105,12 @@ use crate::utils::hex;
 const MINIDUMP_EXTENSION_TYPE: u32 = u32::from_be_bytes([b'S', b'y', 0, 1]);
 const MINIDUMP_FORMAT_VERSION: u32 = 1;
 
+type Minidump = minidump::Minidump<'static, ByteView<'static>>;
+
 /// Extract client-side stacktraces from a minidump file.
 pub fn parse_stacktraces_from_minidump(
-    buf: &[u8],
+    dump: &Minidump,
 ) -> Result<Option<Vec<types::RawStacktrace>>, ExtractStacktraceError> {
-    let dump = minidump::Minidump::read(buf)?;
     let extension_buf = match dump.get_raw_stream(MINIDUMP_EXTENSION_TYPE) {
         Ok(stream) => stream,
         Err(minidump::Error::StreamNotFound) => return Ok(None),


### PR DESCRIPTION
This checks minidumps for invalid `code_file` and `debug_file` strings in modules before attempting to process them. "Invalid" here means that the name contains a control character or is longer than 255 bytes.

It also moves minidump parsing, which currently happens twice in `stackwalk` and `parse_stacktraces_from_minidump`, one level up to `stackwalk_minidump`.

The minidump parsing is wrapped in an individual call to `maybe_persist_minidump`, but I don't know if we actually want to persist the file if we fail to open or parse it.