### PR TITLE
ref: More docs and Cach cleanups

### DIFF
--- a/crates/symbolicator-service/src/caching/config.rs
+++ b/crates/symbolicator-service/src/caching/config.rs
@@ -26,7 +26,7 @@ impl AsRef<str> for CacheName {
             Self::Cficaches => "cficaches",
             Self::PpdbCaches => "ppdb_caches",
             Self::ArtifactCaches => "artifact_caches",
-            Self::SourceMapCaches => "sourcesmap_caches",
+            Self::SourceMapCaches => "sourcemap_caches",
             Self::Diagnostics => "diagnostics",
         }
     }

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -58,9 +58,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             .max_capacity(config.in_memory_capacity)
             .name(config.name().as_ref())
             // NOTE: even though we have a per-item TTL, we still want to have a hard limit here
-            // FIXME: we have a rather conservative hard limit right now before we have properly
-            // immutable caches, and to slowly ramp this up
-            .time_to_live(Duration::from_secs(5 * 60))
+            .time_to_live(Duration::from_secs(60 * 60))
             // NOTE: we count all the bookkeeping structures to the weight as well
             .weigher(|_k, v| {
                 let value_size =

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -141,7 +141,7 @@
 //!
 //! A [`CacheItemRequest`] also needs to specify [`CacheVersions`] which are used for cache fallback
 //! as explained in detail above. Newly added caches should start with version `1`, and all the
-//! cache versions and their versioning history should be recorded in [`caches::versions`](crate::caches::versions).
+//! cache versions and their versioning history should be recorded in [`caches::versions`](crate::services::caches::versions).
 //!
 //! A new cache item also needs a new [`CacheName`] and [`Cache`] configuration. This should be added
 //! to [`Caches`] down below as well, and to [`Caches::cleanup`] to properly clean up cache files.

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -296,12 +296,16 @@ pub struct InMemoryCacheConfig {
 
     /// Capacity (in bytes) for the in-memory `object_meta` Cache.
     ///
+    /// The in-memory size limit is a best-effort approximation, and not an exact limit.
+    ///
     /// Defaults to `100 MiB (= 104_857_600)`.
     pub object_meta_capacity: u64,
 
     /// Capacity (in bytes) for the in-memory `cficaches` Cache.
     ///
-    /// Defaults to `400 MiB (= 419_430_400)`.
+    /// The in-memory size limit is a best-effort approximation, and not an exact limit.
+    ///
+    /// Defaults to `600 MiB (= 629_145_600)`.
     pub cficaches_capacity: u64,
 }
 


### PR DESCRIPTION
- Increases the in-memory defaults a bit
- Cleans up the buggy `expiration_strategy` handling
- Remove a footgun from cache configuration
- Add more docs to the caching infrastructure

#skip-changelog