### PR TITLE
ref: Apply source context to raw frames as the initial processing step

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -16,7 +16,7 @@ use crate::services::sourcemap::SourceMapService;
 use crate::services::symcaches::SymCacheActor;
 use crate::types::{
     CompleteObjectInfo, CompleteStacktrace, CompletedSymbolicationResponse, FrameStatus,
-    FrameTrust, JsProcessingRawStacktrace, ObjectFileStatus, RawFrame, RawStacktrace, Registers,
+    FrameTrust, JsProcessingStacktrace, ObjectFileStatus, RawFrame, RawStacktrace, Registers,
     Scope, Signal, SymbolicatedFrame,
 };
 use crate::utils::hex::HexValue;
@@ -197,7 +197,7 @@ pub struct SymbolicateStacktraces {
 #[derive(Debug, Clone)]
 pub struct JsProcessingSymbolicateStacktraces {
     pub source: Arc<SentrySourceConfig>,
-    pub stacktraces: Vec<JsProcessingRawStacktrace>,
+    pub stacktraces: Vec<JsProcessingStacktrace>,
     pub dist: Option<String>,
 }
 

--- a/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
@@ -8,8 +8,8 @@ use symbolic::sourcemapcache::{File, ScopeLookupResult, SourcePosition};
 use crate::caching::CacheError;
 use crate::services::sourcemap_lookup::SourceMapLookup;
 use crate::types::{
-    CompleteJsStacktrace, JsProcessingCompletedSymbolicationResponse, JsProcessingFrameStatus,
-    JsProcessingRawFrame, JsProcessingRawStacktrace, JsProcessingSymbolicatedFrame,
+    JsProcessingCompletedSymbolicationResponse, JsProcessingFrame, JsProcessingFrameStatus,
+    JsProcessingStacktrace, JsProcessingSymbolicatedFrame, JsProcessingSymbolicatedStacktrace,
 };
 
 use super::{JsProcessingSymbolicateStacktraces, SymbolicationActor};
@@ -50,9 +50,9 @@ impl SymbolicationActor {
 }
 
 async fn js_processing_symbolicate_stacktrace(
-    stacktrace: JsProcessingRawStacktrace,
+    stacktrace: JsProcessingStacktrace,
     sourcemap_lookup: &SourceMapLookup,
-) -> CompleteJsStacktrace {
+) -> JsProcessingSymbolicatedStacktrace {
     let mut symbolicated_frames = vec![];
     let unsymbolicated_frames_iter = stacktrace.frames.into_iter();
 
@@ -65,13 +65,13 @@ async fn js_processing_symbolicate_stacktrace(
         }
     }
 
-    CompleteJsStacktrace {
+    JsProcessingSymbolicatedStacktrace {
         frames: symbolicated_frames,
     }
 }
 
 async fn js_processing_symbolicate_frame(
-    frame: &mut JsProcessingRawFrame,
+    frame: &mut JsProcessingFrame,
     sourcemap_lookup: &SourceMapLookup,
 ) -> Result<JsProcessingSymbolicatedFrame, JsProcessingFrameStatus> {
     let smcache = sourcemap_lookup
@@ -80,7 +80,7 @@ async fn js_processing_symbolicate_frame(
 
     let mut result = JsProcessingSymbolicatedFrame {
         status: JsProcessingFrameStatus::Symbolicated,
-        raw: JsProcessingRawFrame {
+        raw: JsProcessingFrame {
             function: frame.function.clone(),
             filename: frame.filename.clone(),
             abs_path: frame.abs_path.clone(),

--- a/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
@@ -63,7 +63,7 @@ async fn js_processing_symbolicate_stacktrace(
     let mut symbolicated_frames = vec![];
 
     for frame in stacktrace.frames.iter() {
-        match js_processing_symbolicate_frame(&frame, sourcemap_lookup).await {
+        match js_processing_symbolicate_frame(frame, sourcemap_lookup).await {
             Ok(frame) => symbolicated_frames.push(frame),
             Err(status) => {
                 symbolicated_frames.push(JsProcessingSymbolicatedFrame {

--- a/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/symbolication/sourcemap.rs
@@ -56,11 +56,15 @@ async fn js_processing_symbolicate_stacktrace(
     let mut symbolicated_frames = vec![];
     let unsymbolicated_frames_iter = stacktrace.frames.into_iter();
 
-    for mut frame in unsymbolicated_frames_iter {
-        match js_processing_symbolicate_frame(&mut frame, sourcemap_lookup).await {
+    for frame in unsymbolicated_frames_iter {
+        match js_processing_symbolicate_frame(&frame, sourcemap_lookup).await {
             Ok(frame) => symbolicated_frames.push(frame),
             Err(status) => {
-                symbolicated_frames.push(JsProcessingSymbolicatedFrame { status, raw: frame });
+                symbolicated_frames.push(JsProcessingSymbolicatedFrame {
+                    status,
+                    raw: frame,
+                    processed: JsProcessingFrame::default(),
+                });
             }
         }
     }
@@ -71,7 +75,7 @@ async fn js_processing_symbolicate_stacktrace(
 }
 
 async fn js_processing_symbolicate_frame(
-    frame: &mut JsProcessingFrame,
+    frame: &JsProcessingFrame,
     sourcemap_lookup: &SourceMapLookup,
 ) -> Result<JsProcessingSymbolicatedFrame, JsProcessingFrameStatus> {
     let smcache = sourcemap_lookup
@@ -80,20 +84,19 @@ async fn js_processing_symbolicate_frame(
 
     let mut result = JsProcessingSymbolicatedFrame {
         status: JsProcessingFrameStatus::Symbolicated,
-        raw: JsProcessingFrame {
-            function: frame.function.clone(),
-            filename: frame.filename.clone(),
-            abs_path: frame.abs_path.clone(),
-            lineno: frame.lineno,
-            colno: frame.colno,
-            pre_context: vec![],
-            context_line: None,
-            post_context: vec![],
-        },
+        raw: frame.clone(),
+        processed: frame.clone(),
     };
 
+    apply_source_context_from_artifact(&mut result.raw, sourcemap_lookup, &frame.abs_path).await;
+
     if smcache.is_err() || smcache.unwrap().is_err() {
-        apply_source_context_from_artifact(&mut result, sourcemap_lookup, &frame.abs_path).await;
+        apply_source_context_from_artifact(
+            &mut result.processed,
+            sourcemap_lookup,
+            &frame.abs_path,
+        )
+        .await;
         return Ok(result);
     }
 
@@ -123,26 +126,30 @@ async fn js_processing_symbolicate_frame(
         }
     };
 
-    result.raw.function = Some(fold_function_name(&function_name));
+    result.processed.function = Some(fold_function_name(&function_name));
     if let Some(filename) = token.file_name() {
-        result.raw.abs_path = filename.to_string();
+        result.processed.abs_path = filename.to_string();
     }
-    result.raw.lineno = Some(token.line().saturating_add(1));
-    result.raw.colno = Some(token.column().saturating_add(1));
+    result.processed.lineno = Some(token.line().saturating_add(1));
+    result.processed.colno = Some(token.column().saturating_add(1));
 
     if let Some(file) = token.file() {
-        result.raw.filename = file.name().map(|f| f.to_string());
+        result.processed.filename = file.name().map(|f| f.to_string());
 
         if file.source().is_some() {
-            apply_source_context_from_sourcemap_cache(&mut result, file).await;
+            apply_source_context_from_sourcemap_cache(&mut result.processed, file).await;
         } else if let Some(filename) = file.name() {
             if let Some(artifact_url) = Url::parse(&frame.abs_path)
                 .map(|base| base.join(filename).map(|url| url.to_string()).ok())
                 .ok()
                 .flatten()
             {
-                apply_source_context_from_artifact(&mut result, sourcemap_lookup, &artifact_url)
-                    .await;
+                apply_source_context_from_artifact(
+                    &mut result.processed,
+                    sourcemap_lookup,
+                    &artifact_url,
+                )
+                .await;
             }
         }
     }
@@ -150,20 +157,17 @@ async fn js_processing_symbolicate_frame(
     Ok(result)
 }
 
-async fn apply_source_context_from_sourcemap_cache(
-    result: &mut JsProcessingSymbolicatedFrame,
-    file: File<'_>,
-) {
+async fn apply_source_context_from_sourcemap_cache(frame: &mut JsProcessingFrame, file: File<'_>) {
     if let Some(file_source) = file.source() {
         let source = ByteView::from_slice(file_source.as_bytes());
-        apply_source_context(result, source).await
+        apply_source_context(frame, source).await
     } else {
         // report missing source?
     }
 }
 
 async fn apply_source_context_from_artifact(
-    result: &mut JsProcessingSymbolicatedFrame,
+    frame: &mut JsProcessingFrame,
     sourcemap_lookup: &SourceMapLookup,
     abs_path: &str,
 ) {
@@ -179,16 +183,16 @@ async fn apply_source_context_from_artifact(
     };
 
     if let Ok(artifact) = artifact {
-        apply_source_context(result, artifact).await
+        apply_source_context(frame, artifact).await
     } else {
         // report missing source?
     }
 }
 
-async fn apply_source_context(result: &mut JsProcessingSymbolicatedFrame, source: ByteView<'_>) {
+async fn apply_source_context(frame: &mut JsProcessingFrame, source: ByteView<'_>) {
     // At this stage we know we have _some_ line here, so it's safe to unwrap.
-    let frame_line = result.raw.lineno.unwrap();
-    let frame_column = result.raw.colno.unwrap_or_default();
+    let frame_line = frame.lineno.unwrap();
+    let frame_column = frame.colno.unwrap_or_default();
 
     let current_line = frame_line.saturating_sub(1);
     let pre_line = current_line.saturating_sub(5);
@@ -201,16 +205,16 @@ async fn apply_source_context(result: &mut JsProcessingSymbolicatedFrame, source
         lines.push("\n".to_string());
     }
 
-    result.raw.context_line = lines
+    frame.context_line = lines
         .get(current_line as usize)
         .map(|line| trim_context_line(line, frame_column));
 
-    result.raw.pre_context = (pre_line..current_line)
+    frame.pre_context = (pre_line..current_line)
         .filter_map(|line_no| lines.get(line_no as usize))
         .map(|line| trim_context_line(line, frame_column))
         .collect();
 
-    result.raw.post_context = (current_line + 1..=post_line)
+    frame.post_context = (current_line + 1..=post_line)
         .filter_map(|line_no| lines.get(line_no as usize))
         .map(|line| trim_context_line(line, frame_column))
         .collect();

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -583,7 +583,7 @@ pub enum JsProcessingFrameStatus {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingCompletedSymbolicationResponse {
-    pub stacktraces: Vec<CompleteJsStacktrace>,
+    pub stacktraces: Vec<JsProcessingSymbolicatedStacktrace>,
 }
 
 /// Information about the operating system.
@@ -607,7 +607,7 @@ pub struct SystemInfo {
 
 // TODO: Verify which are required fields
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct JsProcessingRawFrame {
+pub struct JsProcessingFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<String>,
 
@@ -632,20 +632,20 @@ pub struct JsProcessingRawFrame {
     pub post_context: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct JsProcessingRawStacktrace {
-    pub frames: Vec<JsProcessingRawFrame>,
-}
-
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingSymbolicatedFrame {
     pub status: JsProcessingFrameStatus,
 
     #[serde(flatten)]
-    pub raw: JsProcessingRawFrame,
+    pub raw: JsProcessingFrame,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct CompleteJsStacktrace {
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct JsProcessingStacktrace {
+    pub frames: Vec<JsProcessingFrame>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct JsProcessingSymbolicatedStacktrace {
     pub frames: Vec<JsProcessingSymbolicatedFrame>,
 }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -584,6 +584,7 @@ pub enum JsProcessingFrameStatus {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingCompletedSymbolicationResponse {
     pub stacktraces: Vec<JsProcessingSymbolicatedStacktrace>,
+    pub raw_stacktraces: Vec<JsProcessingStacktrace>,
 }
 
 /// Information about the operating system.
@@ -635,8 +636,8 @@ pub struct JsProcessingFrame {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingSymbolicatedFrame {
     pub status: JsProcessingFrameStatus,
+    #[serde(flatten)]
     pub raw: JsProcessingFrame,
-    pub processed: JsProcessingFrame,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -635,9 +635,8 @@ pub struct JsProcessingFrame {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsProcessingSymbolicatedFrame {
     pub status: JsProcessingFrameStatus,
-
-    #[serde(flatten)]
     pub raw: JsProcessingFrame,
+    pub processed: JsProcessingFrame,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use symbolicator_service::{
-    services::symbolication::JsProcessingSymbolicateStacktraces, types::JsProcessingRawStacktrace,
+    services::symbolication::JsProcessingSymbolicateStacktraces, types::JsProcessingStacktrace,
 };
 use symbolicator_sources::{SentrySourceConfig, SourceId};
 
@@ -59,7 +59,7 @@ async fn test_sourcemap_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("01_sourcemap_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -114,7 +114,7 @@ async fn test_sourcemap_source_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("02_sourcemap_source_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -173,7 +173,7 @@ async fn test_sourcemap_embedded_source_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("03_sourcemap_embedded_source_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -219,7 +219,7 @@ async fn test_source_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("04_source_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -268,7 +268,7 @@ async fn test_inlined_sources() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("05_inlined_sources");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -307,7 +307,7 @@ async fn test_sourcemap_nofiles_source_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("06_sourcemap_nofiles_source_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {
@@ -354,7 +354,7 @@ async fn test_indexed_sourcemap_source_expansion() {
     let (symbolication, _) = setup_service(|_| ());
     let srv = symbolicator_test::sourcemap_server("07_indexed_sourcemap_source_expansion");
 
-    let stacktraces: Vec<JsProcessingRawStacktrace> =
+    let stacktraces: Vec<JsProcessingStacktrace> =
         serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
     let request = JsProcessingSymbolicateStacktraces {
         source: Arc::new(SentrySourceConfig {

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -70,29 +70,29 @@ async fn test_sourcemap_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
     assert_eq!(frames.len(), 4);
 
-    assert_eq!(
-        frames[0].processed.function,
-        Some("produceStack".to_string())
-    );
-    assert_eq!(frames[0].processed.lineno, Some(6));
-    assert_eq!(frames[0].processed.filename, Some("index.html".to_string()));
+    assert_eq!(frames[0].raw.function, Some("produceStack".to_string()));
+    assert_eq!(frames[0].raw.lineno, Some(6));
+    assert_eq!(frames[0].raw.filename, Some("index.html".to_string()));
 
-    assert_eq!(frames[1].processed.function, Some("test".to_string()));
-    assert_eq!(frames[1].processed.lineno, Some(20));
-    assert_eq!(frames[1].processed.filename, Some("test.js".to_string()));
+    assert_eq!(frames[1].raw.function, Some("test".to_string()));
+    assert_eq!(frames[1].raw.lineno, Some(20));
+    assert_eq!(frames[1].raw.filename, Some("test.js".to_string()));
 
-    assert_eq!(frames[2].processed.function, Some("invoke".to_string()));
-    assert_eq!(frames[2].processed.lineno, Some(15));
-    assert_eq!(frames[2].processed.filename, Some("test.js".to_string()));
+    assert_eq!(frames[2].raw.function, Some("invoke".to_string()));
+    assert_eq!(frames[2].raw.lineno, Some(15));
+    assert_eq!(frames[2].raw.filename, Some("test.js".to_string()));
 
-    assert_eq!(frames[3].processed.function, Some("onFailure".to_string()));
-    assert_eq!(frames[3].processed.lineno, Some(5));
-    assert_eq!(frames[3].processed.filename, Some("test.js".to_string()));
+    assert_eq!(frames[3].raw.function, Some("onFailure".to_string()));
+    assert_eq!(frames[3].raw.lineno, Some(5));
+    assert_eq!(frames[3].raw.filename, Some("test.js".to_string()));
 }
 
 #[tokio::test]
@@ -128,30 +128,34 @@ async fn test_sourcemap_source_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
+    let raw_frames = &response.raw_stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
     // Raw frames
     let pre_context: &[String] = &[];
     let context_line = Some("function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}".to_string());
     let post_context = &["//@ sourceMappingURL=file.min.js.map", ""];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(1));
-    assert_eq!(frames[1].raw.colno, Some(39));
+    assert_eq!(raw_frames[1].pre_context, pre_context);
+    assert_eq!(raw_frames[1].context_line, context_line);
+    assert_eq!(raw_frames[1].post_context, post_context);
+    assert_eq!(raw_frames[1].lineno, Some(1));
+    assert_eq!(raw_frames[1].colno, Some(39));
 
     // Processed frames
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[1].processed.pre_context, pre_context);
-    assert_eq!(frames[1].processed.context_line, context_line);
-    assert_eq!(frames[1].processed.post_context, post_context);
-    assert_eq!(frames[1].processed.lineno, Some(3));
-    assert_eq!(frames[1].processed.colno, Some(9));
+    assert_eq!(frames[1].raw.pre_context, pre_context);
+    assert_eq!(frames[1].raw.context_line, context_line);
+    assert_eq!(frames[1].raw.post_context, post_context);
+    assert_eq!(frames[1].raw.lineno, Some(3));
+    assert_eq!(frames[1].raw.colno, Some(9));
 }
 
 #[tokio::test]
@@ -187,19 +191,22 @@ async fn test_sourcemap_embedded_source_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[1].processed.pre_context, pre_context);
-    assert_eq!(frames[1].processed.context_line, context_line);
-    assert_eq!(frames[1].processed.post_context, post_context);
-    assert_eq!(frames[1].processed.lineno, Some(3));
-    assert_eq!(frames[1].processed.colno, Some(9));
+    assert_eq!(frames[1].raw.pre_context, pre_context);
+    assert_eq!(frames[1].raw.context_line, context_line);
+    assert_eq!(frames[1].raw.post_context, post_context);
+    assert_eq!(frames[1].raw.lineno, Some(3));
+    assert_eq!(frames[1].raw.colno, Some(9));
 }
 
 #[tokio::test]
@@ -233,28 +240,31 @@ async fn test_source_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
     let pre_context: &[String] = &[];
     let context_line = Some("h".to_string());
     let post_context = &["e", "l", "l", "o", " "];
-    assert_eq!(frames[0].processed.pre_context, pre_context);
-    assert_eq!(frames[0].processed.context_line, context_line);
-    assert_eq!(frames[0].processed.post_context, post_context);
-    assert_eq!(frames[0].processed.lineno, Some(1));
-    assert_eq!(frames[0].processed.colno, Some(0));
+    assert_eq!(frames[0].raw.pre_context, pre_context);
+    assert_eq!(frames[0].raw.context_line, context_line);
+    assert_eq!(frames[0].raw.post_context, post_context);
+    assert_eq!(frames[0].raw.lineno, Some(1));
+    assert_eq!(frames[0].raw.colno, Some(0));
 
     let pre_context = &["h", "e", "l"];
     let context_line = Some("l".to_string());
     let post_context = &["o", " ", "w", "o", "r"];
-    assert_eq!(frames[1].processed.pre_context, pre_context);
-    assert_eq!(frames[1].processed.context_line, context_line);
-    assert_eq!(frames[1].processed.post_context, post_context);
-    assert_eq!(frames[1].processed.lineno, Some(4));
-    assert_eq!(frames[1].processed.colno, Some(0));
+    assert_eq!(frames[1].raw.pre_context, pre_context);
+    assert_eq!(frames[1].raw.context_line, context_line);
+    assert_eq!(frames[1].raw.post_context, post_context);
+    assert_eq!(frames[1].raw.lineno, Some(4));
+    assert_eq!(frames[1].raw.colno, Some(0));
 }
 
 #[tokio::test]
@@ -282,19 +292,22 @@ async fn test_inlined_sources() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
     assert_eq!(frames.len(), 1);
 
     let pre_context: &[String] = &[];
     let context_line = Some("console.log('hello, World!')".to_string());
     let post_context: &[String] = &[];
-    assert_eq!(frames[0].processed.pre_context, pre_context);
-    assert_eq!(frames[0].processed.context_line, context_line);
-    assert_eq!(frames[0].processed.post_context, post_context);
-    assert_eq!(frames[0].processed.lineno, Some(1));
-    assert_eq!(frames[0].processed.colno, Some(1));
+    assert_eq!(frames[0].raw.pre_context, pre_context);
+    assert_eq!(frames[0].raw.context_line, context_line);
+    assert_eq!(frames[0].raw.post_context, post_context);
+    assert_eq!(frames[0].raw.lineno, Some(1));
+    assert_eq!(frames[0].raw.colno, Some(1));
 }
 
 #[tokio::test]
@@ -321,20 +334,23 @@ async fn test_sourcemap_nofiles_source_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
     assert_eq!(frames.len(), 1);
 
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[0].processed.pre_context, pre_context);
-    assert_eq!(frames[0].processed.context_line, context_line);
-    assert_eq!(frames[0].processed.post_context, post_context);
-    assert_eq!(frames[0].processed.lineno, Some(3));
-    assert_eq!(frames[0].processed.colno, Some(9));
-    assert_eq!(frames[0].processed.abs_path, "app:///nofiles.js");
+    assert_eq!(frames[0].raw.pre_context, pre_context);
+    assert_eq!(frames[0].raw.context_line, context_line);
+    assert_eq!(frames[0].raw.post_context, post_context);
+    assert_eq!(frames[0].raw.lineno, Some(3));
+    assert_eq!(frames[0].raw.colno, Some(9));
+    assert_eq!(frames[0].raw.abs_path, "app:///nofiles.js");
 }
 
 #[tokio::test]
@@ -368,9 +384,13 @@ async fn test_indexed_sourcemap_source_expansion() {
         stacktraces,
         dist: None,
     };
-    let response = symbolication.js_processing_symbolicate(request).await;
+    let response = symbolication
+        .js_processing_symbolicate(request)
+        .await
+        .unwrap();
 
-    let frames = &mut response.unwrap().stacktraces[0].frames;
+    let frames = &response.stacktraces[0].frames;
+    let raw_frames = &response.raw_stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
     // Raw frames
@@ -382,30 +402,30 @@ async fn test_indexed_sourcemap_source_expansion() {
         "",
     ];
 
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(1));
-    assert_eq!(frames[0].raw.colno, Some(39));
+    assert_eq!(raw_frames[0].pre_context, pre_context);
+    assert_eq!(raw_frames[0].context_line, context_line);
+    assert_eq!(raw_frames[0].post_context, post_context);
+    assert_eq!(raw_frames[0].lineno, Some(1));
+    assert_eq!(raw_frames[0].colno, Some(39));
 
     let pre_context = &["function add(a,b){\"use strict\";return a+b}"];
     let context_line = Some("function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}".to_string());
     let post_context = &["//# sourceMappingURL=indexed.min.js.map", ""];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(2));
-    assert_eq!(frames[1].raw.colno, Some(44));
+    assert_eq!(raw_frames[1].pre_context, pre_context);
+    assert_eq!(raw_frames[1].context_line, context_line);
+    assert_eq!(raw_frames[1].post_context, post_context);
+    assert_eq!(raw_frames[1].lineno, Some(2));
+    assert_eq!(raw_frames[1].colno, Some(44));
 
     // Processed frames
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[0].processed.pre_context, pre_context);
-    assert_eq!(frames[0].processed.context_line, context_line);
-    assert_eq!(frames[0].processed.post_context, post_context);
-    assert_eq!(frames[0].processed.lineno, Some(3));
-    assert_eq!(frames[0].processed.colno, Some(9));
+    assert_eq!(frames[0].raw.pre_context, pre_context);
+    assert_eq!(frames[0].raw.context_line, context_line);
+    assert_eq!(frames[0].raw.post_context, post_context);
+    assert_eq!(frames[0].raw.lineno, Some(3));
+    assert_eq!(frames[0].raw.colno, Some(9));
 
     let pre_context = &["function multiply(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a * b;".to_string());
@@ -416,9 +436,9 @@ async fn test_indexed_sourcemap_source_expansion() {
         "\ttry {",
         "\t\treturn multiply(add(a, b), a, b) / c;",
     ];
-    assert_eq!(frames[1].processed.pre_context, pre_context);
-    assert_eq!(frames[1].processed.context_line, context_line);
-    assert_eq!(frames[1].processed.post_context, post_context);
-    assert_eq!(frames[1].processed.lineno, Some(3));
-    assert_eq!(frames[1].processed.colno, Some(9));
+    assert_eq!(frames[1].raw.pre_context, pre_context);
+    assert_eq!(frames[1].raw.context_line, context_line);
+    assert_eq!(frames[1].raw.post_context, post_context);
+    assert_eq!(frames[1].raw.lineno, Some(3));
+    assert_eq!(frames[1].raw.colno, Some(9));
 }

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -75,21 +75,24 @@ async fn test_sourcemap_expansion() {
     let frames = &mut response.unwrap().stacktraces[0].frames;
     assert_eq!(frames.len(), 4);
 
-    assert_eq!(frames[0].raw.function, Some("produceStack".to_string()));
-    assert_eq!(frames[0].raw.lineno, Some(6));
-    assert_eq!(frames[0].raw.filename, Some("index.html".to_string()));
+    assert_eq!(
+        frames[0].processed.function,
+        Some("produceStack".to_string())
+    );
+    assert_eq!(frames[0].processed.lineno, Some(6));
+    assert_eq!(frames[0].processed.filename, Some("index.html".to_string()));
 
-    assert_eq!(frames[1].raw.function, Some("test".to_string()));
-    assert_eq!(frames[1].raw.lineno, Some(20));
-    assert_eq!(frames[1].raw.filename, Some("test.js".to_string()));
+    assert_eq!(frames[1].processed.function, Some("test".to_string()));
+    assert_eq!(frames[1].processed.lineno, Some(20));
+    assert_eq!(frames[1].processed.filename, Some("test.js".to_string()));
 
-    assert_eq!(frames[2].raw.function, Some("invoke".to_string()));
-    assert_eq!(frames[2].raw.lineno, Some(15));
-    assert_eq!(frames[2].raw.filename, Some("test.js".to_string()));
+    assert_eq!(frames[2].processed.function, Some("invoke".to_string()));
+    assert_eq!(frames[2].processed.lineno, Some(15));
+    assert_eq!(frames[2].processed.filename, Some("test.js".to_string()));
 
-    assert_eq!(frames[3].raw.function, Some("onFailure".to_string()));
-    assert_eq!(frames[3].raw.lineno, Some(5));
-    assert_eq!(frames[3].raw.filename, Some("test.js".to_string()));
+    assert_eq!(frames[3].processed.function, Some("onFailure".to_string()));
+    assert_eq!(frames[3].processed.lineno, Some(5));
+    assert_eq!(frames[3].processed.filename, Some("test.js".to_string()));
 }
 
 #[tokio::test]
@@ -130,25 +133,25 @@ async fn test_sourcemap_source_expansion() {
     let frames = &mut response.unwrap().stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
+    // Raw frames
+    let pre_context: &[String] = &[];
+    let context_line = Some("function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}".to_string());
+    let post_context = &["//@ sourceMappingURL=file.min.js.map", ""];
     assert_eq!(frames[1].raw.pre_context, pre_context);
     assert_eq!(frames[1].raw.context_line, context_line);
     assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
+    assert_eq!(frames[1].raw.lineno, Some(1));
+    assert_eq!(frames[1].raw.colno, Some(39));
 
-    // TODO: Applying source context to original frames is currently not implemented.
-
-    // let pre_context: &[String] = &[];
-    // let context_line = Some("function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}".to_string());
-    // let post_context = &["//@ sourceMappingURL=file.sourcemap.js", ""];
-    // assert_eq!(frames[1].very_raw.pre_context, pre_context);
-    // assert_eq!(frames[1].very_raw.context_line, context_line);
-    // assert_eq!(frames[1].very_raw.post_context, post_context);
-    // assert_eq!(frames[1].very_raw.lineno, Some(1));
-    // assert_eq!(frames[1].very_raw.colno, Some(39));
+    // Processed frames
+    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
+    let context_line = Some("\treturn a + b; // fôo".to_string());
+    let post_context = &["}", ""];
+    assert_eq!(frames[1].processed.pre_context, pre_context);
+    assert_eq!(frames[1].processed.context_line, context_line);
+    assert_eq!(frames[1].processed.post_context, post_context);
+    assert_eq!(frames[1].processed.lineno, Some(3));
+    assert_eq!(frames[1].processed.colno, Some(9));
 }
 
 #[tokio::test]
@@ -192,11 +195,11 @@ async fn test_sourcemap_embedded_source_expansion() {
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
+    assert_eq!(frames[1].processed.pre_context, pre_context);
+    assert_eq!(frames[1].processed.context_line, context_line);
+    assert_eq!(frames[1].processed.post_context, post_context);
+    assert_eq!(frames[1].processed.lineno, Some(3));
+    assert_eq!(frames[1].processed.colno, Some(9));
 }
 
 #[tokio::test]
@@ -238,20 +241,20 @@ async fn test_source_expansion() {
     let pre_context: &[String] = &[];
     let context_line = Some("h".to_string());
     let post_context = &["e", "l", "l", "o", " "];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(1));
-    assert_eq!(frames[0].raw.colno, Some(0));
+    assert_eq!(frames[0].processed.pre_context, pre_context);
+    assert_eq!(frames[0].processed.context_line, context_line);
+    assert_eq!(frames[0].processed.post_context, post_context);
+    assert_eq!(frames[0].processed.lineno, Some(1));
+    assert_eq!(frames[0].processed.colno, Some(0));
 
     let pre_context = &["h", "e", "l"];
     let context_line = Some("l".to_string());
     let post_context = &["o", " ", "w", "o", "r"];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(4));
-    assert_eq!(frames[1].raw.colno, Some(0));
+    assert_eq!(frames[1].processed.pre_context, pre_context);
+    assert_eq!(frames[1].processed.context_line, context_line);
+    assert_eq!(frames[1].processed.post_context, post_context);
+    assert_eq!(frames[1].processed.lineno, Some(4));
+    assert_eq!(frames[1].processed.colno, Some(0));
 }
 
 #[tokio::test]
@@ -287,11 +290,11 @@ async fn test_inlined_sources() {
     let pre_context: &[String] = &[];
     let context_line = Some("console.log('hello, World!')".to_string());
     let post_context: &[String] = &[];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(1));
-    assert_eq!(frames[0].raw.colno, Some(1));
+    assert_eq!(frames[0].processed.pre_context, pre_context);
+    assert_eq!(frames[0].processed.context_line, context_line);
+    assert_eq!(frames[0].processed.post_context, post_context);
+    assert_eq!(frames[0].processed.lineno, Some(1));
+    assert_eq!(frames[0].processed.colno, Some(1));
 }
 
 #[tokio::test]
@@ -326,12 +329,12 @@ async fn test_sourcemap_nofiles_source_expansion() {
     let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a + b; // fôo".to_string());
     let post_context = &["}", ""];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(3));
-    assert_eq!(frames[0].raw.colno, Some(9));
-    assert_eq!(frames[0].raw.abs_path, "app:///nofiles.js");
+    assert_eq!(frames[0].processed.pre_context, pre_context);
+    assert_eq!(frames[0].processed.context_line, context_line);
+    assert_eq!(frames[0].processed.post_context, post_context);
+    assert_eq!(frames[0].processed.lineno, Some(3));
+    assert_eq!(frames[0].processed.colno, Some(9));
+    assert_eq!(frames[0].processed.abs_path, "app:///nofiles.js");
 }
 
 #[tokio::test]
@@ -370,14 +373,39 @@ async fn test_indexed_sourcemap_source_expansion() {
     let frames = &mut response.unwrap().stacktraces[0].frames;
     assert_eq!(frames.len(), 2);
 
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
+    // Raw frames
+    let pre_context: &[String] = &[];
+    let context_line = Some("function add(a,b){\"use strict\";return a+b}".to_string());
+    let post_context = &[
+        "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}",
+        "//# sourceMappingURL=indexed.min.js.map",
+        "",
+    ];
+
     assert_eq!(frames[0].raw.pre_context, pre_context);
     assert_eq!(frames[0].raw.context_line, context_line);
     assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(3));
-    assert_eq!(frames[0].raw.colno, Some(9));
+    assert_eq!(frames[0].raw.lineno, Some(1));
+    assert_eq!(frames[0].raw.colno, Some(39));
+
+    let pre_context = &["function add(a,b){\"use strict\";return a+b}"];
+    let context_line = Some("function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}".to_string());
+    let post_context = &["//# sourceMappingURL=indexed.min.js.map", ""];
+    assert_eq!(frames[1].raw.pre_context, pre_context);
+    assert_eq!(frames[1].raw.context_line, context_line);
+    assert_eq!(frames[1].raw.post_context, post_context);
+    assert_eq!(frames[1].raw.lineno, Some(2));
+    assert_eq!(frames[1].raw.colno, Some(44));
+
+    // Processed frames
+    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
+    let context_line = Some("\treturn a + b; // fôo".to_string());
+    let post_context = &["}", ""];
+    assert_eq!(frames[0].processed.pre_context, pre_context);
+    assert_eq!(frames[0].processed.context_line, context_line);
+    assert_eq!(frames[0].processed.post_context, post_context);
+    assert_eq!(frames[0].processed.lineno, Some(3));
+    assert_eq!(frames[0].processed.colno, Some(9));
 
     let pre_context = &["function multiply(a, b) {", "\t\"use strict\";"];
     let context_line = Some("\treturn a * b;".to_string());
@@ -388,29 +416,9 @@ async fn test_indexed_sourcemap_source_expansion() {
         "\ttry {",
         "\t\treturn multiply(add(a, b), a, b) / c;",
     ];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
-
-    // TODO: Applying source context to original frames is currently not implemented.
-
-    // let pre_context: &[String] = &[];
-    // let context_line = Some("function add(a,b){\"use strict\";return a+b}".to_string());
-    // let post_context = &["//# sourceMappingURL=indexed.sourcemap.js", ""];
-    // assert_eq!(frames[0].very_raw.pre_context, pre_context);
-    // assert_eq!(frames[0].very_raw.context_line, context_line);
-    // assert_eq!(frames[0].very_raw.post_context, post_context);
-    // assert_eq!(frames[0].very_raw.lineno, Some(1));
-    // assert_eq!(frames[0].very_raw.colno, Some(39));
-
-    // let pre_context = &["function add(a,b){\"use strict\";return a+b}"];
-    // let context_line = Some("function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}".to_string());
-    // let post_context = &["}", ""];
-    // assert_eq!(frames[1].very_raw.pre_context, pre_context);
-    // assert_eq!(frames[1].very_raw.context_line, context_line);
-    // assert_eq!(frames[1].very_raw.post_context, post_context);
-    // assert_eq!(frames[1].very_raw.lineno, Some(2));
-    // assert_eq!(frames[1].very_raw.colno, Some(44));
+    assert_eq!(frames[1].processed.pre_context, pre_context);
+    assert_eq!(frames[1].processed.context_line, context_line);
+    assert_eq!(frames[1].processed.post_context, post_context);
+    assert_eq!(frames[1].processed.lineno, Some(3));
+    assert_eq!(frames[1].processed.colno, Some(9));
 }

--- a/crates/symbolicator/src/endpoints/sourcemap.rs
+++ b/crates/symbolicator/src/endpoints/sourcemap.rs
@@ -7,7 +7,7 @@ use symbolicator_service::services::symbolication::JsProcessingSymbolicateStackt
 use symbolicator_sources::SentrySourceConfig;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
-use crate::service::{JsProcessingRawStacktrace, RequestService, SymbolicationResponse};
+use crate::service::{JsProcessingStacktrace, RequestService, SymbolicationResponse};
 use crate::utils::sentry::ConfigureScope;
 
 use super::ResponseError;
@@ -17,7 +17,7 @@ pub struct SourcemapRequestBody {
     #[serde(default)]
     pub source: Option<SentrySourceConfig>,
     #[serde(default)]
-    pub stacktraces: Vec<JsProcessingRawStacktrace>,
+    pub stacktraces: Vec<JsProcessingStacktrace>,
     #[serde(default)]
     pub dist: Option<String>,
 }

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -45,7 +45,7 @@ pub use symbolicator_service::services::symbolication::{
     JsProcessingSymbolicateStacktraces, StacktraceOrigin, SymbolicateStacktraces,
 };
 pub use symbolicator_service::types::{
-    JsProcessingRawStacktrace, RawObjectInfo, RawStacktrace, Scope, Signal,
+    JsProcessingStacktrace, RawObjectInfo, RawStacktrace, Scope, Signal,
 };
 
 /// Symbolication task identifier.


### PR DESCRIPTION
The first commit introduces some changes in naming, specifically:

```
JsProcessingRawFrame => JsProcessingFrame
JsProcessingRawStacktrace => JsProcessingStacktrace
CompleteJsStacktrace => JsProcessingSymbolicatedStacktrace
```

So for JS processing, we now have:

```
JsProcessingFrame {}
JsProcessingSymbolicatedFrame {}
JsProcessingFrameStatus {}

JsProcessingStacktrace {}
JsProcessingSymbolicatedStacktrace {}
    
JsProcessingCompletedSymbolicationResponse {}
```


As for the `raw_stacktrace` passthrough, there's now `frame.status`, `frame.raw` and `frame.processed` attributes, where `raw` and `processed` are clones of the original frame.

I'm not tied to that name though, and other proposals are `frame.symbolicated` or `frame.changed`, I don't mind either.

This makes all commented-out assertions now pass integration tests.

#skip-changelog