### PR TITLE
Simplify SourceMap tests

### DIFF
--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -1,0 +1,57 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: add
+        filename: file1.js
+        abs_path: file1.js
+        lineno: 3
+        colno: 9
+        pre_context:
+          - "function add(a, b) {"
+          - "\t\"use strict\";"
+        context_line: "\treturn a + b; // fôo"
+        post_context:
+          - "}"
+          - ""
+      - status: symbolicated
+        function: multiply
+        filename: file2.js
+        abs_path: file2.js
+        lineno: 3
+        colno: 9
+        pre_context:
+          - "function multiply(a, b) {"
+          - "\t\"use strict\";"
+        context_line: "\treturn a * b;"
+        post_context:
+          - "}"
+          - "function divide(a, b) {"
+          - "\t\"use strict\";"
+          - "\ttry {"
+          - "\t\treturn multiply(add(a, b), a, b) / c;"
+raw_stacktraces:
+  - frames:
+      - filename: indexed.min.js
+        abs_path: "http://example.com/indexed.min.js"
+        lineno: 1
+        colno: 39
+        context_line: "function add(a,b){\"use strict\";return a+b}"
+        post_context:
+          - "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
+          - "//# sourceMappingURL=indexed.min.js.map"
+          - ""
+      - filename: indexed.min.js
+        abs_path: "http://example.com/indexed.min.js"
+        lineno: 2
+        colno: 44
+        pre_context:
+          - "function add(a,b){\"use strict\";return a+b}"
+        context_line: "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
+        post_context:
+          - "//# sourceMappingURL=indexed.min.js.map"
+          - ""
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -1,0 +1,25 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: "<unknown>"
+        filename: /test.js
+        abs_path: /test.js
+        lineno: 1
+        colno: 1
+        context_line: "console.log('hello, World!')"
+raw_stacktraces:
+  - frames:
+      - filename: test.js
+        abs_path: "http://example.com/test.min.js"
+        lineno: 1
+        colno: 1
+        context_line: // <generated source>
+        post_context:
+          - "// Decoded sourcemap: {\"version\":3,\"file\":\"generated.js\",\"sources\":[\"/test.js\"],\"names\":[],\"mappings\":\"AAAA\",\"sourcesContent\":[\"console.log( {snip}"
+          - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
+          - ""
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -1,0 +1,63 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        filename: foo.js
+        abs_path: "http://example.com/foo.js"
+        lineno: 1
+        colno: 0
+        context_line: h
+        post_context:
+          - e
+          - l
+          - l
+          - o
+          - " "
+      - status: symbolicated
+        filename: foo.js
+        abs_path: "http://example.com/foo.js"
+        lineno: 4
+        colno: 0
+        pre_context:
+          - h
+          - e
+          - l
+        context_line: l
+        post_context:
+          - o
+          - " "
+          - w
+          - o
+          - r
+raw_stacktraces:
+  - frames:
+      - filename: foo.js
+        abs_path: "http://example.com/foo.js"
+        lineno: 1
+        colno: 0
+        context_line: h
+        post_context:
+          - e
+          - l
+          - l
+          - o
+          - " "
+      - filename: foo.js
+        abs_path: "http://example.com/foo.js"
+        lineno: 4
+        colno: 0
+        pre_context:
+          - h
+          - e
+          - l
+        context_line: l
+        post_context:
+          - o
+          - " "
+          - w
+          - o
+          - r
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,0 +1,41 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: "function: \"HTMLDocument.<anonymous>\""
+        filename: index.html
+        abs_path: http//example.com/index.html
+        lineno: 283
+        colno: 17
+      - status: symbolicated
+        function: add
+        filename: file1.js
+        abs_path: file1.js
+        lineno: 3
+        colno: 9
+        pre_context:
+          - "function add(a, b) {"
+          - "\t\"use strict\";"
+        context_line: "\treturn a + b; // fôo"
+        post_context:
+          - "}"
+          - ""
+raw_stacktraces:
+  - frames:
+      - function: "function: \"HTMLDocument.<anonymous>\""
+        filename: index.html
+        abs_path: http//example.com/index.html
+        lineno: 283
+        colno: 17
+      - filename: embedded.js
+        abs_path: "http://example.com/embedded.js"
+        lineno: 1
+        colno: 39
+        context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
+        post_context:
+          - "//# sourceMappingURL=embedded.js.map"
+          - ""
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,0 +1,100 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: produceStack
+        filename: index.html
+        abs_path: "http://example.com/index.html"
+        lineno: 6
+        colno: 7
+      - status: symbolicated
+        function: test
+        filename: test.js
+        abs_path: test.js
+        lineno: 20
+        colno: 5
+        pre_context:
+          - "    cb(data);"
+          - "  }"
+          - ""
+          - "  function test() {"
+          - "    var data = {failed: true, value: 42};"
+        context_line: "    invoke(data);"
+        post_context:
+          - "  }"
+          - ""
+          - "  return test;"
+          - "})();"
+          - ""
+      - status: symbolicated
+        function: invoke
+        filename: test.js
+        abs_path: test.js
+        lineno: 15
+        colno: 5
+        pre_context:
+          - "    if (data.failed) {"
+          - "      cb = onFailure;"
+          - "    } else {"
+          - "      cb = onSuccess;"
+          - "    }"
+        context_line: "    cb(data);"
+        post_context:
+          - "  }"
+          - ""
+          - "  function test() {"
+          - "    var data = {failed: true, value: 42};"
+          - "    invoke(data);"
+      - status: symbolicated
+        function: onFailure
+        filename: test.js
+        abs_path: test.js
+        lineno: 5
+        colno: 11
+        pre_context:
+          - "var makeAFailure = (function() {"
+          - "  function onSuccess(data) {}"
+          - ""
+          - "  function onFailure(data) {"
+        context_line: "    throw new Error('failed!');"
+        post_context:
+          - "  }"
+          - ""
+          - "  function invoke(data) {"
+          - "    var cb = null;"
+          - "    if (data.failed) {"
+raw_stacktraces:
+  - frames:
+      - function: produceStack
+        filename: index.html
+        abs_path: "http://example.com/index.html"
+        lineno: 6
+        colno: 7
+      - function: i
+        filename: test.min.js
+        abs_path: "http://example.com/test.min.js"
+        lineno: 1
+        colno: 183
+        context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
+        post_context:
+          - "//# sourceMappingURL=test.min.js.map"
+      - function: r
+        filename: test.min.js
+        abs_path: "http://example.com/test.min.js"
+        lineno: 1
+        colno: 136
+        context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
+        post_context:
+          - "//# sourceMappingURL=test.min.js.map"
+      - function: e
+        filename: test.min.js
+        abs_path: "http://example.com/test.min.js"
+        lineno: 1
+        colno: 64
+        context_line: "var makeAFailure=function(){function n(n){}function e(n){throw new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)} {snip}"
+        post_context:
+          - "//# sourceMappingURL=test.min.js.map"
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -1,0 +1,31 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: add
+        abs_path: "app:///nofiles.js"
+        lineno: 3
+        colno: 9
+        pre_context:
+          - "function add(a, b) {"
+          - "\t\"use strict\";"
+        context_line: "\treturn a + b; // fôo"
+        post_context:
+          - "}"
+          - ""
+raw_stacktraces:
+  - frames:
+      - abs_path: "app:///nofiles.js"
+        lineno: 1
+        colno: 39
+        context_line: "function add(a, b) {"
+        post_context:
+          - "  'use strict';"
+          - "  return a + b;"
+          - "}"
+          - "function multiply(a, b) {"
+          - "  'use strict';"
+

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,0 +1,41 @@
+---
+source: crates/symbolicator-service/tests/integration/sourcemap.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: symbolicated
+        function: "function: \"HTMLDocument.<anonymous>\""
+        filename: index.html
+        abs_path: http//example.com/index.html
+        lineno: 283
+        colno: 17
+      - status: symbolicated
+        function: add
+        filename: file1.js
+        abs_path: file1.js
+        lineno: 3
+        colno: 9
+        pre_context:
+          - "function add(a, b) {"
+          - "\t\"use strict\";"
+        context_line: "\treturn a + b; // fôo"
+        post_context:
+          - "}"
+          - ""
+raw_stacktraces:
+  - frames:
+      - function: "function: \"HTMLDocument.<anonymous>\""
+        filename: index.html
+        abs_path: http//example.com/index.html
+        lineno: 283
+        colno: 17
+      - filename: file.min.js
+        abs_path: "http://example.com/file.min.js"
+        lineno: 1
+        colno: 39
+        context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
+        post_context:
+          - //@ sourceMappingURL=file.min.js.map
+          - ""
+

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use symbolicator_service::types::JsFrame;
 use symbolicator_service::{
     services::symbolication::SymbolicateJsStacktraces, types::JsStacktrace,
 };
-use symbolicator_sources::{SentrySourceConfig, SourceId};
+use symbolicator_sources::SentrySourceConfig;
 
-use crate::setup_service;
+use crate::{assert_snapshot, setup_service};
 
 /*
  * NOTES:
@@ -19,405 +20,191 @@ use crate::setup_service;
  * TODOS:
  *
  * - add all error assertions, by querying for `event.data["errors"]` in monolith
- * - move to snapshots once all tests are ported over by using `assert_snapshot!(response.unwrap());`
- *   everywhere instead of `assert!/assert_eq!`
  */
+
+#[track_caller]
+fn make_js_request(
+    source: SentrySourceConfig,
+    frames: &str,
+    dist: impl Into<Option<String>>,
+) -> SymbolicateJsStacktraces {
+    let frames: Vec<JsFrame> = serde_json::from_str(frames).unwrap();
+    let stacktraces = vec![JsStacktrace { frames }];
+
+    SymbolicateJsStacktraces {
+        source: Arc::new(source),
+        stacktraces,
+        dist: dist.into(),
+    }
+}
 
 #[tokio::test]
 async fn test_sourcemap_expansion() {
-    let input_frames = r#"[
-        {
-            "abs_path": "http://example.com/index.html",
-            "filename": "index.html",
-            "lineno": 6,
-            "colno": 7,
-            "function": "produceStack"
-        },
-        {
-            "abs_path": "http://example.com/test.min.js",
-            "filename": "test.min.js",
-            "lineno": 1,
-            "colno": 183,
-            "function": "i"
-        },
-        {
-            "abs_path": "http://example.com/test.min.js",
-            "filename": "test.min.js",
-            "lineno": 1,
-            "colno": 136,
-            "function": "r"
-        },
-        {
-            "abs_path": "http://example.com/test.min.js",
-            "filename": "test.min.js",
-            "lineno": 1,
-            "colno": 64,
-            "function": "e"
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) = symbolicator_test::sourcemap_server("01_sourcemap_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("01_sourcemap_expansion");
+    let frames = r#"[{
+        "abs_path": "http://example.com/index.html",
+        "filename": "index.html",
+        "lineno": 6,
+        "colno": 7,
+        "function": "produceStack"
+    }, {
+        "abs_path": "http://example.com/test.min.js",
+        "filename": "test.min.js",
+        "lineno": 1,
+        "colno": 183,
+        "function": "i"
+    }, {
+        "abs_path": "http://example.com/test.min.js",
+        "filename": "test.min.js",
+        "lineno": 1,
+        "colno": 136,
+        "function": "r"
+    }, {
+        "abs_path": "http://example.com/test.min.js",
+        "filename": "test.min.js",
+        "lineno": 1,
+        "colno": 64,
+        "function": "e"
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    assert_eq!(frames.len(), 4);
-
-    assert_eq!(frames[0].raw.function, Some("produceStack".to_string()));
-    assert_eq!(frames[0].raw.lineno, Some(6));
-    assert_eq!(frames[0].raw.filename, Some("index.html".to_string()));
-
-    assert_eq!(frames[1].raw.function, Some("test".to_string()));
-    assert_eq!(frames[1].raw.lineno, Some(20));
-    assert_eq!(frames[1].raw.filename, Some("test.js".to_string()));
-
-    assert_eq!(frames[2].raw.function, Some("invoke".to_string()));
-    assert_eq!(frames[2].raw.lineno, Some(15));
-    assert_eq!(frames[2].raw.filename, Some("test.js".to_string()));
-
-    assert_eq!(frames[3].raw.function, Some("onFailure".to_string()));
-    assert_eq!(frames[3].raw.lineno, Some(5));
-    assert_eq!(frames[3].raw.filename, Some("test.js".to_string()));
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_sourcemap_source_expansion() {
-    let input_frames = r#"[
-        {
-            "function": "function: \"HTMLDocument.<anonymous>\"",
-            "abs_path": "http//example.com/index.html",
-            "filename": "index.html",
-            "lineno": 283,
-            "colno": 17,
-            "in_app": false
-        },
-        {
-            "abs_path": "http://example.com/file.min.js",
-            "filename": "file.min.js",
-            "lineno": 1,
-            "colno": 39
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) = symbolicator_test::sourcemap_server("02_sourcemap_source_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("02_sourcemap_source_expansion");
+    let frames = r#"[{
+        "function": "function: \"HTMLDocument.<anonymous>\"",
+        "abs_path": "http//example.com/index.html",
+        "filename": "index.html",
+        "lineno": 283,
+        "colno": 17,
+        "in_app": false
+    }, {
+        "abs_path": "http://example.com/file.min.js",
+        "filename": "file.min.js",
+        "lineno": 1,
+        "colno": 39
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    let raw_frames = &response.raw_stacktraces[0].frames;
-    assert_eq!(frames.len(), 2);
-
-    // Raw frames
-    let pre_context: &[String] = &[];
-    let context_line = Some("function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}".to_string());
-    let post_context = &["//@ sourceMappingURL=file.min.js.map", ""];
-    assert_eq!(raw_frames[1].pre_context, pre_context);
-    assert_eq!(raw_frames[1].context_line, context_line);
-    assert_eq!(raw_frames[1].post_context, post_context);
-    assert_eq!(raw_frames[1].lineno, Some(1));
-    assert_eq!(raw_frames[1].colno, Some(39));
-
-    // Processed frames
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_sourcemap_embedded_source_expansion() {
-    let input_frames = r#"[
-        {
-            "function": "function: \"HTMLDocument.<anonymous>\"",
-            "abs_path": "http//example.com/index.html",
-            "filename": "index.html",
-            "lineno": 283,
-            "colno": 17,
-            "in_app": false
-        },
-        {
-            "abs_path": "http://example.com/embedded.js",
-            "filename": "embedded.js",
-            "lineno": 1,
-            "colno": 39
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) =
+        symbolicator_test::sourcemap_server("03_sourcemap_embedded_source_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("03_sourcemap_embedded_source_expansion");
+    let frames = r#"[{
+        "function": "function: \"HTMLDocument.<anonymous>\"",
+        "abs_path": "http//example.com/index.html",
+        "filename": "index.html",
+        "lineno": 283,
+        "colno": 17,
+        "in_app": false
+    }, {
+        "abs_path": "http://example.com/embedded.js",
+        "filename": "embedded.js",
+        "lineno": 1,
+        "colno": 39
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    assert_eq!(frames.len(), 2);
-
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_source_expansion() {
-    let input_frames = r#"[
-        {
-            "abs_path": "http://example.com/foo.js",
-            "filename": "foo.js",
-            "lineno": 1,
-            "colno": 0
-        },
-        {
-            "abs_path": "http://example.com/foo.js",
-            "filename": "foo.js",
-            "lineno": 4,
-            "colno": 0
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) = symbolicator_test::sourcemap_server("04_source_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("04_source_expansion");
+    let frames = r#"[{
+        "abs_path": "http://example.com/foo.js",
+        "filename": "foo.js",
+        "lineno": 1,
+        "colno": 0
+    }, {
+        "abs_path": "http://example.com/foo.js",
+        "filename": "foo.js",
+        "lineno": 4,
+        "colno": 0
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    assert_eq!(frames.len(), 2);
-
-    let pre_context: &[String] = &[];
-    let context_line = Some("h".to_string());
-    let post_context = &["e", "l", "l", "o", " "];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(1));
-    assert_eq!(frames[0].raw.colno, Some(0));
-
-    let pre_context = &["h", "e", "l"];
-    let context_line = Some("l".to_string());
-    let post_context = &["o", " ", "w", "o", "r"];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(4));
-    assert_eq!(frames[1].raw.colno, Some(0));
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_inlined_sources() {
-    let input_frames = r#"[
-        {
-            "abs_path": "http://example.com/test.min.js",
-            "filename": "test.js",
-            "lineno": 1,
-            "colno": 1
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) = symbolicator_test::sourcemap_server("05_inlined_sources");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("05_inlined_sources");
+    let frames = r#"[{
+        "abs_path": "http://example.com/test.min.js",
+        "filename": "test.js",
+        "lineno": 1,
+        "colno": 1
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    assert_eq!(frames.len(), 1);
-
-    let pre_context: &[String] = &[];
-    let context_line = Some("console.log('hello, World!')".to_string());
-    let post_context: &[String] = &[];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(1));
-    assert_eq!(frames[0].raw.colno, Some(1));
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_sourcemap_nofiles_source_expansion() {
-    let input_frames = r#"[
-        {
-            "abs_path": "app:///nofiles.js",
-            "lineno": 1,
-            "colno": 39
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) =
+        symbolicator_test::sourcemap_server("06_sourcemap_nofiles_source_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("06_sourcemap_nofiles_source_expansion");
+    let frames = r#"[{
+        "abs_path": "app:///nofiles.js",
+        "lineno": 1,
+        "colno": 39
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    assert_eq!(frames.len(), 1);
-
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(3));
-    assert_eq!(frames[0].raw.colno, Some(9));
-    assert_eq!(frames[0].raw.abs_path, "app:///nofiles.js");
+    assert_snapshot!(response.unwrap());
 }
 
 #[tokio::test]
 async fn test_indexed_sourcemap_source_expansion() {
-    let input_frames = r#"[
-        {
-            "abs_path": "http://example.com/indexed.min.js",
-            "filename": "indexed.min.js",
-            "lineno": 1,
-            "colno": 39
-        },
-        {
-            "abs_path": "http://example.com/indexed.min.js",
-            "filename": "indexed.min.js",
-            "lineno": 2,
-            "colno": 44
-        }
-    ]"#;
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) =
+        symbolicator_test::sourcemap_server("07_indexed_sourcemap_source_expansion");
 
-    let (symbolication, _) = setup_service(|_| ());
-    let srv = symbolicator_test::sourcemap_server("07_indexed_sourcemap_source_expansion");
+    let frames = r#"[{
+        "abs_path": "http://example.com/indexed.min.js",
+        "filename": "indexed.min.js",
+        "lineno": 1,
+        "colno": 39
+    }, {
+        "abs_path": "http://example.com/indexed.min.js",
+        "filename": "indexed.min.js",
+        "lineno": 2,
+        "colno": 44
+    }]"#;
 
-    let stacktraces: Vec<JsStacktrace> =
-        serde_json::from_str(&format!(r#"[{{ "frames": {input_frames} }}]"#)).unwrap();
-    let request = SymbolicateJsStacktraces {
-        source: Arc::new(SentrySourceConfig {
-            id: SourceId::new("sentry:project"),
-            url: srv.url("/files/"),
-            token: String::new(),
-        }),
-        stacktraces,
-        dist: None,
-    };
-    let response = symbolication.symbolicate_js(request).await.unwrap();
+    let request = make_js_request(source, frames, None);
+    let response = symbolication.symbolicate_js(request).await;
 
-    let frames = &response.stacktraces[0].frames;
-    let raw_frames = &response.raw_stacktraces[0].frames;
-    assert_eq!(frames.len(), 2);
-
-    // Raw frames
-    let pre_context: &[String] = &[];
-    let context_line = Some("function add(a,b){\"use strict\";return a+b}".to_string());
-    let post_context = &[
-        "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}",
-        "//# sourceMappingURL=indexed.min.js.map",
-        "",
-    ];
-
-    assert_eq!(raw_frames[0].pre_context, pre_context);
-    assert_eq!(raw_frames[0].context_line, context_line);
-    assert_eq!(raw_frames[0].post_context, post_context);
-    assert_eq!(raw_frames[0].lineno, Some(1));
-    assert_eq!(raw_frames[0].colno, Some(39));
-
-    let pre_context = &["function add(a,b){\"use strict\";return a+b}"];
-    let context_line = Some("function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}".to_string());
-    let post_context = &["//# sourceMappingURL=indexed.min.js.map", ""];
-    assert_eq!(raw_frames[1].pre_context, pre_context);
-    assert_eq!(raw_frames[1].context_line, context_line);
-    assert_eq!(raw_frames[1].post_context, post_context);
-    assert_eq!(raw_frames[1].lineno, Some(2));
-    assert_eq!(raw_frames[1].colno, Some(44));
-
-    // Processed frames
-    let pre_context = &["function add(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a + b; // fôo".to_string());
-    let post_context = &["}", ""];
-    assert_eq!(frames[0].raw.pre_context, pre_context);
-    assert_eq!(frames[0].raw.context_line, context_line);
-    assert_eq!(frames[0].raw.post_context, post_context);
-    assert_eq!(frames[0].raw.lineno, Some(3));
-    assert_eq!(frames[0].raw.colno, Some(9));
-
-    let pre_context = &["function multiply(a, b) {", "\t\"use strict\";"];
-    let context_line = Some("\treturn a * b;".to_string());
-    let post_context = &[
-        "}",
-        "function divide(a, b) {",
-        "\t\"use strict\";",
-        "\ttry {",
-        "\t\treturn multiply(add(a, b), a, b) / c;",
-    ];
-    assert_eq!(frames[1].raw.pre_context, pre_context);
-    assert_eq!(frames[1].raw.context_line, context_line);
-    assert_eq!(frames[1].raw.post_context, post_context);
-    assert_eq!(frames[1].raw.lineno, Some(3));
-    assert_eq!(frames[1].raw.colno, Some(9));
+    assert_snapshot!(response.unwrap());
 }

--- a/crates/symbolicator-service/tests/integration/symbolication.rs
+++ b/crates/symbolicator-service/tests/integration/symbolication.rs
@@ -127,23 +127,19 @@ async fn test_dotnet_integration() {
             "instruction_addr": 10,
             "function_id": 6,
             "addr_mode":"rel:0"
-          },
-          {
+          }, {
             "instruction_addr": 6,
             "function_id": 5,
             "addr_mode": "rel:0"
-          },
-          {
+          }, {
             "instruction_addr": 0,
             "function_id": 3,
             "addr_mode": "rel:0"
-          },
-          {
+          }, {
             "instruction_addr": 0,
             "function_id": 2,
             "addr_mode": "rel:0"
-          },
-          {
+          }, {
             "instruction_addr": 45,
             "function_id": 1,
             "addr_mode": "rel:0"

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -32,7 +32,7 @@ use tracing_subscriber::fmt::fmt;
 
 use symbolicator_sources::{
     CommonSourceConfig, DirectoryLayout, DirectoryLayoutType, FileType, FilesystemSourceConfig,
-    GcsSourceKey, HttpSourceConfig, SourceConfig, SourceFilters, SourceId,
+    GcsSourceKey, HttpSourceConfig, SentrySourceConfig, SourceConfig, SourceFilters, SourceId,
 };
 
 pub use tempfile::TempDir;
@@ -371,8 +371,16 @@ pub fn symbol_server() -> (Server, SourceConfig) {
     (server, source)
 }
 
-pub fn sourcemap_server(fixtures_dir: &str) -> Server {
-    Server::with_router(Server::sourcemap_router(fixtures_dir))
+pub fn sourcemap_server(fixtures_dir: &str) -> (Server, SentrySourceConfig) {
+    let server = Server::with_router(Server::sourcemap_router(fixtures_dir));
+
+    let source = SentrySourceConfig {
+        id: SourceId::new("sentry:project"),
+        url: server.url("/files/"),
+        token: String::new(),
+    };
+
+    (server, source)
 }
 
 /// Returns the legacy read-only GCS credentials for testing GCS support.


### PR DESCRIPTION
- Adds a helper fn to create symbolication requests
- Uses snapshots to simplify assertion

#skip-changelog