### PR TITLE
Fix `missing_sourcemap` Status assertions

### DIFF
--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -4,7 +4,7 @@ expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing_sourcemap
         filename: foo.js
         abs_path: "http://example.com/foo.js"
         lineno: 1
@@ -16,7 +16,7 @@ stacktraces:
           - l
           - o
           - " "
-      - status: symbolicated
+      - status: missing_sourcemap
         filename: foo.js
         abs_path: "http://example.com/foo.js"
         lineno: 4

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -4,7 +4,7 @@ expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing_sourcemap
         function: "function: \"HTMLDocument.<anonymous>\""
         filename: index.html
         abs_path: http//example.com/index.html

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -4,7 +4,7 @@ expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing_sourcemap
         function: produceStack
         filename: index.html
         abs_path: "http://example.com/index.html"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -4,7 +4,7 @@ expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: symbolicated
+      - status: missing_sourcemap
         function: "function: \"HTMLDocument.<anonymous>\""
         filename: index.html
         abs_path: http//example.com/index.html


### PR DESCRIPTION
Looks like merging both changes to the sourcemap processing, and switching to snapshot tests was causing conflicts here.

#skip-changelog