### PR TITLE
ref: Create InvalidAbsPath js frame status

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -370,7 +370,7 @@ impl FileKey {
         Ok(Self::MinifiedSource { abs_path, debug_id })
     }
 
-    /// Creates a new [`FileKey`] for a minified file with `abs_path` and `debug_id`.
+    /// Creates a new [`FileKey`] for a source file.
     pub fn new_source(abs_path: Url) -> Self {
         Self::Source { abs_path }
     }

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -42,8 +42,7 @@ impl SymbolicationActor {
                     Ok(key) => key,
                     Err(_) => {
                         symbolicated_frames.push(SymbolicatedJsFrame {
-                            // FIXME: this really means the `abs_path` is invalid!
-                            status: JsFrameStatus::MissingSourcemap,
+                            status: JsFrameStatus::MissingSource,
                             raw: raw_frame.clone(),
                         });
                         continue;

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -42,6 +42,7 @@ impl SymbolicationActor {
                     Ok(key) => key,
                     Err(_) => {
                         symbolicated_frames.push(SymbolicatedJsFrame {
+                            // FIXME: this really means the `abs_path` is invalid!
                             status: JsFrameStatus::MissingSource,
                             raw: raw_frame.clone(),
                         });

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -40,10 +40,10 @@ impl SymbolicationActor {
                 // TODO: handle errors
                 let key = match FileKey::new_minified(&raw_frame.abs_path, None) {
                     Ok(key) => key,
-                    Err(_) => {
+                    Err(e) => {
+                        tracing::warn!("{e}");
                         symbolicated_frames.push(SymbolicatedJsFrame {
-                            // FIXME: this really means the `abs_path` is invalid!
-                            status: JsFrameStatus::MissingSource,
+                            status: JsFrameStatus::InvalidAbsPath,
                             raw: raw_frame.clone(),
                         });
                         continue;

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -577,6 +577,8 @@ pub enum JsFrameStatus {
     InvalidSourceMapLocation,
     /// No sourcemap was found for the frame.
     MissingSourcemap,
+    /// No source file was found for the frame.
+    MissingSource,
     /// The retrieved sourcemap could not be processed.
     MalformedSourcemap,
 }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -577,8 +577,8 @@ pub enum JsFrameStatus {
     InvalidSourceMapLocation,
     /// No sourcemap was found for the frame.
     MissingSourcemap,
-    /// No source file was found for the frame.
-    MissingSource,
+    /// The frame's absolute path is invalid.
+    InvalidAbsPath,
     /// The retrieved sourcemap could not be processed.
     MalformedSourcemap,
 }

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -5,7 +5,7 @@ expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: missing_source
+      - status: invalid_abs_path
         filename: test.js
         abs_path: http//example.com/test.min.js
         lineno: 1

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+assertion_line: 228
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
-      - status: missing_sourcemap
+      - status: missing_source
         filename: test.js
         abs_path: http//example.com/test.min.js
         lineno: 1


### PR DESCRIPTION
This introduces a new ~`MissingSource`~`InvalidAbsPath` variant of the `JsFrameStatus` enum and returns it in the appropriate place. If parsing the abs_path returns an error, we log this at level `warn`.

Also drive-by fixes a docstring.

#skip-changelog