### PR TITLE
Introduce the concept of `modules` to SourceMap processing

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -4,6 +4,7 @@ use symbolicator_sources::SentrySourceConfig;
 
 use crate::caching::{Cache, Cacher, SharedCacheRef};
 use crate::services::download::DownloadService;
+use crate::types::RawObjectInfo;
 use std::sync::Arc;
 
 use super::sourcemap_lookup::{
@@ -31,12 +32,17 @@ impl SourceMapService {
         }
     }
 
-    pub fn create_sourcemap_lookup(&self, source: Arc<SentrySourceConfig>) -> SourceMapLookup {
+    pub fn create_sourcemap_lookup(
+        &self,
+        source: Arc<SentrySourceConfig>,
+        modules: &[RawObjectInfo],
+    ) -> SourceMapLookup {
         SourceMapLookup::new(
             self.artifact_caches.clone(),
             self.sourcemap_caches.clone(),
             self.download_svc.clone(),
             source,
+            modules,
         )
     }
 }

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -1,10 +1,9 @@
 use std::io::BufRead;
 
-use reqwest::Url;
 use symbolic::sourcemapcache::{ScopeLookupResult, SourcePosition};
 
 use crate::caching::{CacheEntry, CacheError};
-use crate::services::sourcemap_lookup::{CachedFile, FileKey, OwnedSourceMapCache};
+use crate::services::sourcemap_lookup::{CachedFile, OwnedSourceMapCache};
 use crate::types::{
     CompletedJsSymbolicationResponse, JsFrame, JsFrameStatus, SymbolicatedJsFrame,
     SymbolicatedJsStacktrace,
@@ -22,7 +21,7 @@ impl SymbolicationActor {
     ) -> Result<CompletedJsSymbolicationResponse, anyhow::Error> {
         let mut lookup = self
             .sourcemaps
-            .create_sourcemap_lookup(request.source.clone());
+            .create_sourcemap_lookup(request.source.clone(), &request.modules);
         lookup.prefetch_artifacts(&request.stacktraces).await;
 
         let mut raw_stacktraces = request.stacktraces;
@@ -35,52 +34,33 @@ impl SymbolicationActor {
             let mut symbolicated_frames = Vec::with_capacity(num_frames);
 
             for raw_frame in &mut raw_stacktrace.frames {
-                // First, we fetch the minified file:
-                // TODO: hook up DebugId
-                // TODO: handle errors
-                let abs_path = match Url::parse(&raw_frame.abs_path) {
-                    Ok(url) => url,
-                    Err(e) => {
-                        tracing::warn!(error = %e, abs_path = &raw_frame.abs_path, "Invalid url");
-                        symbolicated_frames.push(SymbolicatedJsFrame {
-                            status: JsFrameStatus::InvalidAbsPath,
-                            raw: raw_frame.clone(),
-                        });
-                        continue;
-                    }
-                };
-                let key = FileKey::MinifiedSource {
-                    abs_path: abs_path.clone(),
-                    debug_id: None,
-                };
-                let minified_file = lookup.get_file(key.clone()).await;
+                let cached_module = lookup.get_module(&raw_frame.abs_path).await;
+
+                if !cached_module.is_valid() {
+                    symbolicated_frames.push(SymbolicatedJsFrame {
+                        status: JsFrameStatus::InvalidAbsPath,
+                        raw: raw_frame.clone(),
+                    });
+                    continue;
+                }
 
                 // Apply source context to the raw frame
-                apply_source_context_from_artifact(raw_frame, &minified_file);
-
-                // Then, get the `SourceMapCache`:
-                // TODO: maybe get the `SourceMapCache` and the `CachedFile` at the same time?
-                let smcache = lookup.get_sourcemapcache(&abs_path, None).await;
+                apply_source_context_from_artifact(raw_frame, &cached_module.minified_source);
 
                 // And symbolicate
-                match symbolicate_js_frame(raw_frame, smcache) {
+                match symbolicate_js_frame(raw_frame, &cached_module.smcache) {
                     Ok((mut frame, did_apply_source)) => {
                         // If we have no source context from within the `SourceMapCache`,
                         // fall back to applying the source context from a raw artifact file
                         // TODO: we should only do this fallback if there is *no* `DebugId`.
                         if !did_apply_source {
-                            // TODO: create a convenience method that creates a new `FileKey::Source`
-                            // from an existing `abs_path`.
                             let filename = frame.raw.filename.as_ref();
-                            let file_url =
-                                filename.and_then(|filename| abs_path.join(filename).ok());
-                            let file_key = file_url
-                                .ok_or(CacheError::NotFound)
-                                .map(FileKey::new_source);
+                            let file_key =
+                                filename.and_then(|filename| cached_module.file_key(filename));
 
                             let source_file = match file_key {
-                                Ok(key) => lookup.get_file(key).await,
-                                Err(err) => Err(err),
+                                Some(key) => lookup.get_file(key).await,
+                                None => Err(CacheError::NotFound),
                             };
 
                             apply_source_context_from_artifact(&mut frame.raw, &source_file);
@@ -110,7 +90,7 @@ impl SymbolicationActor {
 
 fn symbolicate_js_frame(
     frame: &JsFrame,
-    smcache: CacheEntry<OwnedSourceMapCache>,
+    smcache: &CacheEntry<OwnedSourceMapCache>,
 ) -> Result<(SymbolicatedJsFrame, bool), JsFrameStatus> {
     let smcache = match smcache {
         Ok(smcache) => smcache,

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -16,8 +16,8 @@ use crate::services::sourcemap::SourceMapService;
 use crate::services::symcaches::SymCacheActor;
 use crate::types::{
     CompleteObjectInfo, CompleteStacktrace, CompletedSymbolicationResponse, FrameStatus,
-    FrameTrust, JsStacktrace, ObjectFileStatus, RawFrame, RawStacktrace, Registers, Scope, Signal,
-    SymbolicatedFrame,
+    FrameTrust, JsStacktrace, ObjectFileStatus, RawFrame, RawObjectInfo, RawStacktrace, Registers,
+    Scope, Signal, SymbolicatedFrame,
 };
 use crate::utils::hex::HexValue;
 
@@ -197,8 +197,9 @@ pub struct SymbolicateStacktraces {
 #[derive(Debug, Clone)]
 pub struct SymbolicateJsStacktraces {
     pub source: Arc<SentrySourceConfig>,
-    pub stacktraces: Vec<JsStacktrace>,
     pub dist: Option<String>,
+    pub stacktraces: Vec<JsStacktrace>,
+    pub modules: Vec<RawObjectInfo>,
 }
 
 fn symbolicate_frame(

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -34,6 +34,7 @@ fn make_js_request(
     SymbolicateJsStacktraces {
         source: Arc::new(source),
         stacktraces,
+        modules: vec![],
         dist: dist.into(),
     }
 }

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -187,7 +187,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
                     Some(path) => path,
                     None => return vec![],
                 },
-                ObjectType::Unknown => return vec![],
+                ObjectType::SourceMap | ObjectType::Unknown => return vec![],
             };
 
             primary_path.push_str(".src.zip");
@@ -348,7 +348,7 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
                 ObjectType::Wasm => FileType::WasmCode,
                 ObjectType::PeDotnet => FileType::PortablePdb,
                 // guess we're out of luck.
-                ObjectType::Unknown => return None,
+                ObjectType::SourceMap | ObjectType::Unknown => return None,
             };
             get_search_target_id(filetype, identifier)
         }

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -53,6 +53,10 @@ pub enum ObjectType {
     Wasm,
     /// Portable Executable containing .NET code, which has a Portable PDB companion.
     PeDotnet,
+    /// An Object representing the pair of Minified JS + SourceMap.
+    /// See <https://develop.sentry.dev/sdk/event-payloads/debugmeta/#source-map-images>.
+    #[serde(rename = "sourcemap")]
+    SourceMap,
     /// Unknown Object.
     #[default]
     Unknown,
@@ -68,6 +72,7 @@ impl FromStr for ObjectType {
             "pe" => ObjectType::Pe,
             "pe_dotnet" => ObjectType::PeDotnet,
             "wasm" => ObjectType::Wasm,
+            "sourcemap" => ObjectType::SourceMap,
             _ => ObjectType::Unknown,
         })
     }
@@ -91,6 +96,7 @@ impl fmt::Display for ObjectType {
             ObjectType::Pe => write!(f, "pe"),
             ObjectType::PeDotnet => write!(f, "pe_dotnet"),
             ObjectType::Wasm => write!(f, "wasm"),
+            ObjectType::SourceMap => write!(f, "sourcemap"),
             ObjectType::Unknown => write!(f, "unknown"),
         }
     }


### PR DESCRIPTION
- Adds `modules` to the processing request, along with a new `"sourcemap"` object type.
- Moves parsing and validation of `abs_path` into the `CachedModule`.
- Merges the "fetch minified source" and "fetch sourcemap" into a single step.

I believe this fixes https://github.com/getsentry/symbolicator/issues/1066. Although it does not have any tests for this yet :-(

There is a comment above `get_module` that details some struggles I had with the borrow checker. I believe splitting this into two different structs could solve this. One would handle all the downloads, artifacts and (global) caching. The other one would just maintain this local cache of resolved modules.