### PR TITLE
Fix host blocking to correctly allow-list sentry sources

### DIFF
--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -322,9 +322,8 @@ impl DownloadService {
 
         // Check whether `source` is an internal Sentry source. We don't ever
         // want to put such sources on the block list.
-        let source_is_external = !host.starts_with("sentry:");
-
         let source_metric_key = source.source_metric_key().to_string();
+        let source_is_external = !source_metric_key.starts_with("sentry:");
 
         if source_is_external && self.host_deny_list.is_blocked(&host) {
             metric!(counter("service.download.blocked") += 1, "source" => &source_metric_key);

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -323,6 +323,10 @@ impl DownloadService {
         // Check whether `source` is an internal Sentry source. We don't ever
         // want to put such sources on the block list.
         let source_metric_key = source.source_metric_key().to_string();
+        // NOTE: This allow-lists *all* the builtin symbol servers, even external ones that might
+        // misbehave. If we want to tighten that up to only allow-list the sentry internal source,
+        // this should be `"sentry:project"` instead, as defined here:
+        // <https://github.com/getsentry/sentry/blob/b27ef04df6ecbaa0a34a472f787a163ca8400cc0/src/sentry/lang/native/sources.py#L17>
         let source_is_external = !source_metric_key.starts_with("sentry:");
 
         if source_is_external && self.host_deny_list.is_blocked(&host) {


### PR DESCRIPTION
We were checking the `host` for the `"sentry:"` prefix, not the `source_metric_key` as we should have.

lol 🤦🏻‍♂️ 

#skip-changelog