### PR TITLE
ref: Add --log-level argument to symbolicli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Automatically block downloads from unreliable hosts. ([#1039](https://github.com/getsentry/symbolicator/pull/1039))
 - Fully migrate `CacheKey` usage and remove legacy markers. ([#1043](https://github.com/getsentry/symbolicator/pull/1043))
 - Add support for in-memory caching. ([#1028](https://github.com/getsentry/symbolicator/pull/1028))
+- Add --log-level argument to `symbolicli`. ([#1074](https://github.com/getsentry/symbolicator/pull/1074))
 
 ### Fixes
 

--- a/crates/symbolicli/README.md
+++ b/crates/symbolicli/README.md
@@ -40,8 +40,5 @@ The available options are:
   files.
 
 # Logging
-You can enable logging by setting the `RUST_LOG` environment variable to the desired log level. Available levels
-are `error`, `warn`, `info`, `debug`, `trace`.
-```
-RUST_LOG=debug symbolicli […]
-```
+You can control the level of logging output by passing the desired log level to the `--log-level` option.
+Available levels are `off`, `error`, `warn`, `info`, `debug`, `trace`. The default is `info`.

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, bail, Context};
 use clap::{Parser, ValueEnum};
 use reqwest::Url;
 use serde::Deserialize;
+use tracing::level_filters::LevelFilter;
 
 /// The default API URL
 pub const DEFAULT_URL: &str = "https://sentry.io/";
@@ -82,6 +83,13 @@ struct Cli {
     /// In offline mode symbolicli will still access manually configured symbol sources.
     #[arg(long)]
     offline: bool,
+
+    /// The severity level of logging output.
+    ///
+    /// Possible values:
+    /// off, error, warn, info, debug, trace
+    #[arg(long, value_enum, default_value = "info")]
+    log_level: LevelFilter,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -116,6 +124,7 @@ pub struct Settings {
     pub event_id: String,
     pub symbolicator_config: Config,
     pub output_format: OutputFormat,
+    pub log_level: LevelFilter,
     pub mode: Mode,
 }
 
@@ -193,6 +202,7 @@ impl Settings {
             event_id: cli.event,
             symbolicator_config,
             output_format: cli.format,
+            log_level: cli.log_level,
             mode,
         };
 


### PR DESCRIPTION
This adds a `--log-level` argument to `symbolicli` that controls its log level, replacing the use of the `RUST_LOG` environment variable. All log output that does not originate from `symbolicli` or `symbolicator_service` will be suppressed, regardless of log level.