### PR TITLE
ref: Unify Source Context application

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -23,6 +23,7 @@ use crate::utils::hex::HexValue;
 mod apple;
 mod js;
 mod process_minidump;
+pub mod source_context;
 
 pub use js::SymbolicateJsStacktraces;
 
@@ -142,7 +143,7 @@ impl SymbolicationActor {
         for trace in &mut stacktraces {
             for frame in &mut trace.frames {
                 if let Some((pre_context, context_line, post_context)) =
-                    module_lookup.get_context_lines(&debug_sessions, &frame.raw, 5)
+                    module_lookup.get_context_lines(&debug_sessions, &frame.raw)
                 {
                     frame.raw.pre_context = pre_context;
                     frame.raw.context_line = Some(context_line);

--- a/crates/symbolicator-service/src/services/symbolication/source_context.rs
+++ b/crates/symbolicator-service/src/services/symbolication/source_context.rs
@@ -1,0 +1,98 @@
+pub const DEFAULT_CONTEXT_LINES: usize = 5;
+
+/// Resolves the source context around `lineno` from the `source` file.
+///
+/// N (`context_lines`) lines of context will be resolved in addition to `lineno`.
+/// This defaults to [`DEFAULT_CONTEXT_LINES`].
+/// If `trim_to_column` is provided, every output line will be truncated to ~150 characters
+/// centered around the provided column number, and a `{snip}` marker is added at the trimmed edges.
+///
+/// If no source line for `lineno` is found in `source`, it will return [`None`] instead.
+pub fn get_context_lines(
+    source: &str,
+    lineno: usize,
+    trim_to_column: Option<usize>,
+    context_lines: Option<usize>,
+) -> Option<(Vec<String>, String, Vec<String>)> {
+    let context_lines = context_lines.unwrap_or(DEFAULT_CONTEXT_LINES);
+
+    let start_line = lineno.saturating_sub(context_lines).saturating_sub(1);
+    let line_diff = (lineno - start_line).saturating_sub(1);
+
+    let maybe_trim_line = |line: &str| {
+        if let Some(column) = trim_to_column {
+            trim_context_line(line, column)
+        } else {
+            line.to_string()
+        }
+    };
+
+    let mut lines = source.lines().skip(start_line);
+    let pre_context = (&mut lines).take(line_diff).map(maybe_trim_line).collect();
+    let context = maybe_trim_line(lines.next()?);
+    let post_context = lines.take(context_lines).map(maybe_trim_line).collect();
+
+    Some((pre_context, context, post_context))
+}
+
+/// Trims a line down to a goal of 140 characters, with a little wiggle room to be sensible
+/// and tries to trim around the given `column`. So it tries to extract 60 characters
+/// before the provided `column` and fill the rest up to 140 characters to yield a better context.
+fn trim_context_line(line: &str, column: usize) -> String {
+    let len = line.len();
+
+    if len <= 150 {
+        return line.to_string();
+    }
+
+    let col = std::cmp::min(column, len);
+
+    let mut start = col.saturating_sub(60);
+    // Round down if it brings us close to the edge.
+    if start < 5 {
+        start = 0;
+    }
+
+    let mut end = std::cmp::min(start + 140, len);
+    // Round up to the end if it's close.
+    if end > len.saturating_sub(5) {
+        end = len;
+    }
+
+    // If we are bumped all the way to the end, make sure we still get a full 140 chars in the line.
+    if end == len {
+        start = end.saturating_sub(140);
+    }
+
+    let line = &line[start..end];
+
+    let mut line = if start > 0 {
+        // We've snipped from the beginning.
+        format!("{{snip}} {line}")
+    } else {
+        line.to_string()
+    };
+
+    if end < len {
+        // We've snipped from the end.
+        line.push_str(" {snip}");
+    }
+
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trim_context_line() {
+        let long_line = "The public is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring.";
+        assert_eq!(trim_context_line("foo", 0), "foo".to_string());
+        assert_eq!(trim_context_line(long_line, 0), "The public is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it li {snip}".to_string());
+        assert_eq!(trim_context_line(long_line, 10), "The public is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it li {snip}".to_string());
+        assert_eq!(trim_context_line(long_line, 66), "{snip} blic is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it lives wi {snip}".to_string());
+        assert_eq!(trim_context_line(long_line, 190), "{snip} gn. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring.".to_string());
+        assert_eq!(trim_context_line(long_line, 9999), "{snip} gn. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring.".to_string());
+    }
+}

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -16,7 +16,6 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
-          - ""
       - status: symbolicated
         function: multiply
         filename: file2.js
@@ -43,7 +42,6 @@ raw_stacktraces:
         post_context:
           - "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
           - "//# sourceMappingURL=indexed.min.js.map"
-          - ""
       - filename: indexed.min.js
         abs_path: "http://example.com/indexed.min.js"
         lineno: 2
@@ -53,5 +51,4 @@ raw_stacktraces:
         context_line: "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
         post_context:
           - "//# sourceMappingURL=indexed.min.js.map"
-          - ""
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -21,5 +21,4 @@ raw_stacktraces:
         post_context:
           - "// Decoded sourcemap: {\"version\":3,\"file\":\"generated.js\",\"sources\":[\"/test.js\"],\"names\":[],\"mappings\":\"AAAA\",\"sourcesContent\":[\"console.log( {snip}"
           - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
-          - ""
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -22,7 +22,6 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
-          - ""
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""
@@ -37,5 +36,4 @@ raw_stacktraces:
         context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
         post_context:
           - "//# sourceMappingURL=embedded.js.map"
-          - ""
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -28,7 +28,6 @@ stacktraces:
           - ""
           - "  return test;"
           - "})();"
-          - ""
       - status: symbolicated
         function: invoke
         filename: test.js

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -15,7 +15,6 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
-          - ""
 raw_stacktraces:
   - frames:
       - abs_path: "app:///nofiles.js"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -22,7 +22,6 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
-          - ""
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""
@@ -37,5 +36,4 @@ raw_stacktraces:
         context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
         post_context:
           - //@ sourceMappingURL=file.min.js.map
-          - ""
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__dotnet_embedded_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__dotnet_embedded_sources.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-service/tests/integration/symbolication.rs
-assertion_line: 296
 expression: response.unwrap()
 ---
 stacktraces:
@@ -15,6 +14,7 @@ stacktraces:
         abs_path: "C:\\dev\\sentry-dotnet\\samples\\Sentry.Samples.Console.Basic\\Program.cs"
         lineno: 13
         pre_context:
+          - "    // When debug is enabled, the Sentry client will emit detailed debugging information to the console."
           - "    o.Debug = true;"
           - "});"
           - ""

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__source_candidates.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__symbolication__source_candidates.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-service/tests/integration/symbolication.rs
-assertion_line: 198
 expression: response.unwrap()
 ---
 stacktraces:
@@ -17,6 +16,7 @@ stacktraces:
         abs_path: /Users/swatinem/Coding/sentry-native/examples/example.c
         lineno: 60
         pre_context:
+          - "#endif"
           - ""
           - static void
           - trigger_crash()


### PR DESCRIPTION
This now uses the same code for native and JS source context, which now works with `&str`, and makes it generic over line trimming and number of context lines.

It also avoids outputting a trailing empty line when there is a trailing lineline in JS files.

Fun fact: The source-context application for native was broken since forever basically. Due to an off-by-one, it would only ever give us 4 lines of `pre_context`.

#skip-changelog