### PR TITLE
ref: Restructure construction of SourceMapLookup

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -1,20 +1,17 @@
 //! Service for retrieving Artifacts and SourceMap.
 
-use symbolicator_sources::SentrySourceConfig;
-
 use crate::caching::{Cache, Cacher, SharedCacheRef};
 use crate::services::download::DownloadService;
-use crate::types::{RawObjectInfo, Scope};
 use std::sync::Arc;
 
 use super::caches::SourceFilesCache;
-use super::sourcemap_lookup::{FetchSourceMapCacheInternal, SourceMapLookup};
+use super::sourcemap_lookup::FetchSourceMapCacheInternal;
 
 #[derive(Debug, Clone)]
 pub struct SourceMapService {
-    sourcefiles_cache: Arc<SourceFilesCache>,
-    sourcemap_caches: Arc<Cacher<FetchSourceMapCacheInternal>>,
-    download_svc: Arc<DownloadService>,
+    pub(crate) sourcefiles_cache: Arc<SourceFilesCache>,
+    pub(crate) sourcemap_caches: Arc<Cacher<FetchSourceMapCacheInternal>>,
+    pub(crate) download_svc: Arc<DownloadService>,
 }
 
 impl SourceMapService {
@@ -29,23 +26,5 @@ impl SourceMapService {
             sourcemap_caches: Arc::new(Cacher::new(sourcemap_cache, shared_cache)),
             download_svc,
         }
-    }
-
-    pub fn create_sourcemap_lookup(
-        &self,
-        scope: Scope,
-        source: Arc<SentrySourceConfig>,
-        modules: &[RawObjectInfo],
-        allow_scraping: bool,
-    ) -> SourceMapLookup {
-        SourceMapLookup::new(
-            self.sourcefiles_cache.clone(),
-            self.sourcemap_caches.clone(),
-            self.download_svc.clone(),
-            scope,
-            source,
-            modules,
-            allow_scraping,
-        )
     }
 }


### PR DESCRIPTION
This removes the `create_sourcemap_lookup` method from `SourceMapService` and changes the signature of `SourceMapLookup::new` to
```rust
pub fn new(service: SourceMapService, request: SymbolicateJsStacktraces) -> Self
```

Since the `request`'s `stacktraces` field is not needed by `new`, we `take` it out before calling `new`.

The `ArtifactFetcher::new` function is removed entirely; inlining it into the one place where it was called should be fine.

During the refactoring a question occurred to me: where do we actually use the `dist` field on `SymbolicateJsStacktraces`?

#skip-changelog