### PR TITLE
ref: Cleanup some TODOs comments and add trace logging to test server

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -42,16 +42,16 @@ pub struct SourceMapModule {
     abs_path: Result<Url, (String, url::ParseError)>,
     /// The optional [`DebugId`] of this module.
     debug_id: Option<DebugId>,
-    // TODO: errors that happened when processing this file
+    // TODO(sourcemap): errors that happened when processing this file
     /// A flag showing if we have already resolved the minified and sourcemap files.
     was_fetched: bool,
     /// The base url for fetching source files.
     source_file_base: Option<Url>,
     /// The fetched minified JS file.
-    // TODO: maybe this should not be public?
+    // TODO(sourcemap): maybe this should not be public?
     pub minified_source: CacheEntry<CachedFile>,
     /// The converted SourceMap.
-    // TODO: maybe this should not be public?
+    // TODO(sourcemap): maybe this should not be public?
     pub smcache: CacheEntry<OwnedSourceMapCache>,
 }
 
@@ -72,7 +72,7 @@ impl SourceMapModule {
         }
     }
 
-    /// TODO: we should really maintain a list of all the errors that happened for this image?
+    // TODO(sourcemap): we should really maintain a list of all the errors that happened for this image?
     pub fn is_valid(&self) -> bool {
         self.abs_path.is_ok()
     }
@@ -115,17 +115,17 @@ impl SourceMapLookup {
         let mut modules_by_abs_path = HashMap::with_capacity(modules.len());
         for module in modules {
             if module.ty != ObjectType::SourceMap {
-                // TODO: raise an error?
+                // TODO(sourcemap): raise an error?
                 continue;
             }
             let Some(code_file) = module.code_file.as_ref() else {
-                // TODO: raise an error?
+                // TODO(sourcemap): raise an error?
                 continue;
             };
 
             let debug_id = match &module.debug_id {
                 Some(id) => {
-                    // TODO: raise an error?
+                    // TODO(sourcemap): raise an error?
                     id.parse().ok()
                 }
                 None => None,
@@ -316,7 +316,7 @@ impl FileKey {
 pub struct CachedFile {
     pub contents: ByteViewString,
     sourcemap_url: Option<Arc<SourceMapUrl>>,
-    // TODO: maybe we should add a `FileOrigin` here, as in:
+    // TODO(sourcemap): maybe we should add a `FileOrigin` here, as in:
     // RemoteFile(Artifact)+path_in_zip ; RemoteFile ; "embedded"
 }
 
@@ -324,7 +324,7 @@ impl CachedFile {
     fn from_descriptor(descriptor: SourceFileDescriptor) -> Option<Self> {
         let sourcemap_url = match descriptor.source_mapping_url() {
             Some(url) => {
-                // TODO: error handling?
+                // TODO(sourcemap): error handling?
                 let abs_path = descriptor
                     .url()
                     .expect("descriptor should have an `abs_path`");
@@ -335,7 +335,7 @@ impl CachedFile {
             None => None,
         };
 
-        // TODO: a `into_contents` would be nice, as we are creating a new copy right now
+        // TODO(sourcemap): a `into_contents` would be nice, as we are creating a new copy right now
         let contents = descriptor.contents()?.to_owned();
         let contents = ByteViewString::from(contents);
 
@@ -364,10 +364,10 @@ struct ArtifactFetcher {
 
 impl ArtifactFetcher {
     async fn prefetch_artifacts(&mut self) {
-        // TODO: filter the API call down to only look for the files we want
+        // TODO(sourcemap): filter the API call down to only look for the files we want
         self.remote_artifacts = self.list_artifacts().await;
 
-        // TODO: actually fetch the needed artifacts :-)
+        // TODO(sourcemap): actually fetch the needed artifacts :-)
     }
 
     async fn list_artifacts(&self) -> HashMap<String, SearchArtifactResult> {
@@ -463,7 +463,7 @@ impl ArtifactFetcher {
         let smcache = match &minified_source {
             Ok(minified_source) => match sourcemap {
                 Ok(sourcemap) => {
-                    // TODO: We should track the information where these files came from,
+                    // TODO(sourcemap): We should track the information where these files came from,
                     // and use that as the `CacheKey` for the `sourcemap_caches`.
                     self.fetch_sourcemap_cache(minified_source.contents.clone(), sourcemap.contents)
                         .await
@@ -495,7 +495,7 @@ impl ArtifactFetcher {
 
         // Otherwise: Do a (cached) API lookup for the `abs_path` + `DebugId`
         if self.remote_artifacts.is_empty() {
-            // TODO: the endpoint should really support filtering files,
+            // TODO(sourcemap): the endpoint should really support filtering files,
             // and ideally only giving us a single file that matches, but right now it just gives
             // us the whole list of artifacts
             self.remote_artifacts = self.list_artifacts().await;
@@ -503,7 +503,7 @@ impl ArtifactFetcher {
 
         // At this point, *one* of our known artifacts includes the file we are looking for.
         // So we do the whole dance yet again.
-        // TODO: figure out a way to avoid that?
+        // TODO(sourcemap): figure out a way to avoid that?
         if let Some(file) = self.try_get_file_from_bundles(key) {
             return Ok(file);
         }
@@ -568,7 +568,7 @@ impl ArtifactFetcher {
             .fetch_artifact(self.source.clone(), found_artifact.id.clone())
             .await;
 
-        // TODO: figure out error handling:
+        // TODO(sourcemap): figure out error handling:
         let contents = artifact.ok()?;
 
         // Get the sourcemap reference from the artifact, either from metadata, or file contents
@@ -671,7 +671,7 @@ fn parse_sourcemap_cache_owned(byteview: ByteView<'static>) -> CacheEntry<OwnedS
 /// Computes and writes the SourceMapCache.
 #[tracing::instrument(skip_all)]
 fn write_sourcemap_cache(file: &mut File, source: &str, sourcemap: &str) -> CacheEntry {
-    // TODO: maybe log *what* we are converting?
+    // TODO(sourcemap): maybe log *what* we are converting?
     tracing::debug!("Converting SourceMap cache");
 
     let smcache_writer = SourceMapCacheWriter::new(source, sourcemap).unwrap();

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -23,8 +23,6 @@ pub struct SymbolicateJsStacktraces {
     pub allow_scraping: bool,
 }
 
-// TODO(sourcemap): Use our generic caching solution for all Artifacts.
-// TODO(sourcemap): Rename all `JsProcessing_` and `js_processing_` prefixed names to something we agree on.
 impl SymbolicationActor {
     #[tracing::instrument(skip_all)]
     pub async fn symbolicate_js(
@@ -61,7 +59,7 @@ impl SymbolicationActor {
                     Ok((mut frame, did_apply_source)) => {
                         // If we have no source context from within the `SourceMapCache`,
                         // fall back to applying the source context from a raw artifact file
-                        // TODO: we should only do this fallback if there is *no* `DebugId`.
+                        // TODO(sourcemap): we should only do this fallback if there is *no* `DebugId`.
                         if !did_apply_source {
                             let filename = frame.raw.filename.as_ref();
                             let file_key = filename
@@ -112,7 +110,6 @@ fn symbolicate_js_frame(
         raw: frame.clone(),
     };
 
-    // TODO(sourcemap): Report invalid source location error
     let (line, col) = match (frame.lineno, frame.colno) {
         (Some(line), Some(col)) if line > 0 && col > 0 => (line, col),
         _ => return Err(JsFrameStatus::InvalidSourceMapLocation),
@@ -147,7 +144,7 @@ fn symbolicate_js_frame(
             apply_source_context(&mut result.raw, file_source);
             did_apply_source = true;
         } else {
-            // TODO: report missing source?
+            // TODO(sourcemap): report missing source?
         }
     }
 
@@ -158,7 +155,7 @@ fn apply_source_context_from_artifact(frame: &mut JsFrame, file: &CacheEntry<Cac
     if let Ok(file) = file {
         apply_source_context(frame, &file.contents)
     } else {
-        // TODO: report missing source?
+        // TODO(sourcemap): report missing source?
     }
 }
 

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -608,7 +608,6 @@ pub struct SystemInfo {
     pub device_model: String,
 }
 
-// TODO: Verify which are required fields
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JsFrame {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/symbolicator-test/Cargo.toml
+++ b/crates/symbolicator-test/Cargo.toml
@@ -14,6 +14,6 @@ reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
-tokio = { version = "1.24.2", features = ["rt", "macros", "fs"] }
-tower-http = { version = "0.4.0", features = ["fs"] }
+tokio = { version = "1.26.0", features = ["rt", "macros", "fs"] }
+tower-http = { version = "0.4.0", features = ["fs", "trace"] }
 tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "local-time", "env-filter", "json"] }

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -41,7 +41,7 @@ pub use tempfile::TempDir;
 /// Setup the test environment.
 ///
 ///  - Initializes logs: The logger only captures logs from the `symbolicator` crate
-///    and test server, and mutes all other logs (such as actix or symbolic).
+///    and test server, and mutes all other logs.
 pub fn setup() {
     fmt()
         .with_env_filter(EnvFilter::new(

--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -45,7 +45,6 @@ pub fn create_app(service: RequestService) -> Router {
         .route("/requests/:request_id", get(requests))
         .route("/applecrashreport", post(applecrashreport))
         .route("/minidump", post(minidump))
-        // TODO(sourcemap): Verify whether this is the endpoint name we actually want to use.
         .route("/symbolicate-js", post(symbolicate_js))
         .route("/symbolicate", symbolicate_route)
         .with_state(service)


### PR DESCRIPTION
Just random chores. Removed unused TODOs, added `(sourcemap)` to remaining one and added fixture tracing for sourcemap tests.

#skip-changelog