### PR TITLE
feat: Prepare to fetch ArtifactBundles from Sentry

### DIFF
--- a/crates/symbolicator-service/src/services/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/services/caches/sourcefiles.rs
@@ -4,9 +4,7 @@ use futures::future::BoxFuture;
 use url::Url;
 
 use symbolic::common::{ByteView, SelfCell};
-use symbolicator_sources::{
-    HttpRemoteFile, HttpSourceConfig, RemoteFile, SourceId, SourceLocation,
-};
+use symbolicator_sources::{HttpRemoteFile, RemoteFile};
 use tempfile::NamedTempFile;
 
 use crate::caching::{
@@ -91,15 +89,7 @@ impl SourceFilesCache {
 
     /// Fetches the file from the given [`Url`] and caches it according to the given [`Scope`].
     pub async fn fetch_scoped_url(&self, scope: &Scope, url: Url) -> CacheEntry<ByteViewString> {
-        let source = Arc::new(HttpSourceConfig {
-            id: SourceId::new("web-scraping"),
-            url,
-            headers: Default::default(),
-            files: Default::default(),
-        });
-        let location = SourceLocation::new("");
-
-        let file = HttpRemoteFile::new(source, location);
+        let file = HttpRemoteFile::from_url(url);
         self.fetch_file(scope, file.into()).await
     }
 }

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -88,6 +88,7 @@ pub fn create_service(
         PortablePdbCacheActor::new(caches.ppdb_caches, shared_cache.clone(), objects.clone());
 
     let sourcemaps = SourceMapService::new(
+        objects.clone(),
         sourcefiles_cache,
         caches.sourcemap_caches,
         shared_cache,

--- a/crates/symbolicator-service/src/services/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/meta_cache.rs
@@ -53,6 +53,16 @@ pub struct ObjectMetaHandle {
 }
 
 impl ObjectMetaHandle {
+    /// Creates an [`ObjectMetaHandle`] for an arbitrary [`RemoteFile`].
+    pub fn for_scoped_file(scope: Scope, file_source: RemoteFile) -> Arc<Self> {
+        Arc::new(Self {
+            scope,
+            file_source,
+            object_id: Default::default(),
+            features: Default::default(),
+        })
+    }
+
     pub fn cache_key(&self) -> CacheKey {
         CacheKey::from_scoped_file(&self.scope, &self.file_source)
     }

--- a/crates/symbolicator-service/src/services/sourcemap.rs
+++ b/crates/symbolicator-service/src/services/sourcemap.rs
@@ -5,10 +5,12 @@ use crate::services::download::DownloadService;
 use std::sync::Arc;
 
 use super::caches::SourceFilesCache;
+use super::objects::ObjectsActor;
 use super::sourcemap_lookup::FetchSourceMapCacheInternal;
 
 #[derive(Debug, Clone)]
 pub struct SourceMapService {
+    pub(crate) objects: ObjectsActor,
     pub(crate) sourcefiles_cache: Arc<SourceFilesCache>,
     pub(crate) sourcemap_caches: Arc<Cacher<FetchSourceMapCacheInternal>>,
     pub(crate) download_svc: Arc<DownloadService>,
@@ -16,12 +18,14 @@ pub struct SourceMapService {
 
 impl SourceMapService {
     pub fn new(
+        objects: ObjectsActor,
         sourcefiles_cache: Arc<SourceFilesCache>,
         sourcemap_cache: Cache,
         shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
     ) -> Self {
         Self {
+            objects,
             sourcefiles_cache,
             sourcemap_caches: Arc::new(Cacher::new(sourcemap_cache, shared_cache)),
             download_svc,

--- a/crates/symbolicator-sources/src/sources/http.rs
+++ b/crates/symbolicator-sources/src/sources/http.rs
@@ -50,6 +50,20 @@ impl HttpRemoteFile {
         }
     }
 
+    /// Creates a new [`HttpRemoteFile`] from the given [`Url`].
+    /// This internally creates a bogus [`HttpSourceConfig`].
+    pub fn from_url(url: Url) -> Self {
+        let source = Arc::new(HttpSourceConfig {
+            id: SourceId::new("web-scraping"),
+            url,
+            headers: Default::default(),
+            files: Default::default(),
+        });
+        let location = SourceLocation::new("");
+
+        HttpRemoteFile::new(source, location)
+    }
+
     pub(crate) fn uri(&self) -> RemoteFileUri {
         match self.url() {
             Ok(url) => url.as_ref().into(),


### PR DESCRIPTION
So far this creates the code to query and fetch Individual Artifacts or Bundles from an imaginary not yet existing Sentry API.

This is half the code needed for https://github.com/getsentry/symbolicator/issues/1067.

#skip-changelog