### PR TITLE
ref: Sample more transactions, ignore more errors

### DIFF
--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -243,17 +243,6 @@ impl BitcodeService {
         });
 
         let all_results = future::join_all(fetch_jobs).await;
-        let mut file_handle = None;
-        for result in all_results {
-            match result {
-                Ok(handle) => file_handle = Some(handle),
-                Err(CacheError::NotFound) => (),
-                Err(error) => {
-                    let error: &dyn std::error::Error = &error;
-                    tracing::error!(error, "failed fetching auxiliary DIF");
-                }
-            }
-        }
-        file_handle
+        all_results.into_iter().find_map(Result::ok)
     }
 }

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -149,17 +149,6 @@ impl Il2cppService {
         });
 
         let all_results = future::join_all(fetch_jobs).await;
-        let mut mapping = None;
-        for result in all_results {
-            match result {
-                Ok(handle) => mapping = Some(handle),
-                Err(CacheError::NotFound) => (),
-                Err(error) => {
-                    let error: &dyn std::error::Error = &error;
-                    tracing::error!(error, "failed fetching il2cpp file");
-                }
-            }
-        }
-        mapping
+        all_results.into_iter().find_map(Result::ok)
     }
 }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -96,7 +96,7 @@ pub fn execute() -> Result<()> {
                 // which comes to an effective sampling rate of `1/600` (~0.0016).
                 // Lets crank that up to `0.02`, which would give us ~4 rps,
                 // or ~240 transactions per minute.
-                0.1
+                0.02
             }
         })),
         ..Default::default()


### PR DESCRIPTION
- Increases our transactions sampling rate, fixes #1021.
- Avoids raising internal errors for il2cpp/bitcode fetches. Over all the time we had this error in there, we only ever got `PermissionDenied`.

#skip-changelog