### PR TITLE
ref: Use API query param to prefilter release artifact files

### DIFF
--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -3,7 +3,7 @@
 //! The sources are described on
 //! <https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/>
 
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::convert::TryInto;
 use std::error::Error;
 use std::path::{Path, PathBuf};
@@ -445,9 +445,10 @@ impl DownloadService {
     pub async fn list_artifacts(
         &self,
         source: Arc<SentrySourceConfig>,
+        file_stems: BTreeSet<String>,
     ) -> Vec<SearchArtifactResult> {
         let mut remote_artifacts = vec![];
-        let job = self.sentry.list_artifacts(source.clone());
+        let job = self.sentry.list_artifacts(source.clone(), file_stems);
         let timeout = Duration::from_secs(30);
         let job = tokio::time::timeout(timeout, job);
         let job = measure("service.download.list_artifacts", m::timed_result, job);

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -692,7 +692,7 @@ impl ArtifactFetcher {
 }
 
 /// Extracts a "file stem" from a [`Url`].
-/// This is the `"file"` in `"./path/to/file.min.js?foo=bar"`.
+/// This is the `"/path/to/file"` in `"./path/to/file.min.js?foo=bar"`.
 /// We use the most generic variant instead here, as server-side filtering is using a partial
 /// match on the whole artifact path, thus `index.js` will be fetched no matter it's stored
 /// as `~/index.js`, `~/index.js?foo=bar`, `http://example.com/index.js`,

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -697,8 +697,8 @@ impl ArtifactFetcher {
 /// match on the whole artifact path, thus `index.js` will be fetched no matter it's stored
 /// as `~/index.js`, `~/index.js?foo=bar`, `http://example.com/index.js`,
 /// or `http://example.com/index.js?foo=bar`.
-/// NOTE: We do want a leading slash to be included, eg. `/bundle/app.js` or `/index.js`,
-/// as it's not possible to use artifacts without proper host or `~/` wildcard.
+// NOTE: We do want a leading slash to be included, eg. `/bundle/app.js` or `/index.js`,
+// as it's not possible to use artifacts without proper host or `~/` wildcard.
 fn extract_file_stem(url: &Url) -> String {
     let path = url.path();
     path.rsplit_once('/')
@@ -710,8 +710,8 @@ fn extract_file_stem(url: &Url) -> String {
 }
 
 /// Transforms a full absolute url into 2 or 4 generalized options.
-/// Based on `ReleaseFile.normalize`, see:
-/// https://github.com/getsentry/sentry/blob/master/src/sentry/models/releasefile.py
+// Based on `ReleaseFile.normalize`, see:
+// https://github.com/getsentry/sentry/blob/master/src/sentry/models/releasefile.py
 fn get_release_file_candidate_urls(url: &Url) -> impl Iterator<Item = String> {
     let mut urls = [None, None, None, None];
 


### PR DESCRIPTION
This should make it work for projects with thousands and thousands of release files, without making tens of hundreds of requests to prefetch release files metadata.

#skip-changelog