### PR TITLE
Micro-optimize Sentry Spans

### DIFF
--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -78,6 +78,7 @@ impl SentryDownloader {
     }
 
     /// Make a request to sentry, parse the result as a JSON SearchResult list.
+    #[tracing::instrument(skip_all)]
     async fn fetch_sentry_json<T>(
         client: &reqwest::Client,
         query: &SearchQuery,

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -120,7 +120,6 @@ impl fmt::Display for ObjectHandle {
 /// This is the actual implementation of [`CacheItemRequest::compute`] for
 /// [`FetchFileDataRequest`] but outside of the trait so it can be written as async/await
 /// code.
-#[tracing::instrument(skip_all)]
 async fn fetch_object_file(
     object_id: &ObjectId,
     file_id: RemoteFile,


### PR DESCRIPTION
Removes instrumentation from `fetch_object_file`, which calls out to `fetch_file` which is already instrumented. Also adds intrumentation to `fetch_sentry_json`, which calls out to the external Sentry API which is linked via the trace but was not explicitly measured in symbolicator itself.

This should improve this view a bit:
![Bildschirm­foto 2023-03-17 um 14 31 11](https://user-images.githubusercontent.com/580492/225918958-81717b6a-c8ea-47ed-b663-6b75fd8b8d4d.png)

#skip-changelog