### PR TITLE
Fix `fetch_sentry_json` Span nesting

### DIFF
--- a/crates/symbolicator-service/src/services/symcaches.rs
+++ b/crates/symbolicator-service/src/services/symcaches.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use sentry::{Hub, SentryFutureExt};
 use tempfile::NamedTempFile;
 
 use symbolic::common::{ByteView, SelfCell};
@@ -154,6 +155,7 @@ impl SymCacheActor {
                                 handle.scope().clone(),
                                 request.sources.clone(),
                             )
+                            .bind_hub(Hub::new_from_top(Hub::current()))
                             .await
                     }
                     None => None,
@@ -171,6 +173,7 @@ impl SymCacheActor {
                                 handle.scope().clone(),
                                 request.sources.clone(),
                             )
+                            .bind_hub(Hub::new_from_top(Hub::current()))
                             .await
                     }
                     None => None,


### PR DESCRIPTION
The performance span view was showing nested `fetch_sentry_json` spans, even though that is impossible.

I suspect the problem was with missing future isolation for the bcsymbolmap / il2cpp requests. The first request would call into `fetch_sentry_json` and yield, after which the second future is polled and will then end up as the child of the first one.

![Bildschirm­foto 2023-03-20 um 11 41 44](https://user-images.githubusercontent.com/580492/226316593-ad6719d8-1888-4d90-b08a-ecc53c9a79f6.png)

#skip-changelog