### PR TITLE
Add a bunch of trace logs to JS symbolication

### DIFF
--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -184,10 +184,10 @@ impl SentryDownloader {
         let response = request.send().await?;
 
         if response.status().is_success() {
-            tracing::trace!("Success fetching index from Sentry");
+            tracing::trace!("Success fetching from Sentry API");
             Ok(response.json().await?)
         } else {
-            tracing::warn!("Sentry returned status code {}", response.status());
+            tracing::warn!("Sentry API returned status code {}", response.status());
             let details = response.status().to_string();
             Err(CacheError::DownloadError(details))
         }

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -118,6 +118,12 @@ async fn symbolicate_js_frame(
         return Err(JsFrameStatus::InvalidAbsPath);
     }
 
+    tracing::trace!(
+        abs_path = &raw_frame.abs_path,
+        ?module,
+        "Found Module for `abs_path`"
+    );
+
     // Apply source context to the raw frame
     apply_source_context_from_artifact(raw_frame, &module.minified_source);
 

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -20,12 +20,21 @@ pub struct SentrySourceConfig {
 }
 
 /// The Sentry-specific [`RemoteFile`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SentryRemoteFile {
     /// The underlying [`SentrySourceConfig`].
     pub source: Arc<SentrySourceConfig>,
     pub(crate) file_id: SentryFileId,
     url: Url,
+}
+
+impl fmt::Debug for SentryRemoteFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SentryRemoteFile")
+            .field("id", &self.file_id.0)
+            .field("url", &self.url.as_str())
+            .finish()
+    }
 }
 
 impl From<SentryRemoteFile> for RemoteFile {


### PR DESCRIPTION
Its a bit annoying that the `Debug` output of `Url` is pretty useless :-(

#skip-changelog