### PR TITLE
ref: Dont rename InvalidLocation fields

### DIFF
--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -579,12 +579,7 @@ pub struct CompletedSymbolicationResponse {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum JsModuleErrorKind {
-    InvalidLocation {
-        #[serde(rename = "row")]
-        line: Option<u32>,
-        #[serde(rename = "column")]
-        col: Option<u32>,
-    },
+    InvalidLocation { line: Option<u32>, col: Option<u32> },
     InvalidAbsPath,
     NoColumn,
     MissingSourceContent,

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
@@ -33,6 +33,6 @@ raw_stacktraces:
 errors:
   - abs_path: "http://example.com/invalidlocation.js"
     type: invalid_location
-    row: 0
-    column: 0
+    line: 0
+    col: 0
 


### PR DESCRIPTION
We'll map it on the other side in the monolith.

#skip-changelog