### PR TITLE
Output JS-errors sorted

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -28,7 +28,7 @@
 //! - `js.scraped_files`: The number of files that were scraped from the Web.
 //!   Should be `0`, as we should find/use files from within bundles or as individual artifacts.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use symbolic::sourcemapcache::{ScopeLookupResult, SourcePosition};
@@ -71,7 +71,7 @@ impl SymbolicationActor {
         let num_stacktraces = raw_stacktraces.len();
         let mut stacktraces = Vec::with_capacity(num_stacktraces);
 
-        let mut errors = HashSet::new();
+        let mut errors = BTreeSet::new();
         for raw_stacktrace in &mut raw_stacktraces {
             let num_frames = raw_stacktrace.frames.len();
             let mut symbolicated_frames = Vec::with_capacity(num_frames);
@@ -93,8 +93,8 @@ impl SymbolicationActor {
                     Err(err) => {
                         unsymbolicated_frames += 1;
                         errors.insert(JsModuleError {
-                            kind: err,
                             abs_path: raw_frame.abs_path.clone(),
+                            kind: err,
                         });
                         symbolicated_frames.push(raw_frame.clone());
                     }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -575,7 +575,7 @@ pub struct CompletedSymbolicationResponse {
 
 // Some of the renames are there only to make it synchronized
 // with the already existing monolith naming scheme.
-#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum JsModuleErrorKind {
@@ -590,7 +590,7 @@ pub enum JsModuleErrorKind {
     InvalidBase64Sourcemap,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct JsModuleError {
     pub abs_path: String,
     #[serde(flatten)]

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+assertion_line: 367
 expression: response.unwrap()
 ---
 stacktraces:
@@ -23,8 +24,8 @@ raw_stacktraces:
         lineno: 4
         colno: 0
 errors:
-  - abs_path: "http://localhost:<port>/assets/missing_foo.js"
-    type: missing_sourcemap
   - abs_path: "http://localhost:<port>/assets/missing_bar.js"
+    type: missing_sourcemap
+  - abs_path: "http://localhost:<port>/assets/missing_foo.js"
     type: missing_sourcemap
 


### PR DESCRIPTION
Replaces the HashMap with a BTreeMap for the JS `errors` output, which guarantees a stable sort order.

Looks like the unstable sort was causing problems here: https://github.com/getsentry/symbolicator/actions/runs/4516802731/jobs/7955495364?pr=1117

#skip-changelog