### PR TITLE
Clean up anyhow usage and Symbolication Error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "jemallocator",
  "reqwest",
  "sentry",
+ "sentry-anyhow",
  "serde",
  "serde_json",
  "structopt",

--- a/crates/process-event/src/main.rs
+++ b/crates/process-event/src/main.rs
@@ -37,7 +37,7 @@ struct Cli {
     pretty: bool,
 }
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> anyhow::Result<()> {
     let Cli {
         input,
         symbolicator,

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Display};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Error};
+use anyhow::Context;
 use futures::future::{self, BoxFuture};
 use sentry::{Hub, SentryFutureExt};
 
@@ -40,7 +40,7 @@ pub struct BcSymbolMapHandle {
 
 impl BcSymbolMapHandle {
     /// Parses the map from the handle.
-    pub fn bc_symbol_map(&self) -> Result<BcSymbolMap<'_>, Error> {
+    pub fn bc_symbol_map(&self) -> anyhow::Result<BcSymbolMap<'_>> {
         BcSymbolMap::parse(&self.data).context("Failed to parse BCSymbolMap")
     }
 }

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::sync::Arc;
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use apple_crash_report_parser::AppleCrashReport;
 use chrono::{DateTime, Utc};
 use regex::Regex;
@@ -24,7 +24,7 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-    ) -> anyhow::Result<(SymbolicateStacktraces, AppleCrashReportState)> {
+    ) -> Result<(SymbolicateStacktraces, AppleCrashReportState)> {
         let report =
             AppleCrashReport::from_reader(report).context("failed to parse apple crash report")?;
         let mut metadata = report.metadata;
@@ -122,7 +122,7 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-    ) -> anyhow::Result<CompletedSymbolicationResponse> {
+    ) -> Result<CompletedSymbolicationResponse> {
         let (request, state) = self.parse_apple_crash_report(scope, report, sources)?;
         let mut response = self.symbolicate(request).await?;
 

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -24,7 +24,7 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-    ) -> Result<(SymbolicateStacktraces, AppleCrashReportState), anyhow::Error> {
+    ) -> anyhow::Result<(SymbolicateStacktraces, AppleCrashReportState)> {
         let report =
             AppleCrashReport::from_reader(report).context("failed to parse apple crash report")?;
         let mut metadata = report.metadata;
@@ -122,7 +122,7 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
-    ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
+    ) -> anyhow::Result<CompletedSymbolicationResponse> {
         let (request, state) = self.parse_apple_crash_report(scope, report, sources)?;
         let mut response = self.symbolicate(request).await?;
 

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -60,7 +60,7 @@ impl SymbolicationActor {
     pub async fn symbolicate_js(
         &self,
         mut request: SymbolicateJsStacktraces,
-    ) -> Result<CompletedJsSymbolicationResponse, anyhow::Error> {
+    ) -> anyhow::Result<CompletedJsSymbolicationResponse> {
         let mut raw_stacktraces = std::mem::take(&mut request.stacktraces);
         let mut lookup = SourceMapLookup::new(self.sourcemaps.clone(), request);
         lookup.prefetch_artifacts(&raw_stacktraces).await;

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -114,7 +114,7 @@ impl SymbolicationActor {
     pub async fn symbolicate(
         &self,
         request: SymbolicateStacktraces,
-    ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
+    ) -> anyhow::Result<CompletedSymbolicationResponse> {
         let SymbolicateStacktraces {
             stacktraces,
             sources,

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::{bail, Context};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use minidump::system_info::Os;
@@ -275,7 +275,7 @@ async fn stackwalk(
     minidump: &Minidump,
     scope: Scope,
     sources: Arc<[SourceConfig]>,
-) -> anyhow::Result<StackWalkMinidumpResult> {
+) -> Result<StackWalkMinidumpResult> {
     // Stackwalk the minidump.
     let duration = Instant::now();
     let system_info = minidump
@@ -400,7 +400,7 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
-    ) -> anyhow::Result<CompletedSymbolicationResponse> {
+    ) -> Result<CompletedSymbolicationResponse> {
         let (request, state) = self
             .stackwalk_minidump(scope, minidump_file, sources)
             .await?;
@@ -417,7 +417,7 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
-    ) -> anyhow::Result<(SymbolicateStacktraces, MinidumpState)> {
+    ) -> Result<(SymbolicateStacktraces, MinidumpState)> {
         let len = minidump_file.metadata()?.len();
         tracing::debug!("Processing minidump ({} bytes)", len);
         metric!(time_raw("minidump.upload.size") = len);
@@ -548,7 +548,7 @@ fn normalize_minidump_os_name(os: Os) -> &'static str {
     }
 }
 
-fn read_minidump(path: &Path) -> anyhow::Result<Minidump> {
+fn read_minidump(path: &Path) -> Result<Minidump> {
     let bv = ByteView::open(path)?;
     let md = Minidump::read(bv)?;
     Ok(md)

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -400,7 +400,7 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
-    ) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
+    ) -> anyhow::Result<CompletedSymbolicationResponse> {
         let (request, state) = self
             .stackwalk_minidump(scope, minidump_file, sources)
             .await?;
@@ -417,7 +417,7 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
-    ) -> Result<(SymbolicateStacktraces, MinidumpState), anyhow::Error> {
+    ) -> anyhow::Result<(SymbolicateStacktraces, MinidumpState)> {
         let len = minidump_file.metadata()?.len();
         tracing::debug!("Processing minidump ({} bytes)", len);
         metric!(time_raw("minidump.upload.size") = len);

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -215,7 +215,7 @@ async fn main() -> Result<()> {
 async fn process_payload(
     symbolication: &SymbolicationActor,
     workload: ParsedPayload,
-) -> Result<CompletedSymbolicationResponse, anyhow::Error> {
+) -> Result<CompletedSymbolicationResponse> {
     match workload {
         ParsedPayload::Minidump(payload) => {
             let MinidumpPayload {

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -16,6 +16,7 @@ axum-server = "0.4.0"
 console = "0.15.0"
 futures = "0.3.12"
 hostname = "0.3.1"
+sentry-anyhow = { version = "0.30.0", features = ["backtrace"] }
 sentry = { version = "0.30.0", features = ["anyhow", "debug-images", "tracing", "tower", "tower-http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use symbolicator_service::config::Config;
 use symbolicator_sources::SourceConfig;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, ValueEnum};
 use reqwest::Url;
 use serde::Deserialize;
@@ -104,7 +104,7 @@ struct ConfigFile {
 }
 
 impl ConfigFile {
-    pub fn parse(path: &Path) -> anyhow::Result<Self> {
+    pub fn parse(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(buf) => toml::from_str(&buf).context("Could not parse configuration file"),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -129,7 +129,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn get() -> anyhow::Result<Self> {
+    pub fn get() -> Result<Self> {
         let cli = Cli::parse();
 
         let mut global_config_file = ConfigFile::parse(&find_global_config_file()?)?;
@@ -210,7 +210,7 @@ impl Settings {
     }
 }
 
-fn find_global_config_file() -> anyhow::Result<PathBuf> {
+fn find_global_config_file() -> Result<PathBuf> {
     dirs::home_dir()
         .ok_or_else(|| anyhow!("Could not find home dir"))
         .map(|mut path| {

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -68,7 +68,7 @@ fn is_strippable_section(section: &Section, strip_names: bool) -> bool {
     })
 }
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> anyhow::Result<()> {
     let cli = Cli::from_args();
 
     let mut module = Module::decode_from(BufReader::new(File::open(&cli.input)?))?;


### PR DESCRIPTION
This makes sure that when capturing a Symbolication Error, we do get a proper stack trace and chained errors for it. Also cleans up some general anyhow usage across the codebase.

#skip-changelog