### PR TITLE
Use the absolute `abs_path` when resolving Descriptor sourceMappingURLs

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -283,9 +283,7 @@ impl SourceMapLookup {
 /// Joins a `url` to the `base` [`Url`], taking care of our special `~/` prefix that is treated just
 /// like an absolute url.
 fn join_url(base: &Url, url: &str) -> Option<Url> {
-    if let Some(url) = url.strip_prefix('~') {
-        return base.join(url).ok();
-    }
+    let url = url.strip_prefix('~').unwrap_or(url);
     base.join(url).ok()
 }
 


### PR DESCRIPTION
We were running into an error in `Url::parse`, because the descriptor `url` is a relative one (aka `~/foo/bar.js`) in most cases, and we need a real *absolute* Url in order to resolve the `sourceMappingURL` reference.

#skip-changelog