### PR TITLE
ref(sourcemaps): Make SourceMapCache optional for Module and bail early on processing

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -83,7 +83,7 @@ pub struct SourceMapModule {
     pub minified_source: CachedFileEntry,
     /// The converted SourceMap.
     // TODO(sourcemap): maybe this should not be public?
-    pub smcache: CachedFileEntry<OwnedSourceMapCache>,
+    pub smcache: Option<CachedFileEntry<OwnedSourceMapCache>>,
 }
 
 impl SourceMapModule {
@@ -99,7 +99,7 @@ impl SourceMapModule {
             was_fetched: false,
             source_file_base: None,
             minified_source: CachedFileEntry::empty(),
-            smcache: CachedFileEntry::empty(),
+            smcache: None,
         }
     }
 
@@ -525,7 +525,10 @@ impl ArtifactFetcher {
         &mut self,
         abs_path: Url,
         debug_id: Option<DebugId>,
-    ) -> (CachedFileEntry, CachedFileEntry<OwnedSourceMapCache>) {
+    ) -> (
+        CachedFileEntry,
+        Option<CachedFileEntry<OwnedSourceMapCache>>,
+    ) {
         // First, check if we have already cached / created the `SourceMapCache`.
         let key = FileKey::MinifiedSource {
             abs_path: abs_path.clone(),
@@ -540,6 +543,12 @@ impl ArtifactFetcher {
             Ok(minified_source) => minified_source.sourcemap_url.as_deref(),
             Err(_) => None,
         };
+
+        // If we don't have sourcemap reference, nor a `DebugId`, we skip creating `SourceMapCache`.
+        if sourcemap_url.is_none() && debug_id.is_none() {
+            return (minified_source, None);
+        }
+
         // We have three cases here:
         let sourcemap = match sourcemap_url {
             // We have an embedded SourceMap via data URL
@@ -558,7 +567,7 @@ impl ArtifactFetcher {
                 };
                 self.get_file(&sourcemap_key).await
             }
-            // We *might* have a valid `DebugId`, in which case we don’t need no URL
+            // We have a `DebugId`, in which case we don’t need no URL
             None => {
                 let sourcemap_key = FileKey::SourceMap {
                     abs_path: None,
@@ -584,7 +593,7 @@ impl ArtifactFetcher {
             entry: smcache,
         };
 
-        (minified_source, smcache)
+        (minified_source, Some(smcache))
     }
 
     /// Fetches an arbitrary file using its `abs_path`,

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -989,7 +989,11 @@ fn write_sourcemap_cache(file: &mut File, source: &str, sourcemap: &str) -> Cach
     // TODO(sourcemap): maybe log *what* we are converting?
     tracing::debug!("Converting SourceMap cache");
 
-    let smcache_writer = SourceMapCacheWriter::new(source, sourcemap).unwrap();
+    // There's currently no way to access inner error of `SourceMapCacheWriterError`,
+    // if we change that. We might want to match on `SourceMap` and get actual underlying
+    // `sourcemap::Error` instead to see more details.
+    let smcache_writer = SourceMapCacheWriter::new(source, sourcemap)
+        .map_err(|_| CacheError::Malformed("Unable to produce a SourceMapCache".to_string()))?;
 
     let mut writer = BufWriter::new(file);
     smcache_writer.serialize(&mut writer)?;

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -136,13 +136,18 @@ async fn symbolicate_js_frame(
         "Found Module for `abs_path`"
     );
 
-    // Apply source context to the raw frame
-    apply_source_context_from_artifact(raw_frame, &module.minified_source.entry);
+    // Apply source context to the raw frame. If it fails, we bail early, as it's not possible
+    // to construct a `SourceMapCache` without the minified source anyway.
+    apply_source_context_from_artifact(raw_frame, &module.minified_source.entry)?;
 
-    let smcache = match &module.smcache.entry {
-        Ok(smcache) => smcache,
-        Err(CacheError::Malformed(_)) => return Err(JsModuleErrorKind::MalformedSourcemap),
-        Err(_) => return Err(JsModuleErrorKind::MissingSourcemap),
+    let smcache = match &module.smcache {
+        Some(smcache) => match &smcache.entry {
+            Ok(entry) => entry,
+            Err(CacheError::Malformed(_)) => return Err(JsModuleErrorKind::MalformedSourcemap),
+            Err(_) => return Err(JsModuleErrorKind::MissingSourcemap),
+        },
+        // In case it's just a source file, with no sourcemap reference or any debug id, we bail.
+        None => return Ok(raw_frame.clone()),
     };
 
     let mut frame = raw_frame.clone();
@@ -197,7 +202,7 @@ async fn symbolicate_js_frame(
     if let Some(file) = token.file() {
         frame.filename = file.name().map(|f| f.to_string());
         if let Some(file_source) = file.source() {
-            apply_source_context(&mut frame, file_source);
+            apply_source_context(&mut frame, file_source).ok();
         } else if module.has_debug_id() {
             *missing_sourcescontent += 1;
             tracing::error!("expected `SourceMap` with `DebugId` to have embedded sources");
@@ -213,23 +218,31 @@ async fn symbolicate_js_frame(
                 None => &Err(CacheError::NotFound),
             };
 
-            apply_source_context_from_artifact(&mut frame, source_file);
+            apply_source_context_from_artifact(&mut frame, source_file).ok();
         }
     }
 
     Ok(frame)
 }
 
-fn apply_source_context_from_artifact(frame: &mut JsFrame, file: &CacheEntry<CachedFile>) {
+fn apply_source_context_from_artifact(
+    frame: &mut JsFrame,
+    file: &CacheEntry<CachedFile>,
+) -> Result<(), JsModuleErrorKind> {
     if let Ok(file) = file {
         apply_source_context(frame, &file.contents)
     } else {
-        // TODO(sourcemap): report missing source?
+        Err(JsModuleErrorKind::MissingSourcemap)
     }
 }
 
-fn apply_source_context(frame: &mut JsFrame, source: &str) {
-    let Some(lineno) = frame.lineno else { return; };
+fn apply_source_context(frame: &mut JsFrame, source: &str) -> Result<(), JsModuleErrorKind> {
+    let Some(lineno) = frame.lineno else {
+        return Err(JsModuleErrorKind::InvalidLocation {
+            line: frame.lineno,
+            col: frame.colno,
+        })
+    };
     let lineno = lineno as usize;
     let column = frame.colno.map(|col| col as usize);
 
@@ -240,6 +253,8 @@ fn apply_source_context(frame: &mut JsFrame, source: &str) {
         frame.context_line = Some(context_line);
         frame.post_context = post_context;
     }
+
+    Ok(())
 }
 
 // Names that do not provide any reasonable value, and that can possibly obstruct

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -582,9 +582,8 @@ pub enum JsModuleErrorKind {
     InvalidLocation { line: Option<u32>, col: Option<u32> },
     InvalidAbsPath,
     NoColumn,
-    MissingSourceContent,
+    MissingSourceContent { sourcemap: String },
     MissingSource,
-    // new variants:
     MalformedSourcemap,
     MissingSourcemap,
     InvalidBase64Sourcemap,

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -582,9 +582,9 @@ pub enum JsModuleErrorKind {
     InvalidLocation { line: Option<u32>, col: Option<u32> },
     InvalidAbsPath,
     NoColumn,
-    MissingSourceContent { sourcemap: String },
+    MissingSourceContent { url: String },
     MissingSource,
-    MalformedSourcemap,
+    MalformedSourcemap { url: String },
     MissingSourcemap,
     InvalidBase64Sourcemap,
 }

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -25,7 +25,7 @@ raw_stacktraces:
         colno: 0
 errors:
   - abs_path: "http://localhost:<port>/assets/missing_bar.js"
-    type: missing_sourcemap
+    type: missing_source
   - abs_path: "http://localhost:<port>/assets/missing_foo.js"
-    type: missing_sourcemap
+    type: missing_source
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -59,7 +59,4 @@ raw_stacktraces:
           - w
           - o
           - r
-errors:
-  - abs_path: "http://example.com/foo.js"
-    type: missing_sourcemap
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -37,5 +37,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=embedded.js.map"
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_sourcemap
+    type: missing_source
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -95,5 +95,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=test.min.js.map"
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_sourcemap
+    type: missing_source
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -37,5 +37,5 @@ raw_stacktraces:
           - //@ sourceMappingURL=file.min.js.map
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_sourcemap
+    type: missing_source
 


### PR DESCRIPTION
This change prevents errors about missing sources for events that should not report one.
When we have a frame that points to a valid JS file but has no `sourceMappingUrl` nor a Debug ID, we shouldn't treat it as an error.

We should also bail from further processing when the initial context lines application fails, as it means that minified source (which is required for creating a `SourceMapCache` in the first place) is not present or is not usable.

#skip-changelog