### PR TITLE
Skip Ubuntu symbol server test

### DIFF
--- a/crates/symbolicator-service/tests/integration/public_sources.rs
+++ b/crates/symbolicator-service/tests/integration/public_sources.rs
@@ -48,6 +48,7 @@ async fn test_nuget_source() {
     assert_snapshot!(response.unwrap());
 }
 
+#[ignore]
 #[tokio::test]
 async fn test_ubuntu_source() {
     let (symbolication, _cache_dir) = setup_service(|_| ());


### PR DESCRIPTION
According to the FAQ at https://ubuntu.com/server/docs/service-debuginfod-faq:

> Once a release goes unsupported, we [...] eventually stop serving debug symbols for its packages.

So I guess with those "stability" guarantees we either have to constantly update the testcase with up-to-date debug-ids, or we just skip it entirely :-(

#skip-changelog