### PR TITLE
Do not fail processing minidumps on invalid `code_file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixes
 
-- Reject minidumps containing invalid file names. ([#1047](https://github.com/getsentry/symbolicator/pull/1047))
+- Mask invalid file names in minidumps. ([#1047](https://github.com/getsentry/symbolicator/pull/1047), [#1133](https://github.com/getsentry/symbolicator/pull/1133))
 - Update `minidump-processor` so minidumps with a 0-sized module are being processed. ([#1131](https://github.com/getsentry/symbolicator/pull/1131))
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,7 +4372,6 @@ dependencies = [
  "jemallocator",
  "reqwest",
  "sentry",
- "sentry-anyhow",
  "serde",
  "serde_json",
  "structopt",

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -537,7 +537,7 @@ fn read_minidump(path: &Path) -> Result<Minidump> {
     Ok(md)
 }
 
-/// Replaces invalid file names by a `<invalid>` marker, otherwise returns a `String` for non-empty file names.
+/// Returns an owned version of `file_name`, or `None` if it is empty.
 fn non_empty_file_name(file_name: &str) -> Option<String> {
     if file_name.is_empty() {
         return None;

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -47,7 +47,7 @@ fn get_lldb_path(identifier: &ObjectId) -> Option<String> {
 }
 
 fn get_pdb_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<String> {
-    let debug_file = identifier.debug_file_basename()?;
+    let debug_file = identifier.validated_debug_file_basename()?;
     let debug_id = identifier.debug_id.as_ref()?;
 
     let debug_file = if ssqp_casing {
@@ -74,7 +74,7 @@ fn get_pdb_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<Str
 }
 
 fn get_pe_symstore_path(identifier: &ObjectId, ssqp_casing: bool) -> Option<String> {
-    let code_file = identifier.code_file_basename()?;
+    let code_file = identifier.validated_code_file_basename()?;
     let code_id = identifier.code_id.as_ref()?.as_str();
 
     let code_file = if ssqp_casing {
@@ -103,7 +103,7 @@ fn get_breakpad_path(identifier: &ObjectId) -> Option<String> {
         return None;
     }
 
-    let debug_file = identifier.debug_file_basename()?;
+    let debug_file = identifier.validated_debug_file_basename()?;
     let debug_id = identifier.debug_id.as_ref()?;
     let new_debug_file = debug_file
         .strip_suffix(".exe")
@@ -223,7 +223,7 @@ fn get_symstore_path(
     match filetype {
         FileType::ElfCode => {
             let code_id = identifier.code_id.as_ref()?;
-            let code_file = identifier.code_file_basename()?;
+            let code_file = identifier.validated_code_file_basename()?;
             let code_file = if ssqp_casing {
                 Cow::Owned(code_file.to_lowercase())
             } else {
@@ -237,7 +237,7 @@ fn get_symstore_path(
         }
 
         FileType::MachCode => {
-            let code_file = identifier.code_file_basename()?;
+            let code_file = identifier.validated_code_file_basename()?;
             let code_file = if ssqp_casing {
                 Cow::Owned(code_file.to_lowercase())
             } else {

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -16,7 +16,6 @@ axum-server = "0.4.0"
 console = "0.15.0"
 futures = "0.3.12"
 hostname = "0.3.1"
-sentry-anyhow = { version = "0.30.0", features = ["backtrace"] }
 sentry = { version = "0.30.0", features = ["anyhow", "debug-images", "tracing", "tower", "tower-http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"


### PR DESCRIPTION
Invalid base-names will be excluded from symbol server lookups, which will certainly not find anything useful. We still output the full (invalid) code file into the symbolicated event, as it might still be useful to customers.

As a drive-by change, this reverts the `capture_anyhow` change that captures real stack traces in S4S, as the stack traces are not that useful, and the grouping is worse.

fixes https://github.com/getsentry/symbolicator/issues/1115, and I verified the minidump linked in https://github.com/getsentry/sentry/issues/46231 processes fine after this change.