### PR TITLE
Make the JS `abs_path` actually an absolute path/url

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -277,7 +277,7 @@ impl SourceMapLookup {
 
 /// Joins a `url` to the `base` [`Url`], taking care of our special `~/` prefix that is treated just
 /// like an absolute url.
-pub fn join_url(base: &Url, url: &str) -> Option<Url> {
+fn join_url(base: &Url, url: &str) -> Option<Url> {
     let url = url.strip_prefix('~').unwrap_or(url);
     base.join(url).ok()
 }

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -277,7 +277,7 @@ impl SourceMapLookup {
 
 /// Joins a `url` to the `base` [`Url`], taking care of our special `~/` prefix that is treated just
 /// like an absolute url.
-fn join_url(base: &Url, url: &str) -> Option<Url> {
+pub fn join_url(base: &Url, url: &str) -> Option<Url> {
     let url = url.strip_prefix('~').unwrap_or(url);
     base.join(url).ok()
 }

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 212
+assertion_line: 325
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: add
         filename: file1.js
-        abs_path: file1.js
+        abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9
         pre_context:
@@ -18,7 +18,7 @@ stacktraces:
           - "}"
       - function: multiply
         filename: file2.js
-        abs_path: file2.js
+        abs_path: "http://example.com/file2.js"
         lineno: 3
         colno: 9
         pre_context:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 170
+assertion_line: 245
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: "<unknown>"
         filename: /test.js
-        abs_path: /test.js
+        abs_path: "http://example.com/test.js"
         lineno: 1
         colno: 1
         context_line: "console.log('hello, World!')"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 129
+assertion_line: 188
 expression: response.unwrap()
 ---
 stacktraces:
@@ -12,7 +12,7 @@ stacktraces:
         colno: 17
       - function: add
         filename: file1.js
-        abs_path: file1.js
+        abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9
         pre_context:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 78
+assertion_line: 100
 expression: response.unwrap()
 ---
 stacktraces:
@@ -12,7 +12,7 @@ stacktraces:
         colno: 7
       - function: test
         filename: test.js
-        abs_path: test.js
+        abs_path: "http://example.com/test.js"
         lineno: 20
         colno: 5
         pre_context:
@@ -29,7 +29,7 @@ stacktraces:
           - "})();"
       - function: invoke
         filename: test.js
-        abs_path: test.js
+        abs_path: "http://example.com/test.js"
         lineno: 15
         colno: 5
         pre_context:
@@ -47,7 +47,7 @@ stacktraces:
           - "    invoke(data);"
       - function: onFailure
         filename: test.js
-        abs_path: test.js
+        abs_path: "http://example.com/test.js"
         lineno: 5
         colno: 11
         pre_context:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 103
+assertion_line: 148
 expression: response.unwrap()
 ---
 stacktraces:
@@ -12,7 +12,7 @@ stacktraces:
         colno: 17
       - function: add
         filename: file1.js
-        abs_path: file1.js
+        abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9
         pre_context:


### PR DESCRIPTION
Previously, we just returned the `filename` here. But this is supposed to be a full url, relative to the SourceMap url (or the minified file url as fallback).

#skip-changelog