### PR TITLE
Implement ZipArchive compressed symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add support for in-memory caching. ([#1028](https://github.com/getsentry/symbolicator/pull/1028))
 - Add --log-level argument to `symbolicli`. ([#1074](https://github.com/getsentry/symbolicator/pull/1074))
 - Resolve source context from embedded source links (mainly in Portable PDBs) ([#1103](https://github.com/getsentry/symbolicator/pull/1103), [#1108](https://github.com/getsentry/symbolicator/pull/1108))
+- Add single-file ZipArchive support to `maybe_decompress_file` ([#1139](https://github.com/getsentry/symbolicator/pull/1139))
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,6 +4450,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zip",
  "zstd",
 ]
 

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -51,6 +51,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 zstd = "0.12.1"
 data-encoding = "2.3.3"
 humantime = "2.1.0"
+zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }


### PR DESCRIPTION
Windows symstore.exe added support to compress symbols with /compress ZIP arg.
Rather than simply compressing the file with deflate, it adds it in a ZipArchive.

We use this as CAB compression has a limit on file size (2GB: https://learn.microsoft.com/en-us/archive/blogs/windows_installer_team/what-are-the-upper-limits-of-the-cab-file-format).

From symstore.exe help:
```
/compress [type]    When storing files, store compressed files on the server.
                        Has two optional arguments "CAB" and "ZIP" to specify the
                        compression type to use. Defaults to CAB compression if none is
                        specified. Ignored when storing pointers.
```

Not fluent in rust so don't hesitate with feedback.