### PR TITLE
Instrument `fetch_artifact_bundle`

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -822,6 +822,7 @@ impl ArtifactFetcher {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     async fn fetch_artifact_bundle(&self, file: RemoteFile) -> CacheEntry<ArtifactBundle> {
         let object_handle = ObjectMetaHandle::for_scoped_file(self.scope.clone(), file);
 


### PR DESCRIPTION
I suspect that opening/parsing the artifact-bundles is expensive, so lets instrument this.

#skip-changelog