### PR TITLE
Add the `data.sourcemap` field to JS stack frames

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -166,6 +166,7 @@ async fn symbolicate_js_frame(
     };
 
     let mut frame = raw_frame.clone();
+    frame.data.sourcemap = Some(sourcemap_label.clone());
 
     let (line, col) = match (raw_frame.lineno, raw_frame.colno) {
         (Some(line), Some(col)) if line > 0 && col > 0 => (line, col),

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -651,7 +651,7 @@ pub struct JsFrame {
     #[serde(skip_serializing)]
     pub token_name: Option<String>,
 
-    #[serde(skip_serializing_if = "JsFrameData::is_empty")]
+    #[serde(default, skip_serializing_if = "JsFrameData::is_empty")]
     pub data: JsFrameData,
 }
 

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -650,6 +650,21 @@ pub struct JsFrame {
 
     #[serde(skip_serializing)]
     pub token_name: Option<String>,
+
+    #[serde(skip_serializing_if = "JsFrameData::is_empty")]
+    pub data: JsFrameData,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JsFrameData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sourcemap: Option<String>,
+}
+
+impl JsFrameData {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 325
+assertion_line: 323
 expression: response.unwrap()
 ---
 stacktraces:
@@ -16,6 +16,8 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
+        data:
+          sourcemap: "http://example.com/indexed.min.js.map"
       - function: multiply
         filename: file2.js
         abs_path: "http://example.com/file2.js"
@@ -31,6 +33,8 @@ stacktraces:
           - "\t\"use strict\";"
           - "\ttry {"
           - "\t\treturn multiply(add(a, b), a, b) / c;"
+        data:
+          sourcemap: "http://example.com/indexed.min.js.map"
 raw_stacktraces:
   - frames:
       - filename: indexed.min.js

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 245
+assertion_line: 243
 expression: response.unwrap()
 ---
 stacktraces:
@@ -11,6 +11,8 @@ stacktraces:
         lineno: 1
         colno: 1
         context_line: "console.log('hello, World!')"
+        data:
+          sourcemap: "http://example.com/test.min.js"
 raw_stacktraces:
   - frames:
       - filename: test.js

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 188
+assertion_line: 186
 expression: response.unwrap()
 ---
 stacktraces:
@@ -21,6 +21,8 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
+        data:
+          sourcemap: "http://example.com/embedded.js.map"
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 100
+assertion_line: 98
 expression: response.unwrap()
 ---
 stacktraces:
@@ -27,6 +27,8 @@ stacktraces:
           - ""
           - "  return test;"
           - "})();"
+        data:
+          sourcemap: "http://example.com/test.min.js.map"
       - function: invoke
         filename: test.js
         abs_path: "http://example.com/test.js"
@@ -45,6 +47,8 @@ stacktraces:
           - "  function test() {"
           - "    var data = {failed: true, value: 42};"
           - "    invoke(data);"
+        data:
+          sourcemap: "http://example.com/test.min.js.map"
       - function: onFailure
         filename: test.js
         abs_path: "http://example.com/test.js"
@@ -62,6 +66,8 @@ stacktraces:
           - "  function invoke(data) {"
           - "    var cb = null;"
           - "    if (data.failed) {"
+        data:
+          sourcemap: "http://example.com/test.min.js.map"
 raw_stacktraces:
   - frames:
       - function: produceStack

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 188
+assertion_line: 275
 expression: response.unwrap()
 ---
 stacktraces:
@@ -15,6 +15,8 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
+        data:
+          sourcemap: "app:///nofiles.js.map"
 raw_stacktraces:
   - frames:
       - abs_path: "app:///nofiles.js"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 148
+assertion_line: 146
 expression: response.unwrap()
 ---
 stacktraces:
@@ -21,6 +21,8 @@ stacktraces:
         context_line: "\treturn a + b; // fôo"
         post_context:
           - "}"
+        data:
+          sourcemap: "http://example.com/file.min.js.map"
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""


### PR DESCRIPTION
It appears this field is being used by python code down the road.

#skip-changelog