### PR TITLE
Use FileUri for SourceMap cache keys

### DIFF
--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -384,8 +384,6 @@ impl SentryDownloader {
 
 /// Transforms the given `url` into a [`RemoteFile`].
 ///
-/// Depending on the `source`, this creates either a [`SentryRemoteFile`], or a
-/// [`HttpRemoteFile`].
 /// The problem here is being forward-compatible to a future in which the Sentry API returns
 /// pre-authenticated Urls on some external file storage service.
 /// Whereas right now, these files are still being served from a Sentry API endpoint, which

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -380,7 +380,7 @@ impl FileKey {
 pub enum CachedFileUri {
     /// The file was an individual artifact fetched using its own URI.
     IndividualFile(RemoteFileUri),
-    /// The file was scraped from teh web using the given URI.
+    /// The file was scraped from the web using the given URI.
     ScrapedFile(RemoteFileUri),
     /// The file was found using [`FileKey`] in the bundle identified by the URI.
     Bundled(RemoteFileUri, FileKey),

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -25,6 +25,7 @@ pub struct SentryRemoteFile {
     /// The underlying [`SentrySourceConfig`].
     pub source: Arc<SentrySourceConfig>,
     pub(crate) file_id: SentryFileId,
+    use_credentials: bool,
     url: Url,
 }
 
@@ -45,7 +46,12 @@ impl From<SentryRemoteFile> for RemoteFile {
 
 impl SentryRemoteFile {
     /// Creates a new [`SentryRemoteFile`].
-    pub fn new(source: Arc<SentrySourceConfig>, file_id: SentryFileId, url: Option<Url>) -> Self {
+    pub fn new(
+        source: Arc<SentrySourceConfig>,
+        use_credentials: bool,
+        file_id: SentryFileId,
+        url: Option<Url>,
+    ) -> Self {
         let url = url.unwrap_or_else(|| {
             let mut url = source.url.clone();
             url.query_pairs_mut().append_pair("id", &file_id.0);
@@ -55,6 +61,7 @@ impl SentryRemoteFile {
         Self {
             source,
             file_id,
+            use_credentials,
             url,
         }
     }
@@ -71,6 +78,11 @@ impl SentryRemoteFile {
 
     pub(crate) fn host(&self) -> String {
         self.url.to_string()
+    }
+
+    /// Indicates that credentials should be provided for this request.
+    pub fn use_credentials(&self) -> bool {
+        self.use_credentials
     }
 }
 


### PR DESCRIPTION
This avoids hashing the file contents over and over again, which can be slow. Bundles and individual artifacts have a stable identity using the `SentryRemoteFile`. So files that come from Sentry Artifacts or Bundles can use that as the cache key. Scraped files will still use the content-hash however.

#skip-changelog