### PR TITLE
fix: Don't normalize .. segments in URLs

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -110,6 +110,11 @@ impl SourceMapModule {
         let url = base_url.join(file_path).ok()?;
         Some(FileKey::new_source(url))
     }
+
+    /// The base url for fetching source files.
+    pub fn source_file_base(&self) -> Option<&Url> {
+        self.source_file_base.as_ref()
+    }
 }
 
 pub struct SourceMapLookup {

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -405,9 +405,9 @@ fn fixup_webpack_filename(abs_path: &str) -> String {
 
 /// Joins a path to a base URL without normalizing `..` segments.
 fn nonstandard_path_join(base: &Url, path: &str) -> Option<String> {
-    let path = path.replace("..", "__dotdot__");
+    let path = path.replace("./", "__dotslash__");
     let result = base.join(&path).ok()?.to_string();
-    Some(result.replace("__dotdot__", ".."))
+    Some(result.replace("__dotslash__", "./"))
 }
 
 #[cfg(test)]

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -479,5 +479,11 @@ mod tests {
         let base = "http://example.com".parse().unwrap();
         let path = "webpack:///../node_modules/scheduler/cjs/scheduler.production.min.js";
         assert_eq!(nonstandard_path_join(&base, path).unwrap(), path);
+
+        let path = "path/./to/file.min.js";
+        assert_eq!(
+            nonstandard_path_join(&base, path).unwrap(),
+            "http://example.com/path/./to/file.min.js"
+        );
     }
 }


### PR DESCRIPTION
`Url::join` normalizes away `..` segments when joining URLs. We want to preserve these segments to align with the Python behavior.

#skip-changelog