### PR TITLE
Make data-url parsing more lenient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
+name = "data-url"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,7 +4421,7 @@ dependencies = [
  "backtrace",
  "cadence",
  "chrono",
- "data-encoding",
+ "data-url",
  "filetime",
  "flate2",
  "futures",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -19,10 +19,12 @@ aws-types = { version = "0.52.0", features = ["hardcoded-credentials"] }
 backtrace = "0.3.65"
 cadence = "0.29.0"
 chrono = { version = "0.4.19", features = ["serde"] }
+data-url = "0.2.0"
 filetime = "0.2.16"
 flate2 = "1.0.23"
 futures = "0.3.12"
 gcp_auth = "0.8.0"
+humantime = "2.1.0"
 humantime-serde = "1.1.1"
 ipnetwork = "0.20.0"
 jsonwebtoken = "8.1.0"
@@ -30,6 +32,7 @@ lazy_static = "1.4.0"
 minidump = "0.16.0"
 minidump-processor = "0.16.0"
 moka = { version = "0.10", features = ["future"] }
+once_cell = "1.17.1"
 parking_lot = "0.12.0"
 regex = "1.5.5"
 reqwest = { version = "0.11.0", features = ["gzip", "json", "stream", "trust-dns"] }
@@ -48,11 +51,8 @@ tokio-util = { version = "0.7.1", features = ["io"] }
 tracing = "0.1.34"
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
-zstd = "0.12.1"
-data-encoding = "2.3.3"
-humantime = "2.1.0"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
-once_cell = "1.17.1"
+zstd = "0.12.1"
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }

--- a/crates/symbolicator-service/src/services/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/services/caches/sourcefiles.rs
@@ -44,6 +44,12 @@ impl AsRef<[u8]> for ByteViewString {
     }
 }
 
+impl PartialEq for ByteViewString {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
 /// Provides cached access to source files, with UTF-8 validating contents.
 #[derive(Debug, Clone)]
 pub struct SourceFilesCache {


### PR DESCRIPTION
This accepts any valid `data:` url, also with mismatching mimetype and non-base64 encoding.

fixes #1158

#skip-changelog