### PR TITLE
Cancel in-progress CI and allow deploying from canary/lpq branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,15 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - master
       - release/**
 
-  pull_request:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
       - release/**
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-image:
     strategy:

--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -1,13 +1,14 @@
 name: Lint Deployment Pipelines
 
 on:
-    pull_request:
-    push:
-        branches: [main, test-me-*]
+  pull_request:
+  push:
+    branches:
+      - master
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
     lint:

--- a/gocd/pipelines/symbolicator-canary.yaml
+++ b/gocd/pipelines/symbolicator-canary.yaml
@@ -16,7 +16,7 @@ pipelines:
             symbolicator_repo:
                 git: git@github.com:getsentry/symbolicator.git
                 shallow_clone: true
-                branch: master
+                branch: canary
                 destination: symbolicator
         stages:
             - checks:

--- a/gocd/pipelines/symbolicator-lpq.yaml
+++ b/gocd/pipelines/symbolicator-lpq.yaml
@@ -16,7 +16,7 @@ pipelines:
             symbolicator_repo:
                 git: git@github.com:getsentry/symbolicator.git
                 shallow_clone: true
-                branch: master
+                branch: lpq
                 destination: symbolicator
         stages:
             - checks:


### PR DESCRIPTION
Adds `concurrency` groups to GitHub Actions, so that in-progress jobs will be cancelled when pushing to PRs in quick succession.

Also changes the canary/lpq GoCD scripts to hardcode `canary`/`lpq` branches, to hopefully be able to deploy these from a non-master branch.

#skip-changelog