### PR TITLE
Fix tracing output in tests

### DIFF
--- a/crates/symbolicator-service/src/caching/shared_cache/mod.rs
+++ b/crates/symbolicator-service/src/caching/shared_cache/mod.rs
@@ -669,6 +669,7 @@ impl SharedCacheService {
     /// shared cache was not found nothing will have been written to `writer`.
     ///
     /// Errors are transparently hidden, either a cache item is available or it is not.
+    #[tracing::instrument(name = "fetch_shared_cache", skip(self, file))]
     pub async fn fetch(&self, cache: CacheName, key: &str, mut file: tokio::fs::File) -> bool {
         let _guard = Hub::current().push_scope();
         let backend_name = self.backend_name();

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -469,7 +469,13 @@ pub struct CachedFile {
 
 impl fmt::Debug for CachedFile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let contents: &str = &self.contents;
+        let contents = if self.contents.len() > 64 {
+            // its just `Debug` prints, but we would like the end of the file, as it may
+            // have a `sourceMappingURL`
+            format!("...{}", &self.contents[self.contents.len() - 61..])
+        } else {
+            self.contents.to_string()
+        };
         f.debug_struct("CachedFile")
             .field("contents", &contents)
             .field("sourcemap_url", &self.sourcemap_url)
@@ -1055,18 +1061,6 @@ impl CacheItemRequest for FetchSourceMapCacheInternal {
     }
 }
 
-#[tracing::instrument(skip_all)]
-fn write_artifact_cache(file: &mut File, source_artifact_buf: &str) -> CacheEntry {
-    use std::io::Write;
-
-    let mut writer = BufWriter::new(file);
-    writer.write_all(source_artifact_buf.as_bytes())?;
-    let file = writer.into_inner().map_err(io::Error::from)?;
-    file.sync_all()?;
-
-    Ok(())
-}
-
 fn parse_sourcemap_cache_owned(byteview: ByteView<'static>) -> CacheEntry<OwnedSourceMapCache> {
     SelfCell::try_new(byteview, |p| unsafe {
         SourceMapCache::parse(&*p).map_err(CacheError::from_std_error)
@@ -1076,7 +1070,6 @@ fn parse_sourcemap_cache_owned(byteview: ByteView<'static>) -> CacheEntry<OwnedS
 /// Computes and writes the SourceMapCache.
 #[tracing::instrument(skip_all)]
 fn write_sourcemap_cache(file: &mut File, source: &str, sourcemap: &str) -> CacheEntry {
-    // TODO(sourcemap): maybe log *what* we are converting?
     tracing::debug!("Converting SourceMap cache");
 
     let smcache_writer = SourceMapCacheWriter::new(source, sourcemap)

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -136,7 +136,7 @@ async fn symbolicate_js_frame(
     tracing::trace!(
         abs_path = &raw_frame.abs_path,
         ?module,
-        "Found Module for `abs_path`"
+        "Module for `abs_path`"
     );
 
     // Apply source context to the raw frame. If it fails, we bail early, as it's not possible

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -45,10 +45,7 @@ pub use tempfile::TempDir;
 ///    and test server, and mutes all other logs.
 pub fn setup() {
     fmt()
-        .with_env_filter(EnvFilter::new(
-            "symbolicator_service=trace,tower_http=trace",
-        ))
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(EnvFilter::new("symbolicator=trace,tower_http=trace"))
         .with_target(false)
         .pretty()
         .with_test_writer()


### PR DESCRIPTION
Using two env filters means the first one is overwritten and does not work anymore.

#skip-changelog