### PR TITLE
Fix misplaced changelog entry for ZipArchive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add single-file ZipArchive support to `maybe_decompress_file` ([#1139](https://github.com/getsentry/symbolicator/pull/1139))
+
 ### Fixes
 
 - Allow symbolicli to connect to reserved IPs ([#1165](https://github.com/getsentry/symbolicator/pull/1165))
@@ -21,7 +23,6 @@
 - Add support for in-memory caching. ([#1028](https://github.com/getsentry/symbolicator/pull/1028))
 - Add --log-level argument to `symbolicli`. ([#1074](https://github.com/getsentry/symbolicator/pull/1074))
 - Resolve source context from embedded source links (mainly in Portable PDBs) ([#1103](https://github.com/getsentry/symbolicator/pull/1103), [#1108](https://github.com/getsentry/symbolicator/pull/1108))
-- Add single-file ZipArchive support to `maybe_decompress_file` ([#1139](https://github.com/getsentry/symbolicator/pull/1139))
 
 ### Fixes
 


### PR DESCRIPTION
Commit 8e46e66383775 for #1139 misplaced the changelog entry under the 23.4.0 section.

#skip-changelog, lol