### PR TITLE
feat: Return an error if scraping is disabled

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -689,11 +689,7 @@ impl ArtifactFetcher {
         }
 
         // Otherwise, fall back to scraping from the Web.
-        if self.scraping.enabled {
-            self.scrape(key).await
-        } else {
-            CachedFileEntry::empty()
-        }
+        self.scrape(key).await
     }
 
     /// Attempt to scrape a file from the web.
@@ -701,6 +697,13 @@ impl ArtifactFetcher {
         let Some(abs_path) = key.abs_path() else {
             return CachedFileEntry::empty();
         };
+
+        if !self.scraping.enabled {
+            return CachedFileEntry {
+                uri: CachedFileUri::ScrapedFile(RemoteFileUri::new(abs_path)),
+                entry: Err(CacheError::DownloadError("Scraping disabled".to_string())),
+            };
+        }
 
         let url = match Url::parse(abs_path) {
             Ok(url) => url,

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -698,13 +698,6 @@ impl ArtifactFetcher {
             return CachedFileEntry::empty();
         };
 
-        if !self.scraping.enabled {
-            return CachedFileEntry {
-                uri: CachedFileUri::ScrapedFile(RemoteFileUri::new(abs_path)),
-                entry: Err(CacheError::DownloadError("Scraping disabled".to_string())),
-            };
-        }
-
         let url = match Url::parse(abs_path) {
             Ok(url) => url,
             Err(err) => {
@@ -714,6 +707,13 @@ impl ArtifactFetcher {
                 }
             }
         };
+
+        if !self.scraping.enabled {
+            return CachedFileEntry {
+                uri: CachedFileUri::ScrapedFile(RemoteFileUri::new(abs_path)),
+                entry: Err(CacheError::DownloadError("Scraping disabled".to_string())),
+            };
+        }
 
         if !is_valid_origin(&url, &self.scraping.allowed_origins) {
             return CachedFileEntry {

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -587,6 +587,7 @@ pub enum JsModuleErrorKind {
     MalformedSourcemap { url: String },
     MissingSourcemap,
     InvalidBase64Sourcemap,
+    ScrapingDisabled,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -17,5 +17,5 @@ raw_stacktraces:
         colno: 1
 errors:
   - abs_path: http//example.com/test.min.js
-    type: scraping_disabled
+    type: missing_source
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 342
+assertion_line: 346
 expression: response.unwrap()
 ---
 stacktraces:
@@ -17,5 +17,5 @@ raw_stacktraces:
         colno: 1
 errors:
   - abs_path: http//example.com/test.min.js
-    type: missing_source
+    type: scraping_disabled
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 186
+assertion_line: 190
 expression: response.unwrap()
 ---
 stacktraces:
@@ -39,5 +39,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=embedded.js.map"
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_source
+    type: scraping_disabled
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 98
+assertion_line: 102
 expression: response.unwrap()
 ---
 stacktraces:
@@ -101,5 +101,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=test.min.js.map"
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_source
+    type: scraping_disabled
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 146
+assertion_line: 150
 expression: response.unwrap()
 ---
 stacktraces:
@@ -39,5 +39,5 @@ raw_stacktraces:
           - //@ sourceMappingURL=file.min.js.map
 errors:
   - abs_path: "http://example.com/index.html"
-    type: missing_source
+    type: scraping_disabled
 


### PR DESCRIPTION
This adds a new js module error variant to return when scraping is disabled and refactors js symbolication a bit.

#skip-changelog