### PR TITLE
WIP: JS in-app logic

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -526,6 +526,12 @@ mod tests {
         assert_eq!(is_in_app(abs_path, filename), Some(false));
         assert_eq!(is_in_app_faithful(abs_path, filename), Some(false));
 
+        let abs_path = "webpack:///~/@sentry/browser/esm/helpers.js";
+        let filename = "~/@sentry/browser/esm/helpers.js";
+
+        assert_eq!(is_in_app(abs_path, filename), Some(false));
+        assert_eq!(is_in_app_faithful(abs_path, filename), Some(false));
+
         let abs_path = "webpack:///./@sentry/browser/esm/helpers.js";
         let filename = "./@sentry/browser/esm/helpers.js";
 

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -410,7 +410,7 @@ fn is_in_app(abs_path: &str, filename: &str) -> Option<bool> {
     if abs_path.starts_with("webpack:") {
         Some(filename.starts_with("./") && !filename.contains("/node_modules/"))
     } else if abs_path.starts_with("app:") {
-        Some(!NODE_MODULES_RE.is_match(filename))
+        Some(!filename.contains("/node_modules/"))
     } else if abs_path.contains("/node_modules/") {
         Some(false)
     } else {

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -652,6 +652,9 @@ pub struct JsFrame {
     #[serde(skip_serializing)]
     pub token_name: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_app: Option<bool>,
+
     #[serde(default, skip_serializing_if = "JsFrameData::is_empty")]
     pub data: JsFrameData,
 }

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 495
+assertion_line: 501
 expression: response.unwrap()
 ---
 stacktraces:
@@ -15,6 +15,7 @@ stacktraces:
         context_line: "    throw new Error(\"lets throw!\");"
         post_context:
           - "}"
+        in_app: true
         data:
           sourcemap: "app:///index.android.bundle.map"
 raw_stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 463
+assertion_line: 469
 expression: response.unwrap()
 ---
 stacktraces:
@@ -22,6 +22,7 @@ stacktraces:
           - "  function invoke(data) {"
           - "    var cb = null;"
           - "    if (data.failed) {"
+        in_app: true
         data:
           sourcemap: "app:///_next/server/pages/test.min.js.map"
 raw_stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 190
+assertion_line: 192
 expression: response.unwrap()
 ---
 stacktraces:
@@ -10,6 +10,7 @@ stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 283
         colno: 17
+        in_app: false
       - function: add
         filename: file1.js
         abs_path: "http://example.com/file1.js"
@@ -30,6 +31,7 @@ raw_stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 283
         colno: 17
+        in_app: false
       - filename: embedded.js
         abs_path: "http://example.com/embedded.js"
         lineno: 1

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 150
-expression: response.unwrap()
+assertion_line: 152
+expression: response
 ---
 stacktraces:
   - frames:
@@ -10,6 +10,7 @@ stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 283
         colno: 17
+        in_app: false
       - function: add
         filename: file1.js
         abs_path: "http://example.com/file1.js"
@@ -30,6 +31,7 @@ raw_stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 283
         colno: 17
+        in_app: false
       - filename: file.min.js
         abs_path: "http://example.com/file.min.js"
         lineno: 1


### PR DESCRIPTION
This adds an `in_app` field to `JsFrame`, as well as the logic to set it. `is_in_app_faithful` is a straightforward port of the monolith's logic for determining in-app-ness, while `is_in_app` rewrites it a little more sensibly.

I'm very unsure about the necessity of `NODE_MODULES_RE`. In `is_in_app` we already have checks for whether the `filename` or `abs_path` contain the string `/node_modules/`; `NODE_MODULES_RE` is almost the same thing, except it has a word boundary at the start instead of a `/`. Is this really a meaningful difference?

The fact that we scrutinize both the `filename` and the `abs_path` with no discernible rhyme or reason also bothers me. I wonder if this can be simplified so we only need to look at one or the other.

#skip-changelog