### PR TITLE
Improve symboliclirc "sources" documentation

### DIFF
--- a/crates/symbolicli/README.md
+++ b/crates/symbolicli/README.md
@@ -37,7 +37,26 @@ The available options are:
 * `project`: The default project for which to process events. This can be overridden with the `--project`
   command line option.
 * `sources`: A list of debug file sources that will be queried in addition to the project's uploaded
-  files.
+  files. See [Sources documentation](../../docs/api/index.md#sources).
+
+Below follows an example ~/.symboliclirc suitable for using symbolicli in offline mode to analyze
+Windows Minidumps:
+
+```
+cache_dir = "/home/username/.symbolicli/cache"
+
+[[sources]]
+id = "company-symbol-server"
+type = "http"
+url = "https://symbols.company.com/symbols-home"
+# Configure this to the layout and case sensitivity of your symbol server
+layout = { type = "symstore_index2", casing = "default" }
+
+[[sources]]
+id = "microsoft"
+type = "http"
+url = "https://msdl.microsoft.com/download/symbols"
+```
 
 # Logging
 You can control the level of logging output by passing the desired log level to the `--log-level` option.


### PR DESCRIPTION
The location of the documentation for debug file sources in the API
documentation is not obvious, so include a link. Also include an
example .symboliclirc file. It is useful to have a seed to start from
instead of an empty file.

#skip-changelog