### PR TITLE
Make source-context application optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add single-file ZipArchive support to `maybe_decompress_file` ([#1139](https://github.com/getsentry/symbolicator/pull/1139))
+- Make source-context application optional. ([#1173](https://github.com/getsentry/symbolicator/pull/1173))
 
 ### Fixes
 

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -78,6 +78,7 @@ impl SymbolicationActor {
             origin: StacktraceOrigin::AppleCrashReport,
             signal: None,
             stacktraces,
+            apply_source_context: true,
         };
 
         let mut system_info = SystemInfo {

--- a/crates/symbolicator-service/src/services/symbolication/mod.rs
+++ b/crates/symbolicator-service/src/services/symbolication/mod.rs
@@ -210,7 +210,7 @@ impl SymbolicationActor {
             let cache = self.sourcefiles_cache.as_ref();
             let futures = remote_sources.into_iter().map(|(url, frames)| async {
                 if let Ok(source) = cache
-                    .fetch_file(&scope, HttpRemoteFile::from_url(url).into())
+                    .fetch_file(scope, HttpRemoteFile::from_url(url).into())
                     .await
                 {
                     for frame in frames {

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -473,6 +473,7 @@ impl SymbolicationActor {
             origin: StacktraceOrigin::Minidump,
             signal: None,
             stacktraces,
+            apply_source_context: true,
         };
 
         Ok((request, minidump_state))

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -49,6 +49,7 @@ fn make_js_request(
             enabled: false,
             ..Default::default()
         },
+        apply_source_context: true,
     }
 }
 

--- a/crates/symbolicator-service/tests/integration/utils.rs
+++ b/crates/symbolicator-service/tests/integration/utils.rs
@@ -58,6 +58,7 @@ pub fn make_symbolication_request(
         origin: StacktraceOrigin::Symbolicate,
         sources: Arc::from(sources),
         scope: Default::default(),
+        apply_source_context: true,
     }
 }
 

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -124,6 +124,7 @@ async fn main() -> Result<()> {
                         signal: None,
                         sources,
                         origin: StacktraceOrigin::Symbolicate,
+                        apply_source_context: true,
 
                         stacktraces,
                         modules,

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -69,7 +69,7 @@ pub async fn symbolicate_frames(
             origin: StacktraceOrigin::Symbolicate,
             stacktraces: body.stacktraces,
             modules: body.modules.into_iter().map(From::from).collect(),
-            apply_source_context: options.apply_source_context,
+            apply_source_context: body.options.apply_source_context,
         },
         body.options,
     )?;

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -69,6 +69,7 @@ pub async fn symbolicate_frames(
             origin: StacktraceOrigin::Symbolicate,
             stacktraces: body.stacktraces,
             modules: body.modules.into_iter().map(From::from).collect(),
+            apply_source_context: options.apply_source_context,
         },
         body.options,
     )?;

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -104,7 +104,7 @@ pub enum SymbolicationResponse {
 ///
 /// These options control some features which control the symbolication and general request
 /// handling behaviour.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestOptions {
     /// Whether to return detailed information on DIF object candidates.
     ///
@@ -116,6 +116,23 @@ pub struct RequestOptions {
     /// for which extra information is returned for DIF objects.
     #[serde(default)]
     pub dif_candidates: bool,
+
+    /// Whether to apply source context for the stack frames.
+    #[serde(default = "default_apply_source_context")]
+    pub apply_source_context: bool,
+}
+
+fn default_apply_source_context() -> bool {
+    true
+}
+
+impl Default for RequestOptions {
+    fn default() -> Self {
+        Self {
+            dif_candidates: false,
+            apply_source_context: true,
+        }
+    }
 }
 
 /// Clears out all the information about the DIF object candidates in the modules list.
@@ -564,6 +581,7 @@ mod tests {
             origin: StacktraceOrigin::Symbolicate,
             sources: Arc::new([]),
             scope: Default::default(),
+            apply_source_context: true,
         };
 
         let request_id = service
@@ -603,6 +621,7 @@ mod tests {
                 debug_file: None,
                 debug_checksum: None,
             })],
+            apply_source_context: true,
         }
     }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -597,6 +597,7 @@ mod event {
             origin: StacktraceOrigin::Symbolicate,
             stacktraces,
             modules,
+            apply_source_context: true,
         })
     }
 


### PR DESCRIPTION
This exposes a new `apply_source_context` option on JS and Native symbolication requests that skips applying the source context. This is useful for symbolication requests coming from profiling, as that does not need any source context, and will throw it away immediately anyway.

Fixes #1105