### PR TITLE
Generate/override the `module` in JS symbolication

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -1038,7 +1038,7 @@ impl ArtifactFetcher {
 
 /// Strips the hostname (or leading tilde) from the `path` and returns the path following the
 /// hostname, with a leading `/`.
-fn strip_hostname(path: &str) -> &str {
+pub fn strip_hostname(path: &str) -> &str {
     if let Some(after_tilde) = path.strip_prefix('~') {
         return after_tilde;
     }

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -466,7 +466,7 @@ static CLEAN_MODULE_RE: Lazy<Regex> = Lazy::new(|| {
 /// * Trimming off the initial /
 /// * Trimming off the file extension
 /// * Removes off useless folder prefixes
-/// e.g. http://google.com/js/v1.0/foo/bar/baz.js -> foo/bar/baz
+/// e.g. `http://google.com/js/v1.0/foo/bar/baz.js` -> `foo/bar/baz`
 fn generate_module(abs_path: &str) -> String {
     let path = strip_hostname(abs_path);
     let mut path = path.split(&['#', '?']).next().unwrap_or(path);

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -632,6 +632,9 @@ pub struct JsFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+
     pub abs_path: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 523
+assertion_line: 524
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: onFailure
         filename: test.js
+        module: files/test
         abs_path: "http://localhost:<port>/files/test.js"
         lineno: 5
         colno: 11

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 433
+assertion_line: 438
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -1,12 +1,17 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+<<<<<<< HEAD
 assertion_line: 501
+=======
+assertion_line: 500
+>>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: foo
         filename: module.js
+        module: module
         abs_path: "app:///module.js"
         lineno: 2
         colno: 11

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -1,10 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-<<<<<<< HEAD
-assertion_line: 501
-=======
 assertion_line: 500
->>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -1,12 +1,17 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+<<<<<<< HEAD
 assertion_line: 469
+=======
+assertion_line: 468
+>>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: onFailure
         filename: test.js
+        module: server/pages/test
         abs_path: "app:///_next/server/pages/test.js"
         lineno: 5
         colno: 11

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -1,10 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-<<<<<<< HEAD
-assertion_line: 469
-=======
 assertion_line: 468
->>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 367
+assertion_line: 376
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 323
+assertion_line: 328
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: add
         filename: file1.js
+        module: file1
         abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9
@@ -20,6 +21,7 @@ stacktraces:
           sourcemap: "http://example.com/indexed.min.js.map"
       - function: multiply
         filename: file2.js
+        module: file2
         abs_path: "http://example.com/file2.js"
         lineno: 3
         colno: 9

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 243
+assertion_line: 248
 expression: response.unwrap()
 ---
 stacktraces:
   - frames:
       - function: "<unknown>"
         filename: /test.js
+        module: test
         abs_path: "http://example.com/test.js"
         lineno: 1
         colno: 1

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+assertion_line: 408
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 346
+assertion_line: 347
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 152
+assertion_line: 222
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,10 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-<<<<<<< HEAD
-assertion_line: 192
-=======
 assertion_line: 191
->>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+<<<<<<< HEAD
 assertion_line: 192
+=======
+assertion_line: 191
+>>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 expression: response.unwrap()
 ---
 stacktraces:
@@ -13,6 +17,7 @@ stacktraces:
         in_app: false
       - function: add
         filename: file1.js
+        module: file1
         abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 102
+assertion_line: 103
 expression: response.unwrap()
 ---
 stacktraces:
@@ -12,6 +12,7 @@ stacktraces:
         colno: 7
       - function: test
         filename: test.js
+        module: test
         abs_path: "http://example.com/test.js"
         lineno: 20
         colno: 5
@@ -31,6 +32,7 @@ stacktraces:
           sourcemap: "http://example.com/test.min.js.map"
       - function: invoke
         filename: test.js
+        module: test
         abs_path: "http://example.com/test.js"
         lineno: 15
         colno: 5
@@ -51,6 +53,7 @@ stacktraces:
           sourcemap: "http://example.com/test.min.js.map"
       - function: onFailure
         filename: test.js
+        module: test
         abs_path: "http://example.com/test.js"
         lineno: 5
         colno: 11

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 275
+assertion_line: 280
 expression: response.unwrap()
 ---
 stacktraces:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-<<<<<<< HEAD
-assertion_line: 152
-expression: response
-=======
 assertion_line: 151
 expression: response.unwrap()
->>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 ---
 stacktraces:
   - frames:

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,7 +1,12 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
+<<<<<<< HEAD
 assertion_line: 152
 expression: response
+=======
+assertion_line: 151
+expression: response.unwrap()
+>>>>>>> cc4280b (Generate/override the `module` in JS symbolication)
 ---
 stacktraces:
   - frames:
@@ -13,6 +18,7 @@ stacktraces:
         in_app: false
       - function: add
         filename: file1.js
+        module: file1
         abs_path: "http://example.com/file1.js"
         lineno: 3
         colno: 9


### PR DESCRIPTION
The `module` might also be set from the SDK side, as is done in react-native.

However when applying sourcemaps, we want to override that with whatever sanitized `module` we get out of the source file path.

#skip-changelog