### PR TITLE
fix(js): Fix some bugs in in_app logic

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -239,10 +239,7 @@ async fn symbolicate_js_frame(
             .map(|base| join_paths(base, &filename))
             .unwrap_or_else(|| filename.clone());
 
-        let in_app = is_in_app(&frame.abs_path, &filename);
-        if in_app.is_some() {
-            frame.in_app = in_app;
-        }
+        frame.in_app = is_in_app(&frame.abs_path, &filename);
 
         if filename.starts_with("webpack:") {
             filename = fixup_webpack_filename(&filename);


### PR DESCRIPTION
* Correctly detect cases where filenames begin with `node_modules/`
* Always overwrite the existing `in_app` field if the new value is `Some`

#skip-changelog