### PR TITLE
fix(js): Make sentry source non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Allow symbolicli to connect to reserved IPs ([#1165](https://github.com/getsentry/symbolicator/pull/1165))
+- JS symbolication now requires a Sentry source ([#1180](https://github.com/getsentry/symbolicator/pull/1180))
 
 ## 23.4.0
 

--- a/crates/symbolicator/src/endpoints/symbolicate_js.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_js.rs
@@ -16,8 +16,7 @@ use super::ResponseError;
 
 #[derive(Serialize, Deserialize)]
 pub struct JsSymbolicationRequestBody {
-    #[serde(default)]
-    pub source: Option<SentrySourceConfig>,
+    pub source: SentrySourceConfig,
     #[serde(default)]
     pub stacktraces: Vec<JsStacktrace>,
     #[serde(default)]
@@ -84,7 +83,7 @@ pub async fn handle_symbolication_request(
 
     let request_id = service.symbolicate_js_stacktraces(SymbolicateJsStacktraces {
         scope: params.scope,
-        source: Arc::new(source.unwrap()),
+        source: Arc::new(source),
         stacktraces,
         modules,
         release,


### PR DESCRIPTION
Fixes #1177.