### PR TITLE
Work around "async " abs_path

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -226,9 +226,14 @@ impl SourceMapLookup {
     }
 
     /// Prepares the modules for processing
-    pub fn prepare_modules(&mut self, stacktraces: &[JsStacktrace]) {
+    pub fn prepare_modules(&mut self, stacktraces: &mut [JsStacktrace]) {
         for stacktrace in stacktraces {
-            for frame in &stacktrace.frames {
+            for frame in &mut stacktrace.frames {
+                // NOTE: some older JS SDK versions did not correctly strip a leading `async `
+                // prefix from the `abs_path`, which we will work around here.
+                if let Some(abs_path) = frame.abs_path.strip_prefix("async ") {
+                    frame.abs_path = abs_path.to_owned();
+                }
                 let abs_path = &frame.abs_path;
                 if self.modules_by_abs_path.contains_key(abs_path) {
                     continue;

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -74,7 +74,7 @@ impl SymbolicationActor {
         let mut raw_stacktraces = std::mem::take(&mut request.stacktraces);
         let apply_source_context = request.apply_source_context;
         let mut lookup = SourceMapLookup::new(self.sourcemaps.clone(), request);
-        lookup.prepare_modules(&raw_stacktraces);
+        lookup.prepare_modules(&mut raw_stacktraces[..]);
 
         let mut unsymbolicated_frames = 0;
         let mut missing_sourcescontent = 0;

--- a/crates/symbolicator-service/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-service/tests/integration/sourcemap.rs
@@ -84,7 +84,7 @@ async fn test_sourcemap_expansion() {
         "colno": 183,
         "function": "i"
     }, {
-        "abs_path": "http://example.com/test.min.js",
+        "abs_path": "async http://example.com/test.min.js",
         "filename": "test.min.js",
         "lineno": 1,
         "colno": 136,


### PR DESCRIPTION
Older versions of the JS SDK would not correctly strip the `async ` prefix, and that would then end up in the `abs_path`. We can easily work around that and be able to symbolicate such frames.

#skip-changelog