### PR TITLE
fix(symbolicli): Take raw stacktraces from event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Allow symbolicli to connect to reserved IPs ([#1165](https://github.com/getsentry/symbolicator/pull/1165))
 - JS symbolication now requires a Sentry source ([#1180](https://github.com/getsentry/symbolicator/pull/1180))
+- `symbolicli` now uses the right stacktraces for symbolication. ([#1189](https://github.com/getsentry/symbolicator/pull/1189))
 
 ### Dependencies
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -560,13 +560,13 @@ mod event {
 
         let mut stacktraces = vec![];
         if let Some(mut excs) = exception.map(|excs| excs.values) {
-            stacktraces.extend(excs.iter_mut().filter_map(|exc| exc.stacktrace.take()));
+            stacktraces.extend(excs.iter_mut().filter_map(|exc| exc.raw_stacktrace.take()));
         }
         if let Some(mut threads) = threads.map(|threads| threads.values) {
             stacktraces.extend(
                 threads
                     .iter_mut()
-                    .filter_map(|thread| thread.stacktrace.take()),
+                    .filter_map(|thread| thread.raw_stacktrace.take()),
             );
         }
 
@@ -622,7 +622,7 @@ mod event {
 
     #[derive(Debug, Deserialize)]
     struct Exception {
-        stacktrace: Option<Stacktrace>,
+        raw_stacktrace: Option<Stacktrace>,
     }
 
     #[derive(Debug, Deserialize)]
@@ -632,7 +632,7 @@ mod event {
 
     #[derive(Debug, Deserialize)]
     struct Thread {
-        stacktrace: Option<Stacktrace>,
+        raw_stacktrace: Option<Stacktrace>,
     }
 
     #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Since the purpose of `symbolicli` is to run symbolication, we want to take the `raw_stacktrace`s from events and not the already symbolicated `stacktrace`s.