### PR TITLE
Tighten up download related timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add single-file ZipArchive support to `maybe_decompress_file` ([#1139](https://github.com/getsentry/symbolicator/pull/1139))
 - Make source-context application optional. ([#1173](https://github.com/getsentry/symbolicator/pull/1173))
 - `symbolicli` now supports JS symbolication. ([#1186](https://github.com/getsentry/symbolicator/pull/1186))
+- Tighten up download related timeouts and introduce new `head_timeout`. ([#1190](https://github.com/getsentry/symbolicator/pull/1190))
 
 ### Fixes
 

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -515,7 +515,7 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             // Allow a 4MB/s connection to download 2GB without timing out
             max_download_timeout: Duration::from_secs(315),
-            connect_timeout: Duration::from_millis(500),
+            connect_timeout: Duration::from_secs(1),
             head_timeout: Duration::from_secs(5),
             // Allow a 4MB/s connection to download 1GB without timing out
             streaming_timeout: Duration::from_secs(250),

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -385,12 +385,19 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub max_download_timeout: Duration,
 
-    /// The timeout for the initial HEAD request in a download.
+    /// The timeout for establishing a connection in a download.
     ///
     /// This timeout applies to each individual attempt to establish a
     /// connection with a symbol source if retries take place.
     #[serde(with = "humantime_serde")]
     pub connect_timeout: Duration,
+
+    /// The timeout for the initial HEAD request in a download.
+    ///
+    /// This timeout applies to each individual attempt to establish a
+    /// connection with a symbol source if retries take place.
+    #[serde(with = "humantime_serde")]
+    pub head_timeout: Duration,
 
     /// The time window for the host deny list.
     ///
@@ -508,7 +515,8 @@ impl Default for Config {
             connect_to_reserved_ips: false,
             // Allow a 4MB/s connection to download 2GB without timing out
             max_download_timeout: Duration::from_secs(315),
-            connect_timeout: Duration::from_secs(15),
+            connect_timeout: Duration::from_millis(500),
+            head_timeout: Duration::from_secs(5),
             // Allow a 4MB/s connection to download 1GB without timing out
             streaming_timeout: Duration::from_secs(250),
             deny_list_time_window: Duration::from_secs(60),

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -305,7 +305,7 @@ impl DownloadService {
             ));
         }
 
-        let timeout = self.timeouts.max_download_timeout;
+        let timeout = self.timeouts.max_download;
         let slf = self.clone();
         let job = async move { slf.dispatch_download(&source, &destination).await };
         let job = CancelOnDrop::new(self.runtime.spawn(job.bind_hub(::sentry::Hub::current())));
@@ -498,7 +498,7 @@ async fn download_reqwest(
 ) -> CacheEntry {
     let request = builder.send();
 
-    let timeout = timeouts.head_timeout;
+    let timeout = timeouts.head;
     let request = tokio::time::timeout(timeout, request);
     let request = measure_download_time(source.source_metric_key(), request);
 
@@ -515,8 +515,7 @@ async fn download_reqwest(
             .and_then(|hv| hv.to_str().ok())
             .and_then(|s| s.parse::<i64>().ok());
 
-        let timeout =
-            content_length.map(|cl| content_length_timeout(cl, timeouts.streaming_timeout));
+        let timeout = content_length.map(|cl| content_length_timeout(cl, timeouts.streaming));
         let stream = response.bytes_stream().map_err(CacheError::from);
 
         download_stream(source, stream, destination, timeout).await

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -119,7 +119,7 @@ impl S3Downloader {
         let request = client.get_object().bucket(&bucket).key(&key).send();
 
         let source = RemoteFile::from(file_source);
-        let timeout = self.timeouts.head_timeout;
+        let timeout = self.timeouts.head;
         let request = tokio::time::timeout(timeout, request);
         let request = super::measure_download_time(source.source_metric_key(), request);
 
@@ -183,7 +183,7 @@ impl S3Downloader {
 
         let timeout = Some(content_length_timeout(
             response.content_length(),
-            self.timeouts.streaming_timeout,
+            self.timeouts.streaming,
         ));
 
         let stream = if response.content_length == 0 {

--- a/crates/symbolicator-service/src/utils/http.rs
+++ b/crates/symbolicator-service/src/utils/http.rs
@@ -44,22 +44,22 @@ fn is_external_ip(ip: std::net::IpAddr) -> bool {
 #[derive(Copy, Clone, Debug)]
 pub struct DownloadTimeouts {
     /// The timeout for establishing a connection.
-    pub connect_timeout: Duration,
+    pub connect: Duration,
     /// The timeout for receiving the first headers.
-    pub head_timeout: Duration,
+    pub head: Duration,
     /// An adaptive timeout per 1GB of content.
-    pub streaming_timeout: Duration,
+    pub streaming: Duration,
     /// Global timeout for one download.
-    pub max_download_timeout: Duration,
+    pub max_download: Duration,
 }
 
 impl DownloadTimeouts {
     pub fn from_config(config: &Config) -> Self {
         Self {
-            connect_timeout: config.connect_timeout,
-            head_timeout: config.head_timeout,
-            streaming_timeout: config.streaming_timeout,
-            max_download_timeout: config.max_download_timeout,
+            connect: config.connect_timeout,
+            head: config.head_timeout,
+            streaming: config.streaming_timeout,
+            max_download: config.max_download_timeout,
         }
     }
 }
@@ -67,10 +67,10 @@ impl DownloadTimeouts {
 impl Default for DownloadTimeouts {
     fn default() -> Self {
         Self {
-            connect_timeout: Duration::from_millis(500),
-            head_timeout: Duration::from_secs(5),
-            streaming_timeout: Duration::from_secs(250),
-            max_download_timeout: Duration::from_secs(315),
+            connect: Duration::from_millis(500),
+            head: Duration::from_secs(5),
+            streaming: Duration::from_secs(250),
+            max_download: Duration::from_secs(315),
         }
     }
 }
@@ -86,8 +86,8 @@ pub fn create_client(
         builder = builder.ip_filter(is_external_ip);
     }
     builder = builder
-        .connect_timeout(timeouts.connect_timeout)
-        .timeout(timeouts.max_download_timeout)
+        .connect_timeout(timeouts.connect)
+        .timeout(timeouts.max_download)
         .pool_idle_timeout(Duration::from_secs(30));
 
     builder.build().unwrap()


### PR DESCRIPTION
Introduces a new `DownloadTimeouts` struct to group all the download-related timeouts. Introduces a new distinction between connect/HEAD timeout, and feeds the connect timeout and the global download timeout directly to reqwest.