### PR TITLE
meta: Remove outdated time dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,6 @@ dependencies = [
 [[package]]
 name = "apple-crash-report-parser"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a93af7a900a542a9c20da77e19dc81f374e8f42a2969d833c8766692d5f291"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -268,7 +266,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.21",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -412,7 +410,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
- "time 0.3.21",
+ "time",
  "tracing",
 ]
 
@@ -551,7 +549,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -929,12 +927,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1669,7 +1664,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1695,7 +1690,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2447,7 +2442,7 @@ dependencies = [
  "range-map",
  "scroll",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tracing",
  "uuid",
 ]
@@ -2535,7 +2530,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -3142,7 +3137,7 @@ dependencies = [
  "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -3731,7 +3726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.21",
+ "time",
  "url",
  "uuid",
 ]
@@ -3902,7 +3897,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -4681,17 +4676,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
@@ -4997,7 +4981,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.21",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5254,12 +5238,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -18,7 +18,7 @@ aws-smithy-http = "0.52.0"
 aws-types = { version = "0.52.0", features = ["hardcoded-credentials"] }
 backtrace = "0.3.65"
 cadence = "0.29.0"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "serde", "std"]  }
 data-url = "0.2.0"
 filetime = "0.2.16"
 flate2 = "1.0.23"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.57"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "serde", "std"]  }
 console = "0.15.0"
 lazy_static = "1.4.0"
 rayon = "1.5.2"


### PR DESCRIPTION
The `time` 0.1.45 dependency was pulled in by way of a `chrono` default feature that we don't actually use.

NB: The outdated `time` version is also pulled in via `apple-crash-report-parser`. This is getting fixed in https://github.com/getsentry/apple-crash-report-parser/pull/17.

Part of #634.