### PR TITLE
ref: Make JsFrame::lineno non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- JsFrame::lineno is no longer optional ([#1203](https://github.com/getsentry/symbolicator/pull/1203))
+
 ## 23.5.1
 
 - No documented changes.

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -579,7 +579,7 @@ pub struct CompletedSymbolicationResponse {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum JsModuleErrorKind {
-    InvalidLocation { line: Option<u32>, col: Option<u32> },
+    InvalidLocation { line: u32, col: Option<u32> },
     InvalidAbsPath,
     NoColumn,
     MissingSourceContent { source: String, sourcemap: String },
@@ -596,10 +596,8 @@ impl fmt::Display for JsModuleErrorKind {
             JsModuleErrorKind::InvalidLocation { line, col } => {
                 write!(f, "Invalid source location")?;
                 match (line, col) {
-                    (None, None) => (),
-                    (None, Some(c)) => write!(f, ": col:{c}")?,
-                    (Some(l), None) => write!(f, ": line:{l}")?,
-                    (Some(l), Some(c)) => write!(f, ": line:{l}, col:{c}")?,
+                    (l, None) => write!(f, ": line:{l}")?,
+                    (l, Some(c)) => write!(f, ": line:{l}, col:{c}")?,
                 }
                 Ok(())
             }
@@ -669,8 +667,7 @@ pub struct JsFrame {
 
     pub abs_path: String,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lineno: Option<u32>,
+    pub lineno: u32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub colno: Option<u32>,

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -668,7 +668,7 @@ mod event {
             filename: value.filename,
             module: value.module,
             abs_path: value.abs_path?,
-            lineno: value.lineno,
+            lineno: value.lineno?,
             colno: value.colno,
             pre_context: value.pre_context,
             context_line: value.context_line,

--- a/crates/symbolicli/src/output.rs
+++ b/crates/symbolicli/src/output.rs
@@ -234,8 +234,7 @@ fn print_compact_js(mut response: CompletedJsSymbolicationResponse) {
         let filename = filename.unwrap_or_default();
         row.add_cell(cell!(filename));
 
-        let line = lineno.map(|line| line.to_string()).unwrap_or_default();
-        row.add_cell(cell!(line));
+        row.add_cell(cell!(lineno));
 
         let col = colno.map(|col| col.to_string()).unwrap_or_default();
         row.add_cell(cell!(col));
@@ -285,8 +284,10 @@ fn print_pretty_js(mut response: CompletedJsSymbolicationResponse) {
             table.add_row(row![r->"  File:", name]);
         }
 
-        if let Some((line, col)) = lineno.zip(*colno) {
-            table.add_row(row![r->"  Line/Column:", format!("{line}:{col}")]);
+        if let Some(col) = *colno {
+            table.add_row(row![r->"  Line/Column:", format!("{lineno}:{col}")]);
+        } else {
+            table.add_row(row![r->"  Line:", format!("{lineno}")]);
         }
 
         table.add_empty_row();


### PR DESCRIPTION
Sentry already [filters out](https://github.com/getsentry/sentry/blob/3d1a915e3a7416106666ee0022c27fac487d5d41/src/sentry/lang/javascript/processing.py#L148) frames without line numbers before sending them to Symbolicator. Therefore, there's no reason for the `lineno` field to be optional. Unfortunately we still need to check if the line is 0.