### PR TITLE
ref(js): Return error if no sourcemap is available

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -198,7 +198,7 @@ async fn symbolicate_js_frame(
             Err(_) => return Err(JsModuleErrorKind::MissingSourcemap),
         },
         // In case it's just a source file, with no sourcemap reference or any debug id, we bail.
-        None => return Ok(raw_frame.clone()),
+        None => return Err(JsModuleErrorKind::MissingSourcemap),
     };
 
     let mut frame = raw_frame.clone();

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 222
+assertion_line: 237
 expression: response.unwrap()
 ---
 stacktraces:
@@ -59,4 +59,7 @@ raw_stacktraces:
           - w
           - o
           - r
+errors:
+  - abs_path: "http://example.com/foo.js"
+    type: missing_sourcemap
 


### PR DESCRIPTION
This returns a `MissingSourcemap` error if no sourcemap information is available for a frame at all. Currently we would only return an error if the download failed.

#skip-changelog