### PR TITLE
ref: Migrate from structops to clap for all CLIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,17 +219,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -957,24 +937,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "4.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -983,24 +948,24 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.16",
@@ -1008,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cmake"
@@ -1239,7 +1204,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -1386,7 +1351,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1752,27 +1717,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3076,30 +3023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,10 +3036,10 @@ name = "process-event"
 version = "23.5.2"
 dependencies = [
  "anyhow",
+ "clap",
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "symbolic-common",
 ]
 
@@ -4042,39 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "subtle"
@@ -4371,6 +4264,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-server",
+ "clap",
  "console",
  "futures",
  "hostname",
@@ -4380,7 +4274,6 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "structopt",
  "symbolic",
  "symbolicator-crash",
  "symbolicator-service",
@@ -4482,12 +4375,12 @@ name = "symbolicator-stress"
 version = "23.5.2"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
  "humantime",
  "serde",
  "serde_json",
  "serde_yaml",
- "structopt",
  "symbolicator-service",
  "symbolicator-test",
  "tempfile",
@@ -4518,7 +4411,7 @@ name = "symbolicli"
 version = "23.5.2"
 dependencies = [
  "anyhow",
- "clap 4.2.7",
+ "clap",
  "dirs",
  "prettytable-rs",
  "reqwest",
@@ -4542,13 +4435,13 @@ version = "23.5.2"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "console",
  "lazy_static",
  "rayon",
  "regex",
  "serde",
  "serde_json",
- "structopt",
  "symbolic",
  "walkdir",
  "zip",
@@ -4638,15 +4531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a6da51de149453f5c43fa67d5e73cccd75b3c5727a38a2f18c5f3c47f2db582"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -5129,12 +5013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,12 +5094,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -5338,8 +5210,8 @@ name = "wasm-split"
 version = "23.5.2"
 dependencies = [
  "anyhow",
+ "clap",
  "hex",
- "structopt",
  "uuid",
  "wasmbin",
 ]

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.57"
+clap = { version = "4.3.2", features = ["derive"] }
 reqwest = { version = "0.11.0", features = ["blocking", "json", "multipart", "trust-dns"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-structopt = "0.3.21"
 symbolic-common = "12.1.5"

--- a/crates/process-event/src/main.rs
+++ b/crates/process-event/src/main.rs
@@ -6,9 +6,9 @@ use std::io::{Read, Seek};
 use std::path::PathBuf;
 
 use ::reqwest::blocking::multipart;
+use clap::Parser;
 use reqwest::blocking as reqwest;
 use serde_json::{to_string, Map, Value};
-use structopt::StructOpt;
 use symbolic_common::split_path;
 
 #[path = "../../symbolicator-service/src/utils/hex.rs"]
@@ -17,7 +17,7 @@ mod hex;
 use hex::HexValue;
 
 /// Runs Minidumps or Sentry Events through Symbolicator.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Cli {
     /// Path to the input Minidump or Event JSON.
     input: PathBuf,
@@ -25,15 +25,15 @@ struct Cli {
     /// The URL of the Symbolicator to use.
     ///
     /// Defaults to `http://127.0.0.1:3021` if not provided.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     symbolicator: Option<String>,
 
     /// Whether to include DIF candidate information.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     dif_candidates: bool,
 
     /// Pretty-print the crashing thread in a human readable format.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pretty: bool,
 }
 
@@ -43,7 +43,7 @@ fn main() -> anyhow::Result<()> {
         symbolicator,
         dif_candidates,
         pretty,
-    } = Cli::from_args();
+    } = Cli::parse();
 
     let client = reqwest::Client::new();
     let symbolicator = symbolicator.as_deref().unwrap_or("http://127.0.0.1:3021");

--- a/crates/symbolicator-stress/Cargo.toml
+++ b/crates/symbolicator-stress/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.57"
+clap = { version = "4.3.2", features = ["derive"] }
 futures = "0.3.12"
 humantime = "2.0.1"
 symbolicator-service = { path = "../symbolicator-service" }
@@ -14,6 +15,5 @@ serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
 serde_yaml = "0.9.14"
 tempfile = "3.2.0"
-structopt = "0.3.21"
 serde_json = "1.0.81"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use humantime::parse_duration;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use structopt::StructOpt;
 
 use symbolicator_service::config::Config as SymbolicatorConfig;
 use symbolicator_service::services::download::SourceConfig;
@@ -64,24 +64,24 @@ enum ParsedPayload {
 }
 
 /// Command line interface parser.
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Cli {
     /// Path to your configuration file.
-    #[structopt(long = "config", short = "c", value_name = "FILE")]
+    #[arg(long = "config", short = 'c', value_name = "FILE")]
     config: Option<PathBuf>,
 
     /// Path to the workload definition file.
-    #[structopt(long = "workloads", short = "w", value_name = "FILE")]
+    #[arg(long = "workloads", short = 'w', value_name = "FILE")]
     workloads: PathBuf,
 
     /// Duration of the stresstest.
-    #[structopt(long = "duration", short = "d", parse(try_from_str = parse_duration))]
+    #[arg(long = "duration", short = 'd', value_parser = parse_duration)]
     duration: Duration,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
 
     // parse configs
     let workloads_file =

--- a/crates/symbolicator-test/Cargo.toml
+++ b/crates/symbolicator-test/Cargo.toml
@@ -17,4 +17,4 @@ symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
 tokio = { version = "1.26.0", features = ["rt", "macros", "fs"] }
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }
-tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "local-time", "env-filter", "json"] }
+tracing-subscriber = { version = "0.3.17", features = ["tracing-log", "local-time", "env-filter", "json"] }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -13,13 +13,13 @@ https = ["axum-server/tls-rustls", "symbolicator-service/https"]
 anyhow = "1.0.57"
 axum = { version = "0.6.10", features = ["multipart"] }
 axum-server = "0.5.1"
+clap = { version = "4.3.2", features = ["derive"] }
 console = "0.15.0"
 futures = "0.3.12"
 hostname = "0.3.1"
 sentry = { version = "0.31.0", features = ["anyhow", "debug-images", "tracing", "tower", "tower-http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-structopt = "0.3.21"
 symbolic = "12.1.5"
 symbolicator-crash = { path = "../symbolicator-crash", optional = true }
 symbolicator-service = { path = "../symbolicator-service" }
@@ -34,7 +34,7 @@ thiserror = "1.0.31"
 tower-service = "0.3"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "local-time", "env-filter", "json"] }
+tracing-subscriber = { version = "0.3.17", features = ["tracing-log", "local-time", "env-filter", "json"] }
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::{arg, Parser};
 
 use symbolicator_service::caching;
 use symbolicator_service::metrics;
@@ -26,30 +26,30 @@ fn get_long_crate_version() -> &'static str {
 }
 
 /// Symbolicator commands.
-#[derive(StructOpt)]
-#[structopt(bin_name = "symbolicator")]
+#[derive(Parser)]
+#[command(bin_name = "symbolicator")]
 enum Command {
     /// Run the web server.
-    #[structopt(name = "run")]
+    #[command(name = "run")]
     Run,
 
     /// Clean local caches.
-    #[structopt(name = "cleanup")]
+    #[command(name = "cleanup")]
     Cleanup,
 }
 
 /// Command line interface parser.
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[command(
     version = get_crate_version(),
     long_version = get_long_crate_version(),
 )]
 struct Cli {
     /// Path to your configuration file.
-    #[structopt(long = "config", short = "c", global(true), value_name = "FILE")]
+    #[arg(long = "config", short = 'c', global(true), value_name = "FILE")]
     pub config: Option<PathBuf>,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
@@ -62,7 +62,7 @@ impl Cli {
 
 /// Runs the main application.
 pub fn execute() -> Result<()> {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
     let config = Config::get(cli.config()).context("failed loading config")?;
 
     let release = Some(env!("SYMBOLICATOR_RELEASE").into());

--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.66"
-clap = { version = "4.0.25", features = ["derive"] }
+clap = { version = "4.3.2", features = ["derive"] }
 dirs = "5.0.0"
 prettytable-rs = "0.10.0"
 reqwest = { version = "0.11.12", features = ["json"] }
@@ -21,5 +21,5 @@ tempfile = "3.3.0"
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
 toml = "0.7.1"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["tracing-log", "local-time", "env-filter", "json"] }
+tracing-subscriber = { version = "0.3.17", features = ["tracing-log", "local-time", "env-filter", "json"] }
 url = "2.3.1"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.57"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "serde", "std"]  }
+clap = { version = "4.3.2", features = ["derive"] }
 console = "0.15.0"
 lazy_static = "1.4.0"
 rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-structopt = "0.3.21"
 symbolic = { version = "12.1.5", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.57"
+clap = { version = "4.3.2", features = ["derive"] }
 hex = "0.4.2"
-structopt = "0.3.21"
 uuid = { version = "1.0.0", features = ["v4"] }
 wasmbin = "0.6.0"

--- a/crates/wasm-split/src/main.rs
+++ b/crates/wasm-split/src/main.rs
@@ -7,10 +7,10 @@
     clippy::all
 )]
 
+use clap::Parser;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
-use structopt::StructOpt;
 use uuid::Uuid;
 use wasmbin::sections::{CustomSection, Section};
 use wasmbin::Module;
@@ -25,34 +25,34 @@ use wasmbin::Module;
 /// calculate offsets.
 ///
 /// This prints the embedded build_id in hexadecimal format to stdout.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Cli {
     /// path to the wasm file
     input: PathBuf,
     /// path to the output wasm file.
     ///
     /// If not provided the same file is modified in place.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     out: Option<PathBuf>,
     /// path to the output debug wasm file.
     ///
     /// If not provided the debug data stays in the input file.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     debug_out: Option<PathBuf>,
     /// strip the file of debug info.
-    #[structopt(long)]
+    #[arg(long)]
     strip: bool,
     /// strip the file of symbol names.
-    #[structopt(long)]
+    #[arg(long)]
     strip_names: bool,
     /// do not print the build id.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     quiet: bool,
     /// explicit build id to provide
-    #[structopt(long)]
+    #[arg(long)]
     build_id: Option<Uuid>,
     /// URL for browsers to fetch the separate dwarf debug symbol file
-    #[structopt(long)]
+    #[arg(long)]
     external_dwarf_url: Option<String>,
 }
 
@@ -69,7 +69,7 @@ fn is_strippable_section(section: &Section, strip_names: bool) -> bool {
 }
 
 fn main() -> anyhow::Result<()> {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
 
     let mut module = Module::decode_from(BufReader::new(File::open(&cli.input)?))?;
     let mut should_write_main_module = false;


### PR DESCRIPTION
This fixes RUSTSEC issue that has been a long time overdue.
As a nice side-effect, we have a way better and colored help and error outputs.

Closes https://github.com/getsentry/symbolicator/issues/871

Pre/post output logs generated with:

```bash
for bin in {process-event,symbolicator-stress,symbolicator,symbolicli,symsorter,wasm-split}; do cargo run --package $bin -- --help >> post.out 2>&1; done;
```

[pre.log](https://github.com/getsentry/symbolicator/files/11664677/pre.log)
[post.log](https://github.com/getsentry/symbolicator/files/11664676/post.log)

#skip-changelog