### PR TITLE
ci: Make docs publishing independent from the releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,6 @@ minVersion: 0.23.1
 changelogPolicy: auto
 targets:
   - name: github
-  - name: gh-pages
   - name: registry
     apps:
       app:symbolicator:
@@ -28,7 +27,6 @@ targets:
     target: getsentry/symbolicator
     targetFormat: '{{{target}}}:latest'
 requireNames:
-  - /^gh-pages.zip$/
   - /^symbolicator-Darwin-universal$/
   - /^symbolicator-Linux-x86_64$/
   - /^symbolicator-Linux-x86_64-debug.zip$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,30 +124,3 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: target/release/*-Windows-x86_64.exe
-
-  docs:
-    name: Build Docs
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      - name: Setup python dependencies
-        run: pip install --upgrade mkdocs mkdocs-material pygments
-
-      - name: Build Docs
-        run: |
-          mkdocs build
-          touch site/.nojekyll
-          cd site && zip -r gh-pages .
-
-      - uses: actions/upload-artifact@v3.1.1
-        with:
-          name: ${{ github.sha }}
-          path: site/gh-pages.zip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Setup python dependencies
+        run: pip install --upgrade mkdocs mkdocs-material pygments
+
+      - name: Build Docs
+        run: |
+          mkdocs build
+          touch site/.nojekyll
+
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,6 @@ docserver: .venv/bin/python
 	.venv/bin/mkdocs serve
 .PHONY: doc
 
-travis-upload-docs: docs
-	cd site && zip -r gh-pages .
-	zeus upload -t "application/zip+docs" site/gh-pages.zip \
-		|| [[ ! "$(TRAVIS_BRANCH)" =~ ^release/ ]]
-.PHONY: travis-upload-docs
-
 # Style checking
 
 style:


### PR DESCRIPTION
I'm about 76% positive that it'll work on the first try.

#skip-changelog