### PR TITLE
Update compression level flag to be a u8 everywhere.

### DIFF
--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -51,7 +51,7 @@ struct Cli {
         action = clap::ArgAction::Count,
         value_parser = clap::value_parser!(u8)
     )]
-    pub compression_level: usize,
+    pub compression_level: u8,
 
     /// Ignore broken archives.
     #[arg(long = "ignore-errors", short = 'I')]

--- a/crates/symsorter/src/config.rs
+++ b/crates/symsorter/src/config.rs
@@ -44,5 +44,5 @@ pub struct SortConfig {
 
     /// If enabled debug symbols will be zstd compressed
     /// (repeat to increase compression)
-    pub compression_level: usize,
+    pub compression_level: u8,
 }


### PR DESCRIPTION
 Fixes a panic when running symsorter, [Issue 1215](https://github.com/getsentry/symbolicator/issues/1215)

#skip-changelog