### PR TITLE
feat(js): Track whether frames are symbolicated

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -266,6 +266,8 @@ async fn symbolicate_js_frame(
     frame.lineno = token.line().saturating_add(1);
     frame.colno = Some(token.column().saturating_add(1));
 
+    frame.data.symbolicated = true;
+
     if !should_apply_source_context {
         return Ok(frame);
     }

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -214,6 +214,10 @@ async fn symbolicate_js_frame(
             col: Some(col),
         })?;
 
+    // We consider the frame successfully symbolicated if we can resolve the minified source position
+    // to a token.
+    frame.data.symbolicated = true;
+
     // Store the resolved token name, which can be used for function name resolution in next frame.
     // Refer to https://blog.sentry.io/2022/11/30/how-we-made-javascript-stack-traces-awesome/
     // for more details about "caller naming".
@@ -265,8 +269,6 @@ async fn symbolicate_js_frame(
 
     frame.lineno = token.line().saturating_add(1);
     frame.colno = Some(token.column().saturating_add(1));
-
-    frame.data.symbolicated = true;
 
     if !should_apply_source_context {
         return Ok(frame);

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -697,6 +697,7 @@ pub struct JsFrameData {
     pub sourcemap: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolved_with: Option<ResolvedWith>,
+    pub symbolicated: bool,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -26,6 +26,7 @@ stacktraces:
         data:
           sourcemap: "http://localhost:<port>/files/app.js.map"
           resolved_with: scraping
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - abs_path: "http://localhost:<port>/files/app.js"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -20,6 +20,7 @@ stacktraces:
         data:
           sourcemap: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js.map
           resolved_with: debug-id
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: Object.<anonymous>

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -20,6 +20,7 @@ stacktraces:
         data:
           sourcemap: "app:///index.android.bundle.map"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - abs_path: "app:///index.android.bundle"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -27,6 +27,7 @@ stacktraces:
         data:
           sourcemap: "app:///_next/server/pages/test.min.js.map"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: e

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -20,6 +20,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/indexed.min.js.map"
           resolved_with: release-old
+          symbolicated: true
       - function: multiply
         filename: file2.js
         module: file2
@@ -39,6 +40,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/indexed.min.js.map"
           resolved_with: release-old
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - filename: indexed.min.js

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -15,6 +15,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test.min.js"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - filename: test.js

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -26,6 +26,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/embedded.js.map"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -31,6 +31,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test.min.js.map"
           resolved_with: release
+          symbolicated: true
       - function: invoke
         filename: test.js
         module: test
@@ -53,6 +54,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test.min.js.map"
           resolved_with: release
+          symbolicated: true
       - function: onFailure
         filename: test.js
         module: test
@@ -74,6 +76,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test.min.js.map"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: produceStack

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -18,6 +18,7 @@ stacktraces:
         data:
           sourcemap: "app:///nofiles.js.map"
           resolved_with: release
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - abs_path: "app:///nofiles.js"

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -26,6 +26,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/file.min.js.map"
           resolved_with: release-old
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: "function: \"HTMLDocument.<anonymous>\""

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
@@ -27,6 +27,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test1.min.js.map"
           resolved_with: release-old
+          symbolicated: true
       - function: test
         filename: "./src/node_modules/components/CampaignContent.tsx"
         module: src/node_modules/components/CampaignContent
@@ -49,6 +50,7 @@ stacktraces:
         data:
           sourcemap: "http://example.com/test2.min.js.map"
           resolved_with: release-old
+          symbolicated: true
 raw_stacktraces:
   - frames:
       - function: i


### PR DESCRIPTION
This adds a boolean field `symbolicated` to `JsFrame` so that we can check at a glance in Sentry if the frame was successfully symbolicated.

#skip-changelog