### PR TITLE
Order pipelines and use a single gocd group

### DIFF
--- a/gocd/generated-pipelines/symbolicator-next-monitor.yaml
+++ b/gocd/generated-pipelines/symbolicator-next-monitor.yaml
@@ -1,9 +1,10 @@
 format_version: 10
 pipelines:
   deploy-symbolicator-next-monitor:
+    display_order: 2
     environment_variables:
       SENTRY_REGION: monitor
-    group: symbolicator-next-regions
+    group: symbolicator-next
     lock_behavior: unlockWhenFinished
     materials:
       deploy-symbolicator-next-us-pipeline-complete:

--- a/gocd/generated-pipelines/symbolicator-next-us.yaml
+++ b/gocd/generated-pipelines/symbolicator-next-us.yaml
@@ -1,9 +1,10 @@
 format_version: 10
 pipelines:
   deploy-symbolicator-next-us:
+    display_order: 1
     environment_variables:
       SENTRY_REGION: us
-    group: symbolicator-next-regions
+    group: symbolicator-next
     lock_behavior: unlockWhenFinished
     materials:
       deploy-symbolicator-next-pipeline-complete:

--- a/gocd/generated-pipelines/symbolicator-next.yaml
+++ b/gocd/generated-pipelines/symbolicator-next.yaml
@@ -1,6 +1,7 @@
 format_version: 10
 pipelines:
   deploy-symbolicator-next:
+    display_order: 0
     group: symbolicator-next
     lock_behavior: unlockWhenFinished
     materials:

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "v1.0.0"
         }
       },
-      "version": "64a622b25deec33176e989230bc5f83fc0c77a84",
-      "sum": "KuyVvvF8E8xkLBz5LKh4YQgI9Sy2w10waj1MpQSiM6E="
+      "version": "7636a8579792e6e1e66b0b567583e5e05764c39f",
+      "sum": "eOpSoGZ9y3+6O3qllOXVBdiHfQ2xwcnAJWqlE4k3Rj8="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This doesn't change the pipelines functionality, it puts the pipelines into a single group and orders them.

#skip-changelog