### PR TITLE
fix(js): Record resolved_with for malformed sourcemaps

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -188,9 +188,12 @@ async fn symbolicate_js_frame(
         Some(smcache) => match &smcache.entry {
             Ok(entry) => (entry, smcache.resolved_with),
             Err(CacheError::Malformed(_)) => {
+                // If we succesfully resolved the sourcemap but it's broken somehow,
+                // We should still record that we resolved it.
+                raw_frame.data.resolved_with = smcache.resolved_with;
                 return Err(JsModuleErrorKind::MalformedSourcemap {
                     url: sourcemap_label.to_owned(),
-                })
+                });
             }
             Err(CacheError::DownloadError(msg)) if msg == "Scraping disabled" => {
                 return Err(JsModuleErrorKind::ScrapingDisabled);


### PR DESCRIPTION
In that case we *did* technically resolve the sourcemap.

Question: Does it make sense to record this as well in either of the other cases? For instance, if we get a "scraping disabled" error, you could argue we should make note of the fact that we *tried* to resolve the sourcemap by scraping.

#skip-changelog