### PR TITLE
fix(symbolicli): Don't double read global config

### DIFF
--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -144,10 +144,11 @@ impl Settings {
     pub fn get() -> Result<Self> {
         let cli = Cli::parse();
 
-        let mut global_config_file = ConfigFile::parse(&find_global_config_file()?)?;
+        let global_config_path = find_global_config_file()?;
+        let mut global_config_file = ConfigFile::parse(&global_config_path)?;
         let mut project_config_file = match find_project_config_file() {
-            Some(path) => ConfigFile::parse(&path)?,
-            None => ConfigFile::default(),
+            Some(path) if path != global_config_path => ConfigFile::parse(dbg!(&path))?,
+            _ => ConfigFile::default(),
         };
 
         let mode = if cli.offline {

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -147,7 +147,7 @@ impl Settings {
         let global_config_path = find_global_config_file()?;
         let mut global_config_file = ConfigFile::parse(&global_config_path)?;
         let mut project_config_file = match find_project_config_file() {
-            Some(path) if path != global_config_path => ConfigFile::parse(dbg!(&path))?,
+            Some(path) if path != global_config_path => ConfigFile::parse(&path)?,
             _ => ConfigFile::default(),
         };
 


### PR DESCRIPTION
It was possible (likely, in fact) for `symbolicli` to load `~/.symboliclirc` twice, once as the global config file, then again as the project config file.

#skip-changelog