### PR TITLE
fix: Deduplicate object candidates

### DIFF
--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -406,12 +406,10 @@ impl DownloadService {
                 SourceConfig::Filesystem(cfg) => check_source!(cfg => FilesystemRemoteFile),
             }
         }
-        remote_files.sort_by_cached_key(|remote_file| {
-            (remote_file.source_id().clone(), remote_file.uri().clone())
-        });
-        remote_files.dedup_by_key(|remote_file| {
-            (remote_file.source_id().clone(), remote_file.uri().clone())
-        });
+        remote_files
+            .sort_by_cached_key(|remote_file| (remote_file.source_id().clone(), remote_file.uri()));
+        remote_files
+            .dedup_by_key(|remote_file| (remote_file.source_id().clone(), remote_file.uri()));
         remote_files
     }
 

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -406,6 +406,12 @@ impl DownloadService {
                 SourceConfig::Filesystem(cfg) => check_source!(cfg => FilesystemRemoteFile),
             }
         }
+        remote_files.sort_by_cached_key(|remote_file| {
+            (remote_file.source_id().clone(), remote_file.uri().clone())
+        });
+        remote_files.dedup_by_key(|remote_file| {
+            (remote_file.source_id().clone(), remote_file.uri().clone())
+        });
         remote_files
     }
 

--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -249,24 +249,36 @@ fn object_has_features(meta_handle: &ObjectMetaHandle, purpose: ObjectPurpose) -
 fn create_candidates(sources: &[SourceConfig], lookups: &[FoundMeta]) -> AllObjectCandidates {
     let mut source_ids: BTreeSet<SourceId> =
         sources.iter().map(|source| source.id()).cloned().collect();
-    let mut candidates = BTreeSet::new();
+    let mut candidates: Vec<ObjectCandidate> = Vec::with_capacity(lookups.len() + source_ids.len());
 
     for meta_lookup in lookups.iter() {
         let source_id = meta_lookup.file_source.source_id();
         source_ids.take(source_id);
-        candidates.insert(create_candidate_info(meta_lookup));
+        let location = meta_lookup.file_source.uri();
+        if let Err(idx) =
+            candidates.binary_search_by_key(&(source_id, &location), |c| (&c.source, &c.location))
+        {
+            let info = create_candidate_info(meta_lookup);
+            candidates.insert(idx, info);
+        }
     }
 
     // Create a NotFound entry for each source from which we did not try and fetch anything.
     for source_id in source_ids {
-        let info = ObjectCandidate {
-            source: source_id,
-            location: RemoteFileUri::new("No object files listed on this source"),
-            download: ObjectDownloadInfo::NotFound,
-            unwind: Default::default(),
-            debug: Default::default(),
-        };
-        candidates.insert(info);
+        let location = RemoteFileUri::new("No object files listed on this source");
+
+        if let Err(idx) =
+            candidates.binary_search_by_key(&(&source_id, &location), |c| (&c.source, &c.location))
+        {
+            let info = ObjectCandidate {
+                source: source_id,
+                location,
+                download: ObjectDownloadInfo::NotFound,
+                unwind: Default::default(),
+                debug: Default::default(),
+            };
+            candidates.insert(idx, info);
+        }
     }
 
     candidates.into()

--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -249,12 +249,12 @@ fn object_has_features(meta_handle: &ObjectMetaHandle, purpose: ObjectPurpose) -
 fn create_candidates(sources: &[SourceConfig], lookups: &[FoundMeta]) -> AllObjectCandidates {
     let mut source_ids: BTreeSet<SourceId> =
         sources.iter().map(|source| source.id()).cloned().collect();
-    let mut candidates: Vec<ObjectCandidate> = Vec::with_capacity(lookups.len() + source_ids.len());
+    let mut candidates = BTreeSet::new();
 
     for meta_lookup in lookups.iter() {
         let source_id = meta_lookup.file_source.source_id();
         source_ids.take(source_id);
-        candidates.push(create_candidate_info(meta_lookup));
+        candidates.insert(create_candidate_info(meta_lookup));
     }
 
     // Create a NotFound entry for each source from which we did not try and fetch anything.
@@ -266,7 +266,7 @@ fn create_candidates(sources: &[SourceConfig], lookups: &[FoundMeta]) -> AllObje
             unwind: Default::default(),
             debug: Default::default(),
         };
-        candidates.push(info);
+        candidates.insert(info);
     }
 
     candidates.into()

--- a/crates/symbolicator-service/src/types/objects.rs
+++ b/crates/symbolicator-service/src/types/objects.rs
@@ -49,18 +49,6 @@ pub struct ObjectCandidate {
     pub debug: ObjectUseInfo,
 }
 
-impl Ord for ObjectCandidate {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (&self.source, &self.location).cmp(&(&other.source, &other.location))
-    }
-}
-
-impl PartialOrd for ObjectCandidate {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 /// Information about downloading of a DIF object.
 ///
 /// This is part of the larger [`ObjectCandidate`] struct.

--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -96,8 +96,8 @@ async fn test_path_patterns() {
         let request = request_fixture(vec![source]);
         let mut response = symbolication.symbolicate(request).await.unwrap();
 
-        let mut module = response.modules.pop().unwrap();
-        let candidate = module.candidates.0.pop().unwrap();
+        let module = response.modules.pop().unwrap();
+        let candidate = module.candidates.into_inner().pop().unwrap();
 
         if should_be_found {
             assert!(candidate
@@ -148,7 +148,7 @@ async fn test_no_permission() {
 
     let request = example_request(sources);
     let mut response = symbolication.symbolicate(request).await.unwrap();
-    let candidates = response.modules.pop().unwrap().candidates.0;
+    let candidates = response.modules.pop().unwrap().candidates.into_inner();
 
     // NOTE: every second candidate is a "No object files listed on this source" one for the
     // source bundle lookup
@@ -224,7 +224,7 @@ async fn test_reserved_ip_addresses() {
 
     let request = example_request(sources);
     let mut response = symbolication.symbolicate(request.clone()).await.unwrap();
-    let candidates = response.modules.pop().unwrap().candidates.0;
+    let candidates = response.modules.pop().unwrap().candidates.into_inner();
 
     assert_eq!(hitcounter.accesses(), 3);
 
@@ -258,7 +258,7 @@ async fn test_reserved_ip_addresses() {
         cfg.connect_to_reserved_ips = false;
     });
     let mut response = symbolication.symbolicate(request.clone()).await.unwrap();
-    let candidates = response.modules.pop().unwrap().candidates.0;
+    let candidates = response.modules.pop().unwrap().candidates.into_inner();
 
     assert_eq!(hitcounter.accesses(), 0);
 
@@ -302,8 +302,8 @@ async fn test_redirects() {
     let request = request_fixture(vec![source]);
     let mut response = symbolication.symbolicate(request).await.unwrap();
 
-    let mut module = response.modules.pop().unwrap();
-    let candidate = module.candidates.0.pop().unwrap();
+    let module = response.modules.pop().unwrap();
+    let candidate = module.candidates.into_inner().pop().unwrap();
     let expected_url = hitcounter
         .url("/redirect/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pdb");
     assert_eq!(candidate.location, RemoteFileUri::from(expected_url));
@@ -339,8 +339,8 @@ async fn test_unreachable_bucket() {
             let request = request_fixture(vec![source]);
             let mut response = symbolication.symbolicate(request).await.unwrap();
 
-            let mut module = response.modules.pop().unwrap();
-            let candidate = module.candidates.0.pop().unwrap();
+            let module = response.modules.pop().unwrap();
+            let candidate = module.candidates.into_inner().pop().unwrap();
             let statuses = (module.debug_status, candidate.download);
 
             if ty == "http" && code == "500" {

--- a/crates/symbolicator-service/tests/integration/source_errors.rs
+++ b/crates/symbolicator-service/tests/integration/source_errors.rs
@@ -24,8 +24,8 @@ async fn test_download_errors() {
     // )
     let get_statuses = |mut res: CompletedSymbolicationResponse| {
         let frame = &res.stacktraces[0].frames[0];
-        let mut module = res.modules.pop().unwrap();
-        let candidate = module.candidates.0.pop().unwrap();
+        let module = res.modules.pop().unwrap();
+        let candidate = module.candidates.into_inner().pop().unwrap();
         (
             frame.status,
             module.debug_status,
@@ -146,8 +146,8 @@ async fn test_deny_list() {
     // )
     let get_statuses = |mut res: CompletedSymbolicationResponse| {
         let frame = &res.stacktraces[0].frames[0];
-        let mut module = res.modules.pop().unwrap();
-        let candidate = module.candidates.0.pop().unwrap();
+        let module = res.modules.pop().unwrap();
+        let candidate = module.candidates.into_inner().pop().unwrap();
         (
             frame.status,
             module.debug_status,

--- a/crates/symbolicator-sources/src/remotefile.rs
+++ b/crates/symbolicator-sources/src/remotefile.rs
@@ -3,8 +3,8 @@
 //! This provides the [`RemoteFile`] type which provides a unified way of dealing with a file
 //! which may exist on a source.
 
+use std::fmt;
 use std::path::Path;
-use std::{collections::HashSet, fmt};
 
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -95,9 +95,6 @@ pub struct SourceLocationIter<'a> {
 
     /// Remaining locations to iterate.
     next: Vec<String>,
-
-    /// Paths that were previously returned.
-    previously_returned: HashSet<String>,
 }
 
 impl<'a> SourceLocationIter<'a> {
@@ -113,7 +110,6 @@ impl<'a> SourceLocationIter<'a> {
             object_id,
             layout: config.layout,
             next: vec![],
-            previously_returned: HashSet::new(),
         }
     }
 }
@@ -133,14 +129,7 @@ impl Iterator for SourceLocationIter<'_> {
             }
         }
 
-        self.next.pop().and_then(|next| {
-            if !self.previously_returned.contains(&next) {
-                self.previously_returned.insert(next.clone());
-                Some(SourceLocation::new(next))
-            } else {
-                None
-            }
-        })
+        self.next.pop().map(SourceLocation::new)
     }
 }
 


### PR DESCRIPTION
This documents the invariant that `AllObjectCandidates` is always sorted and unique by `(source, location)` and makes sure that it is always maintained.

#skip-changelog