### PR TITLE
feat(symbolicli): Add --symbols argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `--symbols` argument to `symbolicli` ([#1241](https://github.com/getsentry/symbolicator/pull/1241))
+
 ### Fixes
 
 - Reintroduce `--version` option to `symsorter` and `wasm-split` ([#1219](https://github.com/getsentry/symbolicator/pull/1219))

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -102,6 +102,13 @@ struct Cli {
     /// This flag has no effect on native symbolication.
     #[arg(long)]
     no_scrape: bool,
+
+    /// An additional directory containing native symbols.
+    ///
+    /// The symbols must conform to the `unified` symbol server
+    /// layout, as produced by `symsorter`.
+    #[arg(long)]
+    symbols: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -138,6 +145,7 @@ pub struct Settings {
     pub output_format: OutputFormat,
     pub log_level: LevelFilter,
     pub mode: Mode,
+    pub symbols: Option<PathBuf>,
 }
 
 impl Settings {
@@ -218,6 +226,7 @@ impl Settings {
             output_format: cli.format,
             log_level: cli.log_level,
             mode,
+            symbols: cli.symbols,
         };
 
         Ok(args)


### PR DESCRIPTION
This adds a `--symbols` argument that lets you pass an ad-hoc local symbol directory.