### PR TITLE
Update jsonnet libs and add rollback pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ format:
 gocd:
 	@ rm -rf ./gocd/generated-pipelines
 	@ mkdir -p ./gocd/generated-pipelines
-	@ cd ./gocd/templates && jb install
+	@ cd ./gocd/templates && jb install && jb update
 	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
 	@ find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
 	@ cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./symbolicator.jsonnet

--- a/gocd/generated-pipelines/rollback-symbolicator-next.yaml
+++ b/gocd/generated-pipelines/rollback-symbolicator-next.yaml
@@ -1,0 +1,57 @@
+format_version: 10
+pipelines:
+  rollback-symbolicator-next:
+    display_order: 1
+    environment_variables:
+      ALL_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-next-monitor" --pipeline="deploy-symbolicator-next-us" --pipeline="deploy-symbolicator-next"
+      GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
+      REGION_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-next-monitor" --pipeline="deploy-symbolicator-next-us"
+      ROLLBACK_MATERIAL_NAME: symbolicator_repo
+      ROLLBACK_STAGE: deploy_primary
+    group: symbolicator-next
+    lock_behavior: unlockWhenFinished
+    materials:
+      deploy-symbolicator-next-us-pipeline-complete:
+        pipeline: deploy-symbolicator-next-us
+        stage: pipeline-complete
+    stages:
+      - pause_pipelines:
+          approval:
+            type: manual
+          jobs:
+            rollback:
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ## Note: $ALL_PIPELINE_FLAGS has no quoting, for word expansion
+                    ## shellcheck disable=SC2086
+                    if [[ "${ALL_PIPELINE_FLAGS:-}" ]]; then
+                      set -- $ALL_PIPELINE_FLAGS
+                    fi
+
+                    ## Pause all pipelines in the pipedream
+                    gocd-pause-and-cancel-pipelines \
+                      --pause-message="This pipeline is being rolled back, please check with team before un-pausing." \
+                      "$@"
+        start_rollback:
+          jobs:
+            rollback:
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ## Note: $REGION_PIPELINE_FLAGS has no quoting, for word expansion
+                    ## shellcheck disable=SC2086
+                    if [[ "${REGION_PIPELINE_FLAGS:-}" ]]; then
+                      set -- $REGION_PIPELINE_FLAGS
+                    fi
+
+                    ## Get sha from the given pipeline run to deploy to all pipedream pipelines.
+                    sha=$(gocd-sha-for-pipeline --material-name="${ROLLBACK_MATERIAL_NAME}")
+
+                    gocd-emergency-deploy \
+                      --commit-sha="${sha}" \
+                      --deploy-stage="${ROLLBACK_STAGE}" \
+                      --pause-message="This pipeline was rolled back, please check with team before un-pausing." \
+                      "$@"

--- a/gocd/generated-pipelines/symbolicator-next-monitor.yaml
+++ b/gocd/generated-pipelines/symbolicator-next-monitor.yaml
@@ -7,8 +7,8 @@ pipelines:
     group: symbolicator-next
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-next-us-pipeline-complete:
-        pipeline: deploy-symbolicator-next-us
+      deploy-symbolicator-next-pipeline-complete:
+        pipeline: deploy-symbolicator-next
         stage: pipeline-complete
       symbolicator_repo:
         branch: master

--- a/gocd/generated-pipelines/symbolicator-next-us.yaml
+++ b/gocd/generated-pipelines/symbolicator-next-us.yaml
@@ -1,14 +1,14 @@
 format_version: 10
 pipelines:
   deploy-symbolicator-next-us:
-    display_order: 1
+    display_order: 3
     environment_variables:
       SENTRY_REGION: us
     group: symbolicator-next
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-next-pipeline-complete:
-        pipeline: deploy-symbolicator-next
+      deploy-symbolicator-next-monitor-pipeline-complete:
+        pipeline: deploy-symbolicator-next-monitor
         stage: pipeline-complete
       symbolicator_repo:
         branch: master

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -5,10 +5,10 @@
       "source": {
         "git": {
           "remote": "https://github.com/getsentry/gocd-jsonnet.git",
-          "subdir": "v1.0.0"
+          "subdir": "libs"
         }
       },
-      "version": "main"
+      "version": "v1.1.4"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -5,11 +5,11 @@
       "source": {
         "git": {
           "remote": "https://github.com/getsentry/gocd-jsonnet.git",
-          "subdir": "v1.0.0"
+          "subdir": "libs"
         }
       },
-      "version": "7636a8579792e6e1e66b0b567583e5e05764c39f",
-      "sum": "eOpSoGZ9y3+6O3qllOXVBdiHfQ2xwcnAJWqlE4k3Rj8="
+      "version": "fc28e0fb504269698df9b19109543057eb5549cd",
+      "sum": "/R7fdDl7Sg9wqOEoDVkp49qiuMVtzjvAcqVGX4HbGG4="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -1,4 +1,4 @@
-local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
 
 function(region) {
   environment_variables: {

--- a/gocd/templates/symbolicator.jsonnet
+++ b/gocd/templates/symbolicator.jsonnet
@@ -1,5 +1,5 @@
 local symbolicator = import './pipelines/symbolicator.libsonnet';
-local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
 
 local pipedream_config = {
   // Name of your service
@@ -13,6 +13,12 @@ local pipedream_config = {
       branch: 'master',
       destination: 'symbolicator',
     },
+  },
+
+  // Add rollback
+  rollback: {
+    material_name: 'symbolicator_repo',
+    stage: 'deploy_primary',
   },
 
   // Set to true to auto-deploy changes (defaults to true)


### PR DESCRIPTION
This PR does the following:

- Update the jsonnet libs which have a slight structure change (/v1.0.0 -> /libs)
- Order of the pipelines changes to s4s -> saas
- Add a rollback pipeline to make rolling back with pipedream easier

#skip-changelog