### PR TITLE
feat: Add authentication to Source Context fetching via scraping config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 23.7.0
+
+- Add authentication to Source Context fetching via scraping config ([#1250](https://github.com/getsentry/symbolicator/pull/1250))
+
 ## 23.6.2
 
 ### Features

--- a/crates/symbolicator-service/src/services/mod.rs
+++ b/crates/symbolicator-service/src/services/mod.rs
@@ -42,9 +42,9 @@ use self::ppdb_caches::PortablePdbCacheActor;
 use self::sourcemap::SourceMapService;
 use self::symbolication::SymbolicationActor;
 use self::symcaches::SymCacheActor;
+
+pub use self::symbolication::ScrapingConfig;
 pub use fetch_file::fetch_file;
-// TODO: Not super happy about this
-pub use sourcemap_lookup::ScrapingConfig;
 
 pub fn create_service(
     config: &Config,

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -30,7 +30,6 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use symbolic::common::{ByteView, DebugId, SelfCell};
 use symbolic::debuginfo::js::discover_sourcemaps_location;
@@ -49,6 +48,7 @@ use crate::caching::{
 };
 use crate::services::download::DownloadService;
 use crate::services::objects::ObjectMetaHandle;
+use crate::services::symbolication::ScrapingConfig;
 use crate::types::{JsStacktrace, ResolvedWith, Scope};
 use crate::utils::http::is_valid_origin;
 
@@ -60,38 +60,6 @@ use super::sourcemap::SourceMapService;
 use super::symbolication::SymbolicateJsStacktraces;
 
 pub type OwnedSourceMapCache = SelfCell<ByteView<'static>, SourceMapCache<'static>>;
-
-/// Configuration for scraping of JS sources and sourcemaps from the web.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ScrapingConfig {
-    /// Whether scraping should happen at all.
-    pub enabled: bool,
-    // TODO: Can we even use this?
-    // pub verify_ssl: bool,
-    /// A list of "allowed origin patterns" that control what URLs we are
-    /// allowed to scrape from.
-    ///
-    /// Allowed origins may be defined in several ways:
-    /// - `http://domain.com[:port]`: Exact match for base URI (must include port).
-    /// - `*`: Allow any domain.
-    /// - `*.domain.com`: Matches domain.com and all subdomains, on any port.
-    /// - `domain.com`: Matches domain.com on any port.
-    /// - `*:port`: Wildcard on hostname, but explicit match on port.
-    pub allowed_origins: Vec<String>,
-    /// A map of headers to send with every HTTP request while scraping.
-    pub headers: BTreeMap<String, String>,
-}
-
-impl Default for ScrapingConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            // verify_ssl: false,
-            allowed_origins: vec!["*".to_string()],
-            headers: Default::default(),
-        }
-    }
-}
 
 /// A JS-processing "Module".
 ///

--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -79,6 +79,7 @@ impl SymbolicationActor {
             signal: None,
             stacktraces,
             apply_source_context: true,
+            scraping: Default::default(),
         };
 
         let mut system_info = SystemInfo {

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -37,9 +37,8 @@ use symbolic::sourcemapcache::{ScopeLookupResult, SourcePosition};
 use symbolicator_sources::SentrySourceConfig;
 
 use crate::caching::CacheError;
-use crate::services::sourcemap_lookup::{
-    join_paths, strip_hostname, ScrapingConfig, SourceMapLookup,
-};
+use crate::services::sourcemap_lookup::{join_paths, strip_hostname, SourceMapLookup};
+use crate::services::ScrapingConfig;
 use crate::types::{
     CompletedJsSymbolicationResponse, JsFrame, JsModuleError, JsModuleErrorKind, JsStacktrace,
     RawObjectInfo, Scope,

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -474,6 +474,7 @@ impl SymbolicationActor {
             signal: None,
             stacktraces,
             apply_source_context: true,
+            scraping: Default::default(),
         };
 
         Ok((request, minidump_state))

--- a/crates/symbolicator-service/tests/integration/utils.rs
+++ b/crates/symbolicator-service/tests/integration/utils.rs
@@ -59,6 +59,7 @@ pub fn make_symbolication_request(
         sources: Arc::from(sources),
         scope: Default::default(),
         apply_source_context: true,
+        scraping: Default::default(),
     }
 }
 

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -219,7 +219,7 @@ fn prepare_payload(scope: Scope, sources: Arc<[SourceConfig]>, payload: Payload)
                 sources,
                 origin: StacktraceOrigin::Symbolicate,
                 apply_source_context: true,
-
+                scraping: Default::default(),
                 stacktraces,
                 modules,
             })

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -2,6 +2,7 @@ use axum::extract;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
+use symbolicator_service::services::ScrapingConfig;
 use symbolicator_sources::SourceConfig;
 
 use crate::service::{
@@ -45,6 +46,8 @@ pub struct SymbolicationRequestBody {
     pub modules: Vec<RawObjectInfo>,
     #[serde(default)]
     pub options: RequestOptions,
+    #[serde(default)]
+    pub scraping: ScrapingConfig,
 }
 
 pub async fn symbolicate_frames(
@@ -70,6 +73,7 @@ pub async fn symbolicate_frames(
             stacktraces: body.stacktraces,
             modules: body.modules.into_iter().map(From::from).collect(),
             apply_source_context: body.options.apply_source_context,
+            scraping: body.scraping,
         },
         body.options,
     )?;

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -582,6 +582,7 @@ mod tests {
             sources: Arc::new([]),
             scope: Default::default(),
             apply_source_context: true,
+            scraping: Default::default(),
         };
 
         let request_id = service
@@ -622,6 +623,7 @@ mod tests {
                 debug_checksum: None,
             })],
             apply_source_context: true,
+            scraping: Default::default(),
         }
     }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -532,6 +532,7 @@ mod event {
             stacktraces,
             modules,
             apply_source_context: true,
+            scraping: Default::default(),
         })
     }
 

--- a/docs/api/symbolication.md
+++ b/docs/api/symbolication.md
@@ -74,6 +74,16 @@ as well as external sources to pull symbols from:
   - `frames`: A list of frames with addresses. Arbitrary additional properties
     may be passed with frames, but are discarded. The `addr_mode` property
     defines the beahvior of `instruction_addr`.
+- `scraping`: Configuration for authenticating scraping requests via http headers.
+  - `enabled`: Whether authentication should happen at all.
+  - `allowed_origins`: A list of "allowed origin patterns" that control what
+    URLs we are authenticating. Allowed origins may be defined in several ways:
+    - `http://domain.com[:port]`: Exact match for base URI (must include port).
+    - `*`: Allow any domain.
+    - `*.domain.com`: Matches domain.com and all subdomains, on any port.
+    - `domain.com`: Matches domain.com on any port.
+    - `*:port`: Wildcard on hostname, but explicit match on port.
+  - `headers`: A map of headers to send with every HTTP request while scraping.
 
 ## Response
 


### PR DESCRIPTION
I'm not sure if `enabled` should even be a thing for Source Context, but I wanted to reuse the same `ScrapingConfig` everywhere (which is now extracted from JS modules code).

Closes https://github.com/getsentry/symbolicator/issues/1244