### PR TITLE
Cleanup caches in random order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,6 +4354,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot 0.12.1",
+ "rand",
  "regex",
  "reqwest",
  "sentry",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -36,6 +36,7 @@ minidump-unwind = "0.17.0"
 moka = { version = "0.11.0", features = ["future"] }
 once_cell = "1.17.1"
 parking_lot = "0.12.0"
+rand = "0.8.5"
 regex = "1.5.5"
 reqwest = { version = "0.11.0", features = ["gzip", "brotli", "deflate", "json", "stream", "trust-dns"] }
 sentry = { version = "0.31.4", features = ["tracing"] }

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -72,7 +72,7 @@ impl Caches {
 
         // Collect results so we can fail the entire function.  But we do not want to early
         // return since we should at least attempt to clean up all caches.
-        let results = caches.into_iter().map(|c| c.cleanup()).collect();
+        let results: Vec<_> = caches.into_iter().map(|c| c.cleanup()).collect();
 
         let mut first_error = None;
         for result in results {

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 
 use crate::config::Config;
 
@@ -46,20 +48,31 @@ impl Caches {
             diagnostics,
         } = &self;
 
+        // We want to clean up the caches in a random order. Ideally, this should not matter at all,
+        // but we have seen some cleanup jobs getting stuck or dying reproducibly on certain types
+        // of caches. A random shuffle increases the chance that the cleanup will make progress on
+        // other caches.
+        // The cleanup job dying on specific caches is a very bad thing and should definitely be
+        // fixed, but in the meantime a random shuffle should provide more head room for a proper
+        // fix in this case.
+        let mut caches = vec![
+            objects,
+            object_meta,
+            auxdifs,
+            il2cpp,
+            symcaches,
+            cficaches,
+            ppdb_caches,
+            sourcemap_caches,
+            sourcefiles,
+            diagnostics,
+        ];
+        let mut rng = thread_rng();
+        caches.as_mut_slice().shuffle(&mut rng);
+
         // Collect results so we can fail the entire function.  But we do not want to early
         // return since we should at least attempt to clean up all caches.
-        let results = vec![
-            objects.cleanup(),
-            object_meta.cleanup(),
-            symcaches.cleanup(),
-            cficaches.cleanup(),
-            diagnostics.cleanup(),
-            auxdifs.cleanup(),
-            il2cpp.cleanup(),
-            ppdb_caches.cleanup(),
-            sourcemap_caches.cleanup(),
-            sourcefiles.cleanup(),
-        ];
+        let results = caches.into_iter().map(|c| c.cleanup()).collect();
 
         let mut first_error = None;
         for result in results {


### PR DESCRIPTION
This is a hotfix to give us more headroom while investigating stuck cleanup jobs. See the comment in the relevant function.

#skip-changelog