### PR TITLE
Remove manual insertion-sort from `create_candidates`

### DIFF
--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -254,33 +254,22 @@ fn create_candidates(sources: &[SourceConfig], lookups: &[FoundMeta]) -> AllObje
     for meta_lookup in lookups.iter() {
         let source_id = meta_lookup.file_source.source_id();
         source_ids.take(source_id);
-        let location = meta_lookup.file_source.uri();
-        if let Err(idx) =
-            candidates.binary_search_by_key(&(source_id, &location), |c| (&c.source, &c.location))
-        {
-            let info = create_candidate_info(meta_lookup);
-            candidates.insert(idx, info);
-        }
+        candidates.push(create_candidate_info(meta_lookup));
     }
 
     // Create a NotFound entry for each source from which we did not try and fetch anything.
     for source_id in source_ids {
-        let location = RemoteFileUri::new("No object files listed on this source");
-
-        if let Err(idx) =
-            candidates.binary_search_by_key(&(&source_id, &location), |c| (&c.source, &c.location))
-        {
-            let info = ObjectCandidate {
-                source: source_id,
-                location,
-                download: ObjectDownloadInfo::NotFound,
-                unwind: Default::default(),
-                debug: Default::default(),
-            };
-            candidates.insert(idx, info);
-        }
+        let info = ObjectCandidate {
+            source: source_id,
+            location: RemoteFileUri::new("No object files listed on this source"),
+            download: ObjectDownloadInfo::NotFound,
+            unwind: Default::default(),
+            debug: Default::default(),
+        };
+        candidates.push(info);
     }
 
+    // NOTE: This `into()` (or rather the `From` impl) does `sort` and `dedupe` these candidates.
     candidates.into()
 }
 


### PR DESCRIPTION
The `From` impl of `AllObjectCandidates` already sorts and dedupes, no need to do that manually via a custom insertion-sort.

#skip-changelog