### PR TITLE
Switch pipelines to pipedream

### DIFF
--- a/gocd/generated-pipelines/rollback-symbolicator.yaml
+++ b/gocd/generated-pipelines/rollback-symbolicator.yaml
@@ -1,18 +1,18 @@
 format_version: 10
 pipelines:
-  rollback-symbolicator-next:
+  rollback-symbolicator:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-next-monitor" --pipeline="deploy-symbolicator-next-us" --pipeline="deploy-symbolicator-next"
+      ALL_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-monitor" --pipeline="deploy-symbolicator-us" --pipeline="deploy-symbolicator"
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-next-monitor" --pipeline="deploy-symbolicator-next-us"
+      REGION_PIPELINE_FLAGS: --pipeline="deploy-symbolicator-monitor" --pipeline="deploy-symbolicator-us"
       ROLLBACK_MATERIAL_NAME: symbolicator_repo
       ROLLBACK_STAGE: deploy_primary
-    group: symbolicator-next
+    group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-next-us-pipeline-complete:
-        pipeline: deploy-symbolicator-next-us
+      deploy-symbolicator-us-pipeline-complete:
+        pipeline: deploy-symbolicator-us
         stage: pipeline-complete
     stages:
       - pause_pipelines:

--- a/gocd/generated-pipelines/symbolicator-monitor.yaml
+++ b/gocd/generated-pipelines/symbolicator-monitor.yaml
@@ -1,14 +1,14 @@
 format_version: 10
 pipelines:
-  deploy-symbolicator-next-monitor:
+  deploy-symbolicator-monitor:
     display_order: 2
     environment_variables:
       SENTRY_REGION: monitor
-    group: symbolicator-next
+    group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-next-pipeline-complete:
-        pipeline: deploy-symbolicator-next
+      deploy-symbolicator-pipeline-complete:
+        pipeline: deploy-symbolicator
         stage: pipeline-complete
       symbolicator_repo:
         branch: master

--- a/gocd/generated-pipelines/symbolicator-us.yaml
+++ b/gocd/generated-pipelines/symbolicator-us.yaml
@@ -1,14 +1,14 @@
 format_version: 10
 pipelines:
-  deploy-symbolicator-next-us:
+  deploy-symbolicator-us:
     display_order: 3
     environment_variables:
       SENTRY_REGION: us
-    group: symbolicator-next
+    group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-next-monitor-pipeline-complete:
-        pipeline: deploy-symbolicator-next-monitor
+      deploy-symbolicator-monitor-pipeline-complete:
+        pipeline: deploy-symbolicator-monitor
         stage: pipeline-complete
       symbolicator_repo:
         branch: master

--- a/gocd/generated-pipelines/symbolicator.yaml
+++ b/gocd/generated-pipelines/symbolicator.yaml
@@ -1,8 +1,8 @@
 format_version: 10
 pipelines:
-  deploy-symbolicator-next:
+  deploy-symbolicator:
     display_order: 0
-    group: symbolicator-next
+    group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
       symbolicator_repo:

--- a/gocd/pipelines/symbolicator.yaml
+++ b/gocd/pipelines/symbolicator.yaml
@@ -3,14 +3,14 @@
 # - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
 format_version: 10
 pipelines:
-    deploy-symbolicator:
+    deploy-symbolicator-old:
         environment_variables:
             GCP_PROJECT: internal-sentry
             GKE_CLUSTER: zdpwkxst
             GKE_REGION: us-central1
             GKE_CLUSTER_ZONE: b
             GKE_BASTION_ZONE: b
-        group: symbolicator
+        group: symbolicator-old
         lock_behavior: unlockWhenFinished
         materials:
             symbolicator_repo:

--- a/gocd/templates/symbolicator.jsonnet
+++ b/gocd/templates/symbolicator.jsonnet
@@ -3,7 +3,7 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libso
 
 local pipedream_config = {
   // Name of your service
-  name: 'symbolicator-next',
+  name: 'symbolicator',
 
   // The materials you'd like the pipelines to watch for changes
   materials: {


### PR DESCRIPTION
This switches the symbolicator pipelines over to pipedream which will deploy to monitor (s4s) and then saas.

At the moment the pipeline has 2 manual steps, one for deploying canary and one for deploying primary, this is done for both s4s AND saas deployments, **should I remove these manual steps or leave them as is for now?**

NOTE: The old pipelines will still be available but will be moved to a new group "symbolicator-old" in case they are needed during the transition.

#skip-changelog