### PR TITLE
fix: Emit download failure metric for Sentry sources

### DIFF
--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -322,13 +322,14 @@ impl DownloadService {
             Ok(Ok(res)) => res,
         };
 
+        metric!(counter("service.download.failure") += 1, "source" => &source_metric_key);
+
         if source_is_external
             && matches!(
                 result,
                 Err(CacheError::DownloadError(_) | CacheError::Timeout(_))
             )
         {
-            metric!(counter("service.download.failure") += 1, "source" => &source_metric_key);
             self.host_deny_list.register_failure(host);
         }
 

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -322,15 +322,15 @@ impl DownloadService {
             Ok(Ok(res)) => res,
         };
 
-        metric!(counter("service.download.failure") += 1, "source" => &source_metric_key);
+        if matches!(
+            result,
+            Err(CacheError::DownloadError(_) | CacheError::Timeout(_))
+        ) {
+            metric!(counter("service.download.failure") += 1, "source" => &source_metric_key);
 
-        if source_is_external
-            && matches!(
-                result,
-                Err(CacheError::DownloadError(_) | CacheError::Timeout(_))
-            )
-        {
-            self.host_deny_list.register_failure(host);
+            if source_is_external {
+                self.host_deny_list.register_failure(host);
+            }
         }
 
         result


### PR DESCRIPTION
#skip-changelog