### PR TITLE
fix: Don't sort/deduplicate in list_files

### DIFF
--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -407,10 +407,6 @@ impl DownloadService {
             }
         }
         remote_files
-            .sort_by_cached_key(|remote_file| (remote_file.source_id().clone(), remote_file.uri()));
-        remote_files
-            .dedup_by_key(|remote_file| (remote_file.source_id().clone(), remote_file.uri()));
-        remote_files
     }
 
     /// Look up a list of bundles or individual artifact files covering the


### PR DESCRIPTION
This function's results are passed to `select_meta`, which expects them to be sorted by preference. Therefore we can't sort them by source id willy-nilly here.

#skip-changelog