### PR TITLE
Move symbolicator back to original group

### DIFF
--- a/gocd/pipelines/symbolicator.yaml
+++ b/gocd/pipelines/symbolicator.yaml
@@ -10,7 +10,8 @@ pipelines:
             GKE_REGION: us-central1
             GKE_CLUSTER_ZONE: b
             GKE_BASTION_ZONE: b
-        group: symbolicator-old
+        group: symbolicator
+        display_order: 100 # Ensure it's last pipeline in UI
         lock_behavior: unlockWhenFinished
         materials:
             symbolicator_repo:


### PR DESCRIPTION
I didn't realize that new groups like *-old would not have correct permissions for viewing and operating.

Moving the old pipelines back to address this.

#skip-changelog