### PR TITLE
Rename monitor to s4s and add first customer

### DIFF
--- a/gocd/generated-pipelines/rollback-symbolicator.yaml
+++ b/gocd/generated-pipelines/rollback-symbolicator.yaml
@@ -3,16 +3,16 @@ pipelines:
   rollback-symbolicator:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-monitor --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator
+      ALL_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1 --pipeline=deploy-symbolicator
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-monitor --pipeline=deploy-symbolicator-us
+      REGION_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1
       ROLLBACK_MATERIAL_NAME: symbolicator_repo
       ROLLBACK_STAGE: deploy_primary
     group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-us-pipeline-complete:
-        pipeline: deploy-symbolicator-us
+      deploy-symbolicator-customer-1-pipeline-complete:
+        pipeline: deploy-symbolicator-customer-1
         stage: pipeline-complete
     stages:
       - pause_pipelines:

--- a/gocd/generated-pipelines/symbolicator-customer-1.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-1.yaml
@@ -1,14 +1,14 @@
 format_version: 10
 pipelines:
-  deploy-symbolicator-us:
-    display_order: 3
+  deploy-symbolicator-customer-1:
+    display_order: 4
     environment_variables:
-      SENTRY_REGION: us
+      SENTRY_REGION: customer-1
     group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-symbolicator-s4s-pipeline-complete:
-        pipeline: deploy-symbolicator-s4s
+      deploy-symbolicator-us-pipeline-complete:
+        pipeline: deploy-symbolicator-us
         stage: pipeline-complete
       symbolicator_repo:
         branch: master

--- a/gocd/generated-pipelines/symbolicator-s4s.yaml
+++ b/gocd/generated-pipelines/symbolicator-s4s.yaml
@@ -1,9 +1,9 @@
 format_version: 10
 pipelines:
-  deploy-symbolicator-monitor:
+  deploy-symbolicator-s4s:
     display_order: 2
     environment_variables:
-      SENTRY_REGION: monitor
+      SENTRY_REGION: s4s
     group: symbolicator
     lock_behavior: unlockWhenFinished
     materials:

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.1.9"
+      "version": "v1.2.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "398935d57d495803fc5e677b6b8c4d012da33d41",
-      "sum": "Daqk+eHsSP/IttLc+PlG37AUysHMYZ3VKw1vX+16uO4="
+      "version": "09f7eb7034b4060ac24da3ac0a7424974a715ae2",
+      "sum": "MHRy0TLoc9hgIJMwdp6PoTN9+qmv5PkbTLbNcvLDH4Q="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This switches the name of monitor to s4s (just easier to understand for sentaurs).

The customer-1 pipeline is the first customer pipeline being added, this should follow the same process as the other deploys.

#skip-changelog