### PR TITLE
Report used `ArtifactBundle`s back to Sentry

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -125,10 +125,13 @@ impl SymbolicationActor {
         metric!(time_raw("js.unsymbolicated_frames") = unsymbolicated_frames);
         metric!(time_raw("js.missing_sourcescontent") = missing_sourcescontent);
 
+        let used_artifact_bundles = lookup.into_used_artifact_bundles();
+
         Ok(CompletedJsSymbolicationResponse {
             stacktraces,
             raw_stacktraces,
             errors: errors.into_iter().collect(),
+            used_artifact_bundles,
         })
     }
 }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -4,14 +4,14 @@
 //! HTTP API.  Its messy and things probably need a better place and different way to signal
 //! they are part of the public API.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use symbolic::common::{Arch, CodeId, DebugId, Language};
-use symbolicator_sources::ObjectType;
+use symbolicator_sources::{ObjectType, SentryFileId};
 
 use crate::utils::addr::AddrMode;
 use crate::utils::hex::HexValue;
@@ -634,6 +634,8 @@ pub struct CompletedJsSymbolicationResponse {
     pub raw_stacktraces: Vec<JsStacktrace>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<JsModuleError>,
+    #[serde(skip_serializing_if = "HashSet::is_empty")]
+    pub used_artifact_bundles: HashSet<SentryFileId>,
 }
 
 /// Information about the operating system.

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
@@ -35,4 +35,6 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+used_artifact_bundles:
+  - 02_correct.zip
 

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -87,8 +87,8 @@ impl SentryRemoteFile {
 }
 
 /// An identifier for a file retrievable from a [`SentrySourceConfig`].
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
-pub struct SentryFileId(pub String);
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct SentryFileId(pub Arc<str>);
 
 impl fmt::Display for SentryFileId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
When using the `BundleIndex`, we will report back to Sentry the actually used `ArtifactBundle`s. This way, auto-expiration can work properly when using the `BundleIndex`, and it is even more accurate than using the `artifact-lookup` API.

#skip-changelog