### PR TITLE
Add more logging to failed `BundleIndex` lookups

### DIFF
--- a/crates/symbolicator-service/tests/integration/e2e.rs
+++ b/crates/symbolicator-service/tests/integration/e2e.rs
@@ -306,7 +306,10 @@ async fn test_redirects() {
     let candidate = module.candidates.into_inner().pop().unwrap();
     let expected_url = hitcounter
         .url("/redirect/msdl/wkernel32.pdb/FF9F9F7841DB88F0CDEDA9E1E9BFF3B51/wkernel32.pdb");
-    assert_eq!(candidate.location, RemoteFileUri::from(expected_url));
+    assert_eq!(
+        candidate.location,
+        RemoteFileUri::from(expected_url.as_str())
+    );
     assert!(matches!(candidate.download, ObjectDownloadInfo::Ok { .. }));
 }
 

--- a/crates/symbolicator-sources/src/remotefile.rs
+++ b/crates/symbolicator-sources/src/remotefile.rs
@@ -5,6 +5,7 @@
 
 use std::fmt;
 use std::path::Path;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -289,11 +290,11 @@ impl RemoteFile {
 /// be an `s3://` URI etc.
 ///
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct RemoteFileUri(String);
+pub struct RemoteFileUri(Arc<str>);
 
 impl RemoteFileUri {
     /// Creates a new [`RemoteFileUri`].
-    pub fn new(s: impl Into<String>) -> Self {
+    pub fn new(s: impl Into<Arc<str>>) -> Self {
         Self(s.into())
     }
 
@@ -314,7 +315,7 @@ impl RemoteFileUri {
     pub fn from_parts(scheme: &str, host: &str, path: &str) -> Self {
         Url::parse(&format!("{scheme}://{host}/"))
             .and_then(|base| base.join(path))
-            .map(RemoteFileUri::new)
+            .map(|url| RemoteFileUri::new(url.as_str()))
             .unwrap_or_else(|_| {
                 // All these Result-returning operations *should* be infallible and this
                 // branch should never be used.  Nevertheless, for panic-safety we default
@@ -326,7 +327,7 @@ impl RemoteFileUri {
 
 impl<T> From<T> for RemoteFileUri
 where
-    T: Into<String>,
+    T: Into<Arc<str>>,
 {
     fn from(source: T) -> Self {
         Self(source.into())


### PR DESCRIPTION
Looks like we immediately ran into a problem where the `BundleIndex` says a file has to be in a certain bundle, but it is not.

This will now keep track and log the following things in that case:
- The `BundleIndex` being used
- The `ArtifactBundle` that is claimed to contain the file
- The exact `lookup_key` that is supposed to be found inside the bundle

#skip-changelog