### PR TITLE
Remove canary from non-us regions and remove canary manual step

### DIFF
--- a/gocd/generated-pipelines/rollback-symbolicator.yaml
+++ b/gocd/generated-pipelines/rollback-symbolicator.yaml
@@ -3,9 +3,9 @@ pipelines:
   rollback-symbolicator:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1 --pipeline=deploy-symbolicator-customer-2 --pipeline=deploy-symbolicator-customer-3 --pipeline=deploy-symbolicator-customer-4 --pipeline=deploy-symbolicator-customer-5 --pipeline=deploy-symbolicator-customer-6 --pipeline=deploy-symbolicator
+      ALL_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1 --pipeline=deploy-symbolicator-customer-2 --pipeline=deploy-symbolicator-customer-3 --pipeline=deploy-symbolicator-customer-4 --pipeline=deploy-symbolicator
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1 --pipeline=deploy-symbolicator-customer-2 --pipeline=deploy-symbolicator-customer-3 --pipeline=deploy-symbolicator-customer-4 --pipeline=deploy-symbolicator-customer-5 --pipeline=deploy-symbolicator-customer-6
+      REGION_PIPELINE_FLAGS: --pipeline=deploy-symbolicator-s4s --pipeline=deploy-symbolicator-us --pipeline=deploy-symbolicator-customer-1 --pipeline=deploy-symbolicator-customer-2 --pipeline=deploy-symbolicator-customer-3 --pipeline=deploy-symbolicator-customer-4
       ROLLBACK_MATERIAL_NAME: symbolicator_repo
       ROLLBACK_STAGE: deploy_primary
     group: symbolicator

--- a/gocd/generated-pipelines/symbolicator-customer-1.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-1.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-customer-2.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-2.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-customer-3.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-3.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-customer-4.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-4.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-customer-5.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-5.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-customer-6.yaml
+++ b/gocd/generated-pipelines/symbolicator-customer-6.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-s4s.yaml
+++ b/gocd/generated-pipelines/symbolicator-s4s.yaml
@@ -41,8 +41,6 @@ pipelines:
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
       - deploy_primary:
-          approval:
-            type: manual
           fetch_materials: true
           jobs:
             create_sentry_release:

--- a/gocd/generated-pipelines/symbolicator-s4s.yaml
+++ b/gocd/generated-pipelines/symbolicator-s4s.yaml
@@ -40,40 +40,6 @@ pipelines:
                       sentryio \
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
-      - deploy_canary:
-          approval:
-            type: manual
-          fetch_materials: true
-          jobs:
-            create_sentry_release:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                ENVIRONMENT: canary
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}'
-                SENTRY_URL: https://sentry.my.sentry.io/
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ./symbolicator/scripts/create-sentry-release "${GO_REVISION_SYMBOLICATOR_REPO}" "${ENVIRONMENT}"
-              timeout: 1200
-            deploy:
-              elastic_profile_id: symbolicator
-              environment_variables:
-                LABEL_SELECTOR: service=symbolicator,deploy_if_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-                    /devinfra/scripts/k8s/k8s-deploy.py \
-                      --type="statefulset" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/symbolicator:${GO_REVISION_SYMBOLICATOR_REPO}" \
-                      --container-name="symbolicator" \
-                      --container-name="cleanup"
-              timeout: 1200
       - deploy_primary:
           approval:
             type: manual

--- a/gocd/generated-pipelines/symbolicator-us.yaml
+++ b/gocd/generated-pipelines/symbolicator-us.yaml
@@ -41,8 +41,6 @@ pipelines:
                       "us.gcr.io/sentryio/symbolicator"
               timeout: 1200
       - deploy_canary:
-          approval:
-            type: manual
           fetch_materials: true
           jobs:
             create_sentry_release:

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.4.1"
+      "version": "v1.4.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "f3a6151e1b83f3fad9bfa25f06c95af77104630f",
-      "sum": "6A5JFwhCTvywB8JvE2uFWV2VG0K9LrO3DPkjH4fAgP0="
+      "version": "a4d0a7bedf0dc3cce9a28a85e95b736b139a7d4e",
+      "sum": "iSfWUcTtYZpJ4WEgQAqjD7I/Vi2UFpF0CXvtSIhqMXY="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -75,7 +75,7 @@ function(region) {
   ] + deploy_canary_stage(region) + [
     {
       deploy_primary: {
-        approval: {
+        [if region == 's4s' then null else 'approval']: {
           type: 'manual',
         },
         fetch_materials: true,

--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -1,5 +1,44 @@
 local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
 
+// Only the US region has a canary deployment.
+local deploy_canary_stage(region) =
+  if region != 'us' then
+    []
+  else
+    [
+      {
+        deploy_canary: {
+          fetch_materials: true,
+          jobs: {
+            create_sentry_release: {
+              environment_variables: {
+                SENTRY_URL: 'https://sentry.my.sentry.io/',
+                ENVIRONMENT: 'canary',
+                // Temporary; self-service encrypted secrets aren't implemented yet.
+                // This should really be rotated to an internal integration token.
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}',
+              },
+              timeout: 1200,
+              elastic_profile_id: 'symbolicator',
+              tasks: [
+                gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
+              ],
+            },
+            deploy: {
+              timeout: 1200,
+              elastic_profile_id: 'symbolicator',
+              environment_variables: {
+                LABEL_SELECTOR: 'service=symbolicator,deploy_if_canary=true',
+              },
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ];
+
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
@@ -33,40 +72,7 @@ function(region) {
         },
       },
     },
-    {
-      deploy_canary: {
-        approval: {
-          type: 'manual',
-        },
-        fetch_materials: true,
-        jobs: {
-          create_sentry_release: {
-            environment_variables: {
-              SENTRY_URL: 'https://sentry.my.sentry.io/',
-              ENVIRONMENT: 'canary',
-              // Temporary; self-service encrypted secrets aren't implemented yet.
-              // This should really be rotated to an internal integration token.
-              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}',
-            },
-            timeout: 1200,
-            elastic_profile_id: 'symbolicator',
-            tasks: [
-              gocdtasks.script(importstr '../bash/create-sentry-release.sh'),
-            ],
-          },
-          deploy: {
-            timeout: 1200,
-            elastic_profile_id: 'symbolicator',
-            environment_variables: {
-              LABEL_SELECTOR: 'service=symbolicator,deploy_if_canary=true',
-            },
-            tasks: [
-              gocdtasks.script(importstr '../bash/deploy.sh'),
-            ],
-          },
-        },
-      },
-    },
+  ] + deploy_canary_stage(region) + [
     {
       deploy_primary: {
         approval: {


### PR DESCRIPTION
Removing the canary stage entirely for non-saas deployments makes sense since only the US deployment has any canary pods.

_*Question*_: I think it's safe to skip the "create sentry release" step in canary and just run the prod create sentry release, but could you take a look and confirm.

This PR also removed the manual step from the canary deployment in the US.

The result of these changes is that deployments will have one manual step per deployment (the deploy-prod step.

**In the future it might be worth considering changing this remaining manual step to only be needed for US regions**, even better would be to add automatic checks to the canary deployment in the US using the approaches listed here: https://www.notion.so/sentry/Block-deployments-on-canary-cd96781d331242c097f6959117d70ef3

#skip-changelog