### PR TITLE
Tighten up some internal timeouts

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -521,11 +521,12 @@ impl Default for Config {
             symstore_proxy: true,
             sources: Arc::from(vec![]),
             connect_to_reserved_ips: false,
-            // Allow a 4MB/s connection to download 2GB without timing out
-            max_download_timeout: Duration::from_secs(315),
+            // We want to have a hard download timeout of 5 minutes.
+            // This means a download connection needs to sustain ~6,7MB/s to download a 2GB file.
+            max_download_timeout: Duration::from_secs(5 * 60),
             connect_timeout: Duration::from_secs(1),
             head_timeout: Duration::from_secs(5),
-            // Allow a 4MB/s connection to download 1GB without timing out
+            // Allow a 4MB/s connection to download 1GB without timing out.
             streaming_timeout: Duration::from_secs(250),
             deny_list_time_window: Duration::from_secs(60),
             deny_list_bucket_size: Duration::from_secs(5),

--- a/crates/symbolicator-service/src/services/download/mod.rs
+++ b/crates/symbolicator-service/src/services/download/mod.rs
@@ -512,8 +512,7 @@ async fn download_reqwest(
     let request = tokio::time::timeout(timeout, request);
     let request = measure_download_time(source.source_metric_key(), request);
 
-    let timeout_err = CacheError::Timeout(timeout);
-    let response = request.await.map_err(|_| timeout_err)??;
+    let response = request.await.map_err(|_| CacheError::Timeout(timeout))??;
 
     let status = response.status();
     if status.is_success() {

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -417,7 +417,11 @@ impl RequestService {
         let request_future = async move {
             metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
 
-            let timeout = Duration::from_secs(3600);
+            // The "normal" maximum for Native and JS Symbolication is ~5 minutes,
+            // and ~10 minutes for minidump processing. Going for a hard timeout of 15 minutes
+            // sounds reasonable as we want to support as many events as possible. We might tighten
+            // up this timeout even further in the future.
+            let timeout = Duration::from_secs(15 * 60);
             let f = tokio::time::timeout(timeout, f);
             let f = measure(task_name, m::timed_result, f);
 

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -244,18 +244,8 @@ impl RequestService {
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "symbolicate_stacktraces",
-            "symbolicate_stacktraces",
-            span,
-        );
         self.create_symbolication_request("symbolicate", options, async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf.symbolication.symbolicate(request).await;
-            transaction.finish();
-            res.map(Into::into)
+            slf.symbolication.symbolicate(request).await.map(Into::into)
         })
     }
 
@@ -264,18 +254,11 @@ impl RequestService {
         request: SymbolicateJsStacktraces,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "symbolicate_js_stacktraces",
-            "symbolicate_js_stacktraces",
-            span,
-        );
         self.create_symbolication_request("symbolicate_js", RequestOptions::default(), async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf.symbolication.symbolicate_js(request).await;
-            transaction.finish();
-            res.map(Into::into)
+            slf.symbolication
+                .symbolicate_js(request)
+                .await
+                .map(Into::into)
         })
     }
 
@@ -291,21 +274,11 @@ impl RequestService {
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_minidump",
-            "process_minidump",
-            span,
-        );
         self.create_symbolication_request("minidump_stackwalk", options, async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .symbolication
+            slf.symbolication
                 .process_minidump(scope, minidump_file, sources)
-                .await;
-            transaction.finish();
-            res.map(Into::into)
+                .await
+                .map(Into::into)
         })
     }
 
@@ -321,21 +294,11 @@ impl RequestService {
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
-        let span = sentry::configure_scope(|scope| scope.get_span());
-        let ctx = sentry::TransactionContext::continue_from_span(
-            "process_apple_crash_report",
-            "process_apple_crash_report",
-            span,
-        );
         self.create_symbolication_request("parse_apple_crash_report", options, async move {
-            let transaction = sentry::start_transaction(ctx);
-            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-            let res = slf
-                .symbolication
+            slf.symbolication
                 .process_apple_crash_report(scope, apple_crash_report, sources)
-                .await;
-            transaction.finish();
-            res.map(Into::into)
+                .await
+                .map(Into::into)
         })
     }
 
@@ -417,6 +380,14 @@ impl RequestService {
         let request_future = async move {
             metric!(timer("symbolication.create_request.first_poll") = spawn_time.elapsed());
 
+            let span = sentry::configure_scope(|scope| scope.get_span());
+            let ctx = sentry::TransactionContext::continue_from_span(task_name, task_name, span);
+            let transaction = sentry::start_transaction(ctx);
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            let transaction_guard = CallOnDrop::new(move || {
+                transaction.finish();
+            });
+
             // The "normal" maximum for Native and JS Symbolication is ~5 minutes,
             // and ~10 minutes for minidump processing. Going for a hard timeout of 15 minutes
             // sounds reasonable as we want to support as many events as possible. We might tighten
@@ -424,8 +395,10 @@ impl RequestService {
             let timeout = Duration::from_secs(15 * 60);
             let f = tokio::time::timeout(timeout, f);
             let f = measure(task_name, m::timed_result, f);
+            let response = f.await;
+            drop(transaction_guard);
 
-            let response = match f.await {
+            let response = match response {
                 Ok(Ok(mut response)) => {
                     if !options.dif_candidates {
                         if let CompletedResponse::NativeSymbolication(ref mut res) = response {


### PR DESCRIPTION
- Lowers the global per-task timeout from 60 to 15 minutes.
- Remove a ton of intermediate `measure` usage, replacing those with tracing instead.
- Also remove intermediate timeouts, as those should rather be propagated from the global timeout.
- Adds a stream timeout to the shared cache download code, and a timeout around spawning the download.
- Make sure that we get performance tracing transactions for tasks that are timing out.
- Also reduces the number of cache stores for refreshes.

#skip-changelog