### PR TITLE
deps: Downgrade hyper to 0.14.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
The upgrade to 0.14.27 roughly correlates with the start of https://github.com/getsentry/sentry/issues/52516. We experimentally roll it back to see if there is any effect on these errors.

#skip-changelog