### PR TITLE
Revert "deps: Downgrade hyper to 0.14.26 (#1286)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
Downgrading `hyper` did not alleviate https://github.com/getsentry/sentry/issues/52516. Therefore we're reverting 2f3f57f33ca176ef160b2629deb0a72d8b5a4b02.

#skip-changelog