### PR TITLE
Do not process `.o` files in Symsorter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- Do not process `.o` files in Symsorter. ([#1288](https://github.com/getsentry/symbolicator/pull/1288))
+
 ## 23.8.0
 
 ### Dependencies
@@ -19,7 +25,6 @@
 ### Various fixes & improvements
 
 - Add a new `BundleIndex` for SourceMap processing (#1251) by @Swatinem
-
 
 ## 23.7.0
 

--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -123,6 +123,12 @@ fn process_file(
 
     for obj in archive.objects() {
         let obj = maybe_ignore_error!(obj.map_err(|e| anyhow!(e)));
+        if !matches!(
+            obj.kind(),
+            ObjectKind::Executable | ObjectKind::Library | ObjectKind::Debug | ObjectKind::Sources
+        ) {
+            continue;
+        }
         let new_filename = root.join(maybe_ignore_error!(get_target_filename(&obj)));
 
         fs::create_dir_all(new_filename.parent().unwrap())?;

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -46,7 +46,7 @@ pub fn get_target_filename(obj: &Object) -> Result<PathBuf> {
     let suffix = match obj.kind() {
         ObjectKind::Debug => "debuginfo",
         ObjectKind::Sources if obj.file_format() == FileFormat::SourceBundle => "sourcebundle",
-        ObjectKind::Relocatable | ObjectKind::Library | ObjectKind::Executable => "executable",
+        ObjectKind::Library | ObjectKind::Executable => "executable",
         _ => bail!("unsupported file"),
     };
     Ok(format!("{}/{}/{}", &id[..2], &id[2..], suffix).into())


### PR DESCRIPTION
This will now complete skip any object kinds that do not make any sense to be processed by Symsorter.

fixes https://github.com/getsentry/symbolicator/issues/1280
fixes https://github.com/getsentry/symbolicator/issues/1240