### PR TITLE
Refactor Cache and Downloader Code

### DIFF
--- a/crates/symbolicator-service/src/services/download/gcs.rs
+++ b/crates/symbolicator-service/src/services/download/gcs.rs
@@ -1,9 +1,9 @@
 //! Support to download from Google Cloud Storage buckets.
 
-use std::path::Path;
 use std::sync::Arc;
 
-use symbolicator_sources::{GcsRemoteFile, GcsSourceKey, RemoteFile};
+use symbolicator_sources::{GcsRemoteFile, GcsSourceKey};
+use tokio::fs::File;
 
 use crate::caching::{CacheEntry, CacheError};
 use crate::utils::gcs::{self, GcsToken};
@@ -56,8 +56,9 @@ impl GcsDownloader {
     /// Downloads a source hosted on GCS.
     pub async fn download_source(
         &self,
-        file_source: GcsRemoteFile,
-        destination: &Path,
+        source_name: &str,
+        file_source: &GcsRemoteFile,
+        destination: &mut File,
     ) -> CacheEntry {
         let key = file_source.key();
         let bucket = &file_source.source.bucket;
@@ -67,20 +68,12 @@ impl GcsDownloader {
 
         let url = gcs::download_url(bucket, &key)?;
 
-        let source = RemoteFile::from(file_source);
-        let request = self
+        let builder = self
             .client
             .get(url)
             .header("authorization", token.bearer_token());
 
-        let mut destination = tokio::fs::File::create(destination).await?;
-        super::download_reqwest(
-            source.source_metric_key(),
-            request,
-            &self.timeouts,
-            &mut destination,
-        )
-        .await
+        super::download_reqwest(source_name, builder, &self.timeouts, destination).await
     }
 }
 
@@ -123,7 +116,10 @@ mod tests {
         let source_location = SourceLocation::new("e5/14c9464eed3be5943a2c61d9241fad/executable");
         let file_source = GcsRemoteFile::new(source, source_location);
 
-        let download_status = downloader.download_source(file_source, &target_path).await;
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert!(download_status.is_ok());
         assert!(target_path.exists());
@@ -147,7 +143,10 @@ mod tests {
         let source_location = SourceLocation::new("does/not/exist");
         let file_source = GcsRemoteFile::new(source, source_location);
 
-        let download_status = downloader.download_source(file_source, &target_path).await;
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert_eq!(download_status, Err(CacheError::NotFound));
         assert!(!target_path.exists());
@@ -172,12 +171,11 @@ mod tests {
         let source_location = SourceLocation::new("does/not/exist");
         let file_source = GcsRemoteFile::new(source, source_location);
 
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
         downloader
-            .download_source(file_source, &target_path)
+            .download_source("", &file_source, &mut destination)
             .await
             .expect_err("authentication should fail");
-
-        assert!(!target_path.exists());
     }
 
     #[test]

--- a/crates/symbolicator-service/src/services/download/http.rs
+++ b/crates/symbolicator-service/src/services/download/http.rs
@@ -1,10 +1,9 @@
 //! Support to download from HTTP sources.
 
-use std::path::Path;
-
 use reqwest::{header, Client};
 
-use symbolicator_sources::{HttpRemoteFile, RemoteFile};
+use symbolicator_sources::HttpRemoteFile;
+use tokio::fs::File;
 
 use crate::caching::{CacheEntry, CacheError};
 use crate::utils::http::DownloadTimeouts;
@@ -26,8 +25,9 @@ impl HttpDownloader {
     /// Downloads a source hosted on an HTTP server.
     pub async fn download_source(
         &self,
-        file_source: HttpRemoteFile,
-        destination: &Path,
+        source_name: &str,
+        file_source: &HttpRemoteFile,
+        destination: &mut File,
     ) -> CacheEntry {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 
@@ -44,18 +44,9 @@ impl HttpDownloader {
                 builder = builder.header(key, value.as_str());
             }
         }
+        builder = builder.header(header::USER_AGENT, USER_AGENT);
 
-        let request = builder.header(header::USER_AGENT, USER_AGENT);
-
-        let source = RemoteFile::from(file_source);
-        let mut destination = tokio::fs::File::create(destination).await?;
-        super::download_reqwest(
-            source.source_metric_key(),
-            request,
-            &self.timeouts,
-            &mut destination,
-        )
-        .await
+        super::download_reqwest(source_name, builder, &self.timeouts, destination).await
     }
 }
 
@@ -83,7 +74,10 @@ mod tests {
         let file_source = HttpRemoteFile::new(http_source, loc);
 
         let downloader = HttpDownloader::new(Client::new(), Default::default());
-        let download_status = downloader.download_source(file_source, dest).await;
+        let mut destination = tokio::fs::File::create(&dest).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert!(download_status.is_ok());
 
@@ -107,7 +101,10 @@ mod tests {
         let file_source = HttpRemoteFile::new(http_source, loc);
 
         let downloader = HttpDownloader::new(Client::new(), Default::default());
-        let download_status = downloader.download_source(file_source, dest).await;
+        let mut destination = tokio::fs::File::create(&dest).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert_eq!(download_status, Err(CacheError::NotFound));
     }

--- a/crates/symbolicator-service/src/services/download/s3.rs
+++ b/crates/symbolicator-service/src/services/download/s3.rs
@@ -1,8 +1,6 @@
 //! Support to download from S3 buckets.
 
-use std::any::type_name;
 use std::fmt;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,9 +14,8 @@ pub use aws_sdk_s3::Error as S3Error;
 use futures::TryStreamExt;
 use reqwest::StatusCode;
 
-use symbolicator_sources::{
-    AwsCredentialsProvider, RemoteFile, S3Region, S3RemoteFile, S3SourceKey,
-};
+use symbolicator_sources::{AwsCredentialsProvider, S3Region, S3RemoteFile, S3SourceKey};
+use tokio::fs::File;
 
 use crate::caching::{CacheEntry, CacheError};
 use crate::utils::http::DownloadTimeouts;
@@ -35,7 +32,7 @@ pub struct S3Downloader {
 
 impl fmt::Debug for S3Downloader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct(type_name::<Self>())
+        f.debug_struct("S3Downloader")
             .field("timeouts", &self.timeouts)
             .finish()
     }
@@ -104,8 +101,9 @@ impl S3Downloader {
     /// Downloads a source hosted on an S3 bucket.
     pub async fn download_source(
         &self,
-        file_source: S3RemoteFile,
-        destination: &Path,
+        source_name: &str,
+        file_source: &S3RemoteFile,
+        destination: &mut File,
     ) -> CacheEntry {
         let key = file_source.key();
         let bucket = file_source.bucket();
@@ -115,8 +113,6 @@ impl S3Downloader {
         let client = self.get_s3_client(&source_key).await;
         let request = client.get_object().bucket(&bucket).key(&key).send();
 
-        let source = RemoteFile::from(file_source);
-        let source_name = source.source_metric_key();
         let timeout = self.timeouts.head;
         let request = tokio::time::timeout(timeout, request);
         let request = super::measure_download_time(source_name, request);
@@ -191,8 +187,7 @@ impl S3Downloader {
                 .body
                 .map_err(|err| CacheError::download_error(&err))
         };
-        let mut destination = tokio::fs::File::create(destination).await?;
-        let future = super::download_stream(source_name, stream, &mut destination);
+        let future = super::download_stream(source_name, stream, destination);
 
         let timeout = content_length_timeout(response.content_length, self.timeouts.streaming);
 
@@ -367,7 +362,10 @@ mod tests {
         let source_location = SourceLocation::new("50/2fc0a51ec13e479998684fa139dca7/debuginfo");
         let file_source = S3RemoteFile::new(source, source_location);
 
-        let download_status = downloader.download_source(file_source, &target_path).await;
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert!(download_status.is_ok());
         assert!(target_path.exists());
@@ -393,7 +391,10 @@ mod tests {
         let source_location = SourceLocation::new("does/not/exist");
         let file_source = S3RemoteFile::new(source, source_location);
 
-        let download_status = downloader.download_source(file_source, &target_path).await;
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert_eq!(download_status, Err(CacheError::NotFound));
         assert!(!target_path.exists());
@@ -418,11 +419,14 @@ mod tests {
         let source_location = SourceLocation::new("does/not/exist");
         let file_source = S3RemoteFile::new(source, source_location);
 
-        let result = downloader.download_source(file_source, &target_path).await;
+        let mut destination = tokio::fs::File::create(&target_path).await.unwrap();
+        let download_status = downloader
+            .download_source("", &file_source, &mut destination)
+            .await;
 
         assert!(
-            matches!(result, Err(CacheError::PermissionDenied(_))),
-            "{result:?}"
+            matches!(download_status, Err(CacheError::PermissionDenied(_))),
+            "{download_status:?}"
         );
 
         assert!(!target_path.exists());

--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -412,7 +412,14 @@ impl SentryDownloader {
         }
         let source = RemoteFile::from(file_source);
 
-        super::download_reqwest(&source, request, &self.timeouts, destination).await
+        let mut destination = tokio::fs::File::create(destination).await?;
+        super::download_reqwest(
+            source.source_metric_key(),
+            request,
+            &self.timeouts,
+            &mut destination,
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
This has a couple of random refactors:

- Move `lookup_local_cache` out of the Cacher and make it non-generic in the hopes of improving compile times.
- Remove the `RemoveFile` from the inner Downloader code, passing the `source_metric_key` explicitly instead.
- Also migrate from `&Path` over to `&mut tokio::fs::File`.
- This opens us up to eventually use `download_reqwest` in the `SharedCache` code in the future.