### PR TITLE
Introduce more metrics for JS File Lookup

### DIFF
--- a/crates/symbolicator-service/src/js/metrics.rs
+++ b/crates/symbolicator-service/src/js/metrics.rs
@@ -42,13 +42,16 @@ impl JsMetrics {
         }
     }
 
-    pub fn record_not_found(&mut self, file_ty: SourceFileType, was_needed: bool) {
-        use SourceFileType::*;
-        match (file_ty, was_needed) {
-            (SourceMap, true) => self.sourcemap_not_found += 1,
-            (SourceMap, false) => self.sourcemap_not_needed += 1,
-            (_, _) => self.source_not_found += 1,
+    pub fn record_not_found(&mut self, file_ty: SourceFileType) {
+        if file_ty == SourceFileType::SourceMap {
+            self.sourcemap_not_found += 1
+        } else {
+            self.source_not_found += 1
         }
+    }
+
+    pub fn record_sourcemap_not_needed(&mut self) {
+        self.sourcemap_not_needed += 1
     }
 
     pub fn record_file_found_in_bundle(

--- a/crates/symbolicator-service/src/js/metrics.rs
+++ b/crates/symbolicator-service/src/js/metrics.rs
@@ -1,0 +1,168 @@
+use symbolic::debuginfo::sourcebundle::SourceFileType;
+
+use crate::types::ResolvedWith;
+
+/// Various metrics we want to capture *per-event* for JS events.
+#[derive(Debug, Default)]
+pub struct JsMetrics {
+    pub api_requests: u64,
+    pub queried_artifacts: u64,
+    pub fetched_artifacts: u64,
+    pub queried_bundles: u64,
+    pub scraped_files: u64,
+
+    // Product managers are interested in these metrics as a "funnel":
+    found_source_via_debugid: i64,
+    found_source_via_release: i64,
+    found_source_via_release_old: i64,
+    found_source_via_scraping: i64,
+    source_not_found: i64,
+
+    found_sourcemap_via_debugid: i64,
+    found_sourcemap_via_release: i64,
+    found_sourcemap_via_release_old: i64,
+    found_sourcemap_via_scraping: i64,
+    sourcemap_not_found: i64,
+    sourcemap_not_needed: i64,
+
+    // Engineers might also be interested in these metrics:
+    found_bundle_via_bundleindex: i64,
+    found_bundle_via_debugid: i64,
+    found_bundle_via_index: i64,
+    found_bundle_via_release: i64,
+    found_bundle_via_release_old: i64,
+}
+
+impl JsMetrics {
+    pub fn record_file_scraped(&mut self, file_ty: SourceFileType) {
+        if file_ty == SourceFileType::SourceMap {
+            self.found_sourcemap_via_scraping += 1;
+        } else {
+            self.found_source_via_scraping += 1;
+        }
+    }
+
+    pub fn record_not_found(&mut self, file_ty: SourceFileType, was_needed: bool) {
+        use SourceFileType::*;
+        match (file_ty, was_needed) {
+            (SourceMap, true) => self.sourcemap_not_found += 1,
+            (SourceMap, false) => self.sourcemap_not_needed += 1,
+            (_, _) => self.source_not_found += 1,
+        }
+    }
+
+    pub fn record_file_found_in_bundle(
+        &mut self,
+        file_ty: SourceFileType,
+        file_identified_by: ResolvedWith,
+        bundle_resolved_by: ResolvedWith,
+    ) {
+        use ResolvedWith::*;
+        use SourceFileType::*;
+        match (file_ty, file_identified_by, bundle_resolved_by) {
+            (SourceMap, DebugId, _) => {
+                self.found_sourcemap_via_debugid += 1;
+            }
+            (SourceMap, Url, ReleaseOld) => {
+                self.found_sourcemap_via_release_old += 1;
+            }
+            (SourceMap, _, _) => {
+                self.found_sourcemap_via_release += 1;
+            }
+            (_, DebugId, _) => self.found_source_via_debugid += 1,
+            (_, Url, ReleaseOld) => self.found_source_via_release_old += 1,
+            (_, _, _) => self.found_source_via_release += 1,
+        };
+
+        match bundle_resolved_by {
+            BundleIndex => self.found_bundle_via_bundleindex += 1,
+            DebugId => self.found_bundle_via_debugid += 1,
+            Index => self.found_bundle_via_index += 1,
+            Release => self.found_bundle_via_release += 1,
+            _ => self.found_bundle_via_release_old += 1,
+        }
+    }
+
+    pub fn submit_metrics(&self, artifact_bundles: u64) {
+        metric!(time_raw("js.api_requests") = self.api_requests);
+        metric!(time_raw("js.queried_bundles") = self.queried_bundles);
+        metric!(time_raw("js.fetched_bundles") = artifact_bundles);
+        metric!(time_raw("js.queried_artifacts") = self.queried_artifacts);
+        metric!(time_raw("js.fetched_artifacts") = self.fetched_artifacts);
+        metric!(time_raw("js.scraped_files") = self.scraped_files);
+
+        // TODO: we are currently getting these as counters. maybe we want to use `time_raw` to also
+        // have a per-event avg, etc.
+
+        // Sources:
+        metric!(
+            counter("js.found_via_bundle_debugid") += self.found_source_via_debugid,
+            "type" => "source",
+        );
+        metric!(
+            counter("js.found_via_bundle_url") += self.found_source_via_release,
+            "type" => "source",
+            "lookup" => "release",
+        );
+        metric!(
+            counter("js.found_via_bundle_url") += self.found_source_via_release_old,
+            "type" => "source",
+            "lookup" => "release-old",
+        );
+        metric!(
+            counter("js.found_via_scraping") += self.found_source_via_scraping,
+            "type" => "source",
+        );
+        metric!(
+            counter("js.file_not_found") += self.source_not_found,
+            "type" => "source",
+        );
+
+        // SourceMaps:
+        metric!(
+            counter("js.found_via_bundle_debugid") += self.found_sourcemap_via_debugid,
+            "type" => "sourcemap",
+        );
+        metric!(
+            counter("js.found_via_bundle_url") += self.found_sourcemap_via_release,
+            "type" => "sourcemap",
+            "lookup" => "release",
+        );
+        metric!(
+            counter("js.found_via_bundle_url") += self.found_sourcemap_via_release_old,
+            "type" => "sourcemap",
+            "lookup" => "release-old",
+        );
+        metric!(
+            counter("js.found_via_scraping") += self.found_sourcemap_via_scraping,
+            "type" => "sourcemap",
+        );
+        metric!(
+            counter("js.file_not_found") += self.sourcemap_not_found,
+            "type" => "sourcemap",
+        );
+        metric!(counter("js.sourcemap_not_needed") += self.sourcemap_not_needed);
+
+        // Lookup Method:
+        metric!(
+            counter("js.bundle_lookup") += self.found_bundle_via_bundleindex,
+            "method" => "bundleindex"
+        );
+        metric!(
+            counter("js.bundle_lookup") += self.found_bundle_via_debugid,
+            "method" => "debugid"
+        );
+        metric!(
+            counter("js.bundle_lookup") += self.found_bundle_via_index,
+            "method" => "index"
+        );
+        metric!(
+            counter("js.bundle_lookup") += self.found_bundle_via_release,
+            "method" => "release"
+        );
+        metric!(
+            counter("js.bundle_lookup") += self.found_bundle_via_release_old,
+            "method" => "release-old"
+        );
+    }
+}

--- a/crates/symbolicator-service/src/js/mod.rs
+++ b/crates/symbolicator-service/src/js/mod.rs
@@ -1,0 +1,3 @@
+mod metrics;
+
+pub use metrics::*;

--- a/crates/symbolicator-service/src/lib.rs
+++ b/crates/symbolicator-service/src/lib.rs
@@ -6,6 +6,7 @@ pub mod metrics;
 
 pub mod caching;
 pub mod config;
+mod js;
 pub mod services;
 pub mod types;
 pub mod utils;

--- a/crates/symbolicator-service/src/services/download/sentry.rs
+++ b/crates/symbolicator-service/src/services/download/sentry.rs
@@ -82,7 +82,8 @@ enum RawJsLookupResult {
     Bundle {
         id: SentryFileId,
         url: Url,
-        resolved_with: Option<ResolvedWith>,
+        #[serde(default)]
+        resolved_with: ResolvedWith,
     },
     File {
         id: SentryFileId,
@@ -90,7 +91,8 @@ enum RawJsLookupResult {
         abs_path: String,
         #[serde(default)]
         headers: ArtifactHeaders,
-        resolved_with: Option<ResolvedWith>,
+        #[serde(default)]
+        resolved_with: ResolvedWith,
     },
 }
 
@@ -103,7 +105,7 @@ pub enum JsLookupResult {
     ArtifactBundle {
         /// The [`RemoteFile`] to download this bundle from.
         remote_file: RemoteFile,
-        resolved_with: Option<ResolvedWith>,
+        resolved_with: ResolvedWith,
     },
     /// This is an individual artifact file.
     IndividualArtifact {
@@ -113,7 +115,7 @@ pub enum JsLookupResult {
         abs_path: String,
         /// Arbitrary headers of this file, such as a `Sourcemap` reference.
         headers: ArtifactHeaders,
-        resolved_with: Option<ResolvedWith>,
+        resolved_with: ResolvedWith,
     },
 }
 

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -55,6 +55,8 @@ use crate::services::symbolication::ScrapingConfig;
 use crate::types::{JsStacktrace, ResolvedWith, Scope};
 use crate::utils::http::is_valid_origin;
 
+use crate::js::JsMetrics;
+
 use super::bundle_index::BundleIndex;
 use super::caches::versions::SOURCEMAP_CACHE_VERSIONS;
 use super::caches::{BundleIndexCache, ByteViewString, SourceFilesCache};
@@ -224,16 +226,7 @@ impl SourceMapLookup {
 
             used_artifact_bundles: Default::default(),
 
-            api_requests: 0,
-            queried_artifacts: 0,
-            fetched_artifacts: 0,
-            queried_bundles: 0,
-            scraped_files: 0,
-            found_via_index_debugid: 0,
-            found_via_index_url: 0,
-            found_via_bundle_debugid: 0,
-            found_via_bundle_url: 0,
-            found_via_scraping: 0,
+            metrics: Default::default(),
         };
 
         Self {
@@ -524,7 +517,7 @@ impl fmt::Display for CachedFileUri {
 pub struct CachedFileEntry<T = CachedFile> {
     pub uri: CachedFileUri,
     pub entry: CacheEntry<T>,
-    pub resolved_with: Option<ResolvedWith>,
+    pub resolved_with: ResolvedWith,
 }
 
 impl<T> CachedFileEntry<T> {
@@ -533,7 +526,7 @@ impl<T> CachedFileEntry<T> {
         Self {
             uri: CachedFileUri::IndividualFile(uri),
             entry: Err(CacheError::NotFound),
-            resolved_with: None,
+            resolved_with: ResolvedWith::Unknown,
         }
     }
 }
@@ -607,10 +600,12 @@ impl CachedFile {
 struct IndividualArtifact {
     remote_file: RemoteFile,
     headers: ArtifactHeaders,
-    resolved_with: Option<ResolvedWith>,
+    resolved_with: ResolvedWith,
 }
 
 struct ArtifactFetcher {
+    metrics: JsMetrics,
+
     // other services:
     objects: ObjectsActor,
     sourcefiles_cache: Arc<SourceFilesCache>,
@@ -631,23 +626,11 @@ struct ArtifactFetcher {
     scraping: ScrapingConfig,
 
     /// The set of all the artifact bundles that we have downloaded so far.
-    artifact_bundles: BTreeMap<RemoteFileUri, CacheEntry<(ArtifactBundle, Option<ResolvedWith>)>>,
+    artifact_bundles: BTreeMap<RemoteFileUri, CacheEntry<(ArtifactBundle, ResolvedWith)>>,
     /// The set of individual artifacts, by their `url`.
     individual_artifacts: HashMap<String, IndividualArtifact>,
 
     used_artifact_bundles: HashSet<SentryFileId>,
-
-    // various metrics:
-    api_requests: u64,
-    queried_artifacts: u64,
-    fetched_artifacts: u64,
-    queried_bundles: u64,
-    scraped_files: u64,
-    found_via_index_url: i64,
-    found_via_index_debugid: i64,
-    found_via_bundle_url: i64,
-    found_via_bundle_debugid: i64,
-    found_via_scraping: i64,
 }
 
 impl ArtifactFetcher {
@@ -667,6 +650,9 @@ impl ArtifactFetcher {
 
         // Fetch the minified file first
         let minified_source = self.get_file(&key).await;
+        if minified_source.entry.is_err() {
+            self.metrics.record_not_found(SourceFileType::Source, true);
+        }
 
         // Then fetch the corresponding sourcemap if we have a sourcemap reference
         let sourcemap_url = match &minified_source.entry {
@@ -676,6 +662,8 @@ impl ArtifactFetcher {
 
         // If we don't have sourcemap reference, nor a `DebugId`, we skip creating `SourceMapCache`.
         if sourcemap_url.is_none() && debug_id.is_none() {
+            self.metrics
+                .record_not_found(SourceFileType::SourceMap, false);
             return (minified_source, None);
         }
 
@@ -707,6 +695,14 @@ impl ArtifactFetcher {
                 self.get_file(&sourcemap_key).await
             }
         };
+
+        if matches!(sourcemap.uri, CachedFileUri::Embedded) {
+            self.metrics
+                .record_not_found(SourceFileType::SourceMap, false);
+        } else if sourcemap.entry.is_err() {
+            self.metrics
+                .record_not_found(SourceFileType::SourceMap, true);
+        }
 
         // Now that we (may) have both files, we can create a `SourceMapCache` for it
         let smcache = self
@@ -772,7 +768,7 @@ impl ArtifactFetcher {
         let remote_file: RemoteFile = sentry_file.into();
         let bundle_uri = remote_file.uri();
 
-        self.ensure_artifact_bundle(remote_file, Some(ResolvedWith::Index))
+        self.ensure_artifact_bundle(remote_file, ResolvedWith::BundleIndex)
             .await;
 
         let bundle = self.artifact_bundles.get(&bundle_uri)?;
@@ -785,23 +781,31 @@ impl ArtifactFetcher {
         match &lookup_key {
             IndexLookupKey::DebugId(debug_id) => {
                 if let Ok(Some(descriptor)) = bundle.source_by_debug_id(*debug_id, key.as_type()) {
-                    self.found_via_index_debugid += 1;
+                    self.metrics.record_file_found_in_bundle(
+                        key.as_type(),
+                        ResolvedWith::DebugId,
+                        ResolvedWith::BundleIndex,
+                    );
                     tracing::trace!(?key, "Found file in `BundleIndex` by debug-id");
                     return Some(CachedFileEntry {
                         uri: CachedFileUri::Bundled(bundle_uri.clone(), key.clone()),
                         entry: CachedFile::from_descriptor(key.abs_path(), descriptor),
-                        resolved_with: Some(ResolvedWith::Index),
+                        resolved_with: ResolvedWith::BundleIndex, // TODO: should this be `DebugId` instead?
                     });
                 }
             }
             IndexLookupKey::Url(url) => {
                 if let Ok(Some(descriptor)) = bundle.source_by_url(url) {
-                    self.found_via_index_url += 1;
+                    self.metrics.record_file_found_in_bundle(
+                        key.as_type(),
+                        ResolvedWith::Url,
+                        ResolvedWith::BundleIndex,
+                    );
                     tracing::trace!(?key, url, "Found file in `BundleIndex` by url");
                     return Some(CachedFileEntry {
                         uri: CachedFileUri::Bundled(bundle_uri.clone(), key.clone()),
                         entry: CachedFile::from_descriptor(key.abs_path(), descriptor),
-                        resolved_with: Some(ResolvedWith::Index),
+                        resolved_with: ResolvedWith::BundleIndex,
                     });
                 }
             }
@@ -859,7 +863,7 @@ impl ArtifactFetcher {
         let make_error = |err| CachedFileEntry {
             uri: CachedFileUri::ScrapedFile(RemoteFileUri::new(abs_path)),
             entry: Err(CacheError::DownloadError(err)),
-            resolved_with: None,
+            resolved_with: ResolvedWith::Unknown,
         };
 
         let mut url = match Url::parse(abs_path) {
@@ -898,7 +902,7 @@ impl ArtifactFetcher {
             Some(host) => host,
         };
 
-        self.scraped_files += 1;
+        self.metrics.scraped_files += 1;
 
         let span = sentry::configure_scope(|scope| scope.get_span());
         let ctx = sentry::TransactionContext::continue_from_span(
@@ -918,8 +922,8 @@ impl ArtifactFetcher {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let key = cache_busting_key(url.as_str(), timestamp, SCRAPE_FILES_EVERY);
-        url.set_fragment(Some(&key.to_string()));
+        let cache_key = cache_busting_key(url.as_str(), timestamp, SCRAPE_FILES_EVERY);
+        url.set_fragment(Some(&cache_key.to_string()));
 
         let mut remote_file = HttpRemoteFile::from_url(url);
         remote_file.headers.extend(
@@ -941,7 +945,7 @@ impl ArtifactFetcher {
         CachedFileEntry {
             uri,
             entry: scraped_file.map(|contents| {
-                self.found_via_scraping += 1;
+                self.metrics.record_file_scraped(key.as_type());
                 tracing::trace!(?key, "Found file by scraping the web");
 
                 let sourcemap_url = discover_sourcemaps_location(&contents)
@@ -953,7 +957,7 @@ impl ArtifactFetcher {
                     sourcemap_url,
                 }
             }),
-            resolved_with: Some(ResolvedWith::Scraping),
+            resolved_with: ResolvedWith::Scraping,
         }
     }
 
@@ -966,15 +970,21 @@ impl ArtifactFetcher {
         if let Some(debug_id) = key.debug_id() {
             let ty = key.as_type();
             for (bundle_uri, bundle) in self.artifact_bundles.iter().rev() {
-                let Ok((bundle, _)) = bundle else { continue };
+                let Ok((bundle, bundle_resolved_with)) = bundle else {
+                    continue;
+                };
                 let bundle = bundle.get();
                 if let Ok(Some(descriptor)) = bundle.source_by_debug_id(debug_id, ty) {
-                    self.found_via_bundle_debugid += 1;
+                    self.metrics.record_file_found_in_bundle(
+                        key.as_type(),
+                        ResolvedWith::DebugId,
+                        *bundle_resolved_with,
+                    );
                     tracing::trace!(?key, "Found file in artifact bundles by debug-id");
                     return Some(CachedFileEntry {
                         uri: CachedFileUri::Bundled(bundle_uri.clone(), key.clone()),
                         entry: CachedFile::from_descriptor(key.abs_path(), descriptor),
-                        resolved_with: Some(ResolvedWith::DebugId),
+                        resolved_with: ResolvedWith::DebugId,
                     });
                 }
             }
@@ -989,7 +999,11 @@ impl ArtifactFetcher {
                     };
                     let bundle = bundle.get();
                     if let Ok(Some(descriptor)) = bundle.source_by_url(&url) {
-                        self.found_via_bundle_url += 1;
+                        self.metrics.record_file_found_in_bundle(
+                            key.as_type(),
+                            ResolvedWith::Url,
+                            *resolved_with,
+                        );
                         tracing::trace!(?key, url, "Found file in artifact bundles by url");
                         return Some(CachedFileEntry {
                             uri: CachedFileUri::Bundled(bundle_uri.clone(), key.clone()),
@@ -1018,7 +1032,7 @@ impl ArtifactFetcher {
 
         // NOTE: we have no separate `found_via_artifacts` metric, as we don't expect these to ever
         // error, so one can use the `sum` of this metric:
-        self.fetched_artifacts += 1;
+        self.metrics.fetched_artifacts += 1;
 
         let mut artifact_contents = self
             .sourcefiles_cache
@@ -1087,7 +1101,7 @@ impl ArtifactFetcher {
                 return false;
             }
         }
-        self.api_requests += 1;
+        self.metrics.api_requests += 1;
 
         let results = match self
             .download_svc
@@ -1117,7 +1131,7 @@ impl ArtifactFetcher {
                     headers,
                     resolved_with,
                 } => {
-                    self.queried_artifacts += 1;
+                    self.metrics.queried_artifacts += 1;
                     self.individual_artifacts
                         .entry(abs_path)
                         .or_insert_with(|| {
@@ -1140,7 +1154,7 @@ impl ArtifactFetcher {
                     remote_file,
                     resolved_with,
                 } => {
-                    self.queried_bundles += 1;
+                    self.metrics.queried_bundles += 1;
 
                     did_get_new_data |= self
                         .ensure_artifact_bundle(remote_file, resolved_with)
@@ -1155,7 +1169,7 @@ impl ArtifactFetcher {
     async fn ensure_artifact_bundle(
         &mut self,
         remote_file: RemoteFile,
-        resolved_with: Option<ResolvedWith>,
+        resolved_with: ResolvedWith,
     ) -> bool {
         let uri = remote_file.uri();
         // clippy, you are wrong, as this would result in borrowing errors,
@@ -1262,17 +1276,8 @@ impl ArtifactFetcher {
     }
 
     fn record_metrics(&self) {
-        metric!(time_raw("js.api_requests") = self.api_requests);
-        metric!(time_raw("js.queried_bundles") = self.queried_bundles);
-        metric!(time_raw("js.fetched_bundles") = self.artifact_bundles.len() as u64);
-        metric!(time_raw("js.queried_artifacts") = self.queried_artifacts);
-        metric!(time_raw("js.fetched_artifacts") = self.fetched_artifacts);
-        metric!(time_raw("js.scraped_files") = self.scraped_files);
-        metric!(counter("js.found_via_index_debugid") += self.found_via_index_debugid);
-        metric!(counter("js.found_via_index_url") += self.found_via_index_url);
-        metric!(counter("js.found_via_bundle_debugid") += self.found_via_bundle_debugid);
-        metric!(counter("js.found_via_bundle_url") += self.found_via_bundle_url);
-        metric!(counter("js.found_via_scraping") += self.found_via_scraping);
+        let artifact_bundles = self.artifact_bundles.len() as u64;
+        self.metrics.submit_metrics(artifact_bundles);
     }
 }
 

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -193,9 +193,9 @@ async fn symbolicate_js_frame(
         Some(smcache) => match &smcache.entry {
             Ok(entry) => (entry, smcache.resolved_with),
             Err(CacheError::Malformed(_)) => {
-                // If we succesfully resolved the sourcemap but it's broken somehow,
+                // If we successfully resolved the sourcemap but it's broken somehow,
                 // We should still record that we resolved it.
-                raw_frame.data.resolved_with = smcache.resolved_with;
+                raw_frame.data.resolved_with = Some(smcache.resolved_with);
                 return Err(JsModuleErrorKind::MalformedSourcemap {
                     url: sourcemap_label.to_owned(),
                 });
@@ -211,7 +211,7 @@ async fn symbolicate_js_frame(
 
     let mut frame = raw_frame.clone();
     frame.data.sourcemap = Some(sourcemap_label.clone());
-    frame.data.resolved_with = resolved_with;
+    frame.data.resolved_with = Some(resolved_with);
 
     let sp = SourcePosition::new(line - 1, col.saturating_sub(1));
     let token = smcache

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -704,14 +704,32 @@ pub struct JsFrameData {
     pub symbolicated: bool,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+/// A marker what a File was resolved with.
+///
+/// This enum serves a double purpose, both marking how an individual file was found inside of a
+/// bundle, as well as tracking through which method that bundle itself was found.
+///
+#[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ResolvedWith {
+    /// Both: Found in a Bundle via DebugId
+    /// And: Found the Bundle via API Lookup via DebugId / Database Index
     DebugId,
+    /// Found in a Bundle via Url matching
+    Url,
+    /// Found the Bundle via API Lookup via Database Index
     Index,
+    /// Found the File in a Flat File / Bundle Index
+    BundleIndex,
+    /// Found the Bundle via API Lookup as an ArtifactBundle
     Release,
+    /// Found the Bundle via API Lookup as a ReleaseFile
     ReleaseOld,
+    /// Scraped the File from the Web
     Scraping,
+    /// Unknown
+    #[default]
+    Unknown,
 }
 
 impl JsFrameData {

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -704,7 +704,7 @@ pub struct JsFrameData {
     pub symbolicated: bool,
 }
 
-/// A marker what a File was resolved with.
+/// A marker indicating what a File was resolved with.
 ///
 /// This enum serves a double purpose, both marking how an individual file was found inside of a
 /// bundle, as well as tracking through which method that bundle itself was found.


### PR DESCRIPTION
In order to better measure the success of JS symbolication, this introduces more fine grained metrics that represent a funnel:

We capture metrics for source files and sourcemaps separately, with the following tags:
- found via debug-id
- found via release
- found via release-old
- found via scraping
- not found
- not needed (for sourcemaps)

This reuses existing metrics names as much as possible for now.

Additionally, this also captures more metrics for engineers that go into detail via which method the bundle was found.

fixes https://github.com/getsentry/sentry/issues/49950
#skip-changelog