### PR TITLE
deps: Update symbolic to 12.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Docker containers were updated to debian bookworm. ([#1293](https://github.com/getsentry/symbolicator/pull/1293))
 - Do not process `.o` files in Symsorter. ([#1288](https://github.com/getsentry/symbolicator/pull/1288))
 - symsorter now uses the same filter as sentry-cli to ignore (very) large files and precompiled headers. ([#1273](https://github.com/getsentry/symbolicator/pull/1273))
+- JS source mapping URLs are now read without query strings or fragments. ([#1294](https://github.com/getsentry/symbolicator/pull/1294))
+
+### Dependencies
+- Bump `symbolic` from 12.3.0 to 12.4.0. ([#1294](https://github.com/getsentry/symbolicator/pull/1294))
 
 ## 23.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli 0.28.0",
+ "gimli",
 ]
 
 [[package]]
@@ -1428,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,19 +1676,13 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
-dependencies = [
- "fallible-iterator",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1692,9 +1692,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
 dependencies = [
  "log",
  "plain",
@@ -2823,7 +2823,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "scroll",
  "uuid",
 ]
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f35e609846ed5924d00311809fdc22bfeebf0dfadfd33ec08bae7a8076aa7b"
+checksum = "d3b5247a96aeefec188691938459892bffd23f1c3e9900dc08ac5248fe3bf08e"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4188,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd11c720b3e9c407638d0b4f019b01892116229a1319adf0b60fa021eac4f4ed"
+checksum = "05d3f3ef8f19bfb21ba96eb86505e8afb4e3d2226422fad44c0e40162fe435a4"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4199,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167a4ffd7c35c143fd1030aa3c2caf76ba42220bd5a6b5f4781896434723b8c3"
+checksum = "9e0e9bc48b3852f36a84f8d0da275d50cb3c2b88b59b9ec35fdd8b7fa239e37d"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4212,17 +4212,17 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214a188b70f3e82f56d068096fa9953cc6082b58a949b56629f5eaa30ceb574b"
+checksum = "7ef9a1b95a8ea7b5afb550da0d93ecc706de3ce869a9674fc3bc51fadc019feb"
 dependencies = [
  "debugid",
  "dmsort",
  "elementtree",
  "elsa",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "flate2",
- "gimli 0.27.3",
+ "gimli",
  "goblin",
  "lazy_static",
  "nom",
@@ -4244,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e378c50e80686c1c5c205674e1f86a2858bec3d2a7dfdd690331a8a19330f293"
+checksum = "691e53bdc0702aba3a5abc2cffff89346fcbd4050748883c7e2f714b33a69045"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -4257,11 +4257,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75befe8168a8079855ee1c275451fe9f408248a5e73d99da668c8f4eaf99199d"
+checksum = "efaaade4f5b4815046bc327fe7c56f255c18f57de222efaa8212b554319e7303"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde_json",
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4269,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1ce8734ea2f33b3b8f4a67d1fc58df295a0191f115eab60f9ac5cf7169129d"
+checksum = "b95399a30236ac95fd9ce69a008b8a18e58859e9780a13bcb16fda545802f876"
 dependencies = [
  "flate2",
  "indexmap 1.9.3",
@@ -4285,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a596291f3582865299a1ef7162ea26fdd26d5c26e94c30766d42ca6eca1337"
+checksum = "01364d2f47e67743d871b6b5fd289d47407f39820ee9523b6eb387aa06810346"
 dependencies = [
  "itertools",
  "js-source-scopes",
@@ -4300,11 +4300,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.3.0"
+version = "12.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f996fc4a38d97b9838a4de257c6d5359a2e9ccecc82d5a97b03e3b974f3082"
+checksum = "4339f37007c0fd6d6dddaf6f04619a4a5d6308e71eabbd45c30e0af124014259"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "symbolic-common",
  "symbolic-debuginfo",
  "symbolic-il2cpp",

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -12,4 +12,4 @@ clap = { version = "4.3.2", features = ["derive"] }
 reqwest = { version = "0.11.0", features = ["blocking", "json", "multipart", "trust-dns"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic-common = "12.3.0"
+symbolic-common = "12.4.0"

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.81"
 serde_yaml = "0.9.14"
 sha2 = "0.10.6"
 sourcemap = "6.2.1"
-symbolic = { version = "12.3.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "sourcemapcache", "symcache", "il2cpp", "ppdb"] }
+symbolic = { version = "12.4.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "sourcemapcache", "symcache", "il2cpp", "ppdb"] }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
 thiserror = "1.0.31"

--- a/crates/symbolicator-sources/Cargo.toml
+++ b/crates/symbolicator-sources/Cargo.toml
@@ -12,7 +12,7 @@ aws-types = "0.56.0"
 glob = "0.3.0"
 lazy_static = "1.4.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = "12.3.0"
+symbolic = "12.4.0"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -20,7 +20,7 @@ hostname = "0.3.1"
 sentry = { version = "0.31.0", features = ["anyhow", "debug-images", "tracing", "tower", "tower-http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.3.0"
+symbolic = "12.4.0"
 symbolicator-crash = { path = "../symbolicator-crash", optional = true }
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }

--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { version = "0.11.12", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
-symbolic = "12.3.0"
+symbolic = "12.4.0"
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.3.0"

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic = { version = "12.3.0", features = ["debuginfo-serde"] }
+symbolic = { version = "12.4.0", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2"] }


### PR DESCRIPTION
This pulls in https://github.com/getsentry/symbolic/pull/809, which means that source mapping URLs will be read without query strings or fragments.