### PR TITLE
Add instrumentation to Stresstest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,6 +4434,7 @@ name = "symbolicator-stress"
 version = "23.8.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "futures",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
+ "sentry",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/symbolicator-stress/Cargo.toml
+++ b/crates/symbolicator-stress/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.3.12"
 humantime = "2.0.1"
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-test = { path = "../symbolicator-test" }
+sentry = { version = "0.31.0", features = ["anyhow", "debug-images", "tracing"] }
 serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
 serde_yaml = "0.9.14"

--- a/crates/symbolicator-stress/Cargo.toml
+++ b/crates/symbolicator-stress/Cargo.toml
@@ -6,15 +6,16 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.57"
+axum = "0.6.10"
 clap = { version = "4.3.2", features = ["derive"] }
 futures = "0.3.12"
 humantime = "2.0.1"
-symbolicator-service = { path = "../symbolicator-service" }
-symbolicator-test = { path = "../symbolicator-test" }
 sentry = { version = "0.31.0", features = ["anyhow", "debug-images", "tracing"] }
 serde = { version = "1.0.137", features = ["derive"] }
-tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
-serde_yaml = "0.9.14"
-tempfile = "3.2.0"
 serde_json = "1.0.81"
+serde_yaml = "0.9.14"
+symbolicator-service = { path = "../symbolicator-service" }
+symbolicator-test = { path = "../symbolicator-test" }
+tempfile = "3.2.0"
+tokio = { version = "1.24.2", features = ["rt-multi-thread", "macros", "time", "sync"] }
 tracing-subscriber = "0.3.17"

--- a/crates/symbolicator-stress/src/logging.rs
+++ b/crates/symbolicator-stress/src/logging.rs
@@ -1,0 +1,95 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::io::Write;
+
+use symbolicator_service::metrics;
+use tracing_subscriber::fmt::fmt;
+use tracing_subscriber::fmt::time::UtcTime;
+use tracing_subscriber::prelude::*;
+
+#[derive(Debug, Default)]
+pub struct Config {
+    pub backtraces: bool,
+    pub sentry: bool,
+    pub tracing: bool,
+    pub metrics: bool,
+}
+
+#[derive(Default)]
+pub struct Guard {
+    sentry: Option<sentry::ClientInitGuard>,
+    // TODO: return the ports / futures of the http / upd servers to use
+}
+
+pub fn init(config: Config) -> Guard {
+    if config.backtraces {
+        env::set_var("RUST_BACKTRACE", "1");
+    }
+
+    let mut guard = Guard::default();
+
+    if config.sentry {
+        let dsn = "TODO"; // create a *real* noop http server for sentry to send envelopes to
+
+        guard.sentry = Some(sentry::init((
+            dsn,
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                traces_sample_rate: 1.0,
+                ..Default::default()
+            },
+        )));
+    }
+
+    if config.tracing {
+        // we will log DEBUG output
+        let rust_log = "INFO,symbolicator=DEBUG";
+        let subscriber = fmt()
+            .with_timer(UtcTime::rfc_3339())
+            .with_target(true)
+            .with_env_filter(rust_log);
+
+        // we want all the tracing machinery to be active, but not spam the console,
+        // so redirect everything into the void:
+        let subscriber = subscriber.with_writer(|| NoopWriter);
+
+        // this should mimic the settings used in production:
+        subscriber
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_span_list(true)
+            .with_file(true)
+            .with_line_number(true)
+            .finish()
+            .with(sentry::integrations::tracing::layer())
+            .init();
+    }
+
+    if config.metrics {
+        let host = "TODO"; // create a *real* noop udp server to send metrics to
+
+        // have some default tags, just to be closer to the real world config
+        let mut tags = BTreeMap::new();
+        tags.insert("host".into(), "stresstest".into());
+        tags.insert("env".into(), "stresstest".into());
+
+        metrics::configure_statsd("symbolicator", host, tags);
+    }
+
+    guard
+}
+
+struct NoopWriter;
+impl Write for NoopWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // try to prevent the compiler from optimizing away all the formatting code:
+        let buf = std::hint::black_box(buf);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/symbolicator-stress/src/main.rs
+++ b/crates/symbolicator-stress/src/main.rs
@@ -1,67 +1,18 @@
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use humantime::parse_duration;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 
 use symbolicator_service::config::Config as SymbolicatorConfig;
-use symbolicator_service::services::download::SourceConfig;
-use symbolicator_service::services::symbolication::{
-    StacktraceOrigin, SymbolicateJsStacktraces, SymbolicateStacktraces, SymbolicationActor,
-};
-use symbolicator_service::types::{JsStacktrace, RawObjectInfo, RawStacktrace, Scope};
-use tokio::sync::Semaphore;
 
-#[derive(Debug, Deserialize, Serialize)]
-struct WorkloadsConfig {
-    workloads: Vec<Workload>,
-}
+mod logging;
+mod stresstest;
+mod workloads;
 
-#[derive(Debug, Deserialize, Serialize)]
-struct Workload {
-    concurrency: usize,
-    #[serde(flatten)]
-    payload: Payload,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum Payload {
-    Minidump(PathBuf),
-    Event(PathBuf),
-    Js { source: PathBuf, event: PathBuf },
-}
-
-#[derive(Debug, Deserialize)]
-struct EventFile {
-    stacktraces: Vec<RawStacktrace>,
-    modules: Vec<RawObjectInfo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct JsEventFile {
-    stacktraces: Vec<JsStacktrace>,
-    modules: Vec<RawObjectInfo>,
-}
-
-#[derive(Clone)]
-struct MinidumpPayload {
-    scope: Scope,
-    minidump_file: PathBuf,
-    sources: Arc<[SourceConfig]>,
-}
-
-enum ParsedPayload {
-    Minidump(MinidumpPayload),
-    Event(SymbolicateStacktraces),
-    Js(symbolicator_test::Server, SymbolicateJsStacktraces),
-}
+use stresstest::perform_stresstest;
+use workloads::WorkloadsConfig;
 
 /// Command line interface parser.
 #[derive(Parser)]
@@ -79,8 +30,7 @@ struct Cli {
     duration: Duration,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // parse configs
@@ -92,220 +42,21 @@ async fn main() -> Result<()> {
     let config_path = cli.config;
     let service_config = SymbolicatorConfig::get(config_path.as_deref())?;
 
-    // TODO: we want to profile the effect of tracing without actually outputting stuff
-    // tracing_subscriber::fmt::init();
+    let _guard = logging::init(logging::Config {
+        // TODO: actually make this configurable
+        backtraces: true,
+        tracing: true,
+        // TODO: init metrics and sentry
+        ..Default::default()
+    });
 
-    // start symbolicator service
-    let runtime = tokio::runtime::Handle::current();
-    let (symbolication, _objects) =
-        symbolicator_service::services::create_service(&service_config, runtime)
-            .context("failed starting symbolication service")?;
-    let symbolication = Arc::new(symbolication);
+    let megs = 1024 * 1024;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(8 * megs)
+        .build()?;
 
-    // initialize workloads
-    let workloads: Vec<_> = workloads
-        .workloads
-        .into_iter()
-        .enumerate()
-        .map(|(i, workload)| {
-            let scope = Scope::Scoped(i.to_string().into());
-            let sources = service_config.sources.clone();
-            let payload = prepare_payload(scope, sources, workload.payload);
-            (workload.concurrency, Arc::new(payload))
-        })
-        .collect();
-
-    // warmup: run each workload once to make sure caches are warm
-    {
-        let start = Instant::now();
-
-        let futures = workloads.iter().map(|(_, workload)| {
-            let symbolication = Arc::clone(&symbolication);
-            let workload = Arc::clone(workload);
-            tokio::spawn(async move {
-                process_payload(&symbolication, &workload).await;
-            })
-        });
-
-        let _results = futures::future::join_all(futures).await;
-
-        println!("Warmup: {:?}", start.elapsed());
-    };
-    println!();
-
-    // run the workloads concurrently
-    let mut tasks = Vec::with_capacity(workloads.len());
-    for (concurrency, workload) in workloads.into_iter() {
-        let start = Instant::now();
-        let duration = cli.duration;
-        let deadline = tokio::time::Instant::from_std(start + duration);
-        let symbolication = Arc::clone(&symbolication);
-        let workload = Arc::clone(&workload);
-
-        let task = tokio::spawn(async move {
-            let finished_tasks = Arc::new(AtomicUsize::new(0));
-            let semaphore = Arc::new(Semaphore::new(concurrency));
-
-            // See <https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html#examples>
-            let sleep = tokio::time::sleep_until(deadline);
-            tokio::pin!(sleep);
-
-            loop {
-                if deadline.elapsed() > Duration::ZERO {
-                    break;
-                }
-                tokio::select! {
-                    permit = semaphore.clone().acquire_owned() => {
-                        let workload = Arc::clone(&workload);
-                        let symbolication = Arc::clone(&symbolication);
-                        let finished_tasks = Arc::clone(&finished_tasks);
-
-                        tokio::spawn(async move {
-                            process_payload(&symbolication, &workload).await;
-
-                            // TODO: maybe maintain a histogram?
-                            finished_tasks.fetch_add(1, Ordering::Relaxed);
-
-                            drop(permit);
-                        });
-                    }
-                    _ = &mut sleep => {
-                        break;
-                    }
-                }
-            }
-
-            // we only count finished tasks
-            let ops = finished_tasks.load(Ordering::Relaxed);
-
-            // by acquiring *all* the semaphores, we essentially wait for all outstanding tasks to finish
-            let _permits = semaphore.acquire_many(concurrency as u32).await;
-
-            (concurrency, ops)
-        });
-        tasks.push(task);
-    }
-
-    let finished_tasks = futures::future::join_all(tasks).await;
-
-    for (i, task) in finished_tasks.into_iter().enumerate() {
-        let (concurrency, ops) = task.unwrap();
-
-        let ops_ps = ops as f32 / cli.duration.as_secs() as f32;
-        println!("Workload {i} (concurrency: {concurrency}): {ops} operations, {ops_ps} ops/s");
-    }
+    runtime.block_on(perform_stresstest(service_config, workloads, cli.duration))?;
 
     Ok(())
-}
-
-fn prepare_payload(scope: Scope, sources: Arc<[SourceConfig]>, payload: Payload) -> ParsedPayload {
-    match payload {
-        Payload::Minidump(path) => ParsedPayload::Minidump(MinidumpPayload {
-            scope,
-            sources,
-
-            minidump_file: path,
-        }),
-        Payload::Event(path) => {
-            let EventFile {
-                stacktraces,
-                modules,
-            } = read_json(path);
-            let modules = modules.into_iter().map(From::from).collect();
-
-            ParsedPayload::Event(SymbolicateStacktraces {
-                scope,
-                signal: None,
-                sources,
-                origin: StacktraceOrigin::Symbolicate,
-                apply_source_context: true,
-                scraping: Default::default(),
-                stacktraces,
-                modules,
-            })
-        }
-        Payload::Js { source, event } => {
-            let parent = source.parent().unwrap();
-            let source: serde_json::Value = read_json(&source);
-            let (srv, source) = symbolicator_test::sourcemap_server(parent, move |url, _query| {
-                let lookup = source
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .map(|entry| {
-                        let mut entry = entry.clone();
-                        let map = entry.as_object_mut().unwrap();
-                        let url = map["url"].as_str().unwrap().replace("{url}", url);
-                        map["url"] = serde_json::Value::String(url);
-                        entry
-                    })
-                    .collect();
-                serde_json::Value::Array(lookup)
-            });
-
-            let JsEventFile {
-                stacktraces,
-                modules,
-            } = read_json(event);
-
-            ParsedPayload::Js(
-                srv,
-                SymbolicateJsStacktraces {
-                    scope,
-                    source: Arc::new(source),
-                    release: Some("some-release".into()),
-                    dist: None,
-                    debug_id_index: None,
-                    url_index: None,
-                    scraping: Default::default(),
-                    apply_source_context: true,
-                    stacktraces,
-                    modules,
-                },
-            )
-        }
-    }
-}
-
-fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> T {
-    let file = std::fs::File::open(path).unwrap();
-    let reader = BufReader::new(file);
-    serde_json::from_reader(reader).unwrap()
-}
-
-async fn process_payload(symbolication: &SymbolicationActor, workload: &ParsedPayload) {
-    match workload {
-        ParsedPayload::Minidump(payload) => {
-            let MinidumpPayload {
-                scope,
-                minidump_file,
-                sources,
-            } = payload;
-
-            // processing a minidump requires a tempfile that can be persisted -_-
-            // so that means we have to make a copy of our minidump
-            let mut temp_file = tempfile::Builder::new();
-            temp_file.prefix("minidump").suffix(".dmp");
-            let temp_file = temp_file.tempfile().unwrap();
-            let (temp_file, temp_path) = temp_file.into_parts();
-            let mut temp_file = tokio::fs::File::from_std(temp_file);
-
-            let mut minidump_file = tokio::fs::File::open(minidump_file).await.unwrap();
-
-            tokio::io::copy(&mut minidump_file, &mut temp_file)
-                .await
-                .unwrap();
-
-            symbolication
-                .process_minidump(scope.clone(), temp_path, Arc::clone(sources))
-                .await
-                .unwrap();
-        }
-        ParsedPayload::Event(payload) => {
-            symbolication.symbolicate(payload.clone()).await.unwrap();
-        }
-        ParsedPayload::Js(_srv, payload) => {
-            symbolication.symbolicate_js(payload.clone()).await.unwrap();
-        }
-    };
 }

--- a/crates/symbolicator-stress/src/stresstest.rs
+++ b/crates/symbolicator-stress/src/stresstest.rs
@@ -1,0 +1,128 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+use sentry::SentryFutureExt;
+use symbolicator_service::config::Config as SymbolicatorConfig;
+use symbolicator_service::types::Scope;
+use tokio::sync::Semaphore;
+
+use crate::workloads::{prepare_payload, process_payload, WorkloadsConfig};
+
+pub async fn perform_stresstest(
+    service_config: SymbolicatorConfig,
+    workloads: WorkloadsConfig,
+    duration: Duration,
+) -> Result<()> {
+    // start symbolicator service
+    let runtime = tokio::runtime::Handle::current();
+    let (symbolication, _objects) =
+        symbolicator_service::services::create_service(&service_config, runtime)
+            .context("failed starting symbolication service")?;
+    let symbolication = Arc::new(symbolication);
+
+    // initialize workloads
+    let workloads: Vec<_> = workloads
+        .workloads
+        .into_iter()
+        .enumerate()
+        .map(|(i, workload)| {
+            let scope = Scope::Scoped(i.to_string().into());
+            let sources = service_config.sources.clone();
+            let payload = prepare_payload(scope, sources, workload.payload);
+            (workload.concurrency, Arc::new(payload))
+        })
+        .collect();
+
+    // warmup: run each workload once to make sure caches are warm
+    {
+        let start = Instant::now();
+
+        let futures = workloads.iter().map(|(_, workload)| {
+            let symbolication = Arc::clone(&symbolication);
+            let workload = Arc::clone(workload);
+            tokio::spawn(async move {
+                process_payload(&symbolication, &workload).await;
+            })
+        });
+
+        let _results = futures::future::join_all(futures).await;
+
+        println!("Warmup: {:?}", start.elapsed());
+    };
+    println!();
+
+    // run the workloads concurrently
+    let mut tasks = Vec::with_capacity(workloads.len());
+    for (concurrency, workload) in workloads.into_iter() {
+        let start = Instant::now();
+        let deadline = tokio::time::Instant::from_std(start + duration);
+        let symbolication = Arc::clone(&symbolication);
+        let workload = Arc::clone(&workload);
+
+        let task = tokio::spawn(async move {
+            let finished_tasks = Arc::new(AtomicUsize::new(0));
+            let semaphore = Arc::new(Semaphore::new(concurrency));
+
+            // See <https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html#examples>
+            let sleep = tokio::time::sleep_until(deadline);
+            tokio::pin!(sleep);
+
+            loop {
+                if deadline.elapsed() > Duration::ZERO {
+                    break;
+                }
+                tokio::select! {
+                    permit = semaphore.clone().acquire_owned() => {
+                        let workload = Arc::clone(&workload);
+                        let symbolication = Arc::clone(&symbolication);
+                        let finished_tasks = Arc::clone(&finished_tasks);
+
+                        let hub = sentry::Hub::new_from_top(sentry::Hub::current());
+                        let ctx = sentry::TransactionContext::new("stresstest", "stresstest");
+                        let transaction = hub.start_transaction(ctx);
+
+                        let future = async move {
+                            process_payload(&symbolication, &workload).await;
+
+                            // TODO: maybe maintain a histogram?
+                            finished_tasks.fetch_add(1, Ordering::Relaxed);
+
+                            transaction.finish();
+
+                            drop(permit);
+                        };
+                        let future = future.bind_hub(hub);
+
+                        tokio::spawn(future);
+                    }
+                    _ = &mut sleep => {
+                        break;
+                    }
+                }
+            }
+
+            // we only count finished tasks
+            let ops = finished_tasks.load(Ordering::Relaxed);
+
+            // by acquiring *all* the semaphores, we essentially wait for all outstanding tasks to finish
+            let _permits = semaphore.acquire_many(concurrency as u32).await;
+
+            (concurrency, ops)
+        });
+        tasks.push(task);
+    }
+
+    let finished_tasks = futures::future::join_all(tasks).await;
+
+    for (i, task) in finished_tasks.into_iter().enumerate() {
+        let (concurrency, ops) = task.unwrap();
+
+        let ops_ps = ops as f32 / duration.as_secs() as f32;
+        println!("Workload {i} (concurrency: {concurrency}): {ops} operations, {ops_ps} ops/s");
+    }
+
+    Ok(())
+}

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -1,0 +1,173 @@
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use symbolicator_service::services::download::SourceConfig;
+use symbolicator_service::services::symbolication::{
+    StacktraceOrigin, SymbolicateJsStacktraces, SymbolicateStacktraces, SymbolicationActor,
+};
+use symbolicator_service::types::{JsStacktrace, RawObjectInfo, RawStacktrace, Scope};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WorkloadsConfig {
+    pub workloads: Vec<Workload>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Workload {
+    pub concurrency: usize,
+    #[serde(flatten)]
+    pub payload: Payload,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Payload {
+    Minidump(PathBuf),
+    Event(PathBuf),
+    Js { source: PathBuf, event: PathBuf },
+}
+
+#[derive(Debug, Deserialize)]
+struct EventFile {
+    stacktraces: Vec<RawStacktrace>,
+    modules: Vec<RawObjectInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsEventFile {
+    stacktraces: Vec<JsStacktrace>,
+    modules: Vec<RawObjectInfo>,
+}
+
+#[derive(Clone)]
+pub struct MinidumpPayload {
+    scope: Scope,
+    minidump_file: PathBuf,
+    sources: Arc<[SourceConfig]>,
+}
+
+pub enum ParsedPayload {
+    Minidump(MinidumpPayload),
+    Event(SymbolicateStacktraces),
+    Js(symbolicator_test::Server, SymbolicateJsStacktraces),
+}
+
+pub fn prepare_payload(
+    scope: Scope,
+    sources: Arc<[SourceConfig]>,
+    payload: Payload,
+) -> ParsedPayload {
+    match payload {
+        Payload::Minidump(path) => ParsedPayload::Minidump(MinidumpPayload {
+            scope,
+            sources,
+
+            minidump_file: path,
+        }),
+        Payload::Event(path) => {
+            let EventFile {
+                stacktraces,
+                modules,
+            } = read_json(path);
+            let modules = modules.into_iter().map(From::from).collect();
+
+            ParsedPayload::Event(SymbolicateStacktraces {
+                scope,
+                signal: None,
+                sources,
+                origin: StacktraceOrigin::Symbolicate,
+                apply_source_context: true,
+                scraping: Default::default(),
+                stacktraces,
+                modules,
+            })
+        }
+        Payload::Js { source, event } => {
+            let parent = source.parent().unwrap();
+            let source: serde_json::Value = read_json(&source);
+            let (srv, source) = symbolicator_test::sourcemap_server(parent, move |url, _query| {
+                let lookup = source
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|entry| {
+                        let mut entry = entry.clone();
+                        let map = entry.as_object_mut().unwrap();
+                        let url = map["url"].as_str().unwrap().replace("{url}", url);
+                        map["url"] = serde_json::Value::String(url);
+                        entry
+                    })
+                    .collect();
+                serde_json::Value::Array(lookup)
+            });
+
+            let JsEventFile {
+                stacktraces,
+                modules,
+            } = read_json(event);
+
+            ParsedPayload::Js(
+                srv,
+                SymbolicateJsStacktraces {
+                    scope,
+                    source: Arc::new(source),
+                    release: Some("some-release".into()),
+                    dist: None,
+                    debug_id_index: None,
+                    url_index: None,
+                    scraping: Default::default(),
+                    apply_source_context: true,
+                    stacktraces,
+                    modules,
+                },
+            )
+        }
+    }
+}
+
+pub fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> T {
+    let file = std::fs::File::open(path).unwrap();
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).unwrap()
+}
+
+pub async fn process_payload(symbolication: &SymbolicationActor, workload: &ParsedPayload) {
+    match workload {
+        ParsedPayload::Minidump(payload) => {
+            let MinidumpPayload {
+                scope,
+                minidump_file,
+                sources,
+            } = payload;
+
+            // processing a minidump requires a tempfile that can be persisted -_-
+            // so that means we have to make a copy of our minidump
+            let mut temp_file = tempfile::Builder::new();
+            temp_file.prefix("minidump").suffix(".dmp");
+            let temp_file = temp_file.tempfile().unwrap();
+            let (temp_file, temp_path) = temp_file.into_parts();
+            let mut temp_file = tokio::fs::File::from_std(temp_file);
+
+            let mut minidump_file = tokio::fs::File::open(minidump_file).await.unwrap();
+
+            tokio::io::copy(&mut minidump_file, &mut temp_file)
+                .await
+                .unwrap();
+
+            symbolication
+                .process_minidump(scope.clone(), temp_path, Arc::clone(sources))
+                .await
+                .unwrap();
+        }
+        ParsedPayload::Event(payload) => {
+            symbolication.symbolicate(payload.clone()).await.unwrap();
+        }
+        ParsedPayload::Js(_srv, payload) => {
+            symbolication.symbolicate_js(payload.clone()).await.unwrap();
+        }
+    };
+}

--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -20,13 +20,11 @@ fn get_rust_log(level: LevelFilter) -> &'static str {
         LevelFilter::DEBUG => {
             "INFO,\
              trust_dns_proto=WARN,\
-             actix_web::pipeline=DEBUG,\
              symbolicator=DEBUG"
         }
         LevelFilter::TRACE => {
             "INFO,\
              trust_dns_proto=WARN,\
-             actix_web::pipeline=DEBUG,\
              symbolicator=TRACE"
         }
     }


### PR DESCRIPTION
This adds the stacktraces, tracing, sentry and metrics to the stresstest.

The purpose of this is to also measure and profile the effect that various instrumentation has on the performance.

For this, all the various pieces of instrumentation are being initialized with configuration that is as close to real-world as possible, except all the logging and instrumentation is going to the void.

This is not yet fully complete, it is still missing dummy HTTP and UDP servers that Sentry envelopes and metrics data can be sent to.

#skip-changelog