### PR TITLE
Only write cache metadata on debug builds

### DIFF
--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -251,10 +251,13 @@ impl<T: CacheItemRequest> Cacher<T> {
 
             persist_tempfile(temp_file, &cache_path)?;
 
-            // NOTE: we only create the metadata file once, but do not regularly touch it for now
-            cache_path.set_extension("txt");
-            if let Err(err) = std::fs::write(cache_path, key.metadata()) {
-                tracing::error!(error = &err as &dyn std::error::Error);
+            #[cfg(debug_assertions)]
+            {
+                // NOTE: we only create the metadata file once, but do not regularly touch it for now
+                cache_path.set_extension("txt");
+                if let Err(err) = std::fs::write(cache_path, key.metadata()) {
+                    tracing::error!(error = &err as &dyn std::error::Error);
+                }
             }
         };
 


### PR DESCRIPTION
This should cut the number of files that are written on production builds in half, reducing pressure on the cleanup job.

#skip-changelog