### PR TITLE
Capture minidump modules with usable code-id

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,21 @@
       "program": "${workspaceFolder}/target/debug/symbolicator",
       "stopOnEntry": true,
       "pid": "${command:pickMyProcess}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "sourceLanguages": ["rust"],
+      "name": "symbolicli",
+      "program": "${workspaceFolder}/target/debug/symbolicli",
+      "args": ["--offline", "..."],
+      "env": {
+        "RUST_BACKTRACE": "1"
+      },
+      "cwd": "${workspaceFolder}",
+      "cargo": {
+        "args": ["build", "--package", "symbolicli"]
+      }
     }
   ]
 }

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -339,8 +339,10 @@ async fn stackwalk(
         .filter_map(|module| {
             let key = LookupKey::new(module);
 
-            // Discard modules that weren't used and don't have a debug id.
-            if !provider.cficaches.contains_key(&key) && module.debug_identifier().is_none() {
+            // Discard modules that weren't used and don't have any valid id to go by.
+            let debug_id = module.debug_identifier();
+            let code_id = module.code_identifier();
+            if !provider.cficaches.contains_key(&key) && debug_id.is_none() && code_id.is_none() {
                 return None;
             }
 


### PR DESCRIPTION
We were previously discarding all minidump modules that did not have a debug-id. However you can still at least get a reasonable function name in most cases from the symbol table of a code file using the code-id.

#skip-changelog