### PR TITLE
Thread scraping config through minidump requests

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/apple.rs
+++ b/crates/symbolicator-service/src/services/symbolication/apple.rs
@@ -15,7 +15,7 @@ use crate::types::{
 };
 use crate::utils::hex::HexValue;
 
-use super::{StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor};
+use super::{ScrapingConfig, StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor};
 
 impl SymbolicationActor {
     #[tracing::instrument(skip_all)]
@@ -24,6 +24,7 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
     ) -> Result<(SymbolicateStacktraces, AppleCrashReportState)> {
         let report =
             AppleCrashReport::from_reader(report).context("failed to parse apple crash report")?;
@@ -79,7 +80,7 @@ impl SymbolicationActor {
             signal: None,
             stacktraces,
             apply_source_context: true,
-            scraping: Default::default(),
+            scraping,
         };
 
         let mut system_info = SystemInfo {
@@ -124,8 +125,9 @@ impl SymbolicationActor {
         scope: Scope,
         report: File,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
     ) -> Result<CompletedSymbolicationResponse> {
-        let (request, state) = self.parse_apple_crash_report(scope, report, sources)?;
+        let (request, state) = self.parse_apple_crash_report(scope, report, sources, scraping)?;
         let mut response = self.symbolicate(request).await?;
 
         state.merge_into(&mut response);

--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -29,7 +29,7 @@ use crate::types::{
 };
 use crate::utils::hex::HexValue;
 
-use super::{StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor};
+use super::{ScrapingConfig, StacktraceOrigin, SymbolicateStacktraces, SymbolicationActor};
 
 type Minidump = minidump::Minidump<'static, ByteView<'static>>;
 
@@ -404,9 +404,10 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
     ) -> Result<CompletedSymbolicationResponse> {
         let (request, state) = self
-            .stackwalk_minidump(scope, minidump_file, sources)
+            .stackwalk_minidump(scope, minidump_file, sources, scraping)
             .await?;
 
         let mut response = self.symbolicate(request).await?;
@@ -421,6 +422,7 @@ impl SymbolicationActor {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
     ) -> Result<(SymbolicateStacktraces, MinidumpState)> {
         let len = minidump_file.metadata()?.len();
         tracing::debug!("Processing minidump ({} bytes)", len);
@@ -476,7 +478,7 @@ impl SymbolicationActor {
             signal: None,
             stacktraces,
             apply_source_context: true,
-            scraping: Default::default(),
+            scraping,
         };
 
         Ok((request, minidump_state))

--- a/crates/symbolicator-service/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-service/tests/integration/process_minidump.rs
@@ -21,6 +21,7 @@ macro_rules! stackwalk_minidump {
                     Scope::Global,
                     minidump_file.into_temp_path(),
                     Arc::new([source]),
+                    Default::default(),
                 )
                 .await;
 

--- a/crates/symbolicator-service/tests/integration/symbolication.rs
+++ b/crates/symbolicator-service/tests/integration/symbolication.rs
@@ -53,7 +53,12 @@ async fn test_apple_crash_report() {
     let report_file = std::fs::File::open(fixture("apple_crash_report.txt")).unwrap();
 
     let response = symbolication
-        .process_apple_crash_report(Scope::Global, report_file, Arc::new([source]))
+        .process_apple_crash_report(
+            Scope::Global,
+            report_file,
+            Arc::new([source]),
+            Default::default(),
+        )
         .await;
 
     assert_snapshot!(response.unwrap());

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -159,7 +159,12 @@ pub async fn process_payload(symbolication: &SymbolicationActor, workload: &Pars
                 .unwrap();
 
             symbolication
-                .process_minidump(scope.clone(), temp_path, Arc::clone(sources))
+                .process_minidump(
+                    scope.clone(),
+                    temp_path,
+                    Arc::clone(sources),
+                    Default::default(),
+                )
                 .await
                 .unwrap();
         }

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -24,6 +24,7 @@ use futures::{channel::oneshot, FutureExt as _};
 use sentry::protocol::SessionStatus;
 use sentry::SentryFutureExt;
 use serde::{Deserialize, Deserializer, Serialize};
+use symbolicator_service::services::ScrapingConfig;
 use tempfile::TempPath;
 use uuid::Uuid;
 
@@ -271,12 +272,13 @@ impl RequestService {
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
         self.create_symbolication_request("minidump_stackwalk", options, async move {
             slf.symbolication
-                .process_minidump(scope, minidump_file, sources)
+                .process_minidump(scope, minidump_file, sources, scraping)
                 .await
                 .map(Into::into)
         })

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -293,12 +293,13 @@ impl RequestService {
         scope: Scope,
         apple_crash_report: File,
         sources: Arc<[SourceConfig]>,
+        scraping: ScrapingConfig,
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
         self.create_symbolication_request("parse_apple_crash_report", options, async move {
             slf.symbolication
-                .process_apple_crash_report(scope, apple_crash_report, sources)
+                .process_apple_crash_report(scope, apple_crash_report, sources, scraping)
                 .await
                 .map(Into::into)
         })

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
                 Payload::Minidump(minidump_path) => {
                     tracing::info!("symbolicating minidump");
                     symbolication
-                        .process_minidump(scope, minidump_path, dsym_sources)
+                        .process_minidump(scope, minidump_path, dsym_sources, Default::default())
                         .await
                         .map(CompletedResponse::from)?
                 }


### PR DESCRIPTION
Originally, the ScrapingConfig was only passed down to symbolicate requests. Now it is also being handled for minidump requests.

#skip-changelog