### PR TITLE
Backfill missing DebugId from CFI Cache

### DIFF
--- a/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
+++ b/crates/symbolicator-service/src/services/symbolication/process_minidump.rs
@@ -20,7 +20,7 @@ use tempfile::TempPath;
 use symbolic::common::{Arch, ByteView, CodeId, DebugId};
 use symbolicator_sources::{ObjectId, ObjectType, SourceConfig};
 
-use crate::services::cficaches::{CfiCacheActor, FetchCfiCache, FetchedCfiCache};
+use crate::services::cficaches::{CfiCacheActor, CfiModuleInfo, FetchCfiCache, FetchedCfiCache};
 use crate::services::minidump::parse_stacktraces_from_minidump;
 use crate::services::module_lookup::object_file_status_from_cache_entry;
 use crate::types::{
@@ -230,7 +230,7 @@ impl SymbolProvider for SymbolicatorSymbolProvider {
         walker: &mut (dyn FrameWalker + Send),
     ) -> Option<()> {
         let cfi_module = self.load_cfi_module(module).await;
-        cfi_module.cache.ok()??.walk_frame(module, walker)
+        cfi_module.cache.ok()??.0.walk_frame(module, walker)
     }
 
     async fn get_file_path(
@@ -355,6 +355,15 @@ async fn stackwalk(
                     // NOTE: minidump stackwalking is the first thing that happens to a request,
                     // hence the current candidate list is empty.
                     obj_info.candidates = cfi_module.candidates;
+
+                    // if the debug_id/file is empty, it might be possible to
+                    // backfill that using the reference in the executable file.
+                    if let Ok(Some(cfi_item)) = &cfi_module.cache {
+                        if let Some(cfi_module_info) = &cfi_item.1 {
+                            maybe_backfill_debugid(&mut obj_info.raw, cfi_module_info);
+                        }
+                    }
+
                     object_file_status_from_cache_entry(&cfi_module.cache)
                 }
             });
@@ -374,6 +383,15 @@ async fn stackwalk(
         minidump_state,
         duration,
     })
+}
+
+fn maybe_backfill_debugid(info: &mut RawObjectInfo, cfi_module: &CfiModuleInfo) {
+    if info.debug_id.is_none() {
+        info.debug_id = Some(cfi_module.debug_id.to_string());
+    }
+    if info.debug_file.is_none() {
+        info.debug_file = Some(cfi_module.debug_file.clone());
+    }
 }
 
 impl SymbolicationActor {


### PR DESCRIPTION
We have seen customer minidumps that do not have proper DebugIds in them. However, there is a valid CodeId, which would allow the executable to be fetched from an external SSQP symbol server. We transform this executable to a CfiCache, which in theory could have a breakpad `MODULE` entry. Though in practice it does not (yet), as we never output one.

This would allow backfilling the missing DebugID in the minidump with the one found in the executable that we use to generate the CfiCache.

#skip-changelog