### PR TITLE
Try to fix integration test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
           cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
           python-version: 3.8
 
+      - name: Do the localhost docker dance
+        run: echo "$DJANGO_LIVE_TEST_SERVER_ADDRESS host.docker.internal" | sudo tee --append /etc/hosts
+
       - name: Install rust stable toolchain
         run: rustup toolchain install stable --profile minimal --no-self-update
 


### PR DESCRIPTION
This should add a hosts alias from the internal test server addr to `host.docker.internal`.

#skip-changelog