### PR TITLE
feat: Return "scraping attempts" from JS symbolication

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -309,6 +309,8 @@ impl SourceMapLookup {
         self.fetcher.record_metrics();
     }
 
+    /// Consumes `self` and returns the artifact bundles that were used and
+    /// the scraping attempts that were made.
     pub fn into_records(self) -> (HashSet<SentryFileId>, Vec<JsScrapingAttempt>) {
         (
             self.fetcher.used_artifact_bundles,

--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -747,19 +747,16 @@ impl ArtifactFetcher {
             }
         }
 
-        match file {
-            Some(file) => {
-                if let Some(url) = key.abs_path() {
-                    self.scraping_attempts
-                        .push(JsScrapingAttempt::not_attempted(url.to_owned()));
-                }
-                file
+        if let Some(file) = file {
+            if let Some(url) = key.abs_path() {
+                self.scraping_attempts
+                    .push(JsScrapingAttempt::not_attempted(url.to_owned()));
             }
-            None => {
-                // Otherwise, fall back to scraping from the Web.
-                self.scrape(key).await
-            }
+            return file;
         }
+
+        // Otherwise, fall back to scraping from the Web.
+        self.scrape(key).await
     }
 
     async fn try_get_file_using_index(&mut self, key: &FileKey) -> Option<CachedFileEntry> {

--- a/crates/symbolicator-service/src/services/symbolication/js.rs
+++ b/crates/symbolicator-service/src/services/symbolication/js.rs
@@ -125,13 +125,14 @@ impl SymbolicationActor {
         metric!(time_raw("js.unsymbolicated_frames") = unsymbolicated_frames);
         metric!(time_raw("js.missing_sourcescontent") = missing_sourcescontent);
 
-        let used_artifact_bundles = lookup.into_used_artifact_bundles();
+        let (used_artifact_bundles, scraping_attempts) = lookup.into_records();
 
         Ok(CompletedJsSymbolicationResponse {
             stacktraces,
             raw_stacktraces,
             errors: errors.into_iter().collect(),
             used_artifact_bundles,
+            scraping_attempts,
         })
     }
 }

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -708,7 +708,6 @@ pub enum JsScrapingFailureReason {
     PermissionDenied,
     Timeout,
     DownloadError,
-    Malformed,
     Other,
 }
 

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -670,6 +670,7 @@ impl JsScrapingAttempt {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum JsScrapingResult {
     NotAttempted,
     Success,
@@ -701,6 +702,7 @@ impl From<CacheError> for JsScrapingResult {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum JsScrapingFailureReason {
     NotFound,
     Disabled,

--- a/crates/symbolicator-service/src/types/mod.rs
+++ b/crates/symbolicator-service/src/types/mod.rs
@@ -644,6 +644,7 @@ pub struct CompletedJsSymbolicationResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct JsScrapingAttempt {
     pub url: String,
+    #[serde(flatten)]
     pub result: JsScrapingResult,
 }
 
@@ -671,6 +672,7 @@ impl JsScrapingAttempt {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[serde(tag = "status")]
 pub enum JsScrapingResult {
     NotAttempted,
     Success,

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
@@ -37,4 +37,9 @@ raw_stacktraces:
           - "//# sourceMappingURL=test.min.js.map"
 used_artifact_bundles:
   - 02_correct.zip
+scraping_attempts:
+  - url: "http://example.com/test.min.js"
+    result: NotAttempted
+  - url: "http://example.com/test.min.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
@@ -39,7 +39,7 @@ used_artifact_bundles:
   - 02_correct.zip
 scraping_attempts:
   - url: "http://example.com/test.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/test.min.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__bundle_index.snap
@@ -39,7 +39,7 @@ used_artifact_bundles:
   - 02_correct.zip
 scraping_attempts:
   - url: "http://example.com/test.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/test.min.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -40,8 +40,8 @@ raw_stacktraces:
           - ""
           - //@ sourceMappingURL=another.different.map
 scraping_attempts:
-  - url: "http://localhost:64630/files/app.js"
-    result: success
-  - url: "http://localhost:64630/files/app.js.map"
-    result: success
+  - url: "http://localhost:65187/files/app.js"
+    status: success
+  - url: "http://localhost:65187/files/app.js.map"
+    status: success
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 595
+assertion_line: 636
 expression: response.unwrap()
 ---
 stacktraces:
@@ -39,4 +39,9 @@ raw_stacktraces:
           - "//# sourceMappingURL=a.different.map"
           - ""
           - //@ sourceMappingURL=another.different.map
+scraping_attempts:
+  - url: "http://localhost:56780/files/app.js"
+    result: Success
+  - url: "http://localhost:56780/files/app.js.map"
+    result: Success
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -40,8 +40,8 @@ raw_stacktraces:
           - ""
           - //@ sourceMappingURL=another.different.map
 scraping_attempts:
-  - url: "http://localhost:56780/files/app.js"
-    result: Success
-  - url: "http://localhost:56780/files/app.js.map"
-    result: Success
+  - url: "http://localhost:64630/files/app.js"
+    result: success
+  - url: "http://localhost:64630/files/app.js.map"
+    result: success
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -40,8 +40,8 @@ raw_stacktraces:
           - ""
           - //@ sourceMappingURL=another.different.map
 scraping_attempts:
-  - url: "http://localhost:65187/files/app.js"
+  - url: "http://localhost:<port>/files/app.js"
     status: success
-  - url: "http://localhost:65187/files/app.js.map"
+  - url: "http://localhost:<port>/files/app.js.map"
     status: success
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -42,7 +42,7 @@ raw_stacktraces:
           - ""
 scraping_attempts:
   - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js
-    result: NotAttempted
+    result: not_attempted
   - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js.map
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -42,7 +42,7 @@ raw_stacktraces:
           - ""
 scraping_attempts:
   - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js
-    result: not_attempted
+    status: not_attempted
   - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js.map
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 508
+assertion_line: 549
 expression: response.unwrap()
 ---
 stacktraces:
@@ -40,4 +40,9 @@ raw_stacktraces:
           - exports.main = main;
           - "//# sourceMappingURL=entrypoint1.js.map"
           - ""
+scraping_attempts:
+  - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js
+    result: NotAttempted
+  - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js.map
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -28,7 +28,7 @@ raw_stacktraces:
         colno: 11940
 scraping_attempts:
   - url: "app:///index.android.bundle"
-    result: not_attempted
+    status: not_attempted
   - url: "app:///index.android.bundle.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 572
+assertion_line: 613
 expression: response.unwrap()
 ---
 stacktraces:
@@ -26,4 +26,9 @@ raw_stacktraces:
       - abs_path: "app:///index.android.bundle"
         lineno: 1
         colno: 11940
+scraping_attempts:
+  - url: "app:///index.android.bundle"
+    result: NotAttempted
+  - url: "app:///index.android.bundle.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -28,7 +28,7 @@ raw_stacktraces:
         colno: 11940
 scraping_attempts:
   - url: "app:///index.android.bundle"
-    result: NotAttempted
+    result: not_attempted
   - url: "app:///index.android.bundle.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -39,7 +39,7 @@ raw_stacktraces:
           - "//# sourceMappingURL=test.min.js.map"
 scraping_attempts:
   - url: "app:///_next/server/pages/_error.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "app:///_next/server/pages/test.min.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -39,7 +39,7 @@ raw_stacktraces:
           - "//# sourceMappingURL=test.min.js.map"
 scraping_attempts:
   - url: "app:///_next/server/pages/_error.js"
-    result: not_attempted
+    status: not_attempted
   - url: "app:///_next/server/pages/test.min.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 538
+assertion_line: 579
 expression: response.unwrap()
 ---
 stacktraces:
@@ -37,4 +37,9 @@ raw_stacktraces:
         context_line: "var makeAFailure=function(){function n(n){}function e(n){throw new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)} {snip}"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+scraping_attempts:
+  - url: "app:///_next/server/pages/_error.js"
+    result: NotAttempted
+  - url: "app:///_next/server/pages/test.min.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 376
+assertion_line: 396
 expression: response.unwrap()
 ---
 stacktraces:
@@ -28,4 +28,13 @@ errors:
     type: missing_source
   - abs_path: "http://localhost:<port>/assets/missing_foo.js"
     type: missing_source
+scraping_attempts:
+  - url: "http://localhost:56779/assets/missing_foo.js"
+    result:
+      Failure:
+        reason: NotFound
+  - url: "http://localhost:56779/assets/missing_bar.js"
+    result:
+      Failure:
+        reason: NotFound
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -29,10 +29,10 @@ errors:
   - abs_path: "http://localhost:<port>/assets/missing_foo.js"
     type: missing_source
 scraping_attempts:
-  - url: "http://localhost:65211/assets/missing_foo.js"
+  - url: "http://localhost:<port>/assets/missing_foo.js"
     status: failure
     reason: not_found
-  - url: "http://localhost:65211/assets/missing_bar.js"
+  - url: "http://localhost:<port>/assets/missing_bar.js"
     status: failure
     reason: not_found
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -29,12 +29,10 @@ errors:
   - abs_path: "http://localhost:<port>/assets/missing_foo.js"
     type: missing_source
 scraping_attempts:
-  - url: "http://localhost:64656/assets/missing_foo.js"
-    result:
-      failure:
-        reason: not_found
-  - url: "http://localhost:64656/assets/missing_bar.js"
-    result:
-      failure:
-        reason: not_found
+  - url: "http://localhost:65211/assets/missing_foo.js"
+    status: failure
+    reason: not_found
+  - url: "http://localhost:65211/assets/missing_bar.js"
+    status: failure
+    reason: not_found
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -29,12 +29,12 @@ errors:
   - abs_path: "http://localhost:<port>/assets/missing_foo.js"
     type: missing_source
 scraping_attempts:
-  - url: "http://localhost:56779/assets/missing_foo.js"
+  - url: "http://localhost:64656/assets/missing_foo.js"
     result:
-      Failure:
-        reason: NotFound
-  - url: "http://localhost:56779/assets/missing_bar.js"
+      failure:
+        reason: not_found
+  - url: "http://localhost:64656/assets/missing_bar.js"
     result:
-      Failure:
-        reason: NotFound
+      failure:
+        reason: not_found
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -62,11 +62,11 @@ raw_stacktraces:
           - "//# sourceMappingURL=indexed.min.js.map"
 scraping_attempts:
   - url: "http://example.com/indexed.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/indexed.min.js.map"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/file1.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/file2.js"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -62,11 +62,11 @@ raw_stacktraces:
           - "//# sourceMappingURL=indexed.min.js.map"
 scraping_attempts:
   - url: "http://example.com/indexed.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/indexed.min.js.map"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/file1.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/file2.js"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 345
+assertion_line: 348
 expression: response.unwrap()
 ---
 stacktraces:
@@ -60,4 +60,13 @@ raw_stacktraces:
         context_line: "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
         post_context:
           - "//# sourceMappingURL=indexed.min.js.map"
+scraping_attempts:
+  - url: "http://example.com/indexed.min.js"
+    result: NotAttempted
+  - url: "http://example.com/indexed.min.js.map"
+    result: NotAttempted
+  - url: "http://example.com/file1.js"
+    result: NotAttempted
+  - url: "http://example.com/file2.js"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -28,5 +28,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
 scraping_attempts:
   - url: "http://example.com/test.min.js"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 263
+assertion_line: 266
 expression: response.unwrap()
 ---
 stacktraces:
@@ -26,4 +26,7 @@ raw_stacktraces:
         post_context:
           - "// Decoded sourcemap: {\"version\":3,\"file\":\"generated.js\",\"sources\":[\"/test.js\"],\"names\":[],\"mappings\":\"AAAA\",\"sourcesContent\":[\"console.log( {snip}"
           - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
+scraping_attempts:
+  - url: "http://example.com/test.min.js"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -28,5 +28,5 @@ raw_stacktraces:
           - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
 scraping_attempts:
   - url: "http://example.com/test.min.js"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -61,5 +61,5 @@ raw_stacktraces:
           - r
 scraping_attempts:
   - url: "http://example.com/foo.js"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 222
+assertion_line: 240
 expression: response.unwrap()
 ---
 stacktraces:
@@ -59,4 +59,7 @@ raw_stacktraces:
           - w
           - o
           - r
+scraping_attempts:
+  - url: "http://example.com/foo.js"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -61,5 +61,5 @@ raw_stacktraces:
           - r
 scraping_attempts:
   - url: "http://example.com/foo.js"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -47,11 +47,10 @@ errors:
     type: scraping_disabled
 scraping_attempts:
   - url: "http://example.com/index.html"
-    result:
-      failure:
-        reason: disabled
+    status: failure
+    reason: disabled
   - url: "http://example.com/embedded.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/embedded.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 206
+assertion_line: 209
 expression: response.unwrap()
 ---
 stacktraces:
@@ -45,4 +45,13 @@ raw_stacktraces:
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled
+scraping_attempts:
+  - url: "http://example.com/index.html"
+    result:
+      Failure:
+        reason: Disabled
+  - url: "http://example.com/embedded.js"
+    result: NotAttempted
+  - url: "http://example.com/embedded.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -48,10 +48,10 @@ errors:
 scraping_attempts:
   - url: "http://example.com/index.html"
     result:
-      Failure:
-        reason: Disabled
+      failure:
+        reason: disabled
   - url: "http://example.com/embedded.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/embedded.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -114,10 +114,10 @@ errors:
 scraping_attempts:
   - url: "http://example.com/index.html"
     result:
-      Failure:
-        reason: Disabled
+      failure:
+        reason: disabled
   - url: "http://example.com/test.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/test.min.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -113,11 +113,10 @@ errors:
     type: scraping_disabled
 scraping_attempts:
   - url: "http://example.com/index.html"
-    result:
-      failure:
-        reason: disabled
+    status: failure
+    reason: disabled
   - url: "http://example.com/test.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/test.min.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 115
+assertion_line: 118
 expression: response.unwrap()
 ---
 stacktraces:
@@ -111,4 +111,13 @@ raw_stacktraces:
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled
+scraping_attempts:
+  - url: "http://example.com/index.html"
+    result:
+      Failure:
+        reason: Disabled
+  - url: "http://example.com/test.min.js"
+    result: NotAttempted
+  - url: "http://example.com/test.min.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 295
+assertion_line: 298
 expression: response.unwrap()
 ---
 stacktraces:
@@ -31,4 +31,9 @@ raw_stacktraces:
           - "}"
           - "function multiply(a, b) {"
           - "  'use strict';"
+scraping_attempts:
+  - url: "app:///nofiles.js"
+    result: NotAttempted
+  - url: "app:///nofiles.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -33,7 +33,7 @@ raw_stacktraces:
           - "  'use strict';"
 scraping_attempts:
   - url: "app:///nofiles.js"
-    result: not_attempted
+    status: not_attempted
   - url: "app:///nofiles.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -33,7 +33,7 @@ raw_stacktraces:
           - "  'use strict';"
 scraping_attempts:
   - url: "app:///nofiles.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "app:///nofiles.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 166
+assertion_line: 169
 expression: response.unwrap()
 ---
 stacktraces:
@@ -45,4 +45,15 @@ raw_stacktraces:
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled
+scraping_attempts:
+  - url: "http://example.com/index.html"
+    result:
+      Failure:
+        reason: Disabled
+  - url: "http://example.com/file.min.js"
+    result: NotAttempted
+  - url: "http://example.com/file.min.js.map"
+    result: NotAttempted
+  - url: "http://example.com/file1.js"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -47,13 +47,12 @@ errors:
     type: scraping_disabled
 scraping_attempts:
   - url: "http://example.com/index.html"
-    result:
-      failure:
-        reason: disabled
+    status: failure
+    reason: disabled
   - url: "http://example.com/file.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/file.min.js.map"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/file1.js"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -48,12 +48,12 @@ errors:
 scraping_attempts:
   - url: "http://example.com/index.html"
     result:
-      Failure:
-        reason: Disabled
+      failure:
+        reason: disabled
   - url: "http://example.com/file.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/file.min.js.map"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/file1.js"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
@@ -71,11 +71,11 @@ raw_stacktraces:
           - "//# sourceMappingURL=test2.min.js.map"
 scraping_attempts:
   - url: "http://example.com/test1.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/test1.min.js.map"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/test2.min.js"
-    result: not_attempted
+    status: not_attempted
   - url: "http://example.com/test2.min.js.map"
-    result: not_attempted
+    status: not_attempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-service/tests/integration/sourcemap.rs
-assertion_line: 477
+assertion_line: 480
 expression: response.unwrap()
 ---
 stacktraces:
@@ -69,4 +69,13 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test2.min.js.map"
+scraping_attempts:
+  - url: "http://example.com/test1.min.js"
+    result: NotAttempted
+  - url: "http://example.com/test1.min.js.map"
+    result: NotAttempted
+  - url: "http://example.com/test2.min.js"
+    result: NotAttempted
+  - url: "http://example.com/test2.min.js.map"
+    result: NotAttempted
 

--- a/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
+++ b/crates/symbolicator-service/tests/integration/snapshots/integration__sourcemap__webpack.snap
@@ -71,11 +71,11 @@ raw_stacktraces:
           - "//# sourceMappingURL=test2.min.js.map"
 scraping_attempts:
   - url: "http://example.com/test1.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/test1.min.js.map"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/test2.min.js"
-    result: NotAttempted
+    result: not_attempted
   - url: "http://example.com/test2.min.js.map"
-    result: NotAttempted
+    result: not_attempted
 

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -532,6 +532,9 @@ macro_rules! assert_snapshot {
             ".**.data.sourcemap" => ::insta::dynamic_redaction(
                 $crate::redact_localhost_port
             ),
+            ".**.scraping_attempts[].url" => ::insta::dynamic_redaction(
+                $crate::redact_localhost_port
+            ),
         });
     }
 }


### PR DESCRIPTION
This records the outcome of every attempt to scrape a JS source or sourcemap file from the web and returns these attempts in `CompletedJsSymbolicationResponse`.

It also records a "not attempted" attempt whenever a file is found via another method.

#skip-changelog