### PR TITLE
Update GoCD Jsonnet library

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.2.2"
+      "version": "v2.3.1"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "54bb0adceffb690bf4aa744b23acdb7888c51fd5",
-      "sum": "stYmA7r5/MARC5qkFFR+94R1W5juwjmRNVQFOTxmwVA="
+      "version": "cfd0a0c54a580e1932e14368d0c99b2b5013c434",
+      "sum": "SFeCD13Z2qQftwrjVAKE19IjjgJAk8ninSJwePKhI8A="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/symbolicator.jsonnet
+++ b/gocd/templates/symbolicator.jsonnet
@@ -20,6 +20,8 @@ local pipedream_config = {
     material_name: 'symbolicator_repo',
     stage: 'deploy-primary',
     elastic_profile_id: 'symbolicator',
+    // TODO: Remove the final_stage once we have several deploys with pipeline-complete stage
+    final_stage: 'deploy-primary',
   },
 
   // Set to true to auto-deploy changes (defaults to true)


### PR DESCRIPTION
This fixes an issue in rollbacks that can cause multiple deploys of the same commit. Now rollbacks have a final manual stage that unpauses and unlocks the pipelines once an incident is complete.

For the curious: The I removed the pipeline-complete stage in a previous version, this caused pipelines to be unlocked after a rollback is complete (a problem folks were running into), however this meant the final stage in the deploy was the stage the rollback re-ran. Since this final stage was run, it triggered the downstream pipeline to run which was unintentional.

#skip-changelog