### PR TITLE
Record the `file_id` for failed BundleIndex downloads

### DIFF
--- a/crates/symbolicator-service/src/services/sourcemap_lookup.rs
+++ b/crates/symbolicator-service/src/services/sourcemap_lookup.rs
@@ -137,7 +137,7 @@ async fn maybe_fetch_bundle_index(
         Ok(bundle_index) => Some((file_id, bundle_index)),
         Err(err) => {
             let err: &dyn std::error::Error = &err;
-            tracing::error!(err, "Failed fetching `BundleIndex`");
+            tracing::error!(err, ?file_id, "Failed fetching `BundleIndex`");
             None
         }
     }


### PR DESCRIPTION
#skip-changelog