### PR TITLE
Avoid using shared cache for internally stored files

### DIFF
--- a/crates/symbolicator-js/src/bundle_index_cache.rs
+++ b/crates/symbolicator-js/src/bundle_index_cache.rs
@@ -89,4 +89,11 @@ impl CacheItemRequest for BundleIndexRequest {
     fn weight(item: &Self::Item) -> u32 {
         item.0.max(std::mem::size_of::<Self::Item>() as u32)
     }
+
+    fn use_shared_cache(&self) -> bool {
+        // These change frequently, and are being downloaded from Sentry directly.
+        // Here again, the question is whether we want to waste a bit of storage on GCS vs doing
+        // more requests to Python.
+        true
+    }
 }

--- a/crates/symbolicator-service/src/caching/cache_error.rs
+++ b/crates/symbolicator-service/src/caching/cache_error.rs
@@ -152,7 +152,7 @@ impl CacheError {
 /// object could not be fetched or is otherwise unusable.
 pub type CacheEntry<T = ()> = Result<T, CacheError>;
 
-/// Parses a [`CacheEntry`] from a [`ByteView`](ByteView).
+/// Parses a [`CacheEntry`] from a [`ByteView`].
 pub fn cache_entry_from_bytes(bytes: ByteView<'static>) -> CacheEntry<ByteView<'static>> {
     CacheError::from_bytes(&bytes).map(Err).unwrap_or(Ok(bytes))
 }

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -76,7 +76,7 @@ impl CacheKey {
 
 /// A builder for [`CacheKey`]s.
 ///
-/// This builder implements the [`Write`](std::fmt::Write) trait, and the intention of it is to
+/// This builder implements the [`Write`] trait, and the intention of it is to
 /// accept human readable, but most importantly **stable**, input.
 /// This input in then being hashed to form the [`CacheKey`], and can also be serialized alongside
 /// the cache files to help debugging.

--- a/crates/symbolicator-service/src/services/bitcode.rs
+++ b/crates/symbolicator-service/src/services/bitcode.rs
@@ -132,6 +132,10 @@ impl CacheItemRequest for FetchFileRequest {
             data,
         }))
     }
+
+    fn use_shared_cache(&self) -> bool {
+        self.file_source.worth_using_shared_cache()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/symbolicator-service/src/services/il2cpp.rs
+++ b/crates/symbolicator-service/src/services/il2cpp.rs
@@ -92,6 +92,10 @@ impl CacheItemRequest for FetchFileRequest {
             data,
         })
     }
+
+    fn use_shared_cache(&self) -> bool {
+        self.file_source.worth_using_shared_cache()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/symbolicator-service/src/services/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/services/objects/data_cache.rs
@@ -233,6 +233,10 @@ impl CacheItemRequest for FetchFileDataRequest {
 
         Ok(Arc::new(object_handle))
     }
+
+    fn use_shared_cache(&self) -> bool {
+        self.0.file_source.worth_using_shared_cache()
+    }
 }
 
 #[cfg(test)]

--- a/crates/symbolicator-service/src/services/objects/mod.rs
+++ b/crates/symbolicator-service/src/services/objects/mod.rs
@@ -74,6 +74,11 @@ pub struct FindResult {
 
 #[derive(Clone, Debug)]
 pub struct ObjectsActor {
+    // FIXME(swatinem): Having a fully fledged filesystem and shared cache for these tiny file meta
+    // items is heavy handed and wasteful. However, we *do* want to have this in shared cache, as
+    // it is the primary thing that makes cold starts fast, as we do not need to fetch the whole
+    // objects, but just the derived caches. Some lighter weight solution, like Redis might be more
+    // appropriate at some point.
     meta_cache: Arc<Cacher<FetchFileMetaRequest>>,
     data_cache: Arc<Cacher<FetchFileDataRequest>>,
     download_svc: Arc<DownloadService>,


### PR DESCRIPTION
It is a bit wasteful to look up our internally hosted Symbols on GCS, just to store them on GCS again in the form of the shared cache.
We can avoid doing this needless duplication of roundtrips and storage.

We could also avoid using the shared cache for objects and bundle indexes that are stored in Sentry, but here the benefits are less clear, as avoiding shared cache would mean going through the Python abstraction. Right now, we rather waste a bit of storage in favor of avoiding Python.

These tradeoffs could potentially change in the future with a more efficient filestore implementation though.

#skip-changelog