### PR TITLE
Update to v2.3.2 of gocd-jsonnet

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.3.1"
+      "version": "v2.3.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "cfd0a0c54a580e1932e14368d0c99b2b5013c434",
-      "sum": "SFeCD13Z2qQftwrjVAKE19IjjgJAk8ninSJwePKhI8A="
+      "version": "23117cbe7d9e7296afd80385eafafde15905066c",
+      "sum": "6xnYzI1seufqJFWuf55cln1ISCt7bDqewqiwsJzPY9k="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This should be a noop as it just contains cleanup from v2.3.1

#skip-changelog