### PR TITLE
Update symbolic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1348,12 +1348,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2040,7 +2040,7 @@ checksum = "155c4d7e39ad04c172c5e3a99c434ea3b4a7ba7960b38ecd562b270b097cce09"
 dependencies = [
  "base64",
  "pem",
- "ring 0.17.5",
+ "ring 0.17.6",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2191,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
@@ -3227,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.6",
  "rustls-webpki",
  "sct",
 ]
@@ -3259,7 +3259,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -3331,7 +3331,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -4000,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c95bb608dafe99d26a0299c52cfd476f1e3862b8e97231b6baebc41cc8194e3"
+checksum = "8e070f3ea3406e07af36aeac8ff3168da67dc5e5455e477f4b4b1e3e2308035d"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4016,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cb576274e18007e588230c0bd582cf008d961a6c4ed0c5b1dd057277c62141"
+checksum = "d1b1f972f548f1b1c995f502fcfe10f03834e3b79d41b6f3a8a913c6be1c4afb"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4027,12 +4027,12 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39eac77836da383d35edbd9ff4585b4fc1109929ff641232f2e9a1aefdfc9e91"
+checksum = "9ba238da6058509cda85e388e8bf1caf522894ec38da490de9694fab9238c715"
 dependencies = [
  "debugid",
- "memmap2 0.8.0",
+ "memmap2 0.9.0",
  "serde",
  "stable_deref_trait",
  "uuid",
@@ -4040,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739b8e5adb84c9f7658e9fdd533002c0384af3ff7fc34874634faf670290030a"
+checksum = "fcb5c577d361d8f4d19fc6f6835d0f079899d34bb8499320a41fc27311b35711"
 dependencies = [
  "debugid",
  "dmsort",
@@ -4072,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1608a1d13061fb0e307a316de29f6c6e737b05459fe6bbf5dd8d7837c4fb7"
+checksum = "9b7f36fed2b0d1f3db882e5edb9d1b6595dd8cc095f52f265b17291f09062b70"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -4085,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61323ed9e8e03a5894802a0d8b0863669bd29a46c9b0520ff32c7f47d23572d"
+checksum = "5d8be09c5c82a5060f11dd7ca680873f35d16b810519ee4785447b3b6a2d21b5"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac3a6629c83a0249f2561b89eede30014700828336c0b78a209d1f87c78613a"
+checksum = "1cb9986b9d312ff0ad684d089121e9b96e101a66676afae886127dfa5c872e41"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4113,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca12d0f101ca883cdcb34e3e3b07d9c9b4a2c82618b7701837da8bbc8d9b414f"
+checksum = "28650912f55d9b53f98bf3cf108d85d245d06644e82cb9b9f54e42009a6ffe4d"
 dependencies = [
  "itertools",
  "js-source-scopes",
@@ -4128,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.7.0"
+version = "12.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327aac613f25658f9b35b692d084597aaafaa106df4e2030c16fe88fc1b10b10"
+checksum = "fbe650e3e3e53103df15a27bfd42e985e92ae60620933dd400f215fdd4f02e54"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -5074,9 +5074,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5084,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -5099,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5111,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5121,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5134,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-split"
@@ -5190,9 +5190,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.113.3"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
+checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
 dependencies = [
  "indexmap",
  "semver 1.0.20",
@@ -5210,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5295,6 +5295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5325,6 +5334,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5359,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5349,6 +5379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,6 +5395,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5373,6 +5415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5383,6 +5431,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5397,6 +5451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5407,6 +5467,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -12,4 +12,4 @@ clap = { version = "4.3.2", features = ["derive"] }
 reqwest = { version = "0.11.0", features = ["blocking", "json", "multipart", "trust-dns"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic-common = "12.4.0"
+symbolic-common = "12.7.1"

--- a/crates/symbolicator-js/Cargo.toml
+++ b/crates/symbolicator-js/Cargo.toml
@@ -18,7 +18,7 @@ sentry = { version = "0.31.7", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 sha2 = "0.10.6"
-symbolic = { version = "12.4.0", features = ["common-serde", "sourcemapcache"] }
+symbolic = { version = "12.7.1", features = ["common-serde", "sourcemapcache"] }
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"

--- a/crates/symbolicator-native/Cargo.toml
+++ b/crates/symbolicator-native/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.18.0"
 regex = "1.5.5"
 sentry = { version = "0.31.7", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = { version = "12.4.0", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp", "ppdb"] }
+symbolic = { version = "12.7.1", features = ["cfi", "common-serde", "debuginfo", "demangle", "symcache", "il2cpp", "ppdb"] }
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
 sha2 = "0.10.6"
-symbolic = { version = "12.4.0", features = ["cfi", "common-serde", "debuginfo", "symcache"] }
+symbolic = { version = "12.7.1", features = ["cfi", "common-serde", "debuginfo", "symcache"] }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"
 thiserror = "1.0.31"

--- a/crates/symbolicator-sources/Cargo.toml
+++ b/crates/symbolicator-sources/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.68"
 aws-types = "0.56.0"
 glob = "0.3.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = "12.4.0"
+symbolic = "12.7.1"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -20,7 +20,7 @@ hostname = "0.3.1"
 sentry = { version = "0.31.7", features = ["anyhow", "debug-images", "tracing", "tower", "tower-http"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.4.0"
+symbolic = "12.7.1"
 symbolicator-crash = { path = "../symbolicator-crash", optional = true }
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }

--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { version = "0.11.12", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
-symbolic = "12.4.0"
+symbolic = "12.7.1"
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }
 symbolicator-service = { path = "../symbolicator-service" }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic = { version = "12.4.0", features = ["debuginfo-serde"] }
+symbolic = { version = "12.7.1", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "0.6.2", default-features = false, features = ["deflate", "bzip2"] }


### PR DESCRIPTION
This update properly uses the new abbreviations cache of `gimli`.

#skip-changelog