### PR TITLE
Enable LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ default-members = ["crates/symbolicator", "crates/symbolicli", "crates/symsorter
 [profile.release]
 # For release builds, we do want line-only debug information to be able to symbolicate panic stack traces.
 debug = 1
+codegen-units = 1
+lto = true
 
 [profile.local]
 # For running a local symbolicator, we want the best of both worlds: a fast executable, with quick

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -223,7 +223,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
         if let Some(cache_dir) = self.config.cache_dir() {
             // Cache is enabled, write it!
-            let mut cache_path = cache_dir.join(&cache_path);
+            let cache_path = cache_dir.join(&cache_path);
 
             sentry::configure_scope(|scope| {
                 scope.set_extra(
@@ -258,6 +258,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
             #[cfg(debug_assertions)]
             {
+                let mut cache_path = cache_path;
                 // NOTE: we only create the metadata file once, but do not regularly touch it for now
                 cache_path.set_extension("txt");
                 if let Err(err) = std::fs::write(cache_path, key.metadata()) {


### PR DESCRIPTION
Related to https://github.com/getsentry/symbolicator/issues/1334 CC @zamazan4ik 

This is so far just doing the first step, using 1 CGU and LTO to optimize the compiler output, without relying on instrumentation and gathering profiling.

Using cargo `--timings`, I get local bound times of ~260s of Rust build + ~640s of linking time (LLVM does code generation at link time with LTO if I understand things correctly) for a total of ~15 minutes.

The first part we can mostly solve with dependency caching, but not the last linking step. So our docker builds will most likely take in the order of 10 minutes.

I would actually like to land this and maybe let it run over the weekend in a canary, so we can compare that to the baseline.

#skip-changelog