### PR TITLE
chore(gocd): Bumping gocd-jsonnet version

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.3.2"
+      "version": "v2.7"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "23117cbe7d9e7296afd80385eafafde15905066c",
-      "sum": "6xnYzI1seufqJFWuf55cln1ISCt7bDqewqiwsJzPY9k="
+      "version": "97af8955747da4f68ce4f70a5128b4e53956e9b2",
+      "sum": "qQiTUU6BkUbKBGblpBppxFBewhIqqQaWlz01ZTGEpi4="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumping to v2.7 of gocd-jsonnet which should remove the de region temporarily while we figure out why it is broken and remove customer-5 as we are getting rid of it.

#skip-changelog