### PR TITLE
Ingest metrics with Sentry as well

### DIFF
--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -29,7 +29,7 @@ moka = { version = "0.12.1", features = ["future", "sync"] }
 once_cell = "1.17.1"
 rand = "0.8.5"
 reqwest = { version = "0.11.0", features = ["gzip", "brotli", "deflate", "json", "stream", "trust-dns"] }
-sentry = { version = "0.32.1", features = ["tracing"] }
+sentry = { version = "0.32.1", features = ["tracing", "UNSTABLE_metrics"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"

--- a/crates/symbolicator-service/src/metrics.rs
+++ b/crates/symbolicator-service/src/metrics.rs
@@ -57,6 +57,9 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::incr($id.to_string(), $value as f64)
+            $(.with_tag($k, $v.to_string()))*
+            .send();
     }};
     (counter($id:expr) -= $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
@@ -66,6 +69,9 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::incr($id, -$value as f64)
+            $(.with_tag($k, $v))*
+            .send();
     }};
 
     // gauges
@@ -77,6 +83,9 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::gauge($id, $value as f64)
+            $(.with_tag($k, $v.to_string()))*
+            .send();
     }};
 
     // timers
@@ -88,6 +97,9 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::timing($id.to_string(), $value)
+            $(.with_tag($k, $v.to_string()))*
+            .send();
     }};
 
     // we use statsd timers to send things such as filesizes as well.
@@ -99,6 +111,9 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::distribution($id, $value as f64)
+            $(.with_tag($k, $v.to_string()))*
+            .send();
     }};
 
     // histograms
@@ -110,5 +125,8 @@ macro_rules! metric {
                 $(.with_tag($k, $v))*
                 .send();
         });
+        ::sentry::metrics::Metric::distribution($id.to_string(), $value as f64)
+            $(.with_tag($k, $v.to_string()))*
+            .send();
     }};
 }


### PR DESCRIPTION
The way we often `&X.to_string()` for `cadence` sake because it takes a `&'a str`, and now we have to `.to_string()` a shitton more because Sentry wants a `Cow<'static, str>` makes me die inside :-(

The overhead of using Sentry metrics looks like a ~2x-10x reduction in throughput:

```
# before
Workload 0 (concurrency: 10): 3140 operations, 209.33 ops/s
Workload 1 (concurrency: 10): 2496 operations, 166.40 ops/s
Workload 2 (concurrency: 10): 4581 operations, 305.40 ops/s
Workload 3 (concurrency: 100): 12127 operations, 808.47 ops/s
Workload 4 (concurrency: 100): 16652 operations, 1110.13 ops/s
Workload 5 (concurrency: 50): 17048 operations, 1136.53 ops/s

# after
Workload 0 (concurrency: 10): 1754 operations, 116.93 ops/s
Workload 1 (concurrency: 10): 1352 operations, 90.13 ops/s
Workload 2 (concurrency: 10): 1959 operations, 130.60 ops/s
Workload 3 (concurrency: 100): 999 operations, 66.60 ops/s
Workload 4 (concurrency: 100): 4112 operations, 274.13 ops/s
Workload 5 (concurrency: 50): 10243 operations, 682.87 ops/s
```

#skip-changelog