### PR TITLE
Clean up Metrics usage a bit

### DIFF
--- a/crates/symbolicator-service/src/metrics.rs
+++ b/crates/symbolicator-service/src/metrics.rs
@@ -1,50 +1,15 @@
 //! Provides access to the metrics sytem.
 use std::collections::BTreeMap;
 use std::net::ToSocketAddrs;
-use std::ops::Deref;
 use std::sync::OnceLock;
 
-use cadence::{Metric, MetricBuilder, StatsdClient, UdpMetricSink};
+use cadence::{StatsdClient, UdpMetricSink};
 
-static METRICS_CLIENT: OnceLock<MetricsClient> = OnceLock::new();
-
-thread_local! {
-    static CURRENT_CLIENT: Option<&'static MetricsClient> = METRICS_CLIENT.get();
-}
+static METRICS_CLIENT: OnceLock<StatsdClient> = OnceLock::new();
 
 /// The metrics prelude that is necessary to use the client.
 pub mod prelude {
     pub use cadence::prelude::*;
-}
-
-#[derive(Debug)]
-pub struct MetricsClient {
-    /// The raw statsd client.
-    pub statsd_client: StatsdClient,
-
-    /// A collection of tags and values that will be sent with every metric.
-    tags: BTreeMap<String, String>,
-}
-
-impl MetricsClient {
-    #[inline(always)]
-    pub fn send_metric<'a, T>(&'a self, mut metric: MetricBuilder<'a, '_, T>)
-    where
-        T: Metric + From<String>,
-    {
-        for (tag, value) in self.tags.iter() {
-            metric = metric.with_tag(tag, value);
-        }
-        metric.send()
-    }
-}
-
-impl Deref for MetricsClient {
-    type Target = StatsdClient;
-
-    fn deref(&self) -> &Self::Target {
-        &self.statsd_client
-    }
 }
 
 /// Tell the metrics system to report to statsd.
@@ -56,33 +21,27 @@ pub fn configure_statsd<A: ToSocketAddrs>(prefix: &str, host: A, tags: BTreeMap<
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
     socket.set_nonblocking(true).unwrap();
     let sink = UdpMetricSink::from(&addrs[..], socket).unwrap();
-    let statsd_client = StatsdClient::from_sink(prefix, sink);
+    let mut builder = StatsdClient::builder(prefix, sink);
+    for (key, value) in tags {
+        builder = builder.with_tag(key, value)
+    }
+    let client = builder.build();
 
-    METRICS_CLIENT
-        .set(MetricsClient {
-            statsd_client,
-            tags,
-        })
-        .unwrap();
+    METRICS_CLIENT.set(client).unwrap();
 }
 
-/// Invoke a callback with the current statsd client.
+/// Invoke a callback with the current [`StatsdClient`].
 ///
-/// If statsd is not configured the callback is not invoked. For the most part
-/// the [`metric!`](crate::metric) macro should be used instead.
+/// If no [`StatsdClient`] is configured the callback is not invoked.
+/// For the most part the [`metric!`](crate::metric) macro should be used instead.
 #[inline(always)]
-pub fn with_client<F, R>(f: F) -> R
+pub fn with_client<F>(f: F)
 where
-    F: FnOnce(&MetricsClient) -> R,
-    R: Default,
+    F: FnOnce(&StatsdClient),
 {
-    CURRENT_CLIENT.with(|client| {
-        if let Some(client) = client {
-            f(client)
-        } else {
-            Default::default()
-        }
-    })
+    if let Some(client) = METRICS_CLIENT.get() {
+        f(client)
+    }
 }
 
 /// Emits a metric.
@@ -92,63 +51,63 @@ macro_rules! metric {
     (counter($id:expr) += $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.count_with_tags($id, $value)
-                    $(.with_tag($k, $v))*
-            );
-        })
+            client
+                .count_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
     (counter($id:expr) -= $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.count_with_tags($id, -$value)
-                    $(.with_tag($k, $v))*
-             );
-        })
+            client
+                .count_with_tags($id, -$value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
 
     // gauges
     (gauge($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.gauge_with_tags($id, $value)
-                    $(.with_tag($k, $v))*
-            );
-        })
+            client
+                .gauge_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
 
     // timers
     (timer($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.time_with_tags($id, $value)
-                    $(.with_tag($k, $v))*
-            );
-        })
+            client
+                .time_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
 
     // we use statsd timers to send things such as filesizes as well.
     (time_raw($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.time_with_tags($id, $value)
-                    $(.with_tag($k, $v))*
-            );
-        })
+            client
+                .time_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
 
     // histograms
     (histogram($id:expr) = $value:expr $(, $k:expr => $v:expr)* $(,)?) => {{
         use $crate::metrics::prelude::*;
         $crate::metrics::with_client(|client| {
-            client.send_metric(
-                client.histogram_with_tags($id, $value)
-                    $(.with_tag($k, $v))*
-            );
-        })
+            client
+                .histogram_with_tags($id, $value)
+                $(.with_tag($k, $v))*
+                .send();
+        });
     }};
 }

--- a/crates/symbolicator-service/src/utils/futures.rs
+++ b/crates/symbolicator-service/src/utils/futures.rs
@@ -101,11 +101,10 @@ impl<'a> MeasureGuard<'a> {
     /// metric.
     pub fn start(&mut self) {
         metrics::with_client(|client| {
-            let metric = client
+            client
                 .time_with_tags("futures.wait_time", self.creation_time.elapsed())
-                .with_tag("task_name", self.task_name);
-
-            client.send_metric(metric);
+                .with_tag("task_name", self.task_name)
+                .send();
         })
     }
 
@@ -122,12 +121,11 @@ impl Drop for MeasureGuard<'_> {
             MeasureState::Done(status) => status,
         };
         metrics::with_client(|client| {
-            let metric = client
+            client
                 .time_with_tags("futures.done", self.creation_time.elapsed())
                 .with_tag("task_name", self.task_name)
-                .with_tag("status", status);
-
-            client.send_metric(metric);
+                .with_tag("status", status)
+                .send();
         })
     }
 }


### PR DESCRIPTION
Instead of defining a custom wrapper type to add global tags, use the built in cadence functionality to do so.

---

This is the cleanups from https://github.com/getsentry/symbolicator/pull/1351, but without the part that actually sends things to Sentry.

#skip-changelog