### PR TITLE
Bumping GoCD jsonnet to include de

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.7"
+      "version": "v2.8"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "97af8955747da4f68ce4f70a5128b4e53956e9b2",
-      "sum": "qQiTUU6BkUbKBGblpBppxFBewhIqqQaWlz01ZTGEpi4="
+      "version": "172de74e6347127957707d990f20f3e99c6c1c46",
+      "sum": "pBB9Jio0EnAgB7811tnly/S1B5fz6BeYoi4hQ7KgsHM="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This update to the GoCD jsonnet library adds DE in as a test region to pipedream.
https://github.com/getsentry/gocd-jsonnet/releases/tag/v2.8
#skip-changelog