### PR TITLE
Do not persist SourceMap contents in `FileInBundleCache`

### DIFF
--- a/crates/symbolicator-js/src/bundle_lookup.rs
+++ b/crates/symbolicator-js/src/bundle_lookup.rs
@@ -4,9 +4,11 @@ use std::time::Duration;
 use symbolicator_service::caches::ByteViewString;
 use symbolicator_sources::RemoteFileUri;
 
+use crate::interface::ResolvedWith;
 use crate::lookup::{CachedFileEntry, FileKey};
 
-type FileInBundleCacheInner = moka::sync::Cache<(RemoteFileUri, FileKey), CachedFileEntry>;
+type FileInBundleCacheInner =
+    moka::sync::Cache<(RemoteFileUri, FileKey), (CachedFileEntry, ResolvedWith)>;
 
 /// A cache that memoizes looking up files in artifact bundles.
 #[derive(Clone)]
@@ -33,11 +35,11 @@ impl FileInBundleCache {
             .time_to_idle(Duration::from_secs(60 * 60))
             .name("file-in-bundle")
             .weigher(|_k, v| {
-                let content_size = v
-                    .entry
-                    .as_ref()
-                    .map(|cached_file| cached_file.contents.len())
-                    .unwrap_or_default();
+                let content_size =
+                    v.0.entry
+                        .as_ref()
+                        .map(|cached_file| cached_file.contents.len())
+                        .unwrap_or_default();
                 (std::mem::size_of_val(v) + content_size)
                     .try_into()
                     .unwrap_or(u32::MAX)
@@ -55,12 +57,12 @@ impl FileInBundleCache {
         &self,
         bundle_uris: impl Iterator<Item = RemoteFileUri>,
         mut key: FileKey,
-    ) -> Option<CachedFileEntry> {
+    ) -> Option<(RemoteFileUri, CachedFileEntry, ResolvedWith)> {
         for bundle_uri in bundle_uris {
             // XXX: this is a really horrible workaround for not being able to look up things via `(&A, &B)` instead of `&(A, B)`.
             let lookup_key = (bundle_uri, key);
-            if let Some(file_entry) = self.cache.get(&lookup_key) {
-                return Some(file_entry);
+            if let Some((file_entry, resolved_with)) = self.cache.get(&lookup_key) {
+                return Some((lookup_key.0, file_entry, resolved_with));
             }
             key = lookup_key.1;
         }
@@ -71,7 +73,13 @@ impl FileInBundleCache {
     ///
     /// Files are inserted under a specific bundle so that e.g. files with the same
     /// `abs_path` belonging to different events are disambiguated.
-    pub fn insert(&self, bundle_uri: &RemoteFileUri, key: &FileKey, file_entry: &CachedFileEntry) {
+    pub fn insert(
+        &self,
+        bundle_uri: &RemoteFileUri,
+        key: &FileKey,
+        resolved_with: ResolvedWith,
+        file_entry: &CachedFileEntry,
+    ) {
         let mut file_entry = file_entry.clone();
         if matches!(key, FileKey::SourceMap { .. }) {
             if let Ok(cached_file) = file_entry.entry.as_mut() {
@@ -80,6 +88,6 @@ impl FileInBundleCache {
             }
         }
         let key = (bundle_uri.clone(), key.clone());
-        self.cache.insert(key, file_entry)
+        self.cache.insert(key, (file_entry, resolved_with))
     }
 }

--- a/crates/symbolicator-js/src/lib.rs
+++ b/crates/symbolicator-js/src/lib.rs
@@ -6,6 +6,7 @@ pub mod interface;
 mod lookup;
 mod metrics;
 mod service;
+mod sourcemap_cache;
 mod symbolication;
 mod utils;
 

--- a/crates/symbolicator-js/src/service.rs
+++ b/crates/symbolicator-js/src/service.rs
@@ -11,7 +11,7 @@ use symbolicator_service::services::SharedServices;
 use crate::api_lookup::SentryLookupApi;
 use crate::bundle_index_cache::BundleIndexCache;
 use crate::bundle_lookup::FileInBundleCache;
-use crate::lookup::FetchSourceMapCacheInternal;
+use crate::sourcemap_cache::FetchSourceMapCacheInternal;
 
 #[derive(Debug, Clone)]
 pub struct SourceMapService {

--- a/crates/symbolicator-js/src/sourcemap_cache.rs
+++ b/crates/symbolicator-js/src/sourcemap_cache.rs
@@ -1,0 +1,132 @@
+use std::fs::File;
+use std::io::{self, BufWriter};
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use symbolic::common::{ByteView, SelfCell};
+use symbolic::debuginfo::sourcebundle::SourceFileDescriptor;
+use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
+use symbolicator_service::caches::versions::SOURCEMAP_CACHE_VERSIONS;
+use symbolicator_service::caches::ByteViewString;
+use symbolicator_service::caching::{CacheEntry, CacheError, CacheItemRequest, CacheVersions};
+use symbolicator_service::objects::ObjectHandle;
+use tempfile::NamedTempFile;
+
+use crate::lookup::{
+    open_bundle, ArtifactBundle, ArtifactBundles, CachedFile, CachedFileUri, FileKey,
+    OwnedSourceMapCache,
+};
+use crate::utils::get_release_file_candidate_urls;
+
+#[derive(Clone, Debug)]
+pub enum SourceMapContents {
+    Lazy(Arc<ObjectHandle>, FileKey),
+    Eager(ByteViewString),
+}
+
+impl SourceMapContents {
+    pub fn from_cachedfile(
+        artifact_bundles: &ArtifactBundles,
+        sourcemap_uri: &CachedFileUri,
+        sourcemap: CachedFile,
+    ) -> Self {
+        if !sourcemap.is_lazy {
+            return Self::Eager(sourcemap.contents);
+        }
+
+        let bundle = if let CachedFileUri::Bundled(bundle_uri, key) = sourcemap_uri {
+            artifact_bundles.get(bundle_uri).and_then(|bundle| {
+                let Ok((bundle, _)) = bundle else { return None };
+                let bundle = bundle.owner().clone();
+                let contents = Self::Lazy(bundle, key.clone());
+                Some(contents)
+            })
+        } else {
+            None
+        };
+
+        bundle.unwrap_or(Self::Eager(sourcemap.contents))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FetchSourceMapCacheInternal {
+    pub source: ByteViewString,
+    pub sourcemap: SourceMapContents,
+}
+
+impl CacheItemRequest for FetchSourceMapCacheInternal {
+    type Item = OwnedSourceMapCache;
+
+    const VERSIONS: CacheVersions = SOURCEMAP_CACHE_VERSIONS;
+
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+        Box::pin(async move {
+            let sourcemap = match &self.sourcemap {
+                SourceMapContents::Lazy(bundle, key) => {
+                    let bundle = open_bundle(bundle.clone())?;
+                    let descriptor = get_descriptor_from_bundle(&bundle, key);
+
+                    let contents = descriptor
+                        .and_then(|d| d.into_contents())
+                        .ok_or_else(|| {
+                            CacheError::Malformed("descriptor should have `contents`".into())
+                        })?
+                        .into_owned();
+                    ByteViewString::from(contents)
+                }
+                SourceMapContents::Eager(contents) => contents.clone(),
+            };
+
+            write_sourcemap_cache(temp_file.as_file_mut(), &self.source, &sourcemap)
+        })
+    }
+
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+        parse_sourcemap_cache_owned(data)
+    }
+}
+
+fn parse_sourcemap_cache_owned(byteview: ByteView<'static>) -> CacheEntry<OwnedSourceMapCache> {
+    SelfCell::try_new(byteview, |p| unsafe {
+        SourceMapCache::parse(&*p).map_err(CacheError::from_std_error)
+    })
+}
+
+/// Computes and writes the SourceMapCache.
+#[tracing::instrument(skip_all)]
+fn write_sourcemap_cache(file: &mut File, source: &str, sourcemap: &str) -> CacheEntry {
+    tracing::debug!("Converting SourceMap cache");
+
+    let smcache_writer = SourceMapCacheWriter::new(source, sourcemap)
+        .map_err(|err| CacheError::Malformed(err.to_string()))?;
+
+    let mut writer = BufWriter::new(file);
+    smcache_writer.serialize(&mut writer)?;
+    let file = writer.into_inner().map_err(io::Error::from)?;
+    file.sync_all()?;
+
+    Ok(())
+}
+
+fn get_descriptor_from_bundle<'b>(
+    bundle: &'b ArtifactBundle,
+    key: &FileKey,
+) -> Option<SourceFileDescriptor<'b>> {
+    let bundle = bundle.get();
+    let ty = key.as_type();
+
+    if let Some(debug_id) = key.debug_id() {
+        if let Ok(Some(descriptor)) = bundle.source_by_debug_id(debug_id, ty) {
+            return Some(descriptor);
+        }
+    }
+    if let Some(abs_path) = key.abs_path() {
+        for url in get_release_file_candidate_urls(abs_path) {
+            if let Ok(Some(descriptor)) = bundle.source_by_url(&url) {
+                return Some(descriptor);
+            }
+        }
+    }
+    None
+}

--- a/crates/symbolicator-js/src/symbolication.rs
+++ b/crates/symbolicator-js/src/symbolication.rs
@@ -121,7 +121,7 @@ async fn symbolicate_js_frame(
     match &module.minified_source.entry {
         Ok(minified_source) => {
             if should_apply_source_context {
-                apply_source_context(raw_frame, &minified_source.contents)?
+                apply_source_context(raw_frame, minified_source.contents())?
             }
         }
         Err(CacheError::DownloadError(msg)) if msg == "Scraping disabled" => {
@@ -267,7 +267,7 @@ async fn symbolicate_js_frame(
             if source_file
                 .as_ref()
                 .map_err(|_| JsModuleErrorKind::MissingSource)
-                .and_then(|file| apply_source_context(&mut frame, &file.contents))
+                .and_then(|file| apply_source_context(&mut frame, file.contents()))
                 .is_err()
             {
                 // It's arguable whether we should collect it, but this is what monolith does now,


### PR DESCRIPTION
According to metrics, the cache is quite effective in ST and on LPQ instances. Less so in production, most likely because the cache is too small.

To increase the effective size of the cache, we do not store the actual sourcemap contents in it anymore. These contents are only used for sourcemapcache generation, and are not usually required.

#skip-changelog