### PR TITLE
doc(sources): Document rationale for Sentry list_file behavior

### DIFF
--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -178,7 +178,7 @@ impl SentryDownloader {
         // NOTE: We intentionally don't limit the query to the provided file types, even though
         // the endpoint supports it. The reason is that the result of the query gets cached locally
         // and we can then filter the cached results. This saves us from making individual requests to Sentry
-        // for ever file type or combination of file types we need.
+        // for every file type or combination of file types we need.
         let query = SearchQuery {
             index_url,
             token: source.token.clone(),

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -26,7 +26,6 @@ use crate::utils::http::DownloadTimeouts;
 #[serde(rename_all = "camelCase")]
 struct SearchResult {
     id: SentryFileId,
-    symbol_type: SentryFileType,
 }
 
 /// The is almost the same as [`FileType`], except it does not treat MachO, Elf and Wasm
@@ -64,12 +63,6 @@ impl From<FileType> for SentryFileType {
             FileType::BcSymbolMap => Self::BcSymbolMap,
             FileType::Il2cpp => Self::Il2cpp,
         }
-    }
-}
-
-impl SentryFileType {
-    fn matches(self, file_types: &[FileType]) -> bool {
-        file_types.iter().any(|ty| Self::from(*ty) == self)
     }
 }
 
@@ -175,6 +168,12 @@ impl SentryDownloader {
                 .append_pair("code_id", code_id.as_str());
         }
 
+        for file_type in file_types {
+            index_url
+                .query_pairs_mut()
+                .append_pair("file_formats", file_type.as_ref());
+        }
+
         let query = SearchQuery {
             index_url,
             token: source.token.clone(),
@@ -227,7 +226,6 @@ impl SentryDownloader {
 
         let file_ids = entries
             .iter()
-            .filter(|file| file.symbol_type.matches(file_types))
             .map(|file| SentryRemoteFile::new(source.clone(), true, file.id.clone(), None).into())
             .collect();
         Ok(file_ids)


### PR DESCRIPTION
The debug files endpoint in Sentry supports querying by a list of file formats:
https://github.com/getsentry/sentry/blob/e23668f702957cc09d47977cacfa2b9c8b384928/src/sentry/api/endpoints/debug_files.py#L248

https://github.com/getsentry/sentry/blob/e23668f702957cc09d47977cacfa2b9c8b384928/src/sentry/api/endpoints/debug_files.py#L281-L287

Therefore we can already do the filtering by file type when we make the query to the Sentry source, instead of getting all files and filtering afterwards.