### PR TITLE
feat(proguard): Add types for JVM requests

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -5,58 +5,83 @@ use symbolic::common::DebugId;
 use symbolicator_service::types::Scope;
 use symbolicator_sources::SourceConfig;
 
+/// A request for symbolication/remapping of a JVM event.
 #[derive(Debug, Clone)]
 pub struct SymbolicateJvmStacktraces {
+    /// The scope of this request which determines access to cached files.
     pub scope: Scope,
+    /// A list of external sources to load debug files.
     pub sources: Arc<[SourceConfig]>,
+    /// The exceptions to symbolicate/remap.
     pub exceptions: Vec<JvmException>,
+    /// A list of proguard files to use for remapping.
     pub modules: Vec<JvmModule>,
     /// Whether to apply source context for the stack frames.
     pub apply_source_context: bool,
 }
 
+/// A stack frame in a JVM stacktrace.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JvmFrame {
+    /// The frame's function name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<String>,
 
+    /// The source file name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
+    /// The module name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub module: Option<String>,
 
+    /// The source file's absolute path.
     pub abs_path: String,
 
+    /// The line number within the source file, starting at `1` for the first line.
     pub lineno: u32,
 
+    /// Source context before the context line.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pre_context: Vec<String>,
 
+    /// The context line if available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_line: Option<String>,
 
+    /// Post context after the context line
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub post_context: Vec<String>,
 
+    /// Whether the frame is related to app-code (rather than libraries/dependencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_app: Option<bool>,
 }
 
+/// An exception in a JVM event.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JvmException {
+    /// The type (class name) of the exception.
     #[serde(rename = "type")]
     ty: String,
+    /// The module in which the exception is defined.
     module: String,
+    /// The stacktrace associated with the exception.
     stacktrace: JvmStacktrace,
 }
 
+/// A JVM stacktrace.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JvmStacktrace {
+    /// The stacktrace's frames.
     frames: Vec<JvmFrame>,
 }
 
+/// A JVM module (proguard file).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JvmModule {
+    /// The file's UUID.
+    ///
+    /// This is used to download the file from symbol sources.
     uuid: DebugId,
 }

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use symbolic::common::DebugId;
-use symbolicator_service::types::{RawObjectInfo, Scope};
+use symbolicator_service::types::Scope;
 use symbolicator_sources::SourceConfig;
 
 #[derive(Debug, Clone)]

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -1,1 +1,62 @@
+use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+use symbolic::common::DebugId;
+use symbolicator_service::types::{RawObjectInfo, Scope};
+use symbolicator_sources::SourceConfig;
+
+#[derive(Debug, Clone)]
+pub struct SymbolicateJvmStacktraces {
+    pub scope: Scope,
+    pub sources: Arc<[SourceConfig]>,
+    pub exceptions: Vec<JvmException>,
+    pub modules: Vec<JvmModule>,
+    /// Whether to apply source context for the stack frames.
+    pub apply_source_context: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JvmFrame {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+
+    pub abs_path: String,
+
+    pub lineno: u32,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_app: Option<bool>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JvmException {
+    #[serde(rename = "type")]
+    ty: String,
+    module: String,
+    stacktrace: JvmStacktrace,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JvmStacktrace {
+    frames: Vec<JvmFrame>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JvmModule {
+    uuid: DebugId,
+}


### PR DESCRIPTION
This adds frame, stacktrace, &c., types, as well as `SymbolicateJvmRequest`. Unlike other symbolication request types, we have exceptions here. I kept the structure the same as in events, i.e., stacktraces are contained in exceptions. 

Modules consist of just uuids for now, we might expand them.