### PR TITLE
Slight metrics improvements

### DIFF
--- a/crates/symbolicator-js/src/bundle_lookup.rs
+++ b/crates/symbolicator-js/src/bundle_lookup.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::time::Duration;
 
+use symbolicator_service::metric;
 use symbolicator_sources::RemoteFileUri;
 
 use crate::interface::ResolvedWith;
@@ -62,10 +63,12 @@ impl FileInBundleCache {
             // XXX: this is a really horrible workaround for not being able to look up things via `(&A, &B)` instead of `&(A, B)`.
             let lookup_key = (bundle_uri, key);
             if let Some((file_entry, resolved_with)) = self.cache.get(&lookup_key) {
+                metric!(counter("js.file_in_bundle.hit") += 1);
                 return Some((lookup_key.0, file_entry, resolved_with));
             }
             key = lookup_key.1;
         }
+        metric!(counter("js.file_in_bundle.miss") += 1);
         None
     }
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -615,9 +615,9 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
         };
 
         let duration = self.creation_time.elapsed();
-        let metric_name = format!("{}.duration", self.task_name);
         metric!(
-            timer(&metric_name) = duration,
+            timer("download_duration") = duration,
+            "task_name" => self.task_name,
             "status" => status,
             "source" => self.source_name,
         );
@@ -631,9 +631,9 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
                 .checked_div(duration.as_millis())
                 .and_then(|t| t.try_into().ok())
                 .unwrap_or(bytes_transferred);
-            let throughput_name = format!("{}.throughput", self.task_name);
             metric!(
-                histogram(&throughput_name) = throughput,
+                histogram("download_throughput") = throughput,
+                "task_name" => self.task_name,
                 "status" => status,
                 "source" => self.source_name,
             );

--- a/crates/symbolicator/src/endpoints/metrics.rs
+++ b/crates/symbolicator/src/endpoints/metrics.rs
@@ -39,7 +39,10 @@ where
                 .as_ref()
                 .map(|r| r.status())
                 .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            metric!(counter(&format!("responses.status_code.{status}")) += 1);
+            metric!(
+                counter("responses.status_code") += 1,
+                "status" => status.as_str(),
+            );
         }
         poll
     }


### PR DESCRIPTION
Some of the improvements were extracted from #1379

- Avoid `format!`-ing metric keys
- Use macros instead of manual invocations
- Add a metrics for the JS `file_in_bundle` cache