### PR TITLE
Send distribution-like metrics individually

### DIFF
--- a/crates/symbolicator-service/src/metrics.rs
+++ b/crates/symbolicator-service/src/metrics.rs
@@ -65,7 +65,7 @@ impl Deref for MetricsWrapper {
 
 /// We are not (yet) aggregating distributions, but keeping every value.
 /// To not overwhelm downstream services, we send them in batches instead of all at once.
-const DISTRIBUTION_BATCH_SIZE: usize = 20;
+const DISTRIBUTION_BATCH_SIZE: usize = 1;
 
 /// Creates [`LocalAggregators`] and starts a thread that will periodically
 /// send aggregated metrics upstream to the `sink`.


### PR DESCRIPTION
It looks like distribution-like metrics do not make it through `veneur` properly, possibly because of sending multiple at once.
Sending them individually should solve this problem, hopefully.