### PR TITLE
feat(proguard): Add symbolicate-jvm endpoint

### DIFF
--- a/crates/symbolicator/src/endpoints/mod.rs
+++ b/crates/symbolicator/src/endpoints/mod.rs
@@ -15,6 +15,7 @@ mod proxy;
 mod requests;
 mod symbolicate;
 mod symbolicate_js;
+mod symbolicate_jvm;
 
 pub use error::ResponseError;
 use metrics::MetricsLayer;
@@ -25,6 +26,7 @@ use proxy::proxy_symstore_request as proxy;
 use requests::poll_request as requests;
 use symbolicate::symbolicate_frames as symbolicate;
 use symbolicate_js::handle_symbolication_request as symbolicate_js;
+use symbolicate_jvm::handle_symbolication_request as symbolicate_jvm;
 
 pub async fn healthcheck() -> &'static str {
     crate::metric!(counter("healthcheck") += 1);
@@ -47,6 +49,7 @@ pub fn create_app(service: RequestService) -> Router {
         .route("/minidump", post(minidump))
         .route("/symbolicate-js", post(symbolicate_js))
         .route("/symbolicate", symbolicate_route)
+        .route("/symbolicate-jvm", post(symbolicate_jvm))
         .with_state(service)
         .layer(layer)
         // the healthcheck is last, as it will bypass all the middlewares

--- a/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use axum::{extract, Json};
+use serde::{Deserialize, Serialize};
+use symbolicator_proguard::interface::{
+    JvmException, JvmModule, JvmStacktrace, SymbolicateJvmStacktraces,
+};
+use symbolicator_sources::SourceConfig;
+
+use crate::service::{RequestService, SymbolicationResponse};
+use crate::utils::sentry::ConfigureScope;
+
+use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
+use crate::endpoints::ResponseError;
+
+#[derive(Serialize, Deserialize)]
+pub struct JvmSymbolicationRequestBody {
+    pub sources: Arc<[SourceConfig]>,
+    #[serde(default)]
+    pub exceptions: Vec<JvmException>,
+    #[serde(default)]
+    pub stacktraces: Vec<JvmStacktrace>,
+    #[serde(default)]
+    pub modules: Vec<JvmModule>,
+    #[serde(default)]
+    pub release_package: Option<String>,
+    #[serde(default)]
+    pub options: JvmRequestOptions,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct JvmRequestOptions {
+    /// Whether to apply source context for the stack frames.
+    #[serde(default = "default_apply_source_context")]
+    pub apply_source_context: bool,
+}
+
+fn default_apply_source_context() -> bool {
+    true
+}
+
+impl Default for JvmRequestOptions {
+    fn default() -> Self {
+        Self {
+            apply_source_context: true,
+        }
+    }
+}
+
+pub async fn handle_symbolication_request(
+    extract::State(service): extract::State<RequestService>,
+    extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
+    extract::Json(body): extract::Json<JvmSymbolicationRequestBody>,
+) -> Result<Json<SymbolicationResponse>, ResponseError> {
+    sentry::start_session();
+
+    params.configure_scope();
+
+    let JvmSymbolicationRequestBody {
+        sources,
+        exceptions,
+        stacktraces,
+        modules,
+        release_package,
+        options,
+    } = body;
+
+    let request_id = service.symbolicate_jvm_stacktraces(SymbolicateJvmStacktraces {
+        scope: params.scope,
+        sources,
+        exceptions,
+        stacktraces,
+        modules,
+        release_package,
+        apply_source_context: options.apply_source_context,
+    })?;
+
+    match service.get_response(request_id, params.timeout).await {
+        Some(response) => Ok(Json(response)),
+        None => Err("symbolication request did not start".into()),
+    }
+}

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -28,8 +28,11 @@ use symbolicator_js::interface::{CompletedJsSymbolicationResponse, SymbolicateJs
 use symbolicator_js::SourceMapService;
 use symbolicator_native::interface::{CompletedSymbolicationResponse, SymbolicateStacktraces};
 use symbolicator_native::SymbolicationActor;
+use symbolicator_proguard::interface::{
+    CompletedJvmSymbolicationResponse, SymbolicateJvmStacktraces,
+};
 // TODO: actually use it
-use symbolicator_proguard as _;
+use symbolicator_proguard::{self as _, ProguardService};
 use symbolicator_service::caching::CacheEntry;
 use symbolicator_service::config::Config;
 use symbolicator_service::metric;
@@ -104,8 +107,9 @@ pub enum SymbolicationResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CompletedResponse {
-    NativeSymbolication(CompletedSymbolicationResponse),
-    JsSymbolication(CompletedJsSymbolicationResponse),
+    Native(CompletedSymbolicationResponse),
+    Js(CompletedJsSymbolicationResponse),
+    Jvm(CompletedJvmSymbolicationResponse),
 }
 
 /// Common options for all symbolication API requests.
@@ -168,6 +172,7 @@ struct RequestServiceInner {
 
     native: SymbolicationActor,
     js: SourceMapService,
+    jvm: ProguardService,
     objects: ObjectsActor,
 
     cpu_pool: tokio::runtime::Handle,
@@ -194,6 +199,7 @@ impl RequestService {
         let shared_services = SharedServices::new(config, io_pool.clone())?;
         let native = SymbolicationActor::new(&shared_services);
         let js = SourceMapService::new(&shared_services);
+        let jvm = ProguardService::new(&shared_services);
         let SharedServices {
             objects, config, ..
         } = shared_services;
@@ -216,6 +222,7 @@ impl RequestService {
 
             native,
             js,
+            jvm,
             objects,
 
             cpu_pool,
@@ -262,7 +269,7 @@ impl RequestService {
             slf.native
                 .symbolicate(request)
                 .await
-                .map(CompletedResponse::NativeSymbolication)
+                .map(CompletedResponse::Native)
         })
     }
 
@@ -272,10 +279,24 @@ impl RequestService {
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
         self.create_symbolication_request("symbolicate_js", RequestOptions::default(), async move {
-            Ok(CompletedResponse::JsSymbolication(
-                slf.js.symbolicate_js(request).await,
-            ))
+            Ok(CompletedResponse::Js(slf.js.symbolicate_js(request).await))
         })
+    }
+
+    pub fn symbolicate_jvm_stacktraces(
+        &self,
+        request: SymbolicateJvmStacktraces,
+    ) -> Result<RequestId, MaxRequestsError> {
+        let slf = self.inner.clone();
+        self.create_symbolication_request(
+            "symbolicate_jvm",
+            RequestOptions::default(),
+            async move {
+                Ok(CompletedResponse::Jvm(
+                    slf.jvm.symbolicate_jvm(request).await,
+                ))
+            },
+        )
     }
 
     /// Creates a new request to process a minidump.
@@ -295,7 +316,7 @@ impl RequestService {
             slf.native
                 .process_minidump(scope, minidump_file, sources, scraping)
                 .await
-                .map(CompletedResponse::NativeSymbolication)
+                .map(CompletedResponse::Native)
         })
     }
 
@@ -316,7 +337,7 @@ impl RequestService {
             slf.native
                 .process_apple_crash_report(scope, apple_crash_report, sources, scraping)
                 .await
-                .map(CompletedResponse::NativeSymbolication)
+                .map(CompletedResponse::Native)
         })
     }
 
@@ -419,7 +440,7 @@ impl RequestService {
             let response = match response {
                 Ok(Ok(mut response)) => {
                     if !options.dif_candidates {
-                        if let CompletedResponse::NativeSymbolication(ref mut res) = response {
+                        if let CompletedResponse::Native(ref mut res) = response {
                             clear_dif_candidates(res)
                         }
                     }


### PR DESCRIPTION
This also renames the variants of `SymbolicationResponse` at the suggestion of `clippy`.