### PR TITLE
Increase `FileInBundleCache` size and make it configurable.

### DIFF
--- a/crates/symbolicator-js/src/bundle_lookup.rs
+++ b/crates/symbolicator-js/src/bundle_lookup.rs
@@ -23,15 +23,12 @@ impl std::fmt::Debug for FileInBundleCache {
 }
 
 impl FileInBundleCache {
-    /// Creates a new `FileInBundleCache` with a maximum size of 2GiB and
-    /// idle time of 1h.
-    pub fn new() -> Self {
-        // NOTE: We size the cache at 2 GiB which is quite an arbitrary pick.
+    /// Creates a new `FileInBundleCache` with the given `capacity` and an idle time of 1h.
+    pub fn new(capacity: u64) -> Self {
         // As all the files are living in memory, we return the size of the contents
         // from the `weigher` which is responsible for this accounting.
-        const GIGS: u64 = 1 << 30;
         let cache = FileInBundleCacheInner::builder()
-            .max_capacity(2 * GIGS)
+            .max_capacity(capacity)
             .time_to_idle(Duration::from_secs(60 * 60))
             .name("file-in-bundle")
             .weigher(|_k, v| {

--- a/crates/symbolicator-js/src/service.rs
+++ b/crates/symbolicator-js/src/service.rs
@@ -40,7 +40,7 @@ impl SourceMapService {
 
         Self {
             objects,
-            files_in_bundles: FileInBundleCache::new(),
+            files_in_bundles: FileInBundleCache::new(in_memory.fileinbundle_capacity),
             sourcefiles_cache,
             sourcemap_caches: Arc::new(Cacher::new(caches.sourcemap_caches.clone(), shared_cache)),
             download_svc,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -307,6 +307,13 @@ pub struct InMemoryCacheConfig {
     ///
     /// Defaults to `600 MiB (= 629_145_600)`.
     pub cficaches_capacity: u64,
+
+    /// Capacity (in bytes) for the in-memory "file in bundle" Cache.
+    ///
+    /// The in-memory size limit is a best-effort approximation, and not an exact limit.
+    ///
+    /// Defaults to `3 GiB (= 3_221_225_472)`
+    pub fileinbundle_capacity: u64,
 }
 
 impl Default for InMemoryCacheConfig {
@@ -319,6 +326,10 @@ impl Default for InMemoryCacheConfig {
             s3_client_capacity: 100,
             object_meta_capacity: 100 * meg,
             cficaches_capacity: 400 * meg,
+            // NOTE: JS symbolication is very sensitive to this cache size.
+            // We noticed a significant reduction in CPU usage with a cache size of ~2G, which
+            // resulted in a hit ratio of ~60-65%. Lets give it a bit more then and see what happens.
+            fileinbundle_capacity: 3 * 1024 * meg,
         }
     }
 }


### PR DESCRIPTION
JS symbolication is very sensitive to this cache size.
We noticed a significant reduction in CPU usage with a cache size of ~2G, which
resulted in a hit ratio of ~60-65%. Lets give it a bit more then and see what happens, and make it configurable for the future, so it can be tuned per-deployment.

---

The PR is currently on top of https://github.com/getsentry/symbolicator/pull/1397, but I can also rebase, no problem.