### PR TITLE
ref(proguard): Return raw stacktraces

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -101,6 +101,8 @@ pub struct CompletedJvmSymbolicationResponse {
     pub exceptions: Vec<JvmException>,
     /// The stacktraces after remapping.
     pub stacktraces: Vec<JvmStacktrace>,
+    /// The original stacktraces, possibly enhanced with source context.
+    pub raw_stacktraces: Vec<JvmStacktrace>,
     /// Errors that occurred during symbolication.
     pub errors: Vec<(DebugId, String)>,
 }

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -51,7 +51,7 @@ impl ProguardService {
             .collect();
 
         let remapped_stacktraces = stacktraces
-            .into_iter()
+            .iter()
             .map(|raw_stacktrace| {
                 let remapped_frames = raw_stacktrace
                     .frames
@@ -69,6 +69,9 @@ impl ProguardService {
         CompletedJvmSymbolicationResponse {
             exceptions: remapped_exceptions,
             stacktraces: remapped_stacktraces,
+            // This is pointless for now—it's just the original stacktraces.
+            // However, it will become relevant when we implement source context.
+            raw_stacktraces: stacktraces,
             errors,
         }
     }


### PR DESCRIPTION
Add `raw_stacktraces` to the `CompletedJvmSymbolicationResponse`. For now they're always identical to the input stacktraces; this will become relevant when we implement source context.