### PR TITLE
ref(proguard): Return typed errors

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,39 @@ pub struct JvmModule {
     pub uuid: DebugId,
 }
 
+/// The type of a [`ProguardError`].
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub enum ProguardErrorKind {
+    /// The file couldn't be downloaded.
+    Missing,
+    /// The file is invalid according to [`is_valid`](proguard::ProguardMapping::is_valid).
+    Invalid,
+    /// The file doesn't contain line mapping information.
+    NoLineInfo,
+}
+
+impl fmt::Display for ProguardErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProguardErrorKind::Missing => write!(f, "The proguard mapping file is missing."),
+            ProguardErrorKind::Invalid => write!(f, "The proguard mapping file is invalid."),
+            ProguardErrorKind::NoLineInfo => {
+                write!(f, "The proguard mapping file does not contain line info.")
+            }
+        }
+    }
+}
+
+/// An error that happened when trying to use a proguard mapping file.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ProguardError {
+    /// The UUID of the proguard file.
+    pub uuid: DebugId,
+    /// The type of the error.
+    #[serde(rename = "type")]
+    pub kind: ProguardErrorKind,
+}
+
 // TODO: Expand this
 /// The symbolicated/remapped event data.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -104,5 +138,5 @@ pub struct CompletedJvmSymbolicationResponse {
     /// The original stacktraces, possibly enhanced with source context.
     pub raw_stacktraces: Vec<JvmStacktrace>,
     /// Errors that occurred during symbolication.
-    pub errors: Vec<(DebugId, String)>,
+    pub errors: Vec<JvmError>,
 }

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -138,5 +138,5 @@ pub struct CompletedJvmSymbolicationResponse {
     /// The original stacktraces, possibly enhanced with source context.
     pub raw_stacktraces: Vec<JvmStacktrace>,
     /// Errors that occurred during symbolication.
-    pub errors: Vec<JvmError>,
+    pub errors: Vec<ProguardError>,
 }

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -80,11 +80,7 @@ impl ProguardService {
 }
 
 struct ProguardInner<'a> {
-    // TODO: actually use it
-    #[allow(unused)]
     mapping: proguard::ProguardMapping<'a>,
-    // TODO: actually use it
-    #[allow(unused)]
     mapper: proguard::ProguardMapper<'a>,
 }
 
@@ -98,8 +94,6 @@ impl<'slf, 'a: 'slf> AsSelf<'slf> for ProguardInner<'a> {
 
 #[derive(Clone)]
 pub struct ProguardMapper {
-    // TODO: actually use it
-    #[allow(unused)]
     inner: Arc<SelfCell<ByteView<'static>, ProguardInner<'static>>>,
 }
 

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -80,7 +80,6 @@ impl ProguardService {
 }
 
 struct ProguardInner<'a> {
-    mapping: proguard::ProguardMapping<'a>,
     mapper: proguard::ProguardMapper<'a>,
 }
 
@@ -101,8 +100,8 @@ impl ProguardMapper {
     pub fn new(byteview: ByteView<'static>) -> Self {
         let inner = SelfCell::new(byteview, |data| {
             let mapping = proguard::ProguardMapping::new(unsafe { &*data });
-            let mapper = proguard::ProguardMapper::new(mapping.clone());
-            ProguardInner { mapping, mapper }
+            let mapper = proguard::ProguardMapper::new(mapping);
+            ProguardInner { mapper }
         });
 
         Self {


### PR DESCRIPTION
This maps the `CacheErrors` that may occur when fetching and processing a proguard file to a typed representation before returning it in `CompletedJvmSymbolicationResponse`. This is so we can map the errors to `EventErrors` in Sentry. Having to scrutinize error messages is unfortunately quite ugly.

Strangely enough, on the Sentry side there is no `EventError` variant for invalid proguard files—indeed, the validity is never checked at all. This makes we wonder if we're being overly strict on the Symbolicator side, although I can't really imagine what the use of not rejecting an invalid file would be.

ETA: This PR also removes some `#[allow_unused]` annotations, as well as a useless struct field.