### PR TITLE
Revert "ref(proguard): Return raw stacktraces (#1399)"

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -101,8 +101,6 @@ pub struct CompletedJvmSymbolicationResponse {
     pub exceptions: Vec<JvmException>,
     /// The stacktraces after remapping.
     pub stacktraces: Vec<JvmStacktrace>,
-    /// The original stacktraces, possibly enhanced with source context.
-    pub raw_stacktraces: Vec<JvmStacktrace>,
     /// Errors that occurred during symbolication.
     pub errors: Vec<(DebugId, String)>,
 }

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -51,7 +51,7 @@ impl ProguardService {
             .collect();
 
         let remapped_stacktraces = stacktraces
-            .iter()
+            .into_iter()
             .map(|raw_stacktrace| {
                 let remapped_frames = raw_stacktrace
                     .frames
@@ -69,9 +69,6 @@ impl ProguardService {
         CompletedJvmSymbolicationResponse {
             exceptions: remapped_exceptions,
             stacktraces: remapped_stacktraces,
-            // This is pointless for now—it's just the original stacktraces.
-            // However, it will become relevant when we implement source context.
-            raw_stacktraces: stacktraces,
             errors,
         }
     }


### PR DESCRIPTION
This reverts commit 6d6163b964bed7555939c071478d98b519068ecf.

As pointed out in the discussion of https://github.com/getsentry/symbolicator/pull/1399, adding source context to the raw (obfuscated) stacktrace is not really useful. That makes returning the raw stacktrace pointless.