### PR TITLE
ref: Simplify create_client

### DIFF
--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -230,8 +230,12 @@ impl DownloadService {
     /// Creates a new downloader that runs all downloads in the given remote thread.
     pub fn new(config: &Config, runtime: tokio::runtime::Handle) -> Arc<Self> {
         let timeouts = DownloadTimeouts::from_config(config);
-        let trusted_client = crate::utils::http::create_client(config, &timeouts, true);
-        let restricted_client = crate::utils::http::create_client(config, &timeouts, false);
+
+        // The trusted client can always connect to reserved IPs. The restricted client only can if it's
+        // explicitly allowed in the config.
+        let trusted_client = crate::utils::http::create_client(&timeouts, true, false);
+        let restricted_client =
+            crate::utils::http::create_client(&timeouts, config.connect_to_reserved_ips, false);
 
         let in_memory = &config.caches.in_memory;
         Arc::new(Self {

--- a/crates/symbolicator-service/src/utils/http.rs
+++ b/crates/symbolicator-service/src/utils/http.rs
@@ -88,6 +88,13 @@ impl Default for DownloadTimeouts {
     }
 }
 
+/// Creates a [`reqwest::Client`] with the provided options.
+///
+/// * `timeouts` controls connection and download timeouts.
+/// * `connect_to_reserved_ips` determines whether the client is allowed to
+///   connect to reserved IPs (as defined in `RESERVED_IP_BLOCKS`).
+/// * `accept_invalid_certs` determines whether the client accepts invalid
+///   SSL certificates.
 pub fn create_client(
     timeouts: &DownloadTimeouts,
     connect_to_reserved_ips: bool,


### PR DESCRIPTION
This removes the `config` parameter from `create_client`. The only config setting that was used in the function was `connect_to_reserved_ips`, and that was OR-ed with the `trusted` parameter, so we just do that outside the function now.

This also adds an `accept_invalid_certs` parameter in preparation for #1402.