### PR TITLE
ref(download): Improve configurability of `HostDenyList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- Allow http symbol sources to indicate that invalid SSL certificates should be accepted (#1405) by @loewenheim
+- Make host deny list optional and allow exclusion of individual hosts (#1407) by @loewenheim
+
 ## 24.2.0
 
 ### Various fixes & improvements

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -410,6 +410,12 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub head_timeout: Duration,
 
+    /// Whether to enable the host deny list.
+    ///
+    /// The host deny list temporarily blocks symbol sources when
+    /// they cause too many download failures in a given timespan.
+    pub deny_list_enable: bool,
+
     /// The time window for the host deny list.
     ///
     /// Hosts will be put on the deny list if a certain number of downloads
@@ -531,6 +537,7 @@ impl Default for Config {
             head_timeout: Duration::from_secs(5),
             // Allow a 4MB/s connection to download 1GB without timing out.
             streaming_timeout: Duration::from_secs(250),
+            deny_list_enable: true,
             deny_list_time_window: Duration::from_secs(60),
             deny_list_bucket_size: Duration::from_secs(5),
             deny_list_threshold: 20,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -414,7 +414,7 @@ pub struct Config {
     ///
     /// The host deny list temporarily blocks symbol sources when
     /// they cause too many download failures in a given timespan.
-    pub deny_list_enable: bool,
+    pub deny_list_enabled: bool,
 
     /// The time window for the host deny list.
     ///
@@ -540,7 +540,7 @@ impl Default for Config {
             head_timeout: Duration::from_secs(5),
             // Allow a 4MB/s connection to download 1GB without timing out.
             streaming_timeout: Duration::from_secs(250),
-            deny_list_enable: true,
+            deny_list_enabled: true,
             deny_list_time_window: Duration::from_secs(60),
             deny_list_bucket_size: Duration::from_secs(5),
             deny_list_threshold: 20,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -435,6 +435,9 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub deny_list_block_time: Duration,
 
+    /// A list of hosts to never block regardless of download failures.
+    pub deny_list_never_block_hosts: Vec<String>,
+
     /// The timeout per GB for streaming downloads.
     ///
     /// For downloads with a known size, this timeout applies per individual
@@ -542,6 +545,7 @@ impl Default for Config {
             deny_list_bucket_size: Duration::from_secs(5),
             deny_list_threshold: 20,
             deny_list_block_time: Duration::from_secs(24 * 60 * 60),
+            deny_list_never_block_hosts: Vec::new(),
             max_concurrent_requests: Some(120),
             shared_cache: None,
             _crash_db: None,

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -212,7 +212,7 @@ impl HostDenyList {
 
     /// Returns true if the given `host` is currently blocked.
     fn is_blocked(&self, host: &str) -> bool {
-        self.blocked_hosts.contains_key(host)
+        !self.never_block.contains(host) && self.blocked_hosts.contains_key(host)
     }
 }
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -212,7 +212,7 @@ impl HostDenyList {
 
     /// Returns true if the given `host` is currently blocked.
     fn is_blocked(&self, host: &str) -> bool {
-        !self.never_block.contains(host) && self.blocked_hosts.contains_key(host)
+        self.blocked_hosts.contains_key(host)
     }
 }
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -101,9 +101,11 @@ type CountedFailures = Arc<Mutex<VecDeque<FailureCount>>>;
 /// A structure that keeps track of download failures in a given time interval
 /// and puts hosts on a block list accordingly.
 ///
-/// The logic works like this: if a host has at least `FAILURE_THRESHOLD` download
-/// failures in a window of `TIME_WINDOW` seconds, it will be blocked for a duration of
-/// `BLOCK_TIME`.
+/// The logic works like this: if a host has at least `failure_threshold` download
+/// failures in a window of `time_window_millis` ms, it will be blocked for a duration of
+/// `block_time`.
+///
+/// Hosts included in `never_block` will never be blocked regardless of download_failures.
 #[derive(Clone, Debug)]
 struct HostDenyList {
     time_window_millis: u64,

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -195,7 +195,7 @@ impl HostDenyList {
         let cutoff = current_ts - self.time_window_millis;
         let total_failures: usize = queue
             .iter()
-            .filter(|failure_count| failure_count.timestamp >= cutoff)
+            .skip_while(|failure_count| failure_count.timestamp < cutoff)
             .map(|failure_count| failure_count.failures)
             .sum();
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -260,7 +260,7 @@ impl DownloadService {
             gcs: gcs::GcsDownloader::new(restricted_client, timeouts, in_memory.gcs_token_capacity),
             fs: filesystem::FilesystemDownloader::new(),
             host_deny_list: config
-                .deny_list_enable
+                .deny_list_enabled
                 .then_some(HostDenyList::from_config(config)),
             connect_to_reserved_ips: config.connect_to_reserved_ips,
         })


### PR DESCRIPTION
This makes two fundamental changes to the `HostDenyList`.

1. It's now optional and can be disabled by setting `deny_list_enabled` to `false` (default is `true` so everything keeps working as before).
2. It allows you to exclude a list of hosts, meaning they will never be blocked. This list is configured via `deny_list_never_block_hosts` (defaults to `[]`).