### PR TITLE
ref(proguard): Keep track of frame indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- proguard: Added a mandatory `index` field to `JvmFrame` (#1411) by @loewenheim
+
 ## 24.3.0
 
 ### Various fixes & improvements

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -66,6 +66,12 @@ pub struct JvmFrame {
     /// Whether the frame is related to app-code (rather than libraries/dependencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_app: Option<bool>,
+
+    /// The index of the frame in the stacktrace before filtering and sending to Symbolicator.
+    ///
+    /// When returning frames in a `CompletedJvmSymbolicationResponse`, all frames that were
+    /// expanded from the frame with index `i` will also have index `i`.
+    pub index: usize,
 }
 
 /// An exception in a JVM event.

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -265,6 +265,7 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
                 function: "onClick".to_owned(),
                 module: "e.a.c.a".to_owned(),
                 lineno: 2,
+                index: 0,
                 ..Default::default()
             },
             JvmFrame {
@@ -272,6 +273,7 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
                 module: "io.sentry.sample.MainActivity".to_owned(),
                 filename: Some("MainActivity.java".to_owned()),
                 lineno: 1,
+                index: 1,
                 ..Default::default()
             },
         ];
@@ -291,6 +293,7 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
             mapped_frames[0].module,
             "io.sentry.sample.-$$Lambda$r3Avcbztes2hicEObh02jjhQqd4"
         );
+        assert_eq!(mapped_frames[0].index, 0);
 
         assert_eq!(
             mapped_frames[1].filename,
@@ -299,9 +302,11 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
         assert_eq!(mapped_frames[1].module, "io.sentry.sample.MainActivity");
         assert_eq!(mapped_frames[1].function, "onClickHandler");
         assert_eq!(mapped_frames[1].lineno, 40);
+        assert_eq!(mapped_frames[1].index, 1);
 
         assert_eq!(mapped_frames[2].function, "foo");
         assert_eq!(mapped_frames[2].lineno, 44);
+        assert_eq!(mapped_frames[2].index, 1);
 
         assert_eq!(mapped_frames[3].function, "bar");
         assert_eq!(mapped_frames[3].lineno, 54);
@@ -310,6 +315,7 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
             Some("MainActivity.java".to_owned())
         );
         assert_eq!(mapped_frames[3].module, "io.sentry.sample.MainActivity");
+        assert_eq!(mapped_frames[3].index, 1);
     }
 
     // based on the Python test `test_sets_inapp_after_resolving`.

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -150,6 +150,7 @@ async fn test_resolving_inline() {
                 function: "onClick".into(),
                 module: "e.a.c.a".into(),
                 lineno: 2,
+                index: 0,
                 ..Default::default()
             },
             JvmFrame {
@@ -157,6 +158,7 @@ async fn test_resolving_inline() {
                 module: "io.sentry.sample.MainActivity".into(),
                 filename: Some("MainActivity.java".into()),
                 lineno: 1,
+                index: 1,
                 ..Default::default()
             },
         ],
@@ -183,14 +185,21 @@ async fn test_resolving_inline() {
         frames[0].module,
         "io.sentry.sample.-$$Lambda$r3Avcbztes2hicEObh02jjhQqd4"
     );
+    assert_eq!(frames[0].index, 0);
+
     assert_eq!(frames[1].filename, Some("MainActivity.java".into()));
     assert_eq!(frames[1].module, "io.sentry.sample.MainActivity");
     assert_eq!(frames[1].function, "onClickHandler");
     assert_eq!(frames[1].lineno, 40);
+    assert_eq!(frames[1].index, 1);
+
     assert_eq!(frames[2].function, "foo");
     assert_eq!(frames[2].lineno, 44);
+    assert_eq!(frames[2].index, 1);
+
     assert_eq!(frames[3].function, "bar");
     assert_eq!(frames[3].lineno, 54);
     assert_eq!(frames[3].filename, Some("MainActivity.java".into()));
     assert_eq!(frames[3].module, "io.sentry.sample.MainActivity");
+    assert_eq!(frames[3].index, 1);
 }


### PR DESCRIPTION
Symbolication can expand one raw JVM frame into multiple frames. When we return the symbolicated stacktraces, we want it to be possible to tell which symbolicated frames came from which raw frames. To this end, we add an index to frames that you need to pass in and that gets copied to the symbolicated frames.

Example: You send a stacktrace to Symbolicator containing frames with indices `[0, 1, 3, 4]` (frame `2` has been filtered out for one reason or another). Symbolicator expands frame `3` to 3 frames. Then you'll get back frames with indices `[0, 1, 3, 3, 3, 4]`.