### PR TITLE
fix(proguard): Fix error casing

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -96,6 +96,7 @@ pub struct JvmModule {
 
 /// The type of a [`ProguardError`].
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ProguardErrorKind {
     /// The file couldn't be downloaded.
     Missing,

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -39,6 +39,7 @@ impl ProguardService {
             match res {
                 Ok(mapper) => mappers.push(mapper.get()),
                 Err(e) => {
+                    tracing::error!(%debug_id, error = %e, "Error reading Proguard file");
                     let kind = match e {
                         CacheError::Malformed(msg) => match msg.as_str() {
                             "The file is not a valid ProGuard file" => ProguardErrorKind::Invalid,


### PR DESCRIPTION
This serializes error variants in snake_case. I didn't originally add this because I thought it was the default.

ETA: Also adds an error log message when we encounter an invalid proguard file.