### PR TITLE
ref(proguard): Make line numbers optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Various fixes & improvements
 
 - proguard: Added a mandatory `index` field to `JvmFrame` (#1411) by @loewenheim
+- proguard: Support for source contex (#1414) by @loewenheim
+- proguard: Field `lineno` on `JvmFrame` is now optional (#1417) by @loewenheim
 
 ## 24.3.0
 

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -49,7 +49,11 @@ pub struct JvmFrame {
     pub abs_path: Option<String>,
 
     /// The line number within the source file, starting at `1` for the first line.
-    pub lineno: u32,
+    ///
+    /// If a frame doesn't have a line number, only its class name can be remapped,
+    /// and source context won't work at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u32>,
 
     /// Source context before the context line.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -351,7 +351,6 @@ async fn test_source_lookup_with_proguard() {
         "filename": "Method.java",
         "function": "invoke",
         "module": "java.lang.reflect.Method",
-        "lineno": 0,
         "index": 3
     }, {
         "filename": "ActivityThread.java",

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-proguard/tests/integration/proguard.rs
-assertion_line: 588
+assertion_line: 474
 expression: response
 ---
 exceptions:
@@ -26,7 +26,6 @@ stacktraces:
       - function: invoke
         filename: Method.java
         module: java.lang.reflect.Method
-        lineno: 0
         index: 3
       - function: main
         filename: ActivityThread.java


### PR DESCRIPTION
Based on #1414.

Without a line number, we can still at least try to remap a frame's class name. Of course, source context doesn't work at all without a line number.