### PR TITLE
ref(proguard): Properly size the in-memory cache

### DIFF
--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -295,10 +295,7 @@ impl Caches {
                 config,
                 config.caches.downloaded.into(),
                 max_lazy_redownloads,
-                // We use 2GiB as the in-memory cache size for Proguard files.
-                // Note that a Proguard mapper can take up hundreds of MB
-                // in memory.
-                2 * 1024 * 1024 * 1024,
+                in_memory.proguard_capacity,
             )?,
         })
     }

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -195,6 +195,7 @@ pub struct Caches {
     pub sourcefiles: Cache,
     /// Store for minidump data symbolicator failed to process, for diagnostics purposes
     pub diagnostics: Cache,
+    /// Proguard mapping files.
     pub proguard: Cache,
 }
 
@@ -294,7 +295,10 @@ impl Caches {
                 config,
                 config.caches.downloaded.into(),
                 max_lazy_redownloads,
-                default_cap,
+                // We use 2GiB as the in-memory cache size for Proguard files.
+                // Note that a Proguard mapper can take up hundreds of MB
+                // in memory.
+                2 * 1024 * 1024 * 1024,
             )?,
         })
     }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -314,6 +314,13 @@ pub struct InMemoryCacheConfig {
     ///
     /// Defaults to `3 GiB (= 3_221_225_472)`
     pub fileinbundle_capacity: u64,
+
+    /// Capacity (in bytes) for the in-memory proguard mapper cache.
+    ///
+    /// The in-memory size limit is a best-effort approximation, and not an exact limit.
+    ///
+    /// Defaults to `2 GiB`.
+    pub proguard_capacity: u64,
 }
 
 impl Default for InMemoryCacheConfig {
@@ -330,6 +337,10 @@ impl Default for InMemoryCacheConfig {
             // We noticed a significant reduction in CPU usage with a cache size of ~2G, which
             // resulted in a hit ratio of ~60-65%. Lets give it a bit more then and see what happens.
             fileinbundle_capacity: 3 * 1024 * meg,
+            // We use 2GiB as the in-memory cache size for Proguard files.
+            // Note that a Proguard mapper can take up hundreds of MB
+            // in memory.
+            proguard_capacity: 2 * 1024 * meg,
         }
     }
 }


### PR DESCRIPTION
By default, in-memory caches have a size of 100KiB. This is sufficient for file types where we only cache some bookkeeping structs in memory. In the case of Proguard, we cache `ProguardMapper` structs, and those can be quite hefty. In brief experiments I found a mapper to be slightly less than twice the size of the mapping file on disk, and those files can take up hundreds of megabytes.

Therefore:
* We estimate the memory footprint of a `ProguardMapper` as twice the size of the file on disk;
* We set the in-memory cache capacity for Proguard to 2GiB.