### PR TITLE
feat(proguard): add support for frame signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - proguard: Added a mandatory `index` field to `JvmFrame` (#1411) by @loewenheim
 - proguard: Support for source contex (#1414) by @loewenheim
 - proguard: Field `lineno` on `JvmFrame` is now optional (#1417) by @loewenheim
-- proguard: support method deobfuscation based on parameters mapping (#1418) by @viglia
+- proguard: add support for frame signature (#1425 )by @viglia
 
 ### Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a41ccd6b74401a49ca828617049e5c23d83163d330a4f90a8081aadee0ac45"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.1.8"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec81002d883e5a7fd2bb063d6fb51c4999eb55d404f4fff3dd878bf4733b9f01"
+checksum = "c53572b4cd934ee5e8461ad53caa36e9d246aaef42166e3ac539e206a925d330"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -511,9 +511,10 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
+ "http-body 1.0.0",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "once_cell",
@@ -526,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acb931e0adaf5132de878f1398d83f8677f90ba70f01f65ff87f6d7244be1c5"
+checksum = "ccb2b3a7030dc9a3c9a08ce0b25decea5130e9db19619d4dffbbff34f75fe850"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -552,7 +553,10 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
+ "http 1.1.0",
  "http-body 0.4.6",
+ "http-body 1.0.0",
+ "http-body-util",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -1009,7 +1013,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1785,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1804,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",
@@ -2040,7 +2044,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2063,7 +2067,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.3",
+ "h2 0.4.4",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -3236,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02edf5746919e655cfec7b1accbfc889d76b80e5cf72ba4a4da8024b2c2ee1a6"
+checksum = "b88dddb086b00f5539a95d2c7a2373358fd8bfadb7b1297cc29e0196403a1b98"
 
 [[package]]
 name = "psm"
@@ -3459,7 +3463,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3500,7 +3504,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.3",
+ "h2 0.4.4",
  "hickory-resolver",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -4357,9 +4361,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -4481,9 +4485,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5b3e8d1269a7cb95358fed3412645d9c15aa0eb1f4ca003a25a38ef2f30f1b"
+checksum = "c6af31bfc7b5b7405eb0cfb5158a40f12e827af9db74ce93b0cf8b838ee1c100"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -4917,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/symbolicator-proguard/Cargo.toml
+++ b/crates/symbolicator-proguard/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3.12"
-proguard = "5.4.0"
+proguard = "5.4.1"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 symbolic = "12.8.0"

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -77,14 +77,12 @@ pub struct JvmFrame {
     /// expanded from the frame with index `i` will also have index `i`.
     pub index: usize,
 
-    /// Comma separated list of method's parameters.
+    /// Method signature.
     ///
     /// This has to be set when we want to deobfuscate based on the function parameters
     /// instead of using line numbers.
-    ///
-    /// example of parameters list: `okio.Buffer,long`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<String>,
+    pub signature: Option<String>,
 }
 
 /// An exception in a JVM event.

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -193,7 +193,7 @@ impl ProguardService {
                 }
                 None
             });
-        let mut params = deobfuscated_signature
+        let params = deobfuscated_signature
             .as_ref()
             .map(|sig| sig.parameters_types().collect::<Vec<_>>().join(","));
         let stack_frame = frame
@@ -202,7 +202,7 @@ impl ProguardService {
                 proguard::StackFrame::new(&frame.module, &frame.function, lineno as usize)
             })
             .or_else(|| {
-                params.as_mut().map(|p| {
+                params.as_ref().map(|p| {
                     proguard::StackFrame::with_parameters(
                         &frame.module,
                         &frame.function,

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -193,9 +193,9 @@ impl ProguardService {
                 }
                 None
             });
-        let mut params = deobfuscated_signature.as_ref().map(|sig| {
-            String::from_iter(sig.parameters_types().map(|param| format!("{},", param)))
-        });
+        let mut params = deobfuscated_signature
+            .as_ref()
+            .map(|sig| sig.parameters_types().collect::<Vec<_>>().join(","));
         let stack_frame = frame
             .lineno
             .map(|lineno| {
@@ -203,7 +203,6 @@ impl ProguardService {
             })
             .or_else(|| {
                 params.as_mut().map(|p| {
-                    p.pop();
                     proguard::StackFrame::with_parameters(
                         &frame.module,
                         &frame.function,


### PR DESCRIPTION
The signature will be properly converted from bytecode types to java types, plus the method parameters will be used to map the frame in absence of line numbers.