### PR TITLE
fix(proguard): Don't apply source context to frames with lineno 0

### DIFF
--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -278,9 +278,10 @@ impl ProguardService {
     /// If one of the source bundles contains the correct file name, we apply it, otherwise
     /// the frame stays unmodified.
     fn apply_source_context(source_bundles: &[SourceBundleDebugSession<'_>], frame: &mut JvmFrame) {
-        let Some(lineno) = frame.lineno else {
+        let lineno = match frame.lineno {
             // can't apply source context without line number
-            return;
+            None | Some(0) => return,
+            Some(n) => n,
         };
 
         let source_file_name = build_source_file_name(frame);


### PR DESCRIPTION
The Python implementation only applies source context if the line number is > 0.