### PR TITLE
feat(proguard): Remap filename and abs_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes and improvements
+
+- feat(proguard): Remap filenames and abs_paths (#1432) by @loewenheim
+
 ## 24.4.2
 
 ### Various fixes & improvements

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
@@ -98,7 +98,7 @@ stacktraces:
         lineno: 7
         index: 17
       - function: onMenuItemClick
-        filename: R8$$SyntheticClass
+        filename: EditActivity
         module: io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0
         lineno: 0
         in_app: true

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
@@ -100,6 +100,7 @@ stacktraces:
       - function: onMenuItemClick
         filename: EditActivity
         module: io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0
+        abs_path: EditActivity
         lineno: 0
         in_app: true
         index: 18


### PR DESCRIPTION
This just applies the file name returned by the proguard mapper, if any, to the filename and abs path.

This is actually done, I'm just making it a draft because I don't want to merge it before we're done with our A/B testing.

Closes https://github.com/getsentry/team-processing/issues/139.