### PR TITLE
fix(proguard): Remap method if there's no line number

### DIFF
--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -198,7 +198,7 @@ impl ProguardService {
             .as_ref()
             .map(|sig| sig.parameters_types().collect::<Vec<_>>().join(","));
 
-        let stack_frame = frame
+        let proguard_frame = frame
             .lineno
             .map(|lineno| {
                 proguard::StackFrame::new(&frame.module, &frame.function, lineno as usize)
@@ -215,12 +215,12 @@ impl ProguardService {
 
         // First, try to remap the whole frame.
         // This only works if it has a line number or params.
-        let mut frames = stack_frame
-            .and_then(|stack_frame| {
+        let mut frames = proguard_frame
+            .and_then(|proguard_frame| {
                 let mut mapped_frames = Vec::new();
 
                 mappers.iter().find_map(|mapper| {
-                    Self::map_full_frame(mapper, frame, &stack_frame, &mut mapped_frames)
+                    Self::map_full_frame(mapper, frame, &proguard_frame, &mut mapped_frames)
                 })
             })
             // Second, try to remap the frame's method.


### PR DESCRIPTION
Right now, the logic for remapping a frame is:
* Try to remap the frame with line number if available.
* Otherwise try to remap the frame with params.
* Otherwise don't remap the frame.

But even putting aside the matter of params, this is not [what the Python implementation does](https://github.com/getsentry/sentry/blob/11e254e81180b10de90739f838dccee96fb62bb5/src/sentry/lang/java/plugin.py#L102). It uses 0 as the line number if it's missing.

Therefore, we now do:
* Try to remap the frame with line number if available.
* Otherwise try to remap the frame with params.
* Otherwise try to remap the frame with line number 0.

I'm honestly surprised that remapping a frame with line 0 ever works, but I've seen it happen.