### PR TITLE
feat: Allow scraping without SSL/TLS

### DIFF
--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -748,7 +748,7 @@ impl ArtifactFetcher {
         let cache_key = cache_busting_key(url.as_str(), timestamp, SCRAPE_FILES_EVERY);
         url.set_fragment(Some(&cache_key.to_string()));
 
-        let mut remote_file = HttpRemoteFile::from_url(url);
+        let mut remote_file = HttpRemoteFile::from_url(url, self.scraping.use_ssl);
         remote_file.headers.extend(
             self.scraping
                 .headers

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -748,7 +748,7 @@ impl ArtifactFetcher {
         let cache_key = cache_busting_key(url.as_str(), timestamp, SCRAPE_FILES_EVERY);
         url.set_fragment(Some(&cache_key.to_string()));
 
-        let mut remote_file = HttpRemoteFile::from_url(url, self.scraping.use_ssl);
+        let mut remote_file = HttpRemoteFile::from_url(url, self.scraping.verify_ssl);
         remote_file.headers.extend(
             self.scraping
                 .headers

--- a/crates/symbolicator-native/src/symbolication/source_context.rs
+++ b/crates/symbolicator-native/src/symbolication/source_context.rs
@@ -49,7 +49,8 @@ impl SymbolicationActor {
                 remote_sources
                     .into_iter()
                     .map(|((source_scope, url), frames)| async move {
-                        let mut remote_file = HttpRemoteFile::from_url(url.clone());
+                        let mut remote_file =
+                            HttpRemoteFile::from_url(url.clone(), scraping.use_ssl);
 
                         if scraping.enabled && is_valid_origin(&url, &scraping.allowed_origins) {
                             remote_file.headers.extend(

--- a/crates/symbolicator-native/src/symbolication/source_context.rs
+++ b/crates/symbolicator-native/src/symbolication/source_context.rs
@@ -50,7 +50,7 @@ impl SymbolicationActor {
                     .into_iter()
                     .map(|((source_scope, url), frames)| async move {
                         let mut remote_file =
-                            HttpRemoteFile::from_url(url.clone(), scraping.use_ssl);
+                            HttpRemoteFile::from_url(url.clone(), scraping.verify_ssl);
 
                         if scraping.enabled && is_valid_origin(&url, &scraping.allowed_origins) {
                             remote_file.headers.extend(

--- a/crates/symbolicator-service/src/types.rs
+++ b/crates/symbolicator-service/src/types.rs
@@ -66,6 +66,8 @@ pub struct ScrapingConfig {
     pub allowed_origins: Vec<String>,
     /// A map of headers to send with every HTTP request while scraping.
     pub headers: BTreeMap<String, String>,
+    /// Whether Symbolicator should use SSL/TLS when scraping from the web.
+    pub use_ssl: bool,
 }
 
 impl Default for ScrapingConfig {
@@ -75,6 +77,7 @@ impl Default for ScrapingConfig {
             // verify_ssl: false,
             allowed_origins: vec!["*".to_string()],
             headers: Default::default(),
+            use_ssl: true,
         }
     }
 }

--- a/crates/symbolicator-service/src/types.rs
+++ b/crates/symbolicator-service/src/types.rs
@@ -54,6 +54,7 @@ pub struct ScrapingConfig {
     /// Whether Symbolicator should verify SSL certs when scraping from the web.
     ///
     /// Defaults to `true`, just to be safe.
+    #[serde(default = "default_verify_ssl")]
     pub verify_ssl: bool,
     /// A list of "allowed origin patterns" that control:
     /// - for sourcemaps: what URLs we are allowed to scrape from.
@@ -80,6 +81,10 @@ impl Default for ScrapingConfig {
             verify_ssl: true,
         }
     }
+}
+
+fn default_verify_ssl() -> bool {
+    true
 }
 
 /// Specification of a module loaded into the process.

--- a/crates/symbolicator-service/src/types.rs
+++ b/crates/symbolicator-service/src/types.rs
@@ -51,8 +51,10 @@ impl fmt::Display for Scope {
 pub struct ScrapingConfig {
     /// Whether scraping should happen at all.
     pub enabled: bool,
-    // TODO: Can we even use this?
-    // pub verify_ssl: bool,
+    /// Whether Symbolicator should verify SSL certs when scraping from the web.
+    ///
+    /// Defaults to `true`, just to be safe.
+    pub verify_ssl: bool,
     /// A list of "allowed origin patterns" that control:
     /// - for sourcemaps: what URLs we are allowed to scrape from.
     /// - for source context: which URLs should be authenticated using attached headers
@@ -66,8 +68,6 @@ pub struct ScrapingConfig {
     pub allowed_origins: Vec<String>,
     /// A map of headers to send with every HTTP request while scraping.
     pub headers: BTreeMap<String, String>,
-    /// Whether Symbolicator should use SSL/TLS when scraping from the web.
-    pub use_ssl: bool,
 }
 
 impl Default for ScrapingConfig {
@@ -77,7 +77,7 @@ impl Default for ScrapingConfig {
             // verify_ssl: false,
             allowed_origins: vec!["*".to_string()],
             headers: Default::default(),
-            use_ssl: true,
+            verify_ssl: true,
         }
     }
 }

--- a/crates/symbolicator-sources/src/sources/http.rs
+++ b/crates/symbolicator-sources/src/sources/http.rs
@@ -59,13 +59,13 @@ impl HttpRemoteFile {
 
     /// Creates a new [`HttpRemoteFile`] from the given [`Url`].
     /// This internally creates a bogus [`HttpSourceConfig`].
-    pub fn from_url(url: Url) -> Self {
+    pub fn from_url(url: Url, use_ssl: bool) -> Self {
         let source = Arc::new(HttpSourceConfig {
             id: SourceId::new("web-scraping"),
             url,
             headers: Default::default(),
             files: Default::default(),
-            accept_invalid_certs: false,
+            accept_invalid_certs: !use_ssl,
         });
         let location = SourceLocation::new("");
 

--- a/crates/symbolicator-sources/src/sources/http.rs
+++ b/crates/symbolicator-sources/src/sources/http.rs
@@ -59,13 +59,13 @@ impl HttpRemoteFile {
 
     /// Creates a new [`HttpRemoteFile`] from the given [`Url`].
     /// This internally creates a bogus [`HttpSourceConfig`].
-    pub fn from_url(url: Url, use_ssl: bool) -> Self {
+    pub fn from_url(url: Url, verify_ssl: bool) -> Self {
         let source = Arc::new(HttpSourceConfig {
             id: SourceId::new("web-scraping"),
             url,
             headers: Default::default(),
             files: Default::default(),
-            accept_invalid_certs: !use_ssl,
+            accept_invalid_certs: !verify_ssl,
         });
         let location = SourceLocation::new("");
 


### PR DESCRIPTION
This adds a flag `use_ssl` to `ScrapingConfig` (defaults to `true`). This flag determines whether Symbolicator uses the normal client or the "no ssl" client we added in https://github.com/getsentry/symbolicator/pull/1404 when scraping files from the web.

The other side part that needs to be done is to actually send the flag with the scraping config from Sentry (https://github.com/getsentry/sentry/pull/68682).