### PR TITLE
feat(proguard): Add some tracing

### DIFF
--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -120,6 +120,7 @@ pub struct ProguardMapper {
 }
 
 impl ProguardMapper {
+    #[tracing::instrument(skip_all, fields(size = byteview.len()))]
     pub fn new(byteview: ByteView<'static>) -> Self {
         let inner = SelfCell::new(byteview, |data| {
             let mapping = proguard::ProguardMapping::new(unsafe { &*data });

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -15,6 +15,12 @@ impl ProguardService {
     ///
     /// "Symbolicate" here means that exceptions and stack
     /// frames are remapped using proguard files.
+    #[tracing::instrument(skip_all,
+        fields(
+            exceptions = request.exceptions.len(),
+            frames = request.stacktraces.iter().map(|st| st.frames.len()).sum::<usize>())
+        )
+    ]
     pub async fn symbolicate_jvm(
         &self,
         request: SymbolicateJvmStacktraces,


### PR DESCRIPTION
Adds tracing spans for proguard symbolication and opening a proguard mapper. For the former, we log the number of exceptions and frames, for the latter the size of the mapping file.