### PR TITLE
fix(proguard): Don't set `in_app` if frame wasn't mapped

### DIFF
--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -639,6 +639,23 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
     }
 
     #[test]
+    fn doesnt_set_in_app_if_not_resolved() {
+        let frame = JvmFrame {
+            function: "main".into(),
+            module: "android.app.ActivityThread".into(),
+            lineno: Some(8918),
+            ..Default::default()
+        };
+
+        let remapped = ProguardService::map_frame(&[], &frame, Some("android".into()));
+
+        assert_eq!(remapped.len(), 1);
+        // The frame didn't get mapped, so we shouldn't set `in_app` even though
+        // the condition is satisfied.
+        assert!(remapped[0].in_app.is_none());
+    }
+
+    #[test]
     fn line_0_1() {
         let proguard_source = br#"com.example.App -> com.example.App:
 # {"id":"sourceFile","fileName":"App.java"}

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -655,7 +655,7 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
             ..Default::default()
         };
 
-        let remapped = ProguardService::map_frame(&[], &frame, Some("android".into()));
+        let remapped = ProguardService::map_frame(&[], &frame, Some("android"));
 
         assert_eq!(remapped.len(), 1);
         // The frame didn't get mapped, so we shouldn't set `in_app` even though

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -256,9 +256,7 @@ impl ProguardService {
                 // mark the frame as in_app after deobfuscation based on the release package name
                 // only if it's not present
                 if let Some(package) = release_package {
-                    if dbg!(&frame.module).starts_with(dbg!(package))
-                        && dbg!(frame.in_app).is_none()
-                    {
+                    if frame.module.starts_with(package) && frame.in_app.is_none() {
                         frame.in_app = Some(true);
                     }
                 }


### PR DESCRIPTION
This was a subtle difference between Symbolicator and Python: we erroneously set a frame's `in_app` field even if we didn't map it. This fixes that problem and also adds a test.