### PR TITLE
fix(symbolicli): Add C# platform

### DIFF
--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -545,6 +545,7 @@ mod event {
         Native,
         Javascript,
         Node,
+        Csharp,
     }
 
     #[derive(Debug, Deserialize)]


### PR DESCRIPTION
The code already handles `"csharp"` events correctly, it was just refusing to parse them.