### PR TITLE
updated gocd-jsonnet version

### DIFF
--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -210,7 +210,7 @@ impl SourceMapLookup {
                 // NOTE: some older JS SDK versions did not correctly strip a leading `async `
                 // prefix from the `abs_path`, which we will work around here.
                 if let Some(abs_path) = frame.abs_path.strip_prefix("async ") {
-                    abs_path.clone_into(&mut frame.abs_path)
+                    abs_path.clone_into(&mut frame.abs_path);
                 }
                 let abs_path = &frame.abs_path;
                 if self.modules_by_abs_path.contains_key(abs_path) {

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -210,7 +210,7 @@ impl SourceMapLookup {
                 // NOTE: some older JS SDK versions did not correctly strip a leading `async `
                 // prefix from the `abs_path`, which we will work around here.
                 if let Some(abs_path) = frame.abs_path.strip_prefix("async ") {
-                    abs_path.clone_into(&mut frame.abs_path);
+                    frame.abs_path = abs_path.to_owned();
                 }
                 let abs_path = &frame.abs_path;
                 if self.modules_by_abs_path.contains_key(abs_path) {

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -210,7 +210,7 @@ impl SourceMapLookup {
                 // NOTE: some older JS SDK versions did not correctly strip a leading `async `
                 // prefix from the `abs_path`, which we will work around here.
                 if let Some(abs_path) = frame.abs_path.strip_prefix("async ") {
-                    frame.abs_path = abs_path.to_owned();
+                    abs_path.clone_into(&mut frame.abs_path)
                 }
                 let abs_path = &frame.abs_path;
                 if self.modules_by_abs_path.contains_key(abs_path) {

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.8"
+      "version": "v2.10.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "172de74e6347127957707d990f20f3e99c6c1c46",
-      "sum": "pBB9Jio0EnAgB7811tnly/S1B5fz6BeYoi4hQ7KgsHM="
+      "version": "74ae5728e2d7ed39fdd43cf3b2d28dde7e4567a1",
+      "sum": "AKMGYALLyaVVVjTNnZy64PoCDA8QjxTbHBe5dCnE4tE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Updated `gocd-jsonnet` version to [v2.10](https://github.com/getsentry/gocd-jsonnet/releases/tag/v2.10.0).