### PR TITLE
ref(js): Always serialize `symbolicated` flag

### DIFF
--- a/crates/symbolicator-js/src/interface.rs
+++ b/crates/symbolicator-js/src/interface.rs
@@ -205,7 +205,7 @@ pub struct JsFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_app: Option<bool>,
 
-    #[serde(default, skip_serializing_if = "JsFrameData::is_empty")]
+    #[serde(default)]
     pub data: JsFrameData,
 }
 
@@ -245,12 +245,6 @@ pub enum ResolvedWith {
     /// Unknown
     #[default]
     Unknown,
-}
-
-impl JsFrameData {
-    pub fn is_empty(&self) -> bool {
-        *self == Self::default()
-    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_multiple_smref_scraped.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
-assertion_line: 631
+assertion_line: 671
 expression: response
 ---
 stacktraces:
@@ -40,6 +40,8 @@ raw_stacktraces:
           - "//# sourceMappingURL=a.different.map"
           - ""
           - //@ sourceMappingURL=another.different.map
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "http://localhost:<port>/files/app.js"
     status: success

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_node_debugid.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
-assertion_line: 544
+assertion_line: 584
 expression: response
 ---
 stacktraces:
@@ -46,6 +46,8 @@ raw_stacktraces:
           - exports.main = main;
           - "//# sourceMappingURL=entrypoint1.js.map"
           - ""
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: /Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/öut path/rollup/entrypoint1.js
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_react_native.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
-assertion_line: 608
+assertion_line: 648
 expression: response
 ---
 stacktraces:
@@ -27,6 +27,8 @@ raw_stacktraces:
       - abs_path: "app:///index.android.bundle"
         lineno: 1
         colno: 11940
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "app:///index.android.bundle"
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__e2e_source_no_header.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
-assertion_line: 574
+assertion_line: 614
 expression: response
 ---
 stacktraces:
@@ -42,6 +42,8 @@ raw_stacktraces:
         context_line: "var makeAFailure=function(){function n(n){}function e(n){throw new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)} {snip}"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "app:///_next/server/pages/_error.js"
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__fetch_error.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
+assertion_line: 391
 expression: response
 ---
 stacktraces:
@@ -8,20 +9,28 @@ stacktraces:
         abs_path: "http://localhost:<port>/assets/missing_foo.js"
         lineno: 1
         colno: 0
+        data:
+          symbolicated: false
       - filename: foo.js
         abs_path: "http://localhost:<port>/assets/missing_bar.js"
         lineno: 4
         colno: 0
+        data:
+          symbolicated: false
 raw_stacktraces:
   - frames:
       - filename: foo.js
         abs_path: "http://localhost:<port>/assets/missing_foo.js"
         lineno: 1
         colno: 0
+        data:
+          symbolicated: false
       - filename: foo.js
         abs_path: "http://localhost:<port>/assets/missing_bar.js"
         lineno: 4
         colno: 0
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://localhost:<port>/assets/missing_bar.js"
     type: missing_source
@@ -34,4 +43,3 @@ scraping_attempts:
   - url: "http://localhost:<port>/assets/missing_bar.js"
     status: failure
     reason: not_found
-

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__indexed_sourcemap_source_expansion.snap
@@ -53,6 +53,8 @@ raw_stacktraces:
         post_context:
           - "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
           - "//# sourceMappingURL=indexed.min.js.map"
+        data:
+          symbolicated: false
       - filename: indexed.min.js
         abs_path: "http://example.com/indexed.min.js"
         lineno: 2
@@ -62,6 +64,8 @@ raw_stacktraces:
         context_line: "function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multiply(add(a,b),a,b)/c}catch(e){Raven.captureE {snip}"
         post_context:
           - "//# sourceMappingURL=indexed.min.js.map"
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "http://example.com/indexed.min.js"
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__inlined_sources.snap
@@ -27,6 +27,8 @@ raw_stacktraces:
         post_context:
           - "// Decoded sourcemap: {\"version\":3,\"file\":\"generated.js\",\"sources\":[\"/test.js\"],\"names\":[],\"mappings\":\"AAAA\",\"sourcesContent\":[\"console.log( {snip}"
           - "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W1 {snip}"
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "http://example.com/test.min.js"
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__invalid_location.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
+assertion_line: 424
 expression: response
 ---
 stacktraces:
@@ -9,6 +10,8 @@ stacktraces:
         abs_path: "http://example.com/invalidlocation.js"
         lineno: 0
         colno: 0
+        data:
+          symbolicated: false
 raw_stacktraces:
   - frames:
       - function: e
@@ -16,9 +19,10 @@ raw_stacktraces:
         abs_path: "http://example.com/invalidlocation.js"
         lineno: 0
         colno: 0
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://example.com/invalidlocation.js"
     type: invalid_location
     line: 0
     col: 0
-

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__malformed_abs_path.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
+assertion_line: 362
 expression: response
 ---
 stacktraces:
@@ -8,13 +9,16 @@ stacktraces:
         abs_path: http//example.com/test.min.js
         lineno: 1
         colno: 1
+        data:
+          symbolicated: false
 raw_stacktraces:
   - frames:
       - filename: test.js
         abs_path: http//example.com/test.min.js
         lineno: 1
         colno: 1
+        data:
+          symbolicated: false
 errors:
   - abs_path: http//example.com/test.min.js
     type: missing_source
-

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__no_source_contents.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__no_source_contents.snap
@@ -11,6 +11,8 @@ stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - function: add
         filename: file1.js
         module: file1
@@ -30,6 +32,8 @@ raw_stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - filename: embedded.js
         abs_path: "http://example.com/embedded.js"
         lineno: 1
@@ -37,6 +41,8 @@ raw_stacktraces:
         context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
         post_context:
           - "//# sourceMappingURL=embedded.js.map"
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://example.com/embedded.js"
     type: missing_source_content

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__source_expansion.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/symbolicator-js/tests/integration/sourcemap.rs
+assertion_line: 235
 expression: response
 ---
 stacktraces:
@@ -15,6 +16,8 @@ stacktraces:
           - l
           - o
           - " "
+        data:
+          symbolicated: false
       - filename: foo.js
         abs_path: "http://example.com/foo.js"
         lineno: 4
@@ -30,6 +33,8 @@ stacktraces:
           - w
           - o
           - r
+        data:
+          symbolicated: false
 raw_stacktraces:
   - frames:
       - filename: foo.js
@@ -43,6 +48,8 @@ raw_stacktraces:
           - l
           - o
           - " "
+        data:
+          symbolicated: false
       - filename: foo.js
         abs_path: "http://example.com/foo.js"
         lineno: 4
@@ -58,7 +65,8 @@ raw_stacktraces:
           - w
           - o
           - r
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "http://example.com/foo.js"
     status: not_attempted
-

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_embedded_source_expansion.snap
@@ -11,6 +11,8 @@ stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - function: add
         filename: file1.js
         module: file1
@@ -36,6 +38,8 @@ raw_stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - filename: embedded.js
         abs_path: "http://example.com/embedded.js"
         lineno: 1
@@ -43,6 +47,8 @@ raw_stacktraces:
         context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
         post_context:
           - "//# sourceMappingURL=embedded.js.map"
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_expansion.snap
@@ -10,6 +10,8 @@ stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 6
         colno: 7
+        data:
+          symbolicated: false
       - function: test
         filename: test.js
         module: test
@@ -87,6 +89,8 @@ raw_stacktraces:
         abs_path: "http://example.com/index.html"
         lineno: 6
         colno: 7
+        data:
+          symbolicated: false
       - function: i
         filename: test.min.js
         abs_path: "http://example.com/test.min.js"
@@ -95,6 +99,8 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+        data:
+          symbolicated: false
       - function: r
         filename: test.min.js
         abs_path: "http://example.com/test.min.js"
@@ -103,6 +109,8 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+        data:
+          symbolicated: false
       - function: e
         filename: test.min.js
         abs_path: "http://example.com/test.min.js"
@@ -111,6 +119,8 @@ raw_stacktraces:
         context_line: "var makeAFailure=function(){function n(n){}function e(n){throw new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)} {snip}"
         post_context:
           - "//# sourceMappingURL=test.min.js.map"
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_nofiles_source_expansion.snap
@@ -32,6 +32,8 @@ raw_stacktraces:
           - "}"
           - "function multiply(a, b) {"
           - "  'use strict';"
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "app:///nofiles.js"
     status: not_attempted

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__sourcemap_source_expansion.snap
@@ -11,6 +11,8 @@ stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - function: add
         filename: file1.js
         module: file1
@@ -36,6 +38,8 @@ raw_stacktraces:
         lineno: 283
         colno: 17
         in_app: false
+        data:
+          symbolicated: false
       - filename: file.min.js
         abs_path: "http://example.com/file.min.js"
         lineno: 1
@@ -43,6 +47,8 @@ raw_stacktraces:
         context_line: "function add(a,b){\"use strict\";return a+b}function multiply(a,b){\"use strict\";return a*b}function divide(a,b){\"use strict\";try{return multip {snip}"
         post_context:
           - //@ sourceMappingURL=file.min.js.map
+        data:
+          symbolicated: false
 errors:
   - abs_path: "http://example.com/index.html"
     type: scraping_disabled

--- a/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__webpack.snap
+++ b/crates/symbolicator-js/tests/integration/snapshots/integration__sourcemap__webpack.snap
@@ -63,6 +63,8 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test1.min.js.map"
+        data:
+          symbolicated: false
       - function: i
         filename: test2.min.js
         abs_path: "http://example.com/test2.min.js"
@@ -71,6 +73,8 @@ raw_stacktraces:
         context_line: "{snip} row new Error(\"failed!\")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function i(){var n={failed:true,value:42};r(n)}return i}();"
         post_context:
           - "//# sourceMappingURL=test2.min.js.map"
+        data:
+          symbolicated: false
 scraping_attempts:
   - url: "http://example.com/test1.min.js"
     status: not_attempted


### PR DESCRIPTION
If `data` is not serialized at all, it can be hard to tell whether a frame even went through symbolication. Therefore we now always serialize at least `data.symbolicated` to make it clear that Symbolicator has processed the frame.