### PR TITLE
config: Turn max_concurrent_requests up to 200

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -558,6 +558,7 @@ impl Default for Config {
             deny_list_threshold: 20,
             deny_list_block_time: Duration::from_secs(24 * 60 * 60),
             deny_list_never_block_hosts: Vec::new(),
+            // This value is tuned according to Symbolicator's observed real-world performance.
             max_concurrent_requests: Some(200),
             shared_cache: None,
             _crash_db: None,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -558,7 +558,7 @@ impl Default for Config {
             deny_list_threshold: 20,
             deny_list_block_time: Duration::from_secs(24 * 60 * 60),
             deny_list_never_block_hosts: Vec::new(),
-            max_concurrent_requests: Some(120),
+            max_concurrent_requests: Some(200),
             shared_cache: None,
             _crash_db: None,
         }


### PR DESCRIPTION
We can probably handle more concurrent requests.