### PR TITLE
ref(proguard): Don't log "not found" errors

### DIFF
--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -53,7 +53,9 @@ impl ProguardService {
             match res {
                 Ok(mapper) => mappers.push(mapper.get()),
                 Err(e) => {
-                    tracing::error!(%debug_id, "Error reading Proguard file: {e}");
+                    if !matches!(e, CacheError::NotFound) {
+                        tracing::error!(%debug_id, "Error reading Proguard file: {e}");
+                    }
                     let kind = match e {
                         CacheError::Malformed(msg) => match msg.as_str() {
                             "The file is not a valid ProGuard file" => ProguardErrorKind::Invalid,


### PR DESCRIPTION
Debug files not being found is entirely routine.