### PR TITLE
feat(cache): Emit current size metric on cleanup

### DIFF
--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -129,7 +129,10 @@ impl Cache {
             stats.removed_bytes
         );
 
-        metric!(gauge("caches.size") = stats.retained_bytes, "cache" => self.name.as_ref());
+        metric!(gauge("caches.size.files") = stats.retained_files as u64, "cache" => self.name.as_ref());
+        metric!(gauge("caches.size.bytes") = stats.retained_bytes, "cache" => self.name.as_ref());
+        metric!(counter("caches.cleanup.files") += stats.removed_files as i64, "cache" => self.name.as_ref());
+        metric!(counter("caches.cleanup.bytes") += stats.removed_bytes as i64, "cache" => self.name.as_ref());
 
         Ok(())
     }

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -131,8 +131,8 @@ impl Cache {
 
         metric!(gauge("caches.size.files") = stats.retained_files as u64, "cache" => self.name.as_ref());
         metric!(gauge("caches.size.bytes") = stats.retained_bytes, "cache" => self.name.as_ref());
-        metric!(counter("caches.cleanup.files") += stats.removed_files as i64, "cache" => self.name.as_ref());
-        metric!(counter("caches.cleanup.bytes") += stats.removed_bytes as i64, "cache" => self.name.as_ref());
+        metric!(counter("caches.size.files_removed") += stats.removed_files as i64, "cache" => self.name.as_ref());
+        metric!(counter("caches.size.bytes_removed") += stats.removed_bytes as i64, "cache" => self.name.as_ref());
 
         Ok(())
     }

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -7,6 +7,7 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 
 use crate::config::Config;
+use crate::metric;
 
 use super::fs::catch_not_found;
 use super::{Cache, Caches};
@@ -127,6 +128,8 @@ impl Cache {
             stats.removed_files,
             stats.removed_bytes
         );
+
+        metric!(gauge("cache.size") = stats.retained_bytes, "cache" => self.name.as_ref());
 
         Ok(())
     }

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -129,7 +129,7 @@ impl Cache {
             stats.removed_bytes
         );
 
-        metric!(gauge("cache.size") = stats.retained_bytes, "cache" => self.name.as_ref());
+        metric!(gauge("caches.size") = stats.retained_bytes, "cache" => self.name.as_ref());
 
         Ok(())
     }


### PR DESCRIPTION
We have seen caches eating through the available disk space in production. This should make it easier which caches are taking up the most space on which hosts.