### PR TITLE
ref: Differentiate between memory and file cache keys

### DIFF
--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -1136,7 +1136,9 @@ impl ArtifactFetcher {
                         source: source_content,
                         sourcemap,
                     };
-                    self.sourcemap_caches.compute_memoized(req, cache_key).await
+                    self.sourcemap_caches
+                        .compute_memoized(req, cache_key.clone(), cache_key)
+                        .await
                 }
                 Err(err) => Err(err),
             },

--- a/crates/symbolicator-native/src/caches/bitcode.rs
+++ b/crates/symbolicator-native/src/caches/bitcode.rs
@@ -228,7 +228,7 @@ impl BitcodeService {
             };
             let cache_key = CacheKey::from_scoped_file(&scope, &request.file_source);
             self.cache
-                .compute_memoized(request, cache_key)
+                .compute_memoized(request, cache_key.clone(), cache_key)
                 .bind_hub(hub)
         });
 

--- a/crates/symbolicator-native/src/caches/cficaches.rs
+++ b/crates/symbolicator-native/src/caches/cficaches.rs
@@ -159,7 +159,10 @@ impl CfiCacheActor {
                 meta_handle,
             };
             async {
-                let entry = self.cficaches.compute_memoized(request, cache_key).await;
+                let entry = self
+                    .cficaches
+                    .compute_memoized(request, cache_key.clone(), cache_key)
+                    .await;
 
                 entry.map(|item| item.1)
             }

--- a/crates/symbolicator-native/src/caches/il2cpp.rs
+++ b/crates/symbolicator-native/src/caches/il2cpp.rs
@@ -144,7 +144,7 @@ impl Il2cppService {
                 download_svc: self.download_svc.clone(),
             };
             self.cache
-                .compute_memoized(request, cache_key)
+                .compute_memoized(request, cache_key.clone(), cache_key)
                 .bind_hub(hub)
         });
 

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -71,7 +71,8 @@ impl PortablePdbCacheActor {
                 objects_actor: self.objects.clone(),
                 object_meta,
             };
-            self.ppdb_caches.compute_memoized(request, cache_key)
+            self.ppdb_caches
+                .compute_memoized(request, cache_key.clone(), cache_key)
         })
         .await
     }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -187,7 +187,9 @@ impl SymCacheActor {
                 secondary_sources,
                 object_meta: Arc::clone(&handle),
             };
-            self.symcaches.compute_memoized(request, cache_key).await
+            self.symcaches
+                .compute_memoized(request, cache_key.clone(), cache_key)
+                .await
         })
         .await
     }

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -68,7 +68,7 @@ impl ProguardService {
         };
 
         self.cache
-            .compute_memoized(request, cache_key)
+            .compute_memoized(request, cache_key.clone(), cache_key)
             .await
             .map(|item| item.1)
     }

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -85,7 +85,9 @@ impl SourceFilesCache {
             use_shared_cache,
         };
 
-        self.cache.compute_memoized(request, cache_key).await
+        self.cache
+            .compute_memoized(request, cache_key.clone(), cache_key)
+            .await
     }
 }
 

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -805,15 +805,21 @@ async fn test_cache_fallback() {
     .unwrap();
     let cacher = Cacher::new(cache, Default::default());
 
-    let first_result = cacher.compute_memoized(request.clone(), key.clone()).await;
+    let first_result = cacher
+        .compute_memoized(request.clone(), key.clone(), key.clone())
+        .await;
     assert_eq!(first_result.unwrap().as_str(), "some old cached contents");
 
-    let second_result = cacher.compute_memoized(request.clone(), key.clone()).await;
+    let second_result = cacher
+        .compute_memoized(request.clone(), key.clone(), key.clone())
+        .await;
     assert_eq!(second_result.unwrap().as_str(), "some old cached contents");
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let third_result = cacher.compute_memoized(request.clone(), key).await;
+    let third_result = cacher
+        .compute_memoized(request.clone(), key.clone(), key)
+        .await;
     assert_eq!(third_result.unwrap().as_str(), "some new cached contents");
 
     // we only want to have the actual computation be done a single time
@@ -854,7 +860,9 @@ async fn test_cache_fallback_notfound() {
     .unwrap();
     let cacher = Cacher::new(cache, Default::default());
 
-    let first_result = cacher.compute_memoized(request.clone(), key).await;
+    let first_result = cacher
+        .compute_memoized(request.clone(), key.clone(), key)
+        .await;
     assert_eq!(first_result, Err(CacheError::NotFound));
 
     // no computation should be done
@@ -892,7 +900,9 @@ async fn test_lazy_computation_limit() {
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
-        let result = cacher.compute_memoized(request.clone(), key).await;
+        let result = cacher
+            .compute_memoized(request.clone(), key.clone(), key)
+            .await;
         assert_eq!(result.unwrap().as_str(), "some old cached contents");
     }
 
@@ -909,7 +919,9 @@ async fn test_lazy_computation_limit() {
         let request = request.clone();
         let key = CacheKey::for_testing(*key);
 
-        let result = cacher.compute_memoized(request.clone(), key).await;
+        let result = cacher
+            .compute_memoized(request.clone(), key.clone(), key)
+            .await;
         if result.unwrap().as_str() == "some old cached contents" {
             num_outdated += 1;
         }

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -106,7 +106,11 @@ impl FetchFileMetaRequest {
 
         let object_handle = self
             .data_cache
-            .compute_memoized(FetchFileDataRequest(self.clone()), cache_key.clone())
+            .compute_memoized(
+                FetchFileDataRequest(self.clone()),
+                cache_key.clone(),
+                cache_key.clone(),
+            )
             .await?;
 
         let object = object_handle.object();

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -114,7 +114,9 @@ impl ObjectsActor {
             download_svc: self.download_svc.clone(),
         });
 
-        self.data_cache.compute_memoized(request, cache_key).await
+        self.data_cache
+            .compute_memoized(request, cache_key.clone(), cache_key)
+            .await
     }
 
     /// Fetches matching objects and returns the metadata of the most suitable object.
@@ -175,7 +177,10 @@ impl ObjectsActor {
             };
 
             async move {
-                let handle = self.meta_cache.compute_memoized(request, cache_key).await;
+                let handle = self
+                    .meta_cache
+                    .compute_memoized(request, cache_key.clone(), cache_key)
+                    .await;
                 FoundMeta {
                     file_source,
                     handle,


### PR DESCRIPTION
This passes two different cache keys (`memory_cache_key` and `file_cache_key`) to the `compute_memoized` method. The intended use case comes from proguard processing: we want to keep proguard files on disk as a whole, but only load segments of them into memory at a time. To this end, we want several in-memory cache keys (those of the individual parts of the proguard file) to correspond to one on-disk cache key (that of the entire file).