### PR TITLE
WIP: Only read relevant parts of proguard files into memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,8 +3278,6 @@ dependencies = [
 [[package]]
 name = "proguard"
 version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88dddb086b00f5539a95d2c7a2373358fd8bfadb7b1297cc29e0196403a1b98"
 
 [[package]]
 name = "psm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "circular"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1129,21 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -1312,6 +1354,12 @@ dependencies = [
  "serde",
  "uuid",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
 
 [[package]]
 name = "der"
@@ -2277,6 +2325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inplace-vec-builder"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -3012,6 +3079,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pdb"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3355,7 @@ dependencies = [
 [[package]]
 name = "proguard"
 version = "5.4.1"
+source = "git+https://github.com/getsentry/rust-proguard.git?branch=feat/class-index#67b62d9dd352f62409b0ce6acee4c989d15bbc6c"
 
 [[package]]
 name = "psm"
@@ -4466,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.9.2"
+version = "12.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aabcf85c883278298596217d678c8d3ca256445d732eac59303ce04863c46f"
+checksum = "80ba5800d2939012ebda8737fd2044af019f90cfa52e7edc314366aec5dd0e0f"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4482,9 +4560,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.9.2"
+version = "12.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ed43f6b8769d681296cbbf6f108bed81465f04f3bc3358d0cd76dcc6d8cd27"
+checksum = "6f2f245f715e5f3f04f2ef4901081d18d2b69856d958c4edec374dd461635547"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4506,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.9.2"
+version = "12.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdc791ca87a69a5d09913d87f1e5ac95229be414ec0ff6c0fe2ddff6199f3b6"
+checksum = "599a6d4cb94ac6ba9dc3d88fba6df3585f15f277180f7b4dc69fb4c997a2fdfa"
 dependencies = [
  "debugid",
  "dmsort",
@@ -4533,7 +4611,7 @@ dependencies = [
  "symbolic-ppdb",
  "thiserror",
  "wasmparser",
- "zip 2.1.1",
+ "zip 2.1.3",
  "zstd",
 ]
 
@@ -4552,9 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.9.2"
+version = "12.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cc2a0a415e3cb2dfb900f6f5b3abf5ccd356c236927b36b3d09046175acbde"
+checksum = "4d91b7d6e1ca6dfb19761bde98810185c749f495ddcb83514bd2df67fdf4120d"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4595,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.9.2"
+version = "12.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb772d8bea63f0cc1cbb0690bbd3d955a27746e380954d7e1a30e88d7aaecd5"
+checksum = "0dbc9520c2550cf510cbdb9ce34c7a707e9a4c94cda82fec9447949faeebcada"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -4727,6 +4805,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "zip 2.1.3",
 ]
 
 [[package]]
@@ -5980,6 +6059,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"
@@ -5996,19 +6089,31 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd56a4d5921bc2f99947ac5b3abe5f510b1be7376fdc5e9fce4a23c6a93e87c"
+checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
 dependencies = [
+ "aes",
  "arbitrary",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
  "displaydoc",
  "flate2",
+ "hmac",
  "indexmap",
+ "lzma-rs",
  "memchr",
+ "pbkdf2",
+ "rand",
+ "sha1",
  "thiserror",
+ "time",
+ "zeroize",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "proguard"
 version = "5.4.1"
-source = "git+https://github.com/getsentry/rust-proguard.git?branch=feat/class-index#67b62d9dd352f62409b0ce6acee4c989d15bbc6c"
+source = "git+https://github.com/getsentry/rust-proguard.git?branch=feat/class-index#b295986737c1f5a8a538534c3e18ef9f7b809df0"
 
 [[package]]
 name = "psm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ reqwest = { git = "https://github.com/getsentry/reqwest", branch = "restricted-c
 
 # This patch adds limited "templated lambdas" demangling support
 cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "sentry-patches" }
-proguard = { path = "../rust-proguard" }
 
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { git = "https://github.com/getsentry/reqwest", branch = "restricted-c
 
 # This patch adds limited "templated lambdas" demangling support
 cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "sentry-patches" }
+proguard = { path = "../rust-proguard" }
 
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.

--- a/crates/symbolicator-proguard/Cargo.toml
+++ b/crates/symbolicator-proguard/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3.12"
-proguard = { version = "5.4.1", git = "https://github.com/getsentry/rust-proguard.git", branch = "feat/class-index" }
+proguard = { version = "5.4.1", git = "https://github.com/getsentry/rust-proguard.git" }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 symbolic = "12.8.0"

--- a/crates/symbolicator-proguard/Cargo.toml
+++ b/crates/symbolicator-proguard/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3.12"
-proguard = "5.4.1"
+proguard = { version = "5.4.1", git = "https://github.com/getsentry/rust-proguard.git", branch = "feat/class-index" }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 symbolic = "12.8.0"
@@ -16,6 +16,7 @@ symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.10.0"
 tracing = "0.1.34"
+zip = "2.1.3"
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["redactions", "yaml"] }

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -39,7 +39,7 @@ pub struct JvmFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
-    /// The frame's method name.
+    /// The frame's module name.
     ///
     /// For a JVM frame, this is a fully qualified class name.
     pub module: String,

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -1,6 +1,8 @@
+use std::fmt::Write;
+use std::ops::Range;
 use std::sync::Arc;
 
-use futures::future::BoxFuture;
+use futures::future::{self, BoxFuture};
 use symbolic::common::{AsSelf, ByteView, DebugId, SelfCell};
 use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
 use symbolicator_service::caching::{
@@ -14,6 +16,8 @@ use symbolicator_service::services::SharedServices;
 use symbolicator_service::types::Scope;
 use symbolicator_sources::{FileType, ObjectId, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
+
+use crate::interface::{ProguardError, ProguardErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct ProguardService {
@@ -36,41 +40,6 @@ impl ProguardService {
             cache,
             objects,
         }
-    }
-
-    /// Downloads a proguard file for the given scope and debug id and converts it into a
-    /// `ProguardMapper`.
-    #[tracing::instrument(skip_all)]
-    pub async fn download_proguard_file(
-        &self,
-        sources: &[SourceConfig],
-        scope: &Scope,
-        debug_id: DebugId,
-    ) -> CacheEntry<ProguardMapper> {
-        let identifier = ObjectId {
-            debug_id: Some(debug_id),
-            ..Default::default()
-        };
-
-        let file = self
-            .download_svc
-            .list_files(sources, &[FileType::Proguard], &identifier)
-            .await
-            .into_iter()
-            .next()
-            .ok_or(CacheError::NotFound)?;
-
-        let cache_key = CacheKey::from_scoped_file(scope, &file);
-
-        let request = FetchProguard {
-            file,
-            download_svc: Arc::clone(&self.download_svc),
-        };
-
-        self.cache
-            .compute_memoized(request, cache_key.clone(), cache_key)
-            .await
-            .map(|item| item.1)
     }
 
     /// Downloads a source bundle for the given scope and debug id.
@@ -102,8 +71,129 @@ impl ProguardService {
             None => Err(CacheError::NotFound),
         }
     }
+
+    /// Downloads the proguard file with the given debug ID and extracts a mapper for
+    /// the given class name from it.
+    ///
+    /// This returns:
+    /// * `Ok(Some(mapper))` if the file exists, is valid, and contains a
+    ///   mapping information for `class_name`;
+    /// * `Ok(None)` if the file exists and is valid, but doesn't contain
+    ///   mapping informationfor `class_name`;
+    /// * `Err(_)` if the file wasn't found or is invalid.
+    #[tracing::instrument(skip_all)]
+    pub async fn download_proguard_file(
+        &self,
+        sources: Arc<[SourceConfig]>,
+        scope: &Scope,
+        debug_id: DebugId,
+        class_name: Arc<str>,
+    ) -> Result<Option<ProguardMapper>, ProguardError> {
+        let identifier = ObjectId {
+            debug_id: Some(debug_id),
+            ..Default::default()
+        };
+
+        let file = self
+            .download_svc
+            .list_files(sources.as_ref(), &[FileType::Proguard], &identifier)
+            .await
+            .into_iter()
+            .next()
+            .ok_or(ProguardError {
+                uuid: debug_id,
+                kind: ProguardErrorKind::Missing,
+            })?;
+
+        let file_cache_key = CacheKey::from_scoped_file(scope, &file);
+
+        let memory_cache_key = {
+            let mut builder = CacheKey::scoped_builder(scope);
+            builder.write_file_meta(&file).unwrap();
+            writeln!(&mut builder, "class:").unwrap();
+            writeln!(&mut builder, "{class_name}").unwrap();
+            builder.build()
+        };
+
+        let request = FetchProguard {
+            file,
+            class_name,
+            download_svc: Arc::clone(&self.download_svc),
+        };
+
+        match self
+            .cache
+            .compute_memoized(request, memory_cache_key, file_cache_key)
+            .await
+        {
+            Ok(maybe_mapper) => Ok(maybe_mapper.map(|p| p.1)),
+            Err(e) => {
+                if !matches!(e, CacheError::NotFound) {
+                    tracing::error!(%debug_id, "Error reading Proguard file: {e}");
+                }
+                let kind = match e {
+                    CacheError::Malformed(msg) => match msg.as_str() {
+                        "The file is not a valid ProGuard file" => ProguardErrorKind::Invalid,
+                        "The ProGuard file doesn't contain any line mappings" => {
+                            ProguardErrorKind::NoLineInfo
+                        }
+                        _ => unreachable!(),
+                    },
+                    _ => ProguardErrorKind::Missing,
+                };
+                Err(ProguardError {
+                    uuid: debug_id,
+                    kind,
+                })
+            }
+        }
+    }
+
+    /// Downloads the proguard files with the given debug IDs and extracts mappers for
+    /// the given class names from them.
+    pub async fn download_proguard_files(
+        &self,
+        sources: Arc<[SourceConfig]>,
+        scope: &Scope,
+        debug_ids: Arc<[DebugId]>,
+        class_names: &[Arc<str>],
+    ) -> (Vec<ProguardMapper>, Vec<ProguardError>) {
+        let outer = future::join_all(debug_ids.iter().cloned().map(|debug_id| {
+            let sources = Arc::clone(&sources);
+            async move {
+                let inner = future::join_all(class_names.iter().cloned().map(|class| {
+                    let sources = Arc::clone(&sources);
+                    async move {
+                        self.download_proguard_file(Arc::clone(&sources), scope, debug_id, class)
+                            .await
+                    }
+                }));
+
+                inner.await
+            }
+        }));
+
+        let (mut mappers, mut errors) = (Vec::new(), Vec::new());
+        let outer_results = outer.await;
+        for res in outer_results
+            .into_iter()
+            .flat_map(|inner_result| inner_result.into_iter())
+        {
+            match res {
+                Ok(Some(mapper)) => mappers.push(mapper),
+                Ok(None) => {}
+                Err(e) => errors.push(e),
+            }
+        }
+
+        errors.sort_unstable_by_key(|e| e.uuid);
+        errors.dedup_by_key(|e| e.uuid);
+
+        (mappers, errors)
+    }
 }
 
+#[derive(Debug, Clone)]
 struct ProguardInner<'a> {
     mapper: proguard::ProguardMapper<'a>,
 }
@@ -116,16 +206,17 @@ impl<'slf, 'a: 'slf> AsSelf<'slf> for ProguardInner<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ProguardMapper {
     inner: Arc<SelfCell<ByteView<'static>, ProguardInner<'static>>>,
 }
 
 impl ProguardMapper {
     #[tracing::instrument(name = "ProguardMapper::new", skip_all, fields(size = byteview.len()))]
-    pub fn new(byteview: ByteView<'static>) -> Self {
+    pub fn new(byteview: ByteView<'static>, range: Range<usize>) -> Self {
         let inner = SelfCell::new(byteview, |data| {
             let mapping = proguard::ProguardMapping::new(unsafe { &*data });
+            let mapping = mapping.section(range.start, range.end);
             let mapper = proguard::ProguardMapper::new_with_param_mapping(mapping, true);
             ProguardInner { mapper }
         });
@@ -143,13 +234,14 @@ impl ProguardMapper {
 #[derive(Clone, Debug)]
 pub struct FetchProguard {
     file: RemoteFile,
+    class_name: Arc<str>,
     download_svc: Arc<DownloadService>,
 }
 
 impl CacheItemRequest for FetchProguard {
     /// The first component is the estimated memory footprint of the mapper,
-    /// computed as 2x the size of the mapping file on disk.
-    type Item = (u32, ProguardMapper);
+    /// computed as 2x the size of the relevant section of the mapping ifle in bytes.
+    type Item = Option<(u32, ProguardMapper)>;
 
     const VERSIONS: CacheVersions = PROGUARD_CACHE_VERSIONS;
 
@@ -161,26 +253,36 @@ impl CacheItemRequest for FetchProguard {
 
             let mapping = proguard::ProguardMapping::new(&view);
             if !mapping.is_valid() {
-                Err(CacheError::Malformed(
+                return Err(CacheError::Malformed(
                     "The file is not a valid ProGuard file".into(),
-                ))
-            } else if !mapping.has_line_info() {
-                Err(CacheError::Malformed(
-                    "The ProGuard file doesn't contain any line mappings".into(),
-                ))
-            } else {
-                Ok(())
+                ));
             }
+
+            if !mapping.has_line_info() {
+                return Err(CacheError::Malformed(
+                    "The ProGuard file doesn't contain any line mappings".into(),
+                ));
+            }
+
+            Ok(())
         };
         Box::pin(fut)
     }
 
     fn load(&self, byteview: ByteView<'static>) -> CacheEntry<Self::Item> {
-        let weight = byteview.len().try_into().unwrap_or(u32::MAX);
+        let mapping = proguard::ProguardMapping::new(&byteview);
+        // TODO(sebastian): Creating the index every time we want to load a class from a file is obviously
+        // wasteful, we should cache this.
+        let index = mapping.create_class_index();
+        let Some(range) = index.get(self.class_name.as_ref()).cloned() else {
+            return Ok(None);
+        };
+
         // NOTE: In an extremely unscientific test, the proguard mapper was slightly less
         // than twice as big in memory as the file on disk.
-        let weight = weight.saturating_mul(2);
-        Ok((weight, ProguardMapper::new(byteview)))
+        let weight = ((range.end - range.start) as u32).saturating_mul(2);
+
+        Ok(Some((weight, ProguardMapper::new(byteview, range))))
     }
 
     fn use_shared_cache(&self) -> bool {
@@ -188,6 +290,8 @@ impl CacheItemRequest for FetchProguard {
     }
 
     fn weight(item: &Self::Item) -> u32 {
-        item.0.max(std::mem::size_of::<Self::Item>() as u32)
+        item.as_ref()
+            .map_or(0, |it| it.0)
+            .max(std::mem::size_of::<Self::Item>() as u32)
     }
 }

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -287,13 +287,15 @@ impl CacheItemRequest for FetchProguard {
 
             // Combine the mapping file and the index into a zip archive
             let mut archive = ZipWriter::new(temp_file);
-            archive
-                .start_file(ZIP_PROGUARD_FILE_NAME, SimpleFileOptions::default())
-                .unwrap();
+            // We don't care about disk so much, so we store the files uncompressed in the interest
+            // of extraction speed.
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            archive.start_file(ZIP_PROGUARD_FILE_NAME, options).unwrap();
             archive.write_all(&view)?;
 
             archive
-                .start_file(ZIP_CLASS_INDEX_FILE_NAME, SimpleFileOptions::default())
+                .start_file(ZIP_CLASS_INDEX_FILE_NAME, options)
                 .unwrap();
             let index = mapping.create_class_index();
             index.write(&mut archive)?;

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -311,7 +311,8 @@ impl CacheItemRequest for FetchProguard {
             .by_name(ZIP_CLASS_INDEX_FILE_NAME)
             .map_err(|_| CacheError::InternalError)?;
         let index = ByteView::read(index)?;
-        let index = ClassIndex::parse(&index).ok_or(CacheError::InternalError)?;
+        let index = std::str::from_utf8(&index).map_err(|_| CacheError::InternalError)?;
+        let index = ClassIndex::parse(index).ok_or(CacheError::InternalError)?;
 
         let Some(range) = index.get(self.class_name.as_ref()) else {
             return Ok(None);

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -76,7 +76,12 @@ async fn test_download_proguard_file() {
     let debug_id = DebugId::from_str("246fb328-fc4e-406a-87ff-fc35f6149d8f").unwrap();
 
     assert!(symbolication
-        .download_proguard_file(&[source], &Scope::Global, debug_id)
+        .download_proguard_file(
+            Arc::new([source]),
+            &Scope::Global,
+            debug_id,
+            Arc::from("some.class")
+        )
         .await
         .is_ok());
 }

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -141,8 +141,10 @@ pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
 
 /// Proguard Cache, with the following versions:
 ///
+/// - `2`: Store proguard files and class indices zipped together (#1488).
+///
 /// - `1`: Initial version.
 pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: 2,
     fallbacks: &[],
 };


### PR DESCRIPTION
Depends upon #1487 and https://github.com/getsentry/rust-proguard/pull/41.

This does a few things:
* When we download a proguard file, we create an index from it (see https://github.com/getsentry/rust-proguard/pull/41), zip the file and the index together, and persist them that way.
* When we load a proguard file into memory, we always do so with respect to a class name. We look up the relevant byte range in the index and only create a mapper from that part. Since we want to hold different data on disk and in memory, we need the change from #1487.

This change includes a cache version bump because we now store zip archives instead of just proguard files.