### PR TITLE
Support for -fwasm-exceptions in wasm-split and others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,7 +5581,7 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-split"
-version = "24.6.0"
+version = "24.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/wasm-split/Cargo.toml
+++ b/crates/wasm-split/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-split"
-version = "24.6.0"
+version = "24.6.1"
 authors = ["Sentry <hello@getsentry.com>"]
 edition = "2021"
 license = "MIT"
@@ -10,4 +10,4 @@ anyhow = "1.0.57"
 clap = { version = "4.3.2", features = ["derive"] }
 hex = "0.4.2"
 uuid = { version = "1.0.0", features = ["v4"] }
-wasmbin = "0.8.1"
+wasmbin = { version = "0.8.1", features = ["exception-handling"] }


### PR DESCRIPTION
In this PR I purpose to add `exception-handling` feature to wasmbin dependencies.

With reference to these issuses: 
* [symbolicator/issues/969](https://github.com/getsentry/symbolicator/issues/969), 
* [GoogleChromeLabs/wasmbin/issues/7](https://github.com/GoogleChromeLabs/wasmbin/issues/7),
* [GoogleChromeLabs/wasmbin/pull/9](https://github.com/GoogleChromeLabs/wasmbin/pull/9),  

in order for the symbolizer and wasm-split to support -fwasm-exceptions, is needed to set `exception-handling` feature in the wasmbin dependency.

PS: Just to be sure, I also asked the author of wasmbin [LINK](https://github.com/RReverser/wasmbin/issues/2) for confirmation that these changes were safe. But looking at the sourcecode it looks like it should be safe.