### PR TITLE
feat: Adjust proguard caching

### DIFF
--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -185,6 +185,6 @@ impl CacheItemRequest for FetchProguard {
     }
 
     fn use_shared_cache(&self) -> bool {
-        false
+        true
     }
 }

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -295,7 +295,7 @@ impl Caches {
                 config,
                 config.caches.downloaded.into(),
                 max_lazy_redownloads,
-                in_memory.proguard_capacity,
+                default_cap,
             )?,
         })
     }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -314,19 +314,11 @@ pub struct InMemoryCacheConfig {
     ///
     /// Defaults to `3 GiB (= 3_221_225_472)`
     pub fileinbundle_capacity: u64,
-
-    /// Capacity (in bytes) for the in-memory proguard mapper cache.
-    ///
-    /// The in-memory size limit is a best-effort approximation, and not an exact limit.
-    ///
-    /// Defaults to `5 GiB`.
-    pub proguard_capacity: u64,
 }
 
 impl Default for InMemoryCacheConfig {
     fn default() -> Self {
         let meg = 1024 * 1024;
-        let gig = 1024 * 1024 * 1024;
         Self {
             sentry_index_capacity: 100_000.try_into().unwrap(),
             sentry_index_ttl: Duration::from_secs(3600),
@@ -338,10 +330,6 @@ impl Default for InMemoryCacheConfig {
             // We noticed a significant reduction in CPU usage with a cache size of ~2G, which
             // resulted in a hit ratio of ~60-65%. Lets give it a bit more then and see what happens.
             fileinbundle_capacity: 3 * 1024 * meg,
-            // We use 5GiB as the in-memory cache size for Proguard files.
-            // Note that a Proguard mapper can take up hundreds of MB
-            // in memory.
-            proguard_capacity: 5 * gig,
         }
     }
 }


### PR DESCRIPTION
* Previously there wasn't much point sharing proguard files via the shared cache because we were downloading them exclusively from Sentry anyway. But now we don't use actual proguard files anymore, we compute cache files from them and use those. So it makes sense to share the cache files between Symbolicators.
* For the same reason we wanted a very large in-memory cache for proguard files. Since `ProguardCache` files have a small (on the order of dozens of bytes) constant size, this is not necessary and we can simply use the same logic as for Symcaches.