### PR TITLE
feat(proguard): Remap additional class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#076)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.7.5...0.7.6)
 
+### Various fixes & improvements
+
+- The `symbolicate-jvm` endpoint now additionally accepts a list
+  `classes` of class names to deobfuscate. ([#1496](https://github.com/getsentry/symbolicator/pull/1496))
 ## 24.6.0
 
 ### Dependencies

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::sync::Arc;
+use std::{collections::HashMap, fmt};
 
 use serde::{Deserialize, Serialize};
 use symbolic::common::DebugId;
@@ -25,6 +25,8 @@ pub struct SymbolicateJvmStacktraces {
     ///
     /// This is used to set a remapped frame's `in_app` field.
     pub release_package: Option<String>,
+    /// An list of additional class names that should be remapped.
+    pub classes: Vec<Arc<str>>,
 }
 
 /// A stack frame in a JVM stacktrace.
@@ -159,7 +161,6 @@ pub struct ProguardError {
     pub kind: ProguardErrorKind,
 }
 
-// TODO: Expand this
 /// The symbolicated/remapped event data.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CompletedJvmSymbolicationResponse {
@@ -167,6 +168,8 @@ pub struct CompletedJvmSymbolicationResponse {
     pub exceptions: Vec<JvmException>,
     /// The stacktraces after remapping.
     pub stacktraces: Vec<JvmStacktrace>,
+    /// A mapping from obfuscated to remapped classes.
+    pub classes: HashMap<Arc<str>, Arc<str>>,
     /// Errors that occurred during symbolication.
     pub errors: Vec<ProguardError>,
 }

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -33,6 +33,7 @@ fn make_jvm_request(
         exceptions,
         stacktraces,
         modules,
+        classes: Vec::new(),
     }
 }
 

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__basic_source_lookup.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__basic_source_lookup.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-proguard/tests/integration/proguard.rs
-assertion_line: 517
 expression: response
 ---
 exceptions:
@@ -110,4 +109,5 @@ stacktraces:
           - "}"
           - ""
         index: 6
+classes: {}
 errors: []

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__remap_exception.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__remap_exception.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-proguard/tests/integration/proguard.rs
-assertion_line: 122
 expression: response
 ---
 exceptions:
@@ -8,4 +7,5 @@ exceptions:
     module: org.slf4j.helpers
 stacktraces:
   - frames: []
+classes: {}
 errors: []

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__resolving_inline.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__resolving_inline.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-proguard/tests/integration/proguard.rs
-assertion_line: 232
 expression: response
 ---
 exceptions:
@@ -27,4 +26,5 @@ stacktraces:
         module: io.sentry.sample.MainActivity
         lineno: 54
         index: 1
+classes: {}
 errors: []

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__source_lookup_with_proguard.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-proguard/tests/integration/proguard.rs
-assertion_line: 474
 expression: response
 ---
 exceptions:
@@ -172,6 +171,7 @@ stacktraces:
         lineno: 26
         in_app: true
         index: 18
+classes: {}
 errors:
   - uuid: 8236f5cf-52c8-4e35-a7cf-01421e4c2c88
     type: missing

--- a/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
@@ -25,6 +25,8 @@ pub struct JvmSymbolicationRequestBody {
     #[serde(default)]
     pub release_package: Option<String>,
     #[serde(default)]
+    pub classes: Vec<Arc<str>>,
+    #[serde(default)]
     pub options: JvmRequestOptions,
 }
 
@@ -62,6 +64,7 @@ pub async fn handle_symbolication_request(
         stacktraces,
         modules,
         release_package,
+        classes,
         options,
     } = body;
 
@@ -72,6 +75,7 @@ pub async fn handle_symbolication_request(
         stacktraces,
         modules,
         release_package,
+        classes,
         apply_source_context: options.apply_source_context,
     })?;
 


### PR DESCRIPTION
This allows sending an additional list of class names not attached to any stack frame or exception with a proguard request. These classes will be deobfuscated and returned in the form of a map from obfuscated to deobfuscated names.

The intended use case is deobfuscating view hierarchies.