### PR TITLE
chore(ci): Bump macos image to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     # and ARM binaries into one universal one. This need will go away once
     # https://github.com/rust-lang/cargo/issues/8875 is resolved.
     name: Build Binary on MacOS
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Since macos-11 is no longer supported, we need to bump to a newer version.

#skip-changelog