### PR TITLE
deps: Update symbolic to 12.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,9 +1795,9 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gimli"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 dependencies = [
  "fallible-iterator 0.3.0",
  "stable_deref_trait",
@@ -4618,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aabcf85c883278298596217d678c8d3ca256445d732eac59303ce04863c46f"
+checksum = "6d4e155af9f06f8b44963cdb05ad7c9884f424dc040f08adc5a1bb4960937d1d"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4634,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ed43f6b8769d681296cbbf6f108bed81465f04f3bc3358d0cd76dcc6d8cd27"
+checksum = "e3b4273aee7b62c172f1723eb06dda7462f951760a79524734fb1da4cf3842a2"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4645,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+checksum = "16629323a4ec5268ad23a575110a724ad4544aae623451de600c747bf87b36cf"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4658,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdc791ca87a69a5d09913d87f1e5ac95229be414ec0ff6c0fe2ddff6199f3b6"
+checksum = "f629454e4787591257c96c6c7c676c17f792ef8290638699714152140580717d"
 dependencies = [
  "debugid",
  "dmsort",
@@ -4668,7 +4668,7 @@ dependencies = [
  "elsa",
  "fallible-iterator 0.3.0",
  "flate2",
- "gimli 0.30.0",
+ "gimli 0.31.0",
  "goblin",
  "lazy_static",
  "nom",
@@ -4691,9 +4691,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+checksum = "48c043a45f08f41187414592b3ceb53fb0687da57209cc77401767fb69d5b596"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -4704,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cc2a0a415e3cb2dfb900f6f5b3abf5ccd356c236927b36b3d09046175acbde"
+checksum = "7c5cc3da426cd0a0ea91b3a0e722fda69377a23fa1601d7c55f3cc0533e02b9b"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4716,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccffa1e6b313c007dddcc3a91166a64055a0a956e1429ee179a808fa3b2c62"
+checksum = "2c6eaa9dc4774d5e0a9df62a3145d814b3a9ebcbcf37e973bc51c57bcb9eacc7"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4732,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fbfcf544adcb5173629d64ae663c8d7789760367a37bf9474051871a7ea7f8"
+checksum = "000bdc523e724c9e58cfa175f0ff14eac5db82976b9479603146667384a0f4ac"
 dependencies = [
  "itertools 0.13.0",
  "js-source-scopes",
@@ -4747,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.9.2"
+version = "12.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb772d8bea63f0cc1cbb0690bbd3d955a27746e380954d7e1a30e88d7aaecd5"
+checksum = "ee38ad1bcc90849a49d3c860e3e44331be798101a92e19a1e2a169384cbc6528"
 dependencies = [
  "indexmap",
  "symbolic-common",
@@ -5803,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.209.1"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",
@@ -6218,9 +6218,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.1"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd56a4d5921bc2f99947ac5b3abe5f510b1be7376fdc5e9fce4a23c6a93e87c"
+checksum = "b895748a3ebcb69b9d38dcfdf21760859a4b0d0b0015277640c2ef4c69640e6f"
 dependencies = [
  "arbitrary",
  "bzip2",

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -17,4 +17,4 @@ reqwest = { workspace = true, features = [
 ] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic-common = "12.9.2"
+symbolic-common = "12.10.0"

--- a/crates/symbolicator-js/Cargo.toml
+++ b/crates/symbolicator-js/Cargo.toml
@@ -25,7 +25,7 @@ sentry = { version = "0.34.0", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 sha2 = "0.10.6"
-symbolic = { version = "12.9.2", features = ["common-serde", "sourcemapcache"] }
+symbolic = { version = "12.10.0", features = ["common-serde", "sourcemapcache"] }
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"

--- a/crates/symbolicator-native/Cargo.toml
+++ b/crates/symbolicator-native/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.18.0"
 regex = "1.5.5"
 sentry = { version = "0.34.0", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = { version = "12.9.2", features = [
+symbolic = { version = "12.10.0", features = [
     "cfi",
     "common-serde",
     "debuginfo",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
 sha2 = "0.10.6"
-symbolic = { version = "12.9.2", features = [
+symbolic = { version = "12.10.0", features = [
     "cfi",
     "common-serde",
     "debuginfo",

--- a/crates/symbolicator-sources/Cargo.toml
+++ b/crates/symbolicator-sources/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.68"
 aws-types = "1.0.1"
 glob = "0.3.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = "12.9.2"
+symbolic = "12.10.0"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/symbolicator-sources/src/filetype.rs
+++ b/crates/symbolicator-sources/src/filetype.rs
@@ -85,7 +85,12 @@ impl FileType {
     /// Source providing file types.
     #[inline]
     pub fn sources() -> &'static [Self] {
-        &[FileType::SourceBundle, FileType::PortablePdb]
+        &[
+            Self::SourceBundle,
+            Self::PortablePdb,
+            Self::ElfDebug,
+            Self::WasmDebug,
+        ]
     }
 
     /// Given an object type, returns filetypes in the order they should be tried.

--- a/crates/symbolicator-sources/src/filetype.rs
+++ b/crates/symbolicator-sources/src/filetype.rs
@@ -88,6 +88,7 @@ impl FileType {
         &[
             Self::SourceBundle,
             Self::PortablePdb,
+            // DWARF files can contain sources as of https://github.com/getsentry/symbolic/pull/849.
             Self::ElfDebug,
             Self::WasmDebug,
         ]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -26,7 +26,7 @@ sentry = { version = "0.34.0", features = [
 ] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.9.2"
+symbolic = "12.10.0"
 symbolicator-crash = { path = "../symbolicator-crash", optional = true }
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }

--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -13,7 +13,7 @@ prettytable-rs = "0.10.0"
 reqwest = { workspace = true, features = ["json"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.9.2"
+symbolic = "12.10.0"
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }
 symbolicator-service = { path = "../symbolicator-service" }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -19,7 +19,7 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic = { version = "12.9.2", features = ["debuginfo-serde"] }
+symbolic = { version = "12.10.0", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "2.1.1", default-features = false, features = [


### PR DESCRIPTION
Because of https://github.com/getsentry/symbolic/pull/849, this means Elf/Wasm debug files can now contain source information. We update `FileType::sources` to reflect this.