### PR TITLE
feat: Create object candidates for sourcelink downloads

### DIFF
--- a/crates/symbolicator-native/tests/integration/snapshots/integration__public_sources__nuget_source.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__public_sources__nuget_source.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/symbolicator-service/tests/integration/public_sources.rs
-assertion_line: 48
+source: crates/symbolicator-native/tests/integration/public_sources.rs
 expression: response.unwrap()
 ---
 stacktraces:
@@ -56,4 +55,12 @@ modules:
             has_sources: true
         debug:
           status: ok
-
+      - source: sourcelink
+        location: "https://raw.githubusercontent.com/mattjohnsonpint/TimeZoneConverter/dab355a1e878bfbfd4c659ddb568ca69961d579e/src/TimeZoneConverter/TZConvert.cs"
+        download:
+          status: ok
+          features:
+            has_debug_info: false
+            has_unwind_info: false
+            has_symbols: false
+            has_sources: true

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__dotnet_only_source_links.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__dotnet_only_source_links.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/symbolicator-service/tests/integration/symbolication.rs
-assertion_line: 226
+source: crates/symbolicator-native/tests/integration/symbolication.rs
 expression: response.unwrap()
 ---
 stacktraces:
@@ -54,4 +53,12 @@ modules:
         location: "http://localhost:<port>/symbols/source-links.pdb/0C380A12822140698565BEE6B3AC196Effffffff/source-links.src.zip"
         download:
           status: notfound
-
+      - source: sourcelink
+        location: "https://raw.githubusercontent.com/getsentry/sentry-dotnet/b31b62192e6934ea04396456461f430e143cf4f9/samples/Sentry.Samples.Console.Basic/Program.cs"
+        download:
+          status: ok
+          features:
+            has_debug_info: false
+            has_unwind_info: false
+            has_symbols: false
+            has_sources: true

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__dotnet_source_links.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__dotnet_source_links.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/symbolicator-service/tests/integration/symbolication.rs
-assertion_line: 201
+source: crates/symbolicator-native/tests/integration/symbolication.rs
 expression: response.unwrap()
 ---
 stacktraces:
@@ -60,4 +59,12 @@ modules:
         location: "http://localhost:<port>/symbols/source-links.pdb/37E9E8A61A8E404EB93C6902E277FF55ffffffff/source-links.src.zip"
         download:
           status: notfound
-
+      - source: sourcelink
+        location: "https://raw.githubusercontent.com/dotnet/runtime/d099f075e45d2aa6007a22b71b45a08758559f80/src/libraries/Common/src/System/ThrowHelper.cs"
+        download:
+          status: ok
+          features:
+            has_debug_info: false
+            has_unwind_info: false
+            has_symbols: false
+            has_sources: true

--- a/crates/symbolicator-sources/src/sources/http.rs
+++ b/crates/symbolicator-sources/src/sources/http.rs
@@ -72,7 +72,8 @@ impl HttpRemoteFile {
         HttpRemoteFile::new(source, location)
     }
 
-    pub(crate) fn uri(&self) -> RemoteFileUri {
+    /// Returns a [`RemoteFileUri`] for the file.
+    pub fn uri(&self) -> RemoteFileUri {
         match self.url() {
             Ok(url) => url.as_ref().into(),
             Err(_) => "".into(),


### PR DESCRIPTION
This integrates sourcelink downloads into the object candidate machinery. Previously, if a download from a sourcelink failed, there would be no indication that anything had gone wrong. Now, whenever we try to
download a source file from a sourcelink, we create a "sourcelink" candidate and add it to the module's candidates. Since the object candidate system was not set up for adding candidates after the fact, this
requires some tinkering.