### PR TITLE
feat(metrics): Add platform tag

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -92,6 +92,9 @@ pub struct Metrics {
     /// A tag name to report the environment to, for each metric. Defaults to not sending such a tag.
     pub environment_tag: Option<String>,
     /// A tag name to report the platform to, for each metric. Defaults to not sending such a tag.
+    ///
+    /// If this is set, the platform will be read from the `SYMBOLICLATOR_PLATFORM`
+    /// environment variable.
     pub platform_tag: Option<String>,
     /// A map containing custom tags and their values.
     ///

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -91,6 +91,8 @@ pub struct Metrics {
     pub hostname_tag: Option<String>,
     /// A tag name to report the environment to, for each metric. Defaults to not sending such a tag.
     pub environment_tag: Option<String>,
+    /// A tag name to report the platform to, for each metric. Defaults to not sending such a tag.
+    pub platform_tag: Option<String>,
     /// A map containing custom tags and their values.
     ///
     /// These tags will be appended to every metric.
@@ -107,6 +109,7 @@ impl Default for Metrics {
             prefix: "symbolicator".into(),
             hostname_tag: None,
             environment_tag: None,
+            platform_tag: None,
             custom_tags: BTreeMap::new(),
         }
     }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -147,7 +147,7 @@ pub fn execute() -> Result<()> {
                     platform_tag
                 );
             }
-            if let Some(platform) = get_platform() {
+            if let Ok(platform) = std::env::var("SYMBOLICATOR_PLATFORM") {
                 tags.insert(platform_tag, platform.to_string());
             } else {
                 tracing::error!("platform not available");
@@ -163,17 +163,4 @@ pub fn execute() -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Determines a Symbolicator's platform (`"js"`, `"jvm"`, or `"native"`)
-/// according to the hostname.
-fn get_platform() -> Option<&'static str> {
-    let hostname = hostname::get().ok().and_then(|s| s.into_string().ok())?;
-    if hostname.contains("js") {
-        Some("js")
-    } else if hostname.contains("jvm") {
-        Some("jvm")
-    } else {
-        Some("native")
-    }
 }


### PR DESCRIPTION
This adds a configurable platform tag to metrics. If this is set, the platform ~(determined based on the Symbolicator's hostname)~ (read from the `SYMBOLICATOR_PLATFORM` env variable) will be reported with every metric.

Fixes #1509.