### PR TITLE
fix: Log "platform not available" error

### DIFF
--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -147,10 +147,13 @@ pub fn execute() -> Result<()> {
                     platform_tag
                 );
             }
-            if let Ok(platform) = std::env::var("SYMBOLICATOR_PLATFORM") {
-                tags.insert(platform_tag, platform.to_string());
-            } else {
-                tracing::error!("platform not available");
+            match std::env::var("SYMBOLICATOR_PLATFORM") {
+                Ok(platform) => {
+                    tags.insert(platform_tag, platform.to_string());
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "platform not available");
+                }
             }
         };
 


### PR DESCRIPTION
We're getting a lot of these "platform not available" errors in S4S, for unclear reasons. Maybe logging the error message will shed some light on whether the env var is not set or it contains an invalid value.