### PR TITLE
ci: update actions/upload-artifact to v4 with merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,13 +141,13 @@ jobs:
           compression-level: '0'
 
   merge:
+    name: Create Release Artifact
     runs-on: ubuntu-latest
     needs: [linux, mac, windows]
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      - uses: actions/upload-artifact/merge@v4
         with:
-          # Craft expects release assets to be a single artifact named after the sha.
+          # Craft expects release assets from github to be a single artifact named after the sha.
           name: ${{ github.sha }}
           pattern: artifact-*
           delete-merged: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,12 @@ jobs:
           mv target/release/symsorter build/symsorter-Linux-x86_64
           mv target/release/symbolicli build/symbolicli-Linux-x86_64
 
-      - uses: actions/upload-artifact@v3.1.1
         with:
-          name: ${{ github.sha }}
+          name: artifact-linux-${{ github.sha }}
           path: build/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   mac:
     # Note: This doesn't use a build matrix, as it requires a last step to merge the x86
@@ -99,10 +101,13 @@ jobs:
           cd target/x86_64-apple-darwin/release
           zip -r ../../../build/symbolicator-aarch64-apple-darwin-debug.zip symbolicator.dSYM
 
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-mac-${{ github.sha }}
           path: build/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   windows:
     name: Build Tools on Windows
@@ -127,7 +132,22 @@ jobs:
           mv symbolicli.exe symbolicli-Windows-x86_64.exe
           mv wasm-split.exe wasm-split-Windows-x86_64.exe
 
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-windows-${{ github.sha }}
           path: target/release/*-Windows-x86_64.exe
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [linux, mac, windows]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          # Craft expects release assets to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true


### PR DESCRIPTION
Supersedes https://github.com/getsentry/symbolicator/pull/1503 by using artifacts/merge to merge together multiple artifacts from different jobs into the single one named github.sha that craft expects.

Summarily, upload-artifact v3 is deprecated but v4 doesn't support mutating an artifact with the name name by uploading different filepaths to the same artifact. Because we need a single artifact "github.sha", we have to use actions/merge to create it. Alternatively craft could be modified but this is the easiest way forward and I like the idea of a unified artifact, it makes craft simpler.

ref: https://github.com/getsentry/craft/issues/552