### PR TITLE
deps: Update symbolic to 12.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,12 +1408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dmsort"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
-
-[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4618,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4e155af9f06f8b44963cdb05ad7c9884f424dc040f08adc5a1bb4960937d1d"
+checksum = "6db91671a749934b02b9f3721eb5b4491b901455c91f2c87e166c52d9a6499c9"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4634,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4273aee7b62c172f1723eb06dda7462f951760a79524734fb1da4cf3842a2"
+checksum = "6225df2cfea6a9b934a6189911bc88282b6cb2cb67029f6528d69724a7965ad8"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4645,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16629323a4ec5268ad23a575110a724ad4544aae623451de600c747bf87b36cf"
+checksum = "9fdf97c441f18a4f92425b896a4ec7a27e03631a0b1047ec4e34e9916a9a167e"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4658,12 +4652,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f629454e4787591257c96c6c7c676c17f792ef8290638699714152140580717d"
+checksum = "fa99c4991caf52367d9b59d1974168ac1f237ef0ec681c464eaf58337075ee4b"
 dependencies = [
  "debugid",
- "dmsort",
  "elementtree",
  "elsa",
  "fallible-iterator 0.3.0",
@@ -4691,9 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c043a45f08f41187414592b3ceb53fb0687da57209cc77401767fb69d5b596"
+checksum = "bc8ece6b129e97e53d1fbb3f61d33a6a9e5369b11d01228c068094d6d134eaea"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -4704,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5cc3da426cd0a0ea91b3a0e722fda69377a23fa1601d7c55f3cc0533e02b9b"
+checksum = "9cfeaeded4a18296f088f00262d6c10af29f2db5b46ce79e8bf4baa3b65d6260"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4716,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6eaa9dc4774d5e0a9df62a3145d814b3a9ebcbcf37e973bc51c57bcb9eacc7"
+checksum = "1aadd15c4048f2ba1359052b6a9cec77b26b7e6e39b8afab4efd024693253113"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4732,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000bdc523e724c9e58cfa175f0ff14eac5db82976b9479603146667384a0f4ac"
+checksum = "209b1636b5edcb0b8f6fa52b82b846cc0f3871936a13f356a96440136f930172"
 dependencies = [
  "itertools 0.13.0",
  "js-source-scopes",
@@ -4747,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.10.0"
+version = "12.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee38ad1bcc90849a49d3c860e3e44331be798101a92e19a1e2a169384cbc6528"
+checksum = "36cfe22e017b69aaada0b62b10f48547545e96b8b9dc4b84cd5b26b59a4a10c4"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/crates/process-event/Cargo.toml
+++ b/crates/process-event/Cargo.toml
@@ -17,4 +17,4 @@ reqwest = { workspace = true, features = [
 ] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic-common = "12.10.0"
+symbolic-common = "12.11.1"

--- a/crates/symbolicator-js/Cargo.toml
+++ b/crates/symbolicator-js/Cargo.toml
@@ -25,7 +25,7 @@ sentry = { version = "0.34.0", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 sha2 = "0.10.6"
-symbolic = { version = "12.10.0", features = ["common-serde", "sourcemapcache"] }
+symbolic = { version = "12.11.1", features = ["common-serde", "sourcemapcache"] }
 symbolicator-service = { path = "../symbolicator-service" }
 symbolicator-sources = { path = "../symbolicator-sources" }
 tempfile = "3.2.0"

--- a/crates/symbolicator-native/Cargo.toml
+++ b/crates/symbolicator-native/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.18.0"
 regex = "1.5.5"
 sentry = { version = "0.34.0", features = ["tracing"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = { version = "12.10.0", features = [
+symbolic = { version = "12.11.1", features = [
     "cfi",
     "common-serde",
     "debuginfo",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9.14"
 sha2 = "0.10.6"
-symbolic = { version = "12.10.0", features = [
+symbolic = { version = "12.11.1", features = [
     "cfi",
     "common-serde",
     "debuginfo",

--- a/crates/symbolicator-sources/Cargo.toml
+++ b/crates/symbolicator-sources/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.68"
 aws-types = "1.0.1"
 glob = "0.3.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
-symbolic = "12.10.0"
+symbolic = "12.11.1"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -26,7 +26,7 @@ sentry = { version = "0.34.0", features = [
 ] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.10.0"
+symbolic = "12.11.1"
 symbolicator-crash = { path = "../symbolicator-crash", optional = true }
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }

--- a/crates/symbolicli/Cargo.toml
+++ b/crates/symbolicli/Cargo.toml
@@ -13,7 +13,7 @@ prettytable-rs = "0.10.0"
 reqwest = { workspace = true, features = ["json"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = "1.0.81"
-symbolic = "12.10.0"
+symbolic = "12.11.1"
 symbolicator-js = { path = "../symbolicator-js" }
 symbolicator-native = { path = "../symbolicator-native" }
 symbolicator-service = { path = "../symbolicator-service" }

--- a/crates/symsorter/Cargo.toml
+++ b/crates/symsorter/Cargo.toml
@@ -19,7 +19,7 @@ rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-symbolic = { version = "12.10.0", features = ["debuginfo-serde"] }
+symbolic = { version = "12.11.1", features = ["debuginfo-serde"] }
 walkdir = "2.3.1"
 # NOTE: zip:0.6 by default depends on a version of zstd which conflicts with our other dependencies
 zip = { version = "2.1.1", default-features = false, features = [


### PR DESCRIPTION
This pulls in https://github.com/getsentry/symbolic/pull/868, allowing us to process some CFI in DWARF files that we previously rejected as broken.