### PR TITLE
docs: Document symbolicate-jvm endpoint

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,6 +13,7 @@ or full stack traces. There are the following endpoints:
 - `POST /minidump`: Symbolicate a minidump and extract information
 - `POST /applecrashreport`: Symbolicate an Apple Crash Report
 - `POST /symbolicate-js`: Symbolicate JavaScript stacktrace
+- `POST /symbolicate-jvm`: Symbolicate JVM stacktrace  (TODO: Decide if we want to talk about the deobfuscating view hierarchies)
 - `GET /requests/:id`: Status update on running symbolication jobs
 - `GET /healthcheck`: System status and health monitoring
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,7 +13,7 @@ or full stack traces. There are the following endpoints:
 - `POST /minidump`: Symbolicate a minidump and extract information
 - `POST /applecrashreport`: Symbolicate an Apple Crash Report
 - `POST /symbolicate-js`: Symbolicate JavaScript stacktrace
-- `POST /symbolicate-jvm`: Symbolicate JVM stacktrace  (TODO: Decide if we want to talk about the deobfuscating view hierarchies)
+- `POST /symbolicate-jvm`: Symbolicate JVM stacktrace
 - `GET /requests/:id`: Status update on running symbolication jobs
 - `GET /healthcheck`: System status and health monitoring
 

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -185,3 +185,12 @@ and an optional list of errors that happened during symbolication.
   ]
 }
 ```
+
+## JVM Response
+
+TODO: Discuss what can be seen in the response.
+
+```javascript
+TODO: Seems like there are a couple responses to choose from in integration/snapshots
+Decide on which one would be the most sensible.
+```

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -188,9 +188,60 @@ and an optional list of errors that happened during symbolication.
 
 ## JVM Response
 
-TODO: Discuss what can be seen in the response.
+The response to a JVM symbolication request is a JSON object which contains
+a list of processed stack traces, exceptions and classes as well as an optional list of error that happen during symbolication.
 
 ```javascript
-TODO: Seems like there are a couple responses to choose from in integration/snapshots
-Decide on which one would be the most sensible.
+{
+  "exceptions": [
+    {
+      "type": "RuntimeException",
+      "module": "java.lang"
+    }
+  ],
+  "stacktraces": [
+    {
+      "frames": [
+        {
+          "function": "onMenuItemClick",
+          "filename": "EditActivity",
+          "module": "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
+          "abs_path": "EditActivity",
+          "lineno": 0,
+          "in_app": true,
+          "index": 18
+        },
+        {
+          "function": "onCreate$lambda-1",
+          "module": "io.sentry.samples.instrumentation.ui.EditActivity",
+          "lineno": 37,
+          "pre_context": [
+            "        }",
+            "",
+            "        findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener {",
+            "            if (it.itemId == R.id.action_save) {",
+            "                try {"
+          ],
+          "context_line": "                    SomeService().helloThere()",
+          "post_context": [
+            "                } catch (e: Exception) {",
+            "                    Sentry.captureException(e)",
+            "                }",
+            "",
+            "                val transaction = Sentry.startTransaction("
+          ],
+          "in_app": true,
+          "index": 18
+        }
+      ]
+    }
+  ],
+  "classes": {},
+  "errors": [
+    {
+      "uuid": "8236f5cf-52c8-4e35-a7cf-01421e4c2c88",
+      "type": "missing"
+    }
+  ]
+}
 ```

--- a/docs/api/symbolicate-jvm.md
+++ b/docs/api/symbolicate-jvm.md
@@ -1,0 +1,95 @@
+---
+title: POST /symbolicate-jvm
+---
+
+TODO:
+- [ ] Ensure that this is working like it should by posting it against the endpoint
+- [ ] Find out why only here sources are a list (not for the docs but for personal understanding)
+- [ ] Check if we can only get progard files from sentry and if so mention that
+- [ ] Find an example of a release package and where it is is being used
+- [ ] Find an example for the classes, must be some logic for them somewhere
+- [ ] Update the descriptions of the individual things
+- [ ] Update the response
+
+# Symbolication Request
+
+
+```http
+POST /symbolicate-jvm?timeout=123&scope=123 HTTP/1.1
+Content-Type: application/json
+
+{
+    "source": [
+        {
+            "type": "s3",
+            "id": "<id>",
+            "url": "https://sentry.io/api/0/projects/sentry-org/sentry-project/artifact-lookup/",
+            "token": "secret"
+        }
+    ],
+    "exceptions": [
+        {
+            "type": "RuntimeException",
+            "module": "io.sentry.samples"
+        }
+    ],
+    "stacktraces": [
+        {
+            "frames": [
+                {
+                    "function": "otherMethod",
+                    "filename": "OtherActivity.java",
+                    "module": "OtherActivity",
+                    "abs_path": "OtherActivity.java",
+                    "lineno": 100,
+                    "index": 0
+                }
+            ]
+        }
+    ],
+    "modules": [
+        {
+            "type": "source",
+            "uuid": "246fb328-fc4e-406a-87ff-fc35f6149d8f"
+        },
+        {
+            "type": "proguard",
+            "uuid": "05d96b1c-1786-477c-8615-d3cf83e027c7"
+        }
+    ],
+    "release_package": "TODO",
+    "classes": [],
+    "options": {
+        "apply_source_context": true
+    }
+}
+
+```
+
+## Query Parameters
+
+- `timeout`: If given, a response status of `pending` might be sent by the
+  server.
+- `scope`: An optional scope which will be used to isolate cached files from
+  each other
+
+
+## Request Body
+
+- `source`: A descriptor for the Sentry source to be used for symbolication. See
+  [Sentry](index.md) source.
+- `exceptions`: TODO: fill in a description.
+- `modules`: A list of source code files with a corresponding debug id that
+  were loaded during JVM code execution. The list is handled by the Sentry source.
+- `stacktrace`: A list of stacktraces to symbolicate.
+  - `frames`: A list of frames with corresponding `abs_path`, `lineno`,
+    and other optional fields like `colno` or minified `function` name.
+- `release_package`: Name of Sentry `release` for the processed request.
+- `dist`: Name of Sentry `dist` for the processed request.
+- `classes` TODO: Fill in a description
+- `options`: Symbolication-specific options which control the endpoint's behavior.
+  - `apply_source_context`: Whether to apply source context for the stack frames.
+
+## Response
+
+See [Symbolication Response](response.md).

--- a/docs/api/symbolicate-jvm.md
+++ b/docs/api/symbolicate-jvm.md
@@ -2,15 +2,6 @@
 title: POST /symbolicate-jvm
 ---
 
-TODO:
-- [ ] Ensure that this is working like it should by posting it against the endpoint
-- [ ] Find out why only here sources are a list (not for the docs but for personal understanding)
-- [ ] Check if we can only get progard files from sentry and if so mention that
-- [ ] Find an example of a release package and where it is is being used
-- [ ] Find an example for the classes, must be some logic for them somewhere
-- [ ] Update the descriptions of the individual things
-- [ ] Update the response
-
 # Symbolication Request
 
 
@@ -57,7 +48,7 @@ Content-Type: application/json
             "uuid": "05d96b1c-1786-477c-8615-d3cf83e027c7"
         }
     ],
-    "release_package": "TODO",
+    "release_package": "some_release",
     "classes": [],
     "options": {
         "apply_source_context": true
@@ -77,16 +68,15 @@ Content-Type: application/json
 ## Request Body
 
 - `source`: A descriptor for the Sentry source to be used for symbolication. See
-  [Sentry](index.md) source.
-- `exceptions`: TODO: fill in a description.
+  [Sentry](index.md) source. Note that only progaurd files uploaded to Sentry are supported at the moment.
+- `exceptions`: A list of exceptions which will have their module and type fields remapped.
 - `modules`: A list of source code files with a corresponding debug id that
   were loaded during JVM code execution. The list is handled by the Sentry source.
 - `stacktrace`: A list of stacktraces to symbolicate.
   - `frames`: A list of frames with corresponding `abs_path`, `lineno`,
     and other optional fields like `colno` or minified `function` name.
 - `release_package`: Name of Sentry `release` for the processed request.
-- `dist`: Name of Sentry `dist` for the processed request.
-- `classes` TODO: Fill in a description
+- `classes`: A list of classes which will have their names remapped and returned in the form of a map. Allows for deobfuscation of view hierarchies.
 - `options`: Symbolication-specific options which control the endpoint's behavior.
   - `apply_source_context`: Whether to apply source context for the stack frames.
 

--- a/docs/api/symbolicate-jvm.md
+++ b/docs/api/symbolicate-jvm.md
@@ -68,7 +68,7 @@ Content-Type: application/json
 ## Request Body
 
 - `source`: A descriptor for the Sentry source to be used for symbolication. See
-  [Sentry](index.md) source. Note that only progaurd files uploaded to Sentry are supported at the moment.
+  [Sentry](index.md) source. Note that only proguard files uploaded to Sentry are supported at the moment.
 - `exceptions`: A list of exceptions which will have their module and type fields remapped.
 - `modules`: A list of source code files with a corresponding debug id that
   were loaded during JVM code execution. The list is handled by the Sentry source.


### PR DESCRIPTION
Fix: #1476

Tried to mimic the style of the already existing documentation, content is based on notion documentation and code/tests.