### PR TITLE
feat(cleanup): Add dry-run mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Various fixes & improvements
+
+- Added `dry-run` mode to the `cleanup` command that simulates the cleanup
+  without deleting files. ([#1531](https://github.com/getsentry/symbolicator/pull/1531))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.9 to v0.7.10 ([#1527](https://github.com/getsentry/symbolicator/pull/1527))

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -109,7 +109,7 @@ fn test_max_unused_for() -> Result<()> {
     sleep(Duration::from_millis(100));
 
     File::create(tempdir.path().join("objects/keepthis2"))?.write_all(b"hi")?;
-    cache.cleanup()?;
+    cache.cleanup(false)?;
 
     let mut basenames: Vec<_> = fs::read_dir(tempdir.path().join("objects"))?
         .map(|x| x.unwrap().file_name().into_string().unwrap())
@@ -147,7 +147,7 @@ fn test_retry_misses_after() -> Result<()> {
     sleep(Duration::from_millis(100));
 
     File::create(tempdir.path().join("objects/keepthis2"))?.write_all(b"")?;
-    cache.cleanup()?;
+    cache.cleanup(false)?;
 
     let mut basenames: Vec<_> = fs::read_dir(tempdir.path().join("objects"))?
         .map(|x| x.unwrap().file_name().into_string().unwrap())
@@ -192,7 +192,7 @@ fn test_cleanup_malformed() -> Result<()> {
         1024,
     )?;
 
-    cache.cleanup()?;
+    cache.cleanup(false)?;
 
     let mut basenames: Vec<_> = fs::read_dir(tempdir.path().join("objects"))?
         .map(|x| x.unwrap().file_name().into_string().unwrap())
@@ -236,7 +236,7 @@ fn test_cleanup_cache_download() -> Result<()> {
 
     sleep(Duration::from_millis(30));
 
-    cache.cleanup()?;
+    cache.cleanup(false)?;
 
     let mut basenames: Vec<_> = fs::read_dir(tempdir.path().join("objects"))?
         .map(|x| x.unwrap().file_name().into_string().unwrap())
@@ -444,7 +444,7 @@ fn test_cleanup() {
     assert!(cficaches_entry.is_file());
     assert!(diagnostics_entry.is_file());
 
-    caches.cleanup().unwrap();
+    caches.cleanup(false).unwrap();
 
     assert!(!object_entry.is_file());
     assert!(!object_meta_entry.is_file());

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -35,7 +35,11 @@ enum Command {
 
     /// Clean local caches.
     #[command(name = "cleanup")]
-    Cleanup,
+    Cleanup {
+        /// Only simulate the cleanup without deleting any files.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Command line interface parser.
@@ -170,7 +174,9 @@ pub fn execute() -> Result<()> {
 
     match cli.command {
         Command::Run => server::run(config).context("failed to start the server")?,
-        Command::Cleanup => caching::cleanup(config).context("failed to clean up caches")?,
+        Command::Cleanup { dry_run } => {
+            caching::cleanup(config, dry_run).context("failed to clean up caches")?
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Adds a `dry-run` flag to the cleanup command that will make it simulate the cleanup without deleting files.