### PR TITLE
Revert: feat(metrics): Add region tag

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -96,11 +96,6 @@ pub struct Metrics {
     /// If this is set, the platform will be read from the `SYMBOLICATOR_PLATFORM`
     /// environment variable.
     pub platform_tag: Option<String>,
-    /// A tag name to report the region to, for each metric. Defaults to not sending such a tag.
-    ///
-    /// If this is set, the platform will be read from the `SYMBOLICATOR_REGION` environment
-    /// variable.
-    pub region_tag: Option<String>,
     /// A map containing custom tags and their values.
     ///
     /// These tags will be appended to every metric.
@@ -118,7 +113,6 @@ impl Default for Metrics {
             hostname_tag: None,
             environment_tag: None,
             platform_tag: None,
-            region_tag: None,
             custom_tags: BTreeMap::new(),
         }
     }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -135,23 +135,6 @@ pub fn execute() -> Result<()> {
             }
         };
 
-        if let Some(region_tag) = config.metrics.region_tag.clone() {
-            if tags.contains_key(&region_tag) {
-                tracing::warn!(
-                    "tag {} defined both as region tag and as a custom tag",
-                    region_tag
-                );
-            }
-            match std::env::var("SYMBOLICATOR_REGION") {
-                Ok(region) => {
-                    tags.insert(region_tag, region.to_string());
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "region not available");
-                }
-            }
-        };
-
         if let Some(platform_tag) = config.metrics.platform_tag.clone() {
             if tags.contains_key(&platform_tag) {
                 tracing::warn!(


### PR DESCRIPTION
Turns out that this is redundant as we already have a `sentry_region` tag that does the same thing.