### PR TITLE
fix: Don't log entire S3 error as part of the message

### DIFF
--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -130,8 +130,7 @@ impl S3Downloader {
                         // of these in production and figure out what we actually get here
                         tracing::error!(
                             error = &err as &dyn std::error::Error,
-                            "S3 request timed out: {:?}",
-                            err
+                            "S3 request timed out",
                         );
                         return Err(CacheError::Timeout(Duration::ZERO));
                     }
@@ -169,7 +168,7 @@ impl S3Downloader {
                         tracing::error!(
                             error = &err as &dyn std::error::Error,
                             "S3 request failed: {:?}",
-                            err
+                            err.code(),
                         );
                         let details = err.to_string();
                         Err(CacheError::DownloadError(details))
@@ -179,7 +178,7 @@ impl S3Downloader {
         };
 
         if response.content_length == Some(0) {
-            tracing::debug!("Empty response from s3:{}{}", &bucket, &key);
+            tracing::debug!(bucket, key, "Empty response from s3");
             return Err(CacheError::NotFound);
         }
 


### PR DESCRIPTION
Symbolicator errors in S4S look really bad right now because every individual S3 error is its own issue.