### PR TITLE
fix(s3): Don't log PermanentRedirect errors

### DIFF
--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -164,12 +164,17 @@ impl S3Downloader {
                     _ if matches!(err.code(), Some("NoSuchBucket" | "NoSuchKey" | "NotFound")) => {
                         Err(CacheError::NotFound)
                     }
-                    _ => {
+                    // Log errors, filtering out some uninteresting ones.
+                    _ if !matches!(err.code(), Some("PermanentRedirect")) => {
                         tracing::error!(
                             error = &err as &dyn std::error::Error,
                             "S3 request failed: {:?}",
                             err.code(),
                         );
+                        let details = err.to_string();
+                        Err(CacheError::DownloadError(details))
+                    }
+                    _ => {
                         let details = err.to_string();
                         Err(CacheError::DownloadError(details))
                     }

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -165,6 +165,8 @@ impl S3Downloader {
                         Err(CacheError::NotFound)
                     }
                     // Log errors, filtering out some uninteresting ones.
+                    //
+                    // * PermanentRedirect is a user error.
                     _ if !matches!(err.code(), Some("PermanentRedirect")) => {
                         tracing::error!(
                             error = &err as &dyn std::error::Error,


### PR DESCRIPTION
There's nothing to do on our end for these errors, users need to fix their S3 setups.