### PR TITLE
ref: Split apart native and JS modules

### DIFF
--- a/crates/symbolicator-js/src/interface.rs
+++ b/crates/symbolicator-js/src/interface.rs
@@ -94,7 +94,7 @@ pub struct JsModule {
 
 /// The type of a sourcemap module.
 ///
-/// As per https://develop.sentry.dev/sdk/data-model/event-payloads/debugmeta/#source-map-images,
+/// As per <https://develop.sentry.dev/sdk/data-model/event-payloads/debugmeta/#source-map-images>,
 /// this is always `"sourcemap"`.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]

--- a/crates/symbolicator-js/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-js/tests/integration/sourcemap.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use reqwest::Url;
 use serde_json::json;
-use symbolicator_js::interface::{JsFrame, JsStacktrace, SymbolicateJsStacktraces};
-use symbolicator_service::types::{RawObjectInfo, Scope, ScrapingConfig};
+use symbolicator_js::interface::{JsFrame, JsModule, JsStacktrace, SymbolicateJsStacktraces};
+use symbolicator_service::types::{Scope, ScrapingConfig};
 use symbolicator_sources::{SentrySourceConfig, SourceId};
 
 use crate::{assert_snapshot, setup_service};
@@ -32,7 +32,7 @@ fn make_js_request(
     dist: impl Into<Option<String>>,
 ) -> SymbolicateJsStacktraces {
     let frames: Vec<JsFrame> = serde_json::from_str(frames).unwrap();
-    let modules: Vec<RawObjectInfo> = serde_json::from_str(modules).unwrap();
+    let modules: Vec<JsModule> = serde_json::from_str(modules).unwrap();
     let stacktraces = vec![JsStacktrace { frames }];
 
     SymbolicateJsStacktraces {

--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -187,7 +187,7 @@ fn get_native_paths(filetype: FileType, identifier: &ObjectId) -> Vec<String> {
                     Some(path) => path,
                     None => return vec![],
                 },
-                ObjectType::SourceMap | ObjectType::Unknown => return vec![],
+                ObjectType::Unknown => return vec![],
             };
 
             primary_path.push_str(".src.zip");
@@ -351,7 +351,7 @@ fn get_search_target_id(filetype: FileType, identifier: &ObjectId) -> Option<Cow
                 ObjectType::Wasm => FileType::WasmCode,
                 ObjectType::PeDotnet => FileType::PortablePdb,
                 // guess we're out of luck.
-                ObjectType::SourceMap | ObjectType::Unknown => return None,
+                ObjectType::Unknown => return None,
             };
             get_search_target_id(filetype, identifier)
         }

--- a/crates/symbolicator-sources/src/types.rs
+++ b/crates/symbolicator-sources/src/types.rs
@@ -53,10 +53,6 @@ pub enum ObjectType {
     Wasm,
     /// Portable Executable containing .NET code, which has a Portable PDB companion.
     PeDotnet,
-    /// An Object representing the pair of Minified JS + SourceMap.
-    /// See <https://develop.sentry.dev/sdk/event-payloads/debugmeta/#source-map-images>.
-    #[serde(rename = "sourcemap")]
-    SourceMap,
     /// Unknown Object.
     #[default]
     Unknown,
@@ -72,7 +68,6 @@ impl FromStr for ObjectType {
             "pe" => ObjectType::Pe,
             "pe_dotnet" => ObjectType::PeDotnet,
             "wasm" => ObjectType::Wasm,
-            "sourcemap" => ObjectType::SourceMap,
             _ => ObjectType::Unknown,
         })
     }
@@ -96,7 +91,6 @@ impl fmt::Display for ObjectType {
             ObjectType::Pe => write!(f, "pe"),
             ObjectType::PeDotnet => write!(f, "pe_dotnet"),
             ObjectType::Wasm => write!(f, "wasm"),
-            ObjectType::SourceMap => write!(f, "sourcemap"),
             ObjectType::Unknown => write!(f, "unknown"),
         }
     }

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use symbolicator_js::interface::{JsStacktrace, SymbolicateJsStacktraces};
+use symbolicator_js::interface::{JsModule, JsStacktrace, SymbolicateJsStacktraces};
 use symbolicator_js::SourceMapService;
 use symbolicator_native::interface::{RawStacktrace, StacktraceOrigin, SymbolicateStacktraces};
 use symbolicator_native::SymbolicationActor;
@@ -41,7 +41,7 @@ struct EventFile {
 #[derive(Debug, Deserialize)]
 struct JsEventFile {
     stacktraces: Vec<JsStacktrace>,
-    modules: Vec<RawObjectInfo>,
+    modules: Vec<JsModule>,
 }
 
 #[derive(Clone)]

--- a/crates/symbolicator/src/endpoints/symbolicate_js.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_js.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use axum::extract;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
-use symbolicator_js::interface::{JsStacktrace, SymbolicateJsStacktraces};
-use symbolicator_service::types::RawObjectInfo;
+use symbolicator_js::interface::{JsModule, JsStacktrace, SymbolicateJsStacktraces};
 use symbolicator_sources::SentrySourceConfig;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -19,7 +18,7 @@ pub struct JsSymbolicationRequestBody {
     #[serde(default)]
     pub stacktraces: Vec<JsStacktrace>,
     #[serde(default)]
-    pub modules: Vec<RawObjectInfo>,
+    pub modules: Vec<JsModule>,
     #[serde(default)]
     pub release: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
This is part of the effort to unify Symbolicator's symbolication endpoints. It may seem strange to split types apart in the pursuit of unification, so let
me explain. Currently, it's fine to use the same type for native and JS modules because we are always using them in the context of symbolicating exactly one of these platforms. But once there is only one symbolication endpoint, it will be convenient to be able to split modules according to their platforms.

This change is totally transparent from Sentry's side: the modules it sends for JS symbolication must already have exactly the fields in the new `JsModule` struct. See  https://github.com/getsentry/sentry/blob/59f5d94901166bd457ce13edfc560c661f16e3f1/src/sentry/lang/javascript/processing.py#L92-L98.