### PR TITLE
feat(js/jvm): Emit stacktrace metrics

### DIFF
--- a/crates/symbolicator-js/src/metrics.rs
+++ b/crates/symbolicator-js/src/metrics.rs
@@ -27,9 +27,9 @@
 //!   Should be `0`, as we should find/use files from within bundles or as individual artifacts.
 
 use symbolic::debuginfo::sourcebundle::SourceFileType;
-use symbolicator_service::metrics;
+use symbolicator_service::{metric, metrics};
 
-use crate::interface::ResolvedWith;
+use crate::interface::{JsStacktrace, ResolvedWith};
 
 /// Various metrics we want to capture *per-event* for JS events.
 #[derive(Debug, Default)]
@@ -218,4 +218,21 @@ impl JsMetrics {
             &[("method", "release-old")],
         );
     }
+}
+
+/// Record metrics about stacktraces and frames.
+pub fn record_stacktrace_metrics(
+    stacktraces: &[JsStacktrace],
+    unsymbolicated_frames: u64,
+    missing_sourcescontent: u64,
+) {
+    metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
+    metric!(
+        time_raw("symbolication.num_frames") = stacktraces
+            .iter()
+            .map(|s| s.frames.len() as u64)
+            .sum::<u64>()
+    );
+    metric!(time_raw("symbolication.unsymbolicated_frames") = unsymbolicated_frames);
+    metric!(time_raw("js.missing_sourcescontent") = missing_sourcescontent);
 }

--- a/crates/symbolicator-js/src/symbolication.rs
+++ b/crates/symbolicator-js/src/symbolication.rs
@@ -10,6 +10,7 @@ use crate::interface::{
     SymbolicateJsStacktraces,
 };
 use crate::lookup::SourceMapLookup;
+use crate::metrics::record_stacktrace_metrics;
 use crate::utils::{
     fixup_webpack_filename, fold_function_name, generate_module, get_function_for_token, is_in_app,
     join_paths,
@@ -71,8 +72,7 @@ impl SourceMapService {
         }
 
         lookup.record_metrics();
-        metric!(time_raw("js.unsymbolicated_frames") = unsymbolicated_frames);
-        metric!(time_raw("js.missing_sourcescontent") = missing_sourcescontent);
+        record_stacktrace_metrics(&stacktraces, unsymbolicated_frames, missing_sourcescontent);
 
         let (used_artifact_bundles, scraping_attempts) = lookup.into_records();
 

--- a/crates/symbolicator-js/src/symbolication.rs
+++ b/crates/symbolicator-js/src/symbolication.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 
 use symbolic::sourcemapcache::{ScopeLookupResult, SourcePosition};
 use symbolicator_service::caching::CacheError;
-use symbolicator_service::metric;
 use symbolicator_service::source_context::get_context_lines;
 
 use crate::interface::{

--- a/crates/symbolicator-proguard/src/lib.rs
+++ b/crates/symbolicator-proguard/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod interface;
+mod metrics;
 mod service;
 mod symbolication;
 

--- a/crates/symbolicator-proguard/src/metrics.rs
+++ b/crates/symbolicator-proguard/src/metrics.rs
@@ -1,0 +1,24 @@
+use std::{collections::HashMap, sync::Arc};
+
+use symbolicator_service::metric;
+
+use crate::interface::{JvmException, JvmStacktrace};
+
+/// Record metrics about exceptions, stacktraces, frames, and remapped classes.
+pub fn record_symbolication_metrics(
+    exceptions: &[JvmException],
+    stacktraces: &[JvmStacktrace],
+    classes: &HashMap<Arc<str>, Arc<str>>,
+    unsymbolicated_frames: u64,
+) {
+    metric!(time_raw("symbolication.num_exceptions") = exceptions.len() as u64);
+    metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
+    metric!(
+        time_raw("symbolication.num_frames") = stacktraces
+            .iter()
+            .map(|s| s.frames.len() as u64)
+            .sum::<u64>()
+    );
+    metric!(time_raw("symbolication.num_classes") = classes.len() as u64);
+    metric!(time_raw("symbolication.unsymbolicated_frames") = unsymbolicated_frames);
+}

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -4,6 +4,7 @@ use crate::interface::{
     CompletedJvmSymbolicationResponse, JvmException, JvmFrame, JvmModuleType, JvmStacktrace,
     ProguardError, ProguardErrorKind, SymbolicateJvmStacktraces,
 };
+use crate::metrics::record_symbolication_metrics;
 use crate::ProguardService;
 
 use futures::future;
@@ -37,6 +38,8 @@ impl ProguardService {
             apply_source_context,
             classes,
         } = request;
+
+        let mut unsymbolicated_frames = 0;
 
         let maybe_mappers = future::join_all(
             modules
@@ -112,7 +115,7 @@ impl ProguardService {
             })
             .collect();
 
-        let remapped_exceptions = exceptions
+        let remapped_exceptions: Vec<_> = exceptions
             .into_iter()
             .map(|raw_exception| {
                 Self::map_exception(&mappers, &raw_exception).unwrap_or(raw_exception)
@@ -126,7 +129,13 @@ impl ProguardService {
                     .frames
                     .iter()
                     .flat_map(|frame| {
-                        Self::map_frame(&mappers, frame, release_package.as_deref()).into_iter()
+                        Self::map_frame(
+                            &mappers,
+                            frame,
+                            release_package.as_deref(),
+                            &mut unsymbolicated_frames,
+                        )
+                        .into_iter()
                     })
                     .collect();
                 JvmStacktrace {
@@ -153,6 +162,13 @@ impl ProguardService {
                 Some((class, Arc::from(remapped)))
             })
             .collect();
+
+        record_symbolication_metrics(
+            &remapped_exceptions,
+            &remapped_stacktraces,
+            &remapped_classes,
+            unsymbolicated_frames,
+        );
 
         CompletedJvmSymbolicationResponse {
             exceptions: remapped_exceptions,
@@ -207,6 +223,7 @@ impl ProguardService {
         mappers: &[&proguard::ProguardCache],
         frame: &JvmFrame,
         release_package: Option<&str>,
+        unsymbolicated_frames: &mut u64,
     ) -> Vec<JvmFrame> {
         let deobfuscated_signature = frame.signature.as_ref().and_then(|signature| {
             mappers
@@ -283,7 +300,10 @@ impl ProguardService {
         }
 
         // If all else fails, just return the original frame.
-        let mut frames = frames.unwrap_or_else(|| vec![frame.clone()]);
+        let mut frames = frames.unwrap_or_else(|| {
+            *unsymbolicated_frames += 1;
+            vec![frame.clone()]
+        });
 
         for frame in &mut frames {
             // add the signature if we received one and we were

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -578,7 +578,9 @@ io.sentry.sample.MainActivity -> io.sentry.sample.MainActivity:
 
         let mapped_frames: Vec<_> = frames
             .iter()
-            .flat_map(|frame| ProguardService::map_frame(&[&cache], frame, None).into_iter())
+            .flat_map(|frame| {
+                ProguardService::map_frame(&[&cache], frame, None, &mut 0).into_iter()
+            })
             .collect();
 
         assert_eq!(mapped_frames.len(), 7);
@@ -688,7 +690,7 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
         let mapped_frames: Vec<_> = frames
             .iter()
             .flat_map(|frame| {
-                ProguardService::map_frame(&[&cache], frame, Some("org.slf4j")).into_iter()
+                ProguardService::map_frame(&[&cache], frame, Some("org.slf4j"), &mut 0).into_iter()
             })
             .collect();
 
@@ -712,7 +714,7 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
             ..Default::default()
         };
 
-        let remapped = ProguardService::map_frame(&[], &frame, Some("android"));
+        let remapped = ProguardService::map_frame(&[], &frame, Some("android"), &mut 0);
 
         assert_eq!(remapped.len(), 1);
         // The frame didn't get mapped, so we shouldn't set `in_app` even though
@@ -759,7 +761,7 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
             ..Default::default()
         };
 
-        let mapped_frames = ProguardService::map_frame(&[&cache], &frame, None);
+        let mapped_frames = ProguardService::map_frame(&[&cache], &frame, None, &mut 0);
 
         assert_eq!(mapped_frames.len(), 2);
 
@@ -829,7 +831,7 @@ y.b -> y.b:
             ..Default::default()
         };
 
-        let mapped_frames = ProguardService::map_frame(&[&cache], &frame, None);
+        let mapped_frames = ProguardService::map_frame(&[&cache], &frame, None, &mut 0);
 
         assert_eq!(mapped_frames.len(), 1);
 
@@ -968,7 +970,9 @@ io.wzieba.r8fullmoderenamessources.R -> a.d:
 
         let (remapped_filenames, remapped_abs_paths): (Vec<_>, Vec<_>) = frames
             .iter()
-            .flat_map(|frame| ProguardService::map_frame(&[&cache], frame, None).into_iter())
+            .flat_map(|frame| {
+                ProguardService::map_frame(&[&cache], frame, None, &mut 0).into_iter()
+            })
             .map(|frame| (frame.filename.unwrap(), frame.abs_path.unwrap()))
             .unzip();
 


### PR DESCRIPTION
We never emitted stacktrace metrics (number of stacktraces/frames per request) for JS¹ and JVM. This adds the most important metrics for those platforms.

¹ Well we did for JS but under a different name.