### PR TITLE
feat: Add platforms to events and frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Various fixes & improvements
+
+- All symbolication endpoints (`symbolicate-{,js,jvm}`, `minidump`, `applecrashreport`)
+  now take an additional `platform` parameter. Stack frames gain this parameter
+  as well. ([#1560](https://github.com/getsentry/symbolicator/pull/1560))
+
 ## 24.11.1
 
 ### Dependencies

--- a/crates/symbolicator-js/src/interface.rs
+++ b/crates/symbolicator-js/src/interface.rs
@@ -212,8 +212,9 @@ pub struct JsFrame {
     /// The frame's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// JS frame should only have [`JavaScript`](JsPlatform::JavaScript)
-    /// or [`Node`](JsPlatform::Node). However,
+    /// JS frame should only have
+    /// [`JavaScript`](symbolicator_service::types::JsPlatform::JavaScript)
+    /// or [`Node`](symbolicator_service::types::JsPlatform::Node). However,
     /// we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/symbolicator-js/src/interface.rs
+++ b/crates/symbolicator-js/src/interface.rs
@@ -15,8 +15,9 @@ pub struct SymbolicateJsStacktraces {
     /// The event's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// JS event should only have [`JavaScript`](JsPlatform::JavaScript)
-    /// or [`Node`](JsPlatform::Node). However,
+    /// JS event should only have
+    /// [`JavaScript`](symbolicator_service::types::JsPlatform::JavaScript)
+    /// or [`Node`](symbolicator_service::types::JsPlatform::Node). However,
     /// we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     pub platform: Option<Platform>,

--- a/crates/symbolicator-js/src/interface.rs
+++ b/crates/symbolicator-js/src/interface.rs
@@ -5,13 +5,21 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use symbolicator_service::caching::CacheError;
-use symbolicator_service::types::{Scope, ScrapingConfig};
+use symbolicator_service::types::{Platform, Scope, ScrapingConfig};
 use symbolicator_sources::{SentryFileId, SentrySourceConfig};
 
 use crate::lookup::CachedFileUri;
 
 #[derive(Debug, Clone)]
 pub struct SymbolicateJsStacktraces {
+    /// The event's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// JS event should only have [`JavaScript`](JsPlatform::JavaScript)
+    /// or [`Node`](JsPlatform::Node). However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    pub platform: Option<Platform>,
     pub scope: Scope,
     pub source: Arc<SentrySourceConfig>,
     pub release: Option<String>,
@@ -200,6 +208,16 @@ pub enum JsScrapingFailureReason {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JsFrame {
+    /// The frame's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// JS frame should only have [`JavaScript`](JsPlatform::JavaScript)
+    /// or [`Node`](JsPlatform::Node). However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<Platform>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<String>,
 

--- a/crates/symbolicator-js/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-js/tests/integration/sourcemap.rs
@@ -36,6 +36,7 @@ fn make_js_request(
     let stacktraces = vec![JsStacktrace { frames }];
 
     SymbolicateJsStacktraces {
+        platform: None,
         scope: Scope::Global,
         source: Arc::new(source),
         release: release.into(),

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -25,8 +25,8 @@ pub struct SymbolicateStacktraces {
     /// The event's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// native event should have a [`NativePlatform`]. However,
-    /// we use the general `Platform` type for now to be resilient against
+    /// native event should have a [`symbolicator_service::types::NativePlatform`].
+    /// However, we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     pub platform: Option<Platform>,
     /// The scope of this request which determines access to cached files.

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -197,8 +197,8 @@ pub struct RawFrame {
     /// The frame's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// native frame should have a [`NativePlatform`]. However,
-    /// we use the general `Platform` type for now to be resilient against
+    /// native frame should have a [`symbolicator_service::types::NativePlatform`].
+    /// However, we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<Platform>,

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -10,7 +10,9 @@ use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 use symbolic::common::{Arch, CodeId, DebugId, Language};
 use symbolicator_service::objects::{AllObjectCandidates, ObjectFeatures};
-use symbolicator_service::types::{ObjectFileStatus, RawObjectInfo, Scope, ScrapingConfig};
+use symbolicator_service::types::{
+    ObjectFileStatus, Platform, RawObjectInfo, Scope, ScrapingConfig,
+};
 use symbolicator_service::utils::hex::HexValue;
 use symbolicator_sources::SourceConfig;
 use thiserror::Error;
@@ -20,6 +22,13 @@ pub use crate::metrics::StacktraceOrigin;
 #[derive(Debug, Clone)]
 /// A request for symbolication of multiple stack traces.
 pub struct SymbolicateStacktraces {
+    /// The event's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// native event should have a [`NativePlatform`]. However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    pub platform: Option<Platform>,
     /// The scope of this request which determines access to cached files.
     pub scope: Scope,
 
@@ -185,6 +194,14 @@ fn is_default_value<T: Default + PartialEq>(value: &T) -> bool {
 /// An unsymbolicated frame from a symbolication request.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct RawFrame {
+    /// The frame's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// native frame should have a [`NativePlatform`]. However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<Platform>,
     /// Controls the addressing mode for [`instruction_addr`](Self::instruction_addr) and
     /// [`sym_addr`](Self::sym_addr).
     ///

--- a/crates/symbolicator-native/src/symbolication/native.rs
+++ b/crates/symbolicator-native/src/symbolication/native.rs
@@ -49,6 +49,7 @@ pub fn symbolicate_native_frame(
             status: FrameStatus::Symbolicated,
             original_index: Some(index),
             raw: RawFrame {
+                platform: frame.platform.clone(),
                 package: lookup_result.object_info.raw.code_file.clone(),
                 addr_mode: lookup_result.preferred_addr_mode(),
                 instruction_addr,

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -100,6 +100,7 @@ impl SymbolicationActor {
             modules,
             apply_source_context,
             scraping,
+            ..
         } = request;
 
         let mut module_lookup = ModuleLookup::new(scope.clone(), sources, modules);

--- a/crates/symbolicator-native/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-native/tests/integration/process_minidump.rs
@@ -18,6 +18,7 @@ macro_rules! stackwalk_minidump {
             minidump_file.write_all(&minidump).unwrap();
             let response = symbolication
                 .process_minidump(
+                    None,
                     Scope::Global,
                     minidump_file.into_temp_path(),
                     Arc::new([source]),

--- a/crates/symbolicator-native/tests/integration/symbolication.rs
+++ b/crates/symbolicator-native/tests/integration/symbolication.rs
@@ -54,6 +54,7 @@ async fn test_apple_crash_report() {
 
     let response = symbolication
         .process_apple_crash_report(
+            None,
             Scope::Global,
             report_file,
             Arc::new([source]),

--- a/crates/symbolicator-native/tests/integration/utils.rs
+++ b/crates/symbolicator-native/tests/integration/utils.rs
@@ -52,6 +52,7 @@ pub fn make_symbolication_request(
     let modules: Vec<RawObjectInfo> = serde_json::from_str(modules).unwrap();
     let stacktraces = serde_json::from_str(stacktraces).unwrap();
     SymbolicateStacktraces {
+        platform: None,
         modules: modules.into_iter().map(From::from).collect(),
         stacktraces,
         signal: None,

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -3,12 +3,19 @@ use std::{collections::HashMap, fmt};
 
 use serde::{Deserialize, Serialize};
 use symbolic::common::DebugId;
-use symbolicator_service::types::Scope;
+use symbolicator_service::types::{Platform, Scope};
 use symbolicator_sources::SourceConfig;
 
 /// A request for symbolication/remapping of a JVM event.
 #[derive(Debug, Clone)]
 pub struct SymbolicateJvmStacktraces {
+    /// The event's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// JVM event should only have [`Java`](JvmPlatform::Java). However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    pub platform: Option<Platform>,
     /// The scope of this request which determines access to cached files.
     pub scope: Scope,
     /// A list of external sources to load debug files.
@@ -32,6 +39,15 @@ pub struct SymbolicateJvmStacktraces {
 /// A stack frame in a JVM stacktrace.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JvmFrame {
+    /// The frame's platform.
+    ///
+    /// `Platform` is actually too lenient of a type here—a legitimate
+    /// JVM frame should only have [`Java`](JvmPlatform::Java). However,
+    /// we use the general `Platform` type for now to be resilient against
+    /// wrong values making it through.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<Platform>,
+
     /// The frame's function name.
     ///
     /// For a JVM frame, this is always a class method.

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -43,7 +43,8 @@ pub struct JvmFrame {
     /// The frame's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// JVM frame should only have [`Java`](JvmPlatform::Java). However,
+    /// JVM frame should only have
+    /// [`Java`](symbolicator_service::types::JvmPlatform::Java). However,
     /// we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -12,7 +12,8 @@ pub struct SymbolicateJvmStacktraces {
     /// The event's platform.
     ///
     /// `Platform` is actually too lenient of a type here—a legitimate
-    /// JVM event should only have [`Java`](JvmPlatform::Java). However,
+    /// JVM event should only have
+    /// [`Java`](symbolicator_service::types::JvmPlatform::Java). However,
     /// we use the general `Platform` type for now to be resilient against
     /// wrong values making it through.
     pub platform: Option<Platform>,

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -36,6 +36,7 @@ impl ProguardService {
             release_package,
             apply_source_context,
             classes,
+            ..
         } = request;
 
         let maybe_mappers = future::join_all(

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -25,6 +25,7 @@ fn make_jvm_request(
     let stacktraces = vec![JvmStacktrace { frames }];
 
     SymbolicateJvmStacktraces {
+        platform: None,
         scope: Scope::Global,
         sources: Arc::new([source]),
         apply_source_context: true,

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -77,6 +77,7 @@ pub fn prepare_payload(
             let modules = modules.into_iter().map(From::from).collect();
 
             ParsedPayload::Event(SymbolicateStacktraces {
+                platform: None,
                 scope,
                 signal: None,
                 sources,
@@ -114,6 +115,7 @@ pub fn prepare_payload(
             ParsedPayload::Js(
                 srv,
                 SymbolicateJsStacktraces {
+                    platform: None,
                     scope,
                     source: Arc::new(source),
                     release: Some("some-release".into()),
@@ -163,6 +165,7 @@ pub async fn process_payload(
             symbolication
                 .0
                 .process_minidump(
+                    None,
                     scope.clone(),
                     temp_path,
                     Arc::clone(sources),

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use symbolicator_native::interface::{
     RawStacktrace, Signal, StacktraceOrigin, SymbolicateStacktraces,
 };
-use symbolicator_service::types::RawObjectInfo;
+use symbolicator_service::types::{Platform, RawObjectInfo};
 use symbolicator_sources::SourceConfig;
 
 use crate::service::{
@@ -38,6 +38,7 @@ impl ConfigureScope for SymbolicationRequestQueryParams {
 /// JSON body of the symbolication request.
 #[derive(Serialize, Deserialize)]
 pub struct SymbolicationRequestBody {
+    pub platform: Option<Platform>,
     #[serde(default)]
     pub signal: Option<Signal>,
     #[serde(default)]
@@ -68,6 +69,7 @@ pub async fn symbolicate_frames(
 
     let request_id = service.symbolicate_stacktraces(
         SymbolicateStacktraces {
+            platform: body.platform,
             scope: params.scope,
             signal: body.signal,
             sources,

--- a/crates/symbolicator/src/endpoints/symbolicate_js.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_js.rs
@@ -4,6 +4,7 @@ use axum::extract;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 use symbolicator_js::interface::{JsModule, JsStacktrace, SymbolicateJsStacktraces};
+use symbolicator_service::types::Platform;
 use symbolicator_sources::SentrySourceConfig;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -14,6 +15,7 @@ use super::ResponseError;
 
 #[derive(Serialize, Deserialize)]
 pub struct JsSymbolicationRequestBody {
+    pub platform: Option<Platform>,
     pub source: SentrySourceConfig,
     #[serde(default)]
     pub stacktraces: Vec<JsStacktrace>,
@@ -66,6 +68,7 @@ pub async fn handle_symbolication_request(
     params.configure_scope();
 
     let JsSymbolicationRequestBody {
+        platform,
         source,
         stacktraces,
         modules,
@@ -80,6 +83,7 @@ pub async fn handle_symbolication_request(
     scraping.enabled &= allow_scraping;
 
     let request_id = service.symbolicate_js_stacktraces(SymbolicateJsStacktraces {
+        platform,
         scope: params.scope,
         source: Arc::new(source),
         stacktraces,

--- a/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use symbolicator_proguard::interface::{
     JvmException, JvmModule, JvmStacktrace, SymbolicateJvmStacktraces,
 };
+use symbolicator_service::types::Platform;
 use symbolicator_sources::SourceConfig;
 
 use crate::service::{RequestService, SymbolicationResponse};
@@ -15,6 +16,7 @@ use crate::endpoints::ResponseError;
 
 #[derive(Serialize, Deserialize)]
 pub struct JvmSymbolicationRequestBody {
+    pub platform: Option<Platform>,
     pub sources: Arc<[SourceConfig]>,
     #[serde(default)]
     pub exceptions: Vec<JvmException>,
@@ -59,6 +61,7 @@ pub async fn handle_symbolication_request(
     params.configure_scope();
 
     let JvmSymbolicationRequestBody {
+        platform,
         sources,
         exceptions,
         stacktraces,
@@ -69,6 +72,7 @@ pub async fn handle_symbolication_request(
     } = body;
 
     let request_id = service.symbolicate_jvm_stacktraces(SymbolicateJvmStacktraces {
+        platform,
         scope: params.scope,
         sources,
         exceptions,

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -37,6 +37,7 @@ use symbolicator_service::config::Config;
 use symbolicator_service::metric;
 use symbolicator_service::objects::ObjectsActor;
 use symbolicator_service::services::SharedServices;
+use symbolicator_service::types::Platform;
 use symbolicator_service::utils::futures::CallOnDrop;
 use symbolicator_service::utils::futures::{m, measure};
 use symbolicator_sources::SourceConfig;
@@ -308,6 +309,7 @@ impl RequestService {
     /// maximum number of requests, as configured by the `max_concurrent_requests` option.
     pub fn process_minidump(
         &self,
+        platform: Option<Platform>,
         scope: Scope,
         minidump_file: TempPath,
         sources: Arc<[SourceConfig]>,
@@ -317,7 +319,7 @@ impl RequestService {
         let slf = self.inner.clone();
         self.create_symbolication_request("minidump_stackwalk", options, async move {
             slf.native
-                .process_minidump(scope, minidump_file, sources, scraping)
+                .process_minidump(platform, scope, minidump_file, sources, scraping)
                 .await
                 .map(CompletedResponse::Native)
         })
@@ -329,6 +331,7 @@ impl RequestService {
     /// maximum number of requests, as configured by the `max_concurrent_requests` option.
     pub fn process_apple_crash_report(
         &self,
+        platform: Option<Platform>,
         scope: Scope,
         apple_crash_report: File,
         sources: Arc<[SourceConfig]>,
@@ -338,7 +341,7 @@ impl RequestService {
         let slf = self.inner.clone();
         self.create_symbolication_request("parse_apple_crash_report", options, async move {
             slf.native
-                .process_apple_crash_report(scope, apple_crash_report, sources, scraping)
+                .process_apple_crash_report(platform, scope, apple_crash_report, sources, scraping)
                 .await
                 .map(CompletedResponse::Native)
         })
@@ -605,6 +608,7 @@ mod tests {
         .unwrap();
 
         let request = SymbolicateStacktraces {
+            platform: None,
             modules: Vec::new(),
             stacktraces,
             signal: None,
@@ -631,6 +635,7 @@ mod tests {
 
     fn get_symbolication_request(sources: Vec<SourceConfig>) -> SymbolicateStacktraces {
         SymbolicateStacktraces {
+            platform: None,
             scope: Scope::Global,
             signal: None,
             sources: Arc::from(sources),

--- a/docs/api/applecrashreport.md
+++ b/docs/api/applecrashreport.md
@@ -24,6 +24,11 @@ Content-Type: application/json
   },
   ...
 ]
+
+--xxx
+Content-Disposition: form-data; name="platform"
+"native"
+
 --xxx--
 ```
 
@@ -39,6 +44,7 @@ Content-Type: application/json
 A multipart form data body containing the minidump, as well as the external
 sources to pull symbols from.
 
+- `platform`: The event' platform.
 - `sources`: A list of descriptors for internal or external symbol sources. See
   [Sources](index.md).
 - `upload_file_minidump`: The minidump file to be analyzed.

--- a/docs/api/minidump.md
+++ b/docs/api/minidump.md
@@ -23,6 +23,10 @@ Content-Disposition: form-data; name="sources"
   ...
 ]
 
+--xxx
+Content-Disposition: form-data; name="platform"
+"native"
+
 --xxx--
 ```
 
@@ -38,6 +42,7 @@ Content-Disposition: form-data; name="sources"
 A multipart form data body containing the minidump, as well as the external
 sources to pull symbols from.
 
+- `platform`: The event' platform.
 - `sources`: A list of descriptors for internal or external symbol sources. See
   [Sources](index.md).
 - `upload_file_minidump`: The minidump file to be analyzed.

--- a/docs/api/sourcemaps.md
+++ b/docs/api/sourcemaps.md
@@ -9,6 +9,7 @@ POST /symbolicate-js?timeout=123&scope=123 HTTP/1.1
 Content-Type: application/json
 
 {
+  "platform": "node",
   "source": {
     "id": "<id>",
     "url": "https://sentry.io/api/0/projects/sentry-org/sentry-project/artifact-lookup/",
@@ -57,6 +58,7 @@ Content-Type: application/json
 A JSON payload describing the stack traces and code modules for symbolication,
 as well as configuration for scraping sources from external servers:
 
+- `platform`: The event's platform.
 - `source`: A descriptor for the Sentry source to be used for symbolication. See
   [Sentry](index.md) source.
 - `modules`: A list of source code files with a corresponding debug id that

--- a/docs/api/symbolicate-jvm.md
+++ b/docs/api/symbolicate-jvm.md
@@ -10,6 +10,7 @@ POST /symbolicate-jvm?timeout=123&scope=123 HTTP/1.1
 Content-Type: application/json
 
 {
+    "platform": "java",
     "source": [
         {
             "type": "s3",
@@ -67,6 +68,7 @@ Content-Type: application/json
 
 ## Request Body
 
+- `platform`: The event's platform.
 - `source`: A descriptor for the Sentry source to be used for symbolication. See
   [Sentry](index.md) source. Note that only proguard files uploaded to Sentry are supported at the moment.
 - `exceptions`: A list of exceptions which will have their module and type fields remapped.

--- a/docs/api/symbolication.md
+++ b/docs/api/symbolication.md
@@ -9,6 +9,7 @@ POST /symbolicate?timeout=123&scope=123 HTTP/1.1
 Content-Type: application/json
 
 {
+  "platform": "native",
   "signal": 11,
   "sources": [
     {
@@ -59,6 +60,7 @@ Content-Type: application/json
 A JSON payload describing the stack traces and code modules for symbolication,
 as well as external sources to pull symbols from:
 
+- `platform`: The event's platform.
 - `sources`: A list of descriptors for internal or external symbol sources. See
   [Sources](index.md).
 - `modules`: A list of code modules (aka debug images) that were loaded into the


### PR DESCRIPTION
This adds `platform` values to all stack frame and symbolication request types and endpoints.

We're intentionally using `Platform` everywhere instead of the more narrow types appropriate to native, JS, or JVM, just in case Sentry sends an unexpected value.