### PR TITLE
feat: Tag "number of frames" metrics with platforms

### DIFF
--- a/crates/symbolicator-js/src/metrics.rs
+++ b/crates/symbolicator-js/src/metrics.rs
@@ -26,8 +26,10 @@
 //! - `js.scraped_files`: The number of files that were scraped from the Web.
 //!   Should be `0`, as we should find/use files from within bundles or as individual artifacts.
 
+use std::collections::HashMap;
+
 use symbolic::debuginfo::sourcebundle::SourceFileType;
-use symbolicator_service::{metric, metrics};
+use symbolicator_service::{metric, metrics, types::Platform};
 
 use crate::interface::{JsStacktrace, ResolvedWith};
 
@@ -222,17 +224,37 @@ impl JsMetrics {
 
 /// Record metrics about stacktraces and frames.
 pub fn record_stacktrace_metrics(
+    event_platform: Option<Platform>,
     stacktraces: &[JsStacktrace],
     unsymbolicated_frames: u64,
     missing_sourcescontent: u64,
 ) {
+    let event_platform = event_platform
+        .as_ref()
+        .map(|p| p.as_ref())
+        .unwrap_or("none");
+
     metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
-    metric!(
-        time_raw("symbolication.num_frames") = stacktraces
-            .iter()
-            .map(|s| s.frames.len() as u64)
-            .sum::<u64>()
+
+    // Count number of frames by platform (including no platform)
+    let frames_by_platform = stacktraces.iter().flat_map(|st| st.frames.iter()).fold(
+        HashMap::new(),
+        |mut map, frame| {
+            let platform = frame.platform.as_ref();
+            let count: &mut usize = map.entry(platform).or_default();
+            *count += 1;
+            map
+        },
     );
+
+    for (p, count) in &frames_by_platform {
+        let frame_platform = p.map(|p| p.as_ref()).unwrap_or("none");
+        metric!(
+            time_raw("symbolication.num_frames") =
+                count,
+            "frame_platform" => frame_platform, "event_platform" => event_platform
+        );
+    }
     metric!(time_raw("symbolication.unsymbolicated_frames") = unsymbolicated_frames);
     metric!(time_raw("js.missing_sourcescontent") = missing_sourcescontent);
 }

--- a/crates/symbolicator-js/src/symbolication.rs
+++ b/crates/symbolicator-js/src/symbolication.rs
@@ -24,6 +24,7 @@ impl SourceMapService {
     ) -> CompletedJsSymbolicationResponse {
         let mut raw_stacktraces = std::mem::take(&mut request.stacktraces);
         let apply_source_context = request.apply_source_context;
+        let platform = request.platform.clone();
         let mut lookup = SourceMapLookup::new(self.clone(), request).await;
         lookup.prepare_modules(&mut raw_stacktraces[..]);
 
@@ -71,7 +72,12 @@ impl SourceMapService {
         }
 
         lookup.record_metrics();
-        record_stacktrace_metrics(&stacktraces, unsymbolicated_frames, missing_sourcescontent);
+        record_stacktrace_metrics(
+            platform,
+            &stacktraces,
+            unsymbolicated_frames,
+            missing_sourcescontent,
+        );
 
         let (used_artifact_bundles, scraping_attempts) = lookup.into_records();
 

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -92,6 +92,7 @@ impl SymbolicationActor {
         request: SymbolicateStacktraces,
     ) -> anyhow::Result<CompletedSymbolicationResponse> {
         let SymbolicateStacktraces {
+            platform,
             stacktraces,
             sources,
             scope,
@@ -133,7 +134,7 @@ impl SymbolicationActor {
 
         // bring modules back into the original order
         let modules = module_lookup.into_inner();
-        record_symbolication_metrics(origin, metrics, &modules, &stacktraces);
+        record_symbolication_metrics(platform, origin, metrics, &modules, &stacktraces);
 
         Ok(CompletedSymbolicationResponse {
             signal,

--- a/crates/symbolicator-proguard/src/metrics.rs
+++ b/crates/symbolicator-proguard/src/metrics.rs
@@ -1,24 +1,44 @@
 use std::{collections::HashMap, sync::Arc};
 
-use symbolicator_service::metric;
+use symbolicator_service::{metric, types::Platform};
 
 use crate::interface::{JvmException, JvmStacktrace};
 
 /// Record metrics about exceptions, stacktraces, frames, and remapped classes.
 pub fn record_symbolication_metrics(
+    event_platform: Option<Platform>,
     exceptions: &[JvmException],
     stacktraces: &[JvmStacktrace],
     classes: &HashMap<Arc<str>, Arc<str>>,
     unsymbolicated_frames: u64,
 ) {
+    let event_platform = event_platform
+        .as_ref()
+        .map(|p| p.as_ref())
+        .unwrap_or("none");
+
     metric!(time_raw("symbolication.num_exceptions") = exceptions.len() as u64);
     metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
-    metric!(
-        time_raw("symbolication.num_frames") = stacktraces
-            .iter()
-            .map(|s| s.frames.len() as u64)
-            .sum::<u64>()
+
+    // Count number of frames by platform (including no platform)
+    let frames_by_platform = stacktraces.iter().flat_map(|st| st.frames.iter()).fold(
+        HashMap::new(),
+        |mut map, frame| {
+            let platform = frame.platform.as_ref();
+            let count: &mut usize = map.entry(platform).or_default();
+            *count += 1;
+            map
+        },
     );
+
+    for (p, count) in &frames_by_platform {
+        let frame_platform = p.map(|p| p.as_ref()).unwrap_or("none");
+        metric!(
+            time_raw("symbolication.num_frames") =
+                count,
+            "frame_platform" => frame_platform, "event_platform" => event_platform
+        );
+    }
     metric!(time_raw("symbolication.num_classes") = classes.len() as u64);
     metric!(time_raw("symbolication.unsymbolicated_frames") = unsymbolicated_frames);
 }

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -29,6 +29,7 @@ impl ProguardService {
         request: SymbolicateJvmStacktraces,
     ) -> CompletedJvmSymbolicationResponse {
         let SymbolicateJvmStacktraces {
+            platform,
             scope,
             sources,
             exceptions,
@@ -37,7 +38,6 @@ impl ProguardService {
             release_package,
             apply_source_context,
             classes,
-            ..
         } = request;
 
         let mut unsymbolicated_frames = 0;
@@ -165,6 +165,7 @@ impl ProguardService {
             .collect();
 
         record_symbolication_metrics(
+            platform,
             &remapped_exceptions,
             &remapped_stacktraces,
             &remapped_classes,

--- a/crates/symbolicator-service/src/types.rs
+++ b/crates/symbolicator-service/src/types.rs
@@ -187,16 +187,22 @@ pub enum NativePlatform {
     CSharp,
 }
 
+impl AsRef<str> for NativePlatform {
+    fn as_ref(&self) -> &str {
+        match self {
+            NativePlatform::ObjC => "objc",
+            NativePlatform::Cocoa => "cocoa",
+            NativePlatform::Swift => "swift",
+            NativePlatform::Native => "native",
+            NativePlatform::C => "c",
+            NativePlatform::CSharp => "csharp",
+        }
+    }
+}
+
 impl fmt::Display for NativePlatform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NativePlatform::ObjC => write!(f, "objc"),
-            NativePlatform::Cocoa => write!(f, "cocoa"),
-            NativePlatform::Swift => write!(f, "swift"),
-            NativePlatform::Native => write!(f, "native"),
-            NativePlatform::C => write!(f, "c"),
-            NativePlatform::CSharp => write!(f, "csharp"),
-        }
+        self.as_ref().fmt(f)
     }
 }
 
@@ -210,12 +216,18 @@ pub enum JsPlatform {
     JavaScript,
 }
 
+impl AsRef<str> for JsPlatform {
+    fn as_ref(&self) -> &str {
+        match self {
+            JsPlatform::Node => "node",
+            JsPlatform::JavaScript => "javascript",
+        }
+    }
+}
+
 impl fmt::Display for JsPlatform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JsPlatform::Node => write!(f, "node"),
-            JsPlatform::JavaScript => write!(f, "javascript"),
-        }
+        self.as_ref().fmt(f)
     }
 }
 
@@ -228,11 +240,17 @@ pub enum JvmPlatform {
     Java,
 }
 
+impl AsRef<str> for JvmPlatform {
+    fn as_ref(&self) -> &str {
+        match self {
+            JvmPlatform::Java => "java",
+        }
+    }
+}
+
 impl fmt::Display for JvmPlatform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JvmPlatform::Java => write!(f, "java"),
-        }
+        self.as_ref().fmt(f)
     }
 }
 
@@ -272,13 +290,19 @@ impl Default for Platform {
     }
 }
 
+impl AsRef<str> for Platform {
+    fn as_ref(&self) -> &str {
+        match self {
+            Platform::Native(p) => p.as_ref(),
+            Platform::Js(p) => p.as_ref(),
+            Platform::Jvm(p) => p.as_ref(),
+            Platform::Other(p) => p.as_ref(),
+        }
+    }
+}
+
 impl fmt::Display for Platform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Platform::Native(p) => p.fmt(f),
-            Platform::Js(p) => p.fmt(f),
-            Platform::Jvm(p) => p.fmt(f),
-            Platform::Other(p) => p.fmt(f),
-        }
+        self.as_ref().fmt(f)
     }
 }


### PR DESCRIPTION
Each count is tagged with the platform of the individual frames as well as that of the whole event.

As a drive-by, this also implements `AsRef<str>` for the platform types.