### PR TITLE
feat(jvm): Tag class & exception metrics with platform

### DIFF
--- a/crates/symbolicator-proguard/src/metrics.rs
+++ b/crates/symbolicator-proguard/src/metrics.rs
@@ -17,7 +17,7 @@ pub fn record_symbolication_metrics(
         .map(|p| p.as_ref())
         .unwrap_or("none");
 
-    metric!(time_raw("symbolication.num_exceptions") = exceptions.len() as u64);
+    metric!(time_raw("symbolication.num_exceptions") = exceptions.len() as u64, "event_platform" => event_platform);
     metric!(time_raw("symbolication.num_stacktraces") = stacktraces.len() as u64);
 
     // Count number of frames by platform (including no platform)
@@ -39,6 +39,6 @@ pub fn record_symbolication_metrics(
             "frame_platform" => frame_platform, "event_platform" => event_platform
         );
     }
-    metric!(time_raw("symbolication.num_classes") = classes.len() as u64);
+    metric!(time_raw("symbolication.num_classes") = classes.len() as u64, "event_platform" => event_platform);
     metric!(time_raw("symbolication.unsymbolicated_frames") = unsymbolicated_frames);
 }


### PR DESCRIPTION
This is to make sure that gating JVM events behind platform values is actually sound. We know that's the case for stacktraces, but we don't know it for exceptions or classes.