### PR TITLE
deat(devservices): Add devservices label for symbolicator container

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -23,6 +23,8 @@ services:
       - devservices
     extra_hosts:
       - host.docker.internal:host-gateway # Allow host.docker.internal to resolve to the host machine
+    labels:
+      - orchestrator=devservices
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Adding a label to the docker compose config to signify that devservices is the orchestrator.