### PR TITLE
build: Build Symbolicator on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   linux:
     name: Build Binary on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       # IMG_CACHE: ghcr.io/getsentry/symbolicator:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/symbolicator:${{ matrix.arch }}-${{ github.sha }}


### PR DESCRIPTION
Adjusts the "Release build" and "image" jobs to run on Ubuntu 20.04 instead of latest.

Fixes #1466.