### PR TITLE
fix: Don't persist cache files that error while writing

### DIFF
--- a/crates/symbolicator-js/src/sourcemap_cache.rs
+++ b/crates/symbolicator-js/src/sourcemap_cache.rs
@@ -104,6 +104,13 @@ fn write_sourcemap_cache(file: &mut File, source: &str, sourcemap: &str) -> Cach
     let file = writer.into_inner().map_err(io::Error::from)?;
     file.sync_all()?;
 
+    // Parse the sourcemapcache file to verify integrity
+    let bv = ByteView::map_file_ref(file)?;
+    if SourceMapCache::parse(&bv).is_err() {
+        tracing::error!("Failed to verify integrity of freshly written SourceMapCache");
+        return Err(CacheError::InternalError);
+    }
+
     Ok(())
 }
 

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -149,5 +149,12 @@ fn write_ppdb_cache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry
     let file = writer.into_inner().map_err(io::Error::from)?;
     file.sync_all()?;
 
+    // Parse the ppdbcache file to verify integrity
+    let bv = ByteView::map_file_ref(file)?;
+    if PortablePdbCache::parse(&bv).is_err() {
+        tracing::error!("Failed to verify integrity of freshly written PortablePDB Cache");
+        return Err(CacheError::InternalError);
+    }
+
     Ok(())
 }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -271,6 +271,13 @@ fn write_symcache(
     let file = writer.into_inner().map_err(io::Error::from)?;
     file.sync_all()?;
 
+    // Parse the symcache file to verify integrity
+    let bv = ByteView::map_file_ref(file)?;
+    if SymCache::parse(&bv).is_err() {
+        tracing::error!("Failed to verify integrity of freshly written SymCache");
+        return Err(CacheError::InternalError);
+    }
+
     Ok(())
 }
 

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -212,6 +212,12 @@ impl<T: CacheItemRequest> Cacher<T> {
                     let byte_view = ByteView::map_file_ref(temp_file.as_file())?;
                     entry = Ok(byte_view);
                 }
+                Err(CacheError::InternalError) => {
+                    // If there was an `InternalError` during computation (for instance because
+                    // of an io error), we return immediately without writing the error
+                    // or persisting the temp file.
+                    return Err(CacheError::InternalError);
+                }
                 Err(err) => {
                     let mut temp_fd = tokio::fs::File::from_std(temp_file.reopen()?);
                     err.write(&mut temp_fd).await?;

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::sleep;
@@ -916,4 +916,62 @@ async fn test_lazy_computation_limit() {
     }
 
     assert_eq!(num_outdated, 2);
+}
+
+/// A request to compute a cache item that always fails.
+#[derive(Clone, Default)]
+struct FailingTestCacheItem;
+
+impl CacheItemRequest for FailingTestCacheItem {
+    type Item = String;
+
+    const VERSIONS: CacheVersions = CacheVersions {
+        current: 1,
+        fallbacks: &[],
+    };
+
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+        Box::pin(async move {
+            fs::write(temp_file.path(), "garbage data")?;
+            Err(io::Error::from(io::ErrorKind::WriteZero))?
+        })
+    }
+
+    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+        Ok(std::str::from_utf8(data.as_slice()).unwrap().to_owned())
+    }
+}
+
+/// Verifies that an io error during computation results in the temporary
+/// file being discarded instead of persisted.
+#[tokio::test]
+async fn test_failing_cache_write() {
+    test::setup();
+    let cache_dir = test::tempdir();
+
+    let request = FailingTestCacheItem;
+    let key = CacheKey::for_testing("global/some_cache_key");
+
+    let config = Config {
+        cache_dir: Some(cache_dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let cache = Cache::from_config(
+        CacheName::Objects,
+        &config,
+        CacheConfig::from(CacheConfigs::default().derived),
+        Arc::new(AtomicIsize::new(1)),
+        1024,
+    )
+    .unwrap();
+    let cacher = Cacher::new(cache, Default::default());
+
+    // An `io::Error` during computation should be converted to an `InternalError`
+    let entry = cacher.compute_memoized(request, key.clone()).await;
+    assert!(matches!(entry, Err(CacheError::InternalError)));
+
+    // The computation returned an `io::Error`, so the file should not have been
+    // persisted
+    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path(1));
+    assert!(!fs::exists(cache_file_path).unwrap());
 }


### PR DESCRIPTION
This adds an early return in `memory.rs` so that if an `InternalError` is returned by a cache computation¹, we don't attempt to write the error and don't persist the temp file. This kills two birds with one stone:

1. It fixes the "Internal errors should never be written out" issue we see in Sentry.
2. More importantly, if a computation fails with an `InternalError` because of lack of disk space, we discard the resulting file immediately instead of preserving its (likely useless) contents.

Moreover, I also added some extra validation after `symcache`/`ppdbcache`/`sourcemapcache` conversion. Now, if _somehow_ the write goes through but the file is invalid, we also return an `InternalError` and it will be deleted. This costs us nothing because parsing these files is essentially free. I thought about doing the same for `cficache` files, but there the tradeoff is less clear—parsing them takes significant resources, for a case we don't know ever occurs.

¹ Caused by an `io::Error`, for instance.