### PR TITLE
fix(caching): Eagerly cleanup old versions

### DIFF
--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -447,7 +447,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             let value = (expiration.as_instant(), item);
 
             // refresh the memory cache with the newly refreshed result
-            this.cache.insert(cache_key.clone(), value).await;
+            this.cache.insert(cache_key, value).await;
 
             transaction.finish();
         };

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -439,15 +439,15 @@ impl<T: CacheItemRequest> Cacher<T> {
                 .cache_dir()
                 .expect("cache dir must exist if we're doing recomputations");
             for &version in T::VERSIONS.fallbacks {
-                let item_path = cache_dir.join(cache_key.cache_path(version));
+                let item_path = cache_key.cache_path(version);
 
-                if let Err(e) = fs::remove_file(&item_path) {
+                if let Err(e) = fs::remove_file(cache_dir.join(&item_path)) {
                     // `NotFound` errors are no cause for concern—it's likely that not all fallback versions exist anymore.
                     if e.kind() != std::io::ErrorKind::NotFound {
                         let dynerror = &e as &dyn std::error::Error;
                         tracing::error!(
                             error = dynerror,
-                            path = cache_key.cache_path(version),
+                            path = item_path,
                             "Failed to remove old cache file"
                         );
                     }

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -444,9 +444,8 @@ impl<T: CacheItemRequest> Cacher<T> {
                 if let Err(e) = fs::remove_file(cache_dir.join(&item_path)) {
                     // `NotFound` errors are no cause for concern—it's likely that not all fallback versions exist anymore.
                     if e.kind() != std::io::ErrorKind::NotFound {
-                        let dynerror = &e as &dyn std::error::Error;
                         tracing::error!(
-                            error = dynerror,
+                            error = &e as &dyn std::error::Error,
                             path = item_path,
                             "Failed to remove old cache file"
                         );

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -754,8 +754,8 @@ impl CacheItemRequest for TestCacheItem {
     type Item = String;
 
     const VERSIONS: CacheVersions = CacheVersions {
-        current: 1,
-        fallbacks: &[0],
+        current: 2,
+        fallbacks: &[1],
     };
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
@@ -784,7 +784,11 @@ async fn test_cache_fallback() {
     let request = TestCacheItem::new();
     let key = CacheKey::for_testing("global/some_cache_key");
 
-    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path(0));
+    let very_old_cache_file = cache_dir.path().join("objects").join(key.cache_path(0));
+    fs::create_dir_all(very_old_cache_file.parent().unwrap()).unwrap();
+    fs::write(&very_old_cache_file, "some incompatible cached contents").unwrap();
+
+    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path(1));
     fs::create_dir_all(old_cache_file.parent().unwrap()).unwrap();
     fs::write(&old_cache_file, "some old cached contents").unwrap();
 
@@ -816,7 +820,8 @@ async fn test_cache_fallback() {
     // we only want to have the actual computation be done a single time
     assert_eq!(request.computations.load(Ordering::SeqCst), 1);
 
-    // the old cache file should have been removed during the recomputation
+    // the old cache files should have been removed during the recomputation
+    assert!(!fs::exists(very_old_cache_file).unwrap());
     assert!(!fs::exists(old_cache_file).unwrap());
 }
 
@@ -831,11 +836,11 @@ async fn test_cache_fallback_notfound() {
 
     {
         let cache_dir = cache_dir.path().join("objects");
-        let cache_file = cache_dir.join(key.cache_path(0));
+        let cache_file = cache_dir.join(key.cache_path(1));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
-        let cache_file = cache_dir.join(key.cache_path(1));
+        let cache_file = cache_dir.join(key.cache_path(2));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "").unwrap();
     }
@@ -888,7 +893,7 @@ async fn test_lazy_computation_limit() {
         let request = request.clone();
         let key = CacheKey::for_testing(*key);
 
-        let cache_file = cache_dir.join(key.cache_path(0));
+        let cache_file = cache_dir.join(key.cache_path(1));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 


### PR DESCRIPTION
Currently, when we recompute a cache entry for which a fallback version exists, we just add the new version and leave the fallback in place. The idea was that the fallback version would fall out of use and *eventually* be cleaned up by the cleanup task.

While this is true, "eventually" is doing a lot of work here. In the immediate term, it's massively wasteful. Therefore, we now delete the fallback versions in `spawn_refresh` immediately after the new cache entry has been computed.

Fixes #1577.

ETA: Changed this to always deleting old versions on compute, not just on lazy recomputes. That way it also covers incompatible cache version bumps.