### PR TITLE
ref(js): Add instrumentation to JS file fetching

### DIFF
--- a/crates/symbolicator-js/src/api_lookup.rs
+++ b/crates/symbolicator-js/src/api_lookup.rs
@@ -106,6 +106,7 @@ impl SentryLookupApi {
 
     /// Look up a list of bundles or individual artifact files covering the
     /// `debug_ids` and `file_stems` (using the `release` + `dist`).
+    #[tracing::instrument(skip(self, debug_ids, file_stems))]
     pub async fn lookup_js_artifacts(
         &self,
         source: Arc<SentrySourceConfig>,

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -667,6 +667,7 @@ impl ArtifactFetcher {
     }
 
     /// Attempt to scrape a file from the web.
+    #[tracing::instrument(skip(self))]
     async fn scrape(&mut self, key: &FileKey) -> CachedFileEntry {
         let Some(abs_path) = key.abs_path() else {
             return CachedFileEntry::empty();
@@ -800,6 +801,7 @@ impl ArtifactFetcher {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     fn try_get_file_from_bundles(&mut self, key: &FileKey) -> Option<CachedFileEntry> {
         if self.artifact_bundles.is_empty() {
             return None;
@@ -889,6 +891,7 @@ impl ArtifactFetcher {
         None
     }
 
+    #[tracing::instrument(skip(self))]
     async fn try_fetch_file_from_artifacts(&mut self, key: &FileKey) -> Option<CachedFileEntry> {
         if self.individual_artifacts.is_empty() {
             return None;
@@ -940,6 +943,7 @@ impl ArtifactFetcher {
     /// Queries the Sentry API for a single file (by its [`DebugId`] and file stem).
     ///
     /// Returns `true` if any new data was made available through this API request.
+    #[tracing::instrument(skip(self))]
     async fn query_sentry_for_file(&mut self, key: &FileKey) -> bool {
         let mut debug_ids = BTreeSet::new();
         let mut file_stems = BTreeSet::new();
@@ -961,6 +965,7 @@ impl ArtifactFetcher {
     /// Individual files are not eagerly downloaded, but their metadata will be available.
     ///
     /// Returns `true` if any new data was made available through this API request.
+    #[tracing::instrument(skip_all)]
     async fn query_sentry_for_files(
         &mut self,
         debug_ids: BTreeSet<DebugId>,
@@ -1045,9 +1050,6 @@ impl ArtifactFetcher {
         resolved_with: ResolvedWith,
     ) -> bool {
         let uri = remote_file.uri();
-        // clippy, you are wrong, as this would result in borrowing errors,
-        // because we are calling a `self` method while borrowing from `self`
-        #[allow(clippy::map_entry)]
         if self.artifact_bundles.contains_key(&uri) {
             return false;
         }

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -104,6 +104,7 @@ impl ObjectsActor {
     ///
     /// This fetches the requested object, re-downloading it from the source if it is no
     /// longer in the cache.
+    #[tracing::instrument(skip_all, fields(file_source = ?file_handle.file_source))]
     pub async fn fetch(&self, file_handle: Arc<ObjectMetaHandle>) -> CacheEntry<Arc<ObjectHandle>> {
         let cache_key = CacheKey::from_scoped_file(&file_handle.scope, &file_handle.file_source);
         let request = FetchFileDataRequest(FetchFileMetaRequest {


### PR DESCRIPTION
This adds `tracing::instrument` calls to a number of functions in the code path of JS symbolication, specifically the fetching of sourcemaps/source files.