### PR TITLE
fix(s3): Demote S3 errors to debug

### DIFF
--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -164,19 +164,12 @@ impl S3Downloader {
                     _ if matches!(err.code(), Some("NoSuchBucket" | "NoSuchKey" | "NotFound")) => {
                         Err(CacheError::NotFound)
                     }
-                    // Log errors, filtering out some uninteresting ones.
-                    //
-                    // * PermanentRedirect is a user error.
-                    _ if !matches!(err.code(), Some("PermanentRedirect")) => {
-                        tracing::error!(
+                    _ => {
+                        tracing::debug!(
                             error = &err as &dyn std::error::Error,
                             "S3 request failed: {:?}",
                             err.code(),
                         );
-                        let details = err.to_string();
-                        Err(CacheError::DownloadError(details))
-                    }
-                    _ => {
                         let details = err.to_string();
                         Err(CacheError::DownloadError(details))
                     }


### PR DESCRIPTION
These errors show up in Sentry to no practical effect other than spam. We can keep adding exceptions every time we see an error we don't care about or we can make a clean slate and only log them at a low level. Note that they will still show up as download errors in users' events.