### PR TITLE
feat(devservices): Use new devservices for sentry integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
         uses: ./.github/actions/setup-sentry
         with:
           workdir: sentry
-          kafka: true
-          snuba: true
+          use-new-devservices: true
+          mode: minimal
 
       - name: Do the localhost docker dance
         run: echo "$DJANGO_LIVE_TEST_SERVER_ADDRESS host.docker.internal" | sudo tee --append /etc/hosts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions/
           cp -r sentry/.github/actions/setup-sentry .github/actions/
+          cd sentry
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
   test_against_latest_sentry:
     name: Sentry-Symbolicator Tests
     runs-on: ubuntu-latest
+    env:
+      USE_NEW_DEVSERVICES: 1
 
     steps:
       - name: Install libcurl-dev
@@ -92,7 +94,6 @@ jobs:
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions/
           cp -r sentry/.github/actions/setup-sentry .github/actions/
-          cd sentry
 
       - name: Setup Sentry
         uses: ./.github/actions/setup-sentry


### PR DESCRIPTION
As we get closer to the release of the revamped devservices, we want CI in symbolicator to use the new devservices when running integration tests. Especially since the older `sentry devservices` will be deprecated soon.

Using the changes from https://github.com/getsentry/sentry/pull/83415