### PR TITLE
ref(build): Switch LTO profile to thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ debug = 1
 [profile.release-lto]
 inherits = "release"
 codegen-units = 1
-lto = true
+lto = "thin"
 
 [profile.local]
 # For running a local symbolicator, we want the best of both worlds: a fast executable, with quick


### PR DESCRIPTION
Thin LTO to speed up the build. Going to have a look if performance noticeably changes, but from looking into it for Relay, there were no noticeable changes.