### PR TITLE
build: remove google cloud build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,0 @@
-steps:
-  - name: "gcr.io/cloud-builders/git"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - echo noop


### PR DESCRIPTION
The trigger is already gone, images are only built in github actions and pushed from github actions.