### PR TITLE
feat(ci): Use free arm64 runner

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: |-
       ${{fromJson('{
         "amd64": "ubuntu-20.04",
-        "arm64": "ubuntu-22.04-arm64-relay"
+        "arm64": "ubuntu-22.04-arm"
       }')[matrix.arch] }}
 
     env:


### PR DESCRIPTION
This PR uses the new free arm runners for CI.

Related to: https://github.com/getsentry/relay/pull/4465