### PR TITLE
chore(ci): Remove use new devservices flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
         uses: ./.github/actions/setup-sentry
         with:
           workdir: sentry
-          use-new-devservices: true
           mode: minimal
 
       - name: Do the localhost docker dance


### PR DESCRIPTION
This flag is now removed in https://github.com/getsentry/sentry/pull/84184, so removing this in all places that use it