### PR TITLE
instr(pdb): Upgrade warning to error

### DIFF
--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -125,7 +125,7 @@ fn write_ppdb_cache(file: &mut File, object_handle: &ObjectHandle) -> CacheEntry
     let ppdb_obj = match object_handle.object() {
         Object::PortablePdb(ppdb_obj) => ppdb_obj,
         _ => {
-            tracing::warn!("Trying to symbolicate a .NET event with a non-PPDB object file");
+            tracing::error!("Trying to symbolicate a .NET event with a non-PPDB object file");
             return Err(CacheError::Unsupported(
                 "Only portable PDB files can be used for .NET symbolication".to_owned(),
             ));


### PR DESCRIPTION
Temporarily update warning about .NET with Windows PDB to an error so we can aggregate by `request.scope` on the sentry error to see how many projects are affected.

ref: https://github.com/getsentry/symbolic/issues/871

#skip-changelog