### PR TITLE
feat: Add metadata to cache entries

### DIFF
--- a/crates/symbolicator-js/src/api_lookup.rs
+++ b/crates/symbolicator-js/src/api_lookup.rs
@@ -11,7 +11,7 @@ use symbolicator_service::download::sentry::{SearchQuery, SentryDownloader};
 use symbolicator_service::metric;
 use url::Url;
 
-use symbolicator_service::caching::{CacheEntry, CacheError};
+use symbolicator_service::caching::{CacheContents, CacheError};
 use symbolicator_service::config::InMemoryCacheConfig;
 use symbolicator_service::utils::futures::{m, measure, CancelOnDrop};
 use symbolicator_service::utils::http::DownloadTimeouts;
@@ -63,7 +63,7 @@ pub enum JsLookupResult {
 }
 
 /// An LRU Cache for Sentry JS Artifact lookups.
-type SentryJsCache = moka::future::Cache<SearchQuery, CacheEntry<Arc<[RawJsLookupResult]>>>;
+type SentryJsCache = moka::future::Cache<SearchQuery, CacheContents<Arc<[RawJsLookupResult]>>>;
 
 pub struct SentryLookupApi {
     client: reqwest::Client,
@@ -114,7 +114,7 @@ impl SentryLookupApi {
         file_stems: BTreeSet<String>,
         release: Option<&str>,
         dist: Option<&str>,
-    ) -> CacheEntry<Vec<JsLookupResult>> {
+    ) -> CacheContents<Vec<JsLookupResult>> {
         let mut lookup_url = source.url.clone();
         {
             let mut query = lookup_url.query_pairs_mut();

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -797,7 +797,7 @@ impl ArtifactFetcher {
             .fetch_file(&self.scope, remote_file, false)
             .await;
 
-        let entry = match scraped_file {
+        let entry = match scraped_file.into_contents() {
             Ok(contents) => {
                 self.metrics
                     .record_file_scraped(key.as_type(), key.debug_id().is_some());
@@ -947,7 +947,8 @@ impl ArtifactFetcher {
         let mut artifact_contents = self
             .sourcefiles_cache
             .fetch_file(&self.scope, artifact.remote_file.clone(), true)
-            .await;
+            .await
+            .into_contents();
 
         if artifact_contents == Err(CacheError::NotFound) && !artifact.headers.is_empty() {
             // We save (React Native) Hermes Bytecode files as empty 0-size files,
@@ -1171,7 +1172,10 @@ impl ArtifactFetcher {
                         source: source_content,
                         sourcemap,
                     };
-                    self.sourcemap_caches.compute_memoized(req, cache_key).await
+                    self.sourcemap_caches
+                        .compute_memoized(req, cache_key)
+                        .await
+                        .into_contents()
                 }
                 Err(err) => Err(err),
             },

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -42,7 +42,7 @@ use symbolicator_sources::{
 };
 
 use symbolicator_service::caches::{ByteViewString, SourceFilesCache};
-use symbolicator_service::caching::{CacheEntry, CacheError, CacheKey, CacheKeyBuilder, Cacher};
+use symbolicator_service::caching::{CacheContents, CacheError, CacheKey, CacheKeyBuilder, Cacher};
 use symbolicator_service::download::DownloadService;
 use symbolicator_service::objects::{ObjectHandle, ObjectMetaHandle, ObjectsActor};
 use symbolicator_service::types::{Scope, ScrapingConfig};
@@ -297,7 +297,7 @@ impl SourceMapUrl {
     ///
     /// If it starts with `"data:"`, it is parsed as a data-URL that is base64 or url-encoded.
     /// Otherwise, the string is joined to the `base` URL.
-    pub fn parse_with_prefix(base: &str, url_string: &str) -> CacheEntry<Self> {
+    pub fn parse_with_prefix(base: &str, url_string: &str) -> CacheContents<Self> {
         if url_string.starts_with("data:") {
             let decoded = data_url::DataUrl::process(url_string)
                 .map_err(|_| ())
@@ -413,7 +413,7 @@ impl fmt::Display for CachedFileUri {
 #[derive(Clone, Debug)]
 pub struct CachedFileEntry<T = CachedFile> {
     pub uri: CachedFileUri,
-    pub entry: CacheEntry<T>,
+    pub entry: CacheContents<T>,
     pub resolved_with: ResolvedWith,
 }
 
@@ -458,7 +458,7 @@ impl CachedFile {
     fn from_descriptor(
         abs_path: Option<&str>,
         descriptor: SourceFileDescriptor,
-    ) -> CacheEntry<Self> {
+    ) -> CacheContents<Self> {
         let sourcemap_url = match descriptor.source_mapping_url() {
             Some(url) => {
                 // `abs_path` here is expected to be the *absolute* `descriptor.url()`
@@ -513,7 +513,7 @@ struct IndividualArtifact {
     resolved_with: ResolvedWith,
 }
 
-pub type ArtifactBundles = BTreeMap<RemoteFileUri, CacheEntry<(ArtifactBundle, ResolvedWith)>>;
+pub type ArtifactBundles = BTreeMap<RemoteFileUri, CacheContents<(ArtifactBundle, ResolvedWith)>>;
 
 struct ArtifactFetcher {
     metrics: JsMetrics,
@@ -1099,7 +1099,7 @@ impl ArtifactFetcher {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn fetch_artifact_bundle(&self, file: RemoteFile) -> CacheEntry<ArtifactBundle> {
+    async fn fetch_artifact_bundle(&self, file: RemoteFile) -> CacheContents<ArtifactBundle> {
         let object_handle = ObjectMetaHandle::for_scoped_file(self.scope.clone(), file);
 
         let fetched_bundle = self.objects.fetch(object_handle).await?;
@@ -1196,7 +1196,7 @@ impl ArtifactFetcher {
 
 /// This opens `artifact_bundle` [`Object`], ensuring that it is a [`SourceBundle`](`Object::SourceBundle`),
 /// and opening up a debug session to it.
-pub fn open_bundle(artifact_bundle: Arc<ObjectHandle>) -> CacheEntry<ArtifactBundle> {
+pub fn open_bundle(artifact_bundle: Arc<ObjectHandle>) -> CacheContents<ArtifactBundle> {
     SelfCell::try_new(artifact_bundle, |handle| unsafe {
         match (*handle).object() {
             Object::SourceBundle(source_bundle) => source_bundle

--- a/crates/symbolicator-native/src/caches/bitcode.rs
+++ b/crates/symbolicator-native/src/caches/bitcode.rs
@@ -233,6 +233,8 @@ impl BitcodeService {
         });
 
         let all_results = future::join_all(fetch_jobs).await;
-        all_results.into_iter().find_map(Result::ok)
+        all_results
+            .into_iter()
+            .find_map(|cache_entry| cache_entry.into_contents().ok())
     }
 }

--- a/crates/symbolicator-native/src/caches/cficaches.rs
+++ b/crates/symbolicator-native/src/caches/cficaches.rs
@@ -159,7 +159,11 @@ impl CfiCacheActor {
                 meta_handle,
             };
             async {
-                let entry = self.cficaches.compute_memoized(request, cache_key).await;
+                let entry = self
+                    .cficaches
+                    .compute_memoized(request, cache_key)
+                    .await
+                    .into_contents();
 
                 entry.map(|item| item.1)
             }

--- a/crates/symbolicator-native/src/caches/derived.rs
+++ b/crates/symbolicator-native/src/caches/derived.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use symbolicator_service::caching::{CacheEntry, CacheError};
+use symbolicator_service::caching::{CacheContents, CacheError};
 use symbolicator_service::objects::{
     AllObjectCandidates, CandidateStatus, FindResult, ObjectFeatures, ObjectMetaHandle,
     ObjectUseInfo,
@@ -8,11 +8,11 @@ use symbolicator_service::objects::{
 
 /// This is the result of fetching a derived cache file.
 ///
-/// This has the requested [`CacheEntry`], as well as [`AllObjectCandidates`] that were considered
+/// This has the requested [`CacheContents`], as well as [`AllObjectCandidates`] that were considered
 /// and the [`ObjectFeatures`] of the primarily used object file.
 #[derive(Clone, Debug)]
 pub struct DerivedCache<T> {
-    pub cache: CacheEntry<T>,
+    pub cache: CacheContents<T>,
     pub candidates: AllObjectCandidates,
     pub features: ObjectFeatures,
 }
@@ -33,7 +33,7 @@ pub async fn derive_from_object_handle<T, Derive, Fut>(
 where
     T: Clone,
     Derive: FnOnce(Arc<ObjectMetaHandle>) -> Fut,
-    Fut: std::future::Future<Output = CacheEntry<T>>,
+    Fut: std::future::Future<Output = CacheContents<T>>,
 {
     let Some(meta) = meta else {
         return DerivedCache {

--- a/crates/symbolicator-native/src/caches/il2cpp.rs
+++ b/crates/symbolicator-native/src/caches/il2cpp.rs
@@ -149,6 +149,8 @@ impl Il2cppService {
         });
 
         let all_results = future::join_all(fetch_jobs).await;
-        all_results.into_iter().find_map(Result::ok)
+        all_results
+            .into_iter()
+            .find_map(|cache_entry| cache_entry.into_contents().ok())
     }
 }

--- a/crates/symbolicator-native/src/caches/il2cpp.rs
+++ b/crates/symbolicator-native/src/caches/il2cpp.rs
@@ -12,7 +12,7 @@ use symbolic::common::{ByteView, DebugId};
 use symbolic::il2cpp::LineMapping;
 use symbolicator_service::caches::versions::IL2CPP_CACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
     SharedCacheRef,
 };
 use symbolicator_service::download::{fetch_file, DownloadService};
@@ -52,7 +52,7 @@ struct FetchFileRequest {
 
 impl FetchFileRequest {
     #[tracing::instrument(skip_all)]
-    async fn fetch_il2cpp(&self, temp_file: &mut NamedTempFile) -> CacheEntry {
+    async fn fetch_il2cpp(&self, temp_file: &mut NamedTempFile) -> CacheContents {
         fetch_file(
             Arc::clone(&self.download_svc),
             self.file_source.clone(),
@@ -80,11 +80,11 @@ impl CacheItemRequest for FetchFileRequest {
     /// Downloads a file, writing it to `path`.
     ///
     /// Only when [`Ok`] is returned is the data written to `path` used.
-    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
         Box::pin(self.fetch_il2cpp(temp_file))
     }
 
-    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
         Ok(Il2cppHandle {
             file: self.file_source.clone(),
             data,

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -65,13 +65,16 @@ impl PortablePdbCacheActor {
                 purpose: ObjectPurpose::Debug,
             })
             .await;
-        derive_from_object_handle(found_object, CandidateStatus::Debug, |object_meta| {
+        derive_from_object_handle(found_object, CandidateStatus::Debug, |object_meta| async {
             let cache_key = object_meta.cache_key();
             let request = FetchPortablePdbCacheInternal {
                 objects_actor: self.objects.clone(),
                 object_meta,
             };
-            self.ppdb_caches.compute_memoized(request, cache_key)
+            self.ppdb_caches
+                .compute_memoized(request, cache_key)
+                .await
+                .into_contents()
         })
         .await
     }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -190,7 +190,10 @@ impl SymCacheActor {
                 secondary_sources,
                 object_meta: Arc::clone(&handle),
             };
-            self.symcaches.compute_memoized(request, cache_key).await
+            self.symcaches
+                .compute_memoized(request, cache_key)
+                .await
+                .into_contents()
         })
         .await
     }

--- a/crates/symbolicator-native/src/symbolication/process_minidump.rs
+++ b/crates/symbolicator-native/src/symbolication/process_minidump.rs
@@ -33,7 +33,7 @@ use crate::interface::{
 use crate::metrics::StacktraceOrigin;
 
 use super::minidump_stacktraces::parse_stacktraces_from_minidump;
-use super::module_lookup::object_file_status_from_cache_entry;
+use super::module_lookup::object_file_status_from_cache_contents;
 use super::symbolicate::SymbolicationActor;
 
 type Minidump = minidump::Minidump<'static, ByteView<'static>>;
@@ -407,7 +407,7 @@ async fn stackwalk(
                     }
                 }
 
-                object_file_status_from_cache_entry(&cfi_module.cache)
+                object_file_status_from_cache_contents(&cfi_module.cache)
             }
             _ => ObjectFileStatus::Unused,
         };

--- a/crates/symbolicator-native/src/symbolication/source_context.rs
+++ b/crates/symbolicator-native/src/symbolication/source_context.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use futures::future;
-use symbolicator_service::caching::{CacheEntry, CacheError};
+use symbolicator_service::caching::{CacheContents, CacheError};
 use symbolicator_service::objects::{
     ObjectCandidate, ObjectDownloadInfo, ObjectFeatures, ObjectUseInfo,
 };
@@ -95,7 +95,7 @@ impl SymbolicationActor {
     // source file from a link.
     fn object_candidate_for_sourcelink<T>(
         location: RemoteFileUri,
-        res: CacheEntry<T>,
+        res: CacheContents<T>,
     ) -> ObjectCandidate {
         let source = SourceId::new("sourcelink");
         let unwind = ObjectUseInfo::None;

--- a/crates/symbolicator-native/src/symbolication/source_context.rs
+++ b/crates/symbolicator-native/src/symbolication/source_context.rs
@@ -68,7 +68,8 @@ impl SymbolicationActor {
                     let uri = remote_file.uri();
                     let res = cache
                         .fetch_file(&source_scope, remote_file.into(), true)
-                        .await;
+                        .await
+                        .into_contents();
 
                     if let Ok(source) = res.as_ref() {
                         for frame in frames {

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -6,7 +6,7 @@ use proguard::ProguardCache;
 use symbolic::common::{AsSelf, ByteView, DebugId, SelfCell};
 use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
 use symbolicator_service::caching::{
-    CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
 };
 use symbolicator_service::download::{fetch_file, tempfile_in_parent, DownloadService};
 use symbolicator_service::objects::{
@@ -48,7 +48,7 @@ impl ProguardService {
         sources: &[SourceConfig],
         scope: &Scope,
         debug_id: DebugId,
-    ) -> CacheEntry<OwnedProguardCache> {
+    ) -> CacheContents<OwnedProguardCache> {
         let identifier = ObjectId {
             debug_id: Some(debug_id),
             ..Default::default()
@@ -82,7 +82,7 @@ impl ProguardService {
         sources: Arc<[SourceConfig]>,
         scope: &Scope,
         debug_id: DebugId,
-    ) -> CacheEntry<Arc<ObjectHandle>> {
+    ) -> CacheContents<Arc<ObjectHandle>> {
         let identifier = ObjectId {
             debug_id: Some(debug_id),
             ..Default::default()
@@ -155,7 +155,7 @@ impl CacheItemRequest for FetchProguard {
 
     const VERSIONS: CacheVersions = PROGUARD_CACHE_VERSIONS;
 
-    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
         let fut = async {
             fetch_file(self.download_svc.clone(), self.file.clone(), temp_file).await?;
 
@@ -183,7 +183,7 @@ impl CacheItemRequest for FetchProguard {
         Box::pin(fut)
     }
 
-    fn load(&self, byteview: ByteView<'static>) -> CacheEntry<Self::Item> {
+    fn load(&self, byteview: ByteView<'static>) -> CacheContents<Self::Item> {
         OwnedProguardCache::new(byteview)
     }
 

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -69,7 +69,10 @@ impl ProguardService {
             download_svc: Arc::clone(&self.download_svc),
         };
 
-        self.cache.compute_memoized(request, cache_key).await
+        self.cache
+            .compute_memoized(request, cache_key)
+            .await
+            .into_contents()
     }
 
     /// Downloads a source bundle for the given scope and debug id.

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -7,8 +7,8 @@ use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher, MdCacheEntry,
-    SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    MdCacheEntry, SharedCacheRef,
 };
 use crate::download::{fetch_file, DownloadService};
 use crate::types::Scope;
@@ -101,7 +101,7 @@ impl CacheItemRequest for FetchFileRequest {
 
     const VERSIONS: CacheVersions = SOURCEFILES_CACHE_VERSIONS;
 
-    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
         let fut = async {
             fetch_file(self.download_svc.clone(), self.file.clone(), temp_file).await?;
 
@@ -113,7 +113,7 @@ impl CacheItemRequest for FetchFileRequest {
         Box::pin(fut)
     }
 
-    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
         let inner = SelfCell::try_new(data, |s| unsafe {
             std::str::from_utf8(&*s).map_err(|err| CacheError::Malformed(err.to_string()))
         })?;

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -7,8 +7,8 @@ use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
-    MdCacheEntry, SharedCacheRef,
+    Cache, CacheContents, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions,
+    Cacher, SharedCacheRef,
 };
 use crate::download::{fetch_file, DownloadService};
 use crate::types::Scope;
@@ -76,7 +76,7 @@ impl SourceFilesCache {
         scope: &Scope,
         file: RemoteFile,
         use_shared_cache: bool,
-    ) -> MdCacheEntry<ByteViewString> {
+    ) -> CacheEntry<ByteViewString> {
         let cache_key = CacheKey::from_scoped_file(scope, &file);
 
         let request = FetchFileRequest {

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -7,7 +7,7 @@ use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
 use crate::caching::{
-    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    Cache, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher, MdCacheEntry,
     SharedCacheRef,
 };
 use crate::download::{fetch_file, DownloadService};
@@ -76,7 +76,7 @@ impl SourceFilesCache {
         scope: &Scope,
         file: RemoteFile,
         use_shared_cache: bool,
-    ) -> CacheEntry<ByteViewString> {
+    ) -> MdCacheEntry<ByteViewString> {
         let cache_key = CacheKey::from_scoped_file(scope, &file);
 
         let request = FetchFileRequest {

--- a/crates/symbolicator-service/src/caching/cache_error.rs
+++ b/crates/symbolicator-service/src/caching/cache_error.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::time::Duration;
 
 use humantime_serde::re::humantime::{format_duration, parse_duration};
+use serde::{Deserialize, Serialize};
 use symbolic::common::ByteView;
 use thiserror::Error;
 use tokio::fs::File;
@@ -12,7 +13,7 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 ///
 /// This error enum is intended for persisting in caches, except for the
 /// [`InternalError`](Self::InternalError) variant.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum CacheError {
     /// The object was not found at the remote source.
     #[error("not found")]
@@ -180,9 +181,9 @@ fn utf8_message(raw_message: &[u8]) -> Cow<'_, str> {
 
 /// An entry in a cache, containing either `Ok(T)` or an error denoting the reason why an
 /// object could not be fetched or is otherwise unusable.
-pub type CacheEntry<T = ()> = Result<T, CacheError>;
+pub type CacheContents<T = ()> = Result<T, CacheError>;
 
-/// Parses a [`CacheEntry`] from a [`ByteView`].
-pub fn cache_entry_from_bytes(bytes: ByteView<'static>) -> CacheEntry<ByteView<'static>> {
+/// Parses a [`CacheContents`] from a [`ByteView`].
+pub fn cache_contents_from_bytes(bytes: ByteView<'static>) -> CacheContents<ByteView<'static>> {
     CacheError::from_bytes(&bytes).map(Err).unwrap_or(Ok(bytes))
 }

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -10,6 +10,7 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 
+use super::metadata::MdCacheEntry;
 use super::shared_cache::{CacheStoreReason, SharedCacheRef};
 use crate::utils::futures::CallOnDrop;
 
@@ -22,7 +23,7 @@ struct InMemoryItem<T> {
     /// in-memory cache.
     deadline: Instant,
     /// The actual data.
-    data: CacheEntry<T>,
+    data: MdCacheEntry<T>,
 }
 
 impl<T> InMemoryItem<T> {
@@ -135,6 +136,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             .weigher(|_k, v| {
                 let value_size = v
                     .data
+                    .contents()
                     .as_ref()
                     .map_or(0, T::weight)
                     .max(std::mem::size_of::<CacheError>() as u32);
@@ -338,7 +340,7 @@ impl<T: CacheItemRequest> Cacher<T> {
     ///
     /// Cache computation can fail, in which case [`T::compute`](CacheItemRequest::compute)
     /// will return an `Err`. This err may be persisted in the cache for a time.
-    pub async fn compute_memoized(&self, request: T, cache_key: CacheKey) -> CacheEntry<T::Item> {
+    pub async fn compute_memoized(&self, request: T, cache_key: CacheKey) -> MdCacheEntry<T::Item> {
         let name = self.config.name();
         metric!(counter("caches.access") += 1, "cache" => name.as_ref());
 
@@ -364,6 +366,7 @@ impl<T: CacheItemRequest> Cacher<T> {
                             let data = Err(err);
                             let deadline =
                                 ExpirationTime::for_fresh_status(&self.config, &data).as_instant();
+                            let data = MdCacheEntry::without_md(data);
                             return InMemoryItem { deadline, data };
                         }
                         Ok(item) => item.and_then(|byteview| request.load(byteview)),
@@ -400,6 +403,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
             // we just created a fresh cache, so use the initial expiration times
             let expiration = ExpirationTime::for_fresh_status(&self.config, &data);
+            let data = MdCacheEntry::without_md(data);
 
             InMemoryItem {
                 deadline: expiration.as_instant(),
@@ -473,7 +477,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             let expiration = ExpirationTime::for_fresh_status(&this.config, &item);
             let value = InMemoryItem {
                 deadline: expiration.as_instant(),
-                data: item,
+                data: MdCacheEntry::without_md(item),
             };
 
             // refresh the memory cache with the newly refreshed result
@@ -540,7 +544,7 @@ fn lookup_local_cache(
 
     Ok(InMemoryItem {
         deadline: expiration.as_instant(),
-        data: entry,
+        data: MdCacheEntry::without_md(entry),
     })
 }
 

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -366,7 +366,7 @@ impl<T: CacheItemRequest> Cacher<T> {
                             let data = Err(err);
                             let deadline =
                                 ExpirationTime::for_fresh_status(&self.config, &data).as_instant();
-                            let data = MdCacheEntry::without_md(data);
+                            let data = MdCacheEntry::without_metadata(data);
                             return InMemoryItem { deadline, data };
                         }
                         Ok(item) => item.and_then(|byteview| request.load(byteview)),
@@ -403,7 +403,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
             // we just created a fresh cache, so use the initial expiration times
             let expiration = ExpirationTime::for_fresh_status(&self.config, &data);
-            let data = MdCacheEntry::without_md(data);
+            let data = MdCacheEntry::without_metadata(data);
 
             InMemoryItem {
                 deadline: expiration.as_instant(),
@@ -477,7 +477,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             let expiration = ExpirationTime::for_fresh_status(&this.config, &item);
             let value = InMemoryItem {
                 deadline: expiration.as_instant(),
-                data: MdCacheEntry::without_md(item),
+                data: MdCacheEntry::without_metadata(item),
             };
 
             // refresh the memory cache with the newly refreshed result
@@ -544,7 +544,7 @@ fn lookup_local_cache(
 
     Ok(InMemoryItem {
         deadline: expiration.as_instant(),
-        data: MdCacheEntry::without_md(entry),
+        data: MdCacheEntry::without_metadata(entry),
     })
 }
 

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -23,7 +23,7 @@ pub struct MdCacheEntry<T> {
 
 impl<T> MdCacheEntry<T> {
     /// Create a cache entry without attached metadata.
-    pub(crate) fn without_md(contents: CacheEntry<T>) -> Self {
+    pub(crate) fn without_metadata(contents: CacheEntry<T>) -> Self {
         Self {
             metadata: None,
             contents,

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::Scope;
 
-use super::CacheEntry;
+use super::CacheContents;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Metadata {
@@ -18,12 +18,12 @@ pub struct MdCacheEntry<T> {
     /// Metadata attached to this cache entry.
     pub(crate) metadata: Option<Metadata>,
     /// The cache entry itself.
-    pub(crate) contents: CacheEntry<T>,
+    pub(crate) contents: CacheContents<T>,
 }
 
 impl<T> MdCacheEntry<T> {
     /// Create a cache entry without attached metadata.
-    pub(crate) fn without_metadata(contents: CacheEntry<T>) -> Self {
+    pub(crate) fn without_metadata(contents: CacheContents<T>) -> Self {
         Self {
             metadata: None,
             contents,
@@ -44,7 +44,7 @@ impl<T> MdCacheEntry<T> {
     /// Maps a fallible function over this entry's contents.
     pub fn and_then<U, F>(self, f: F) -> MdCacheEntry<U>
     where
-        F: FnOnce(T) -> CacheEntry<U>,
+        F: FnOnce(T) -> CacheContents<U>,
     {
         MdCacheEntry {
             metadata: self.metadata,
@@ -58,12 +58,12 @@ impl<T> MdCacheEntry<T> {
     }
 
     /// Returns a reference to this entry's contents.
-    pub fn contents(&self) -> &CacheEntry<T> {
+    pub fn contents(&self) -> &CacheContents<T> {
         &self.contents
     }
 
     /// Consumes this entry and returns the contents.
-    pub fn into_contents(self) -> CacheEntry<T> {
+    pub fn into_contents(self) -> CacheContents<T> {
         self.contents
     }
 }

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -1,0 +1,69 @@
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::Scope;
+
+use super::CacheEntry;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Metadata {
+    pub scope: Scope,
+    pub time_created: SystemTime,
+}
+
+/// A cache entry with optional metadata.
+#[derive(Debug, Clone)]
+pub struct MdCacheEntry<T> {
+    /// Metadata attached to this cache entry.
+    pub(crate) metadata: Option<Metadata>,
+    /// The cache entry itself.
+    pub(crate) contents: CacheEntry<T>,
+}
+
+impl<T> MdCacheEntry<T> {
+    /// Create a cache entry without attached metadata.
+    pub(crate) fn without_md(contents: CacheEntry<T>) -> Self {
+        Self {
+            metadata: None,
+            contents,
+        }
+    }
+
+    /// Maps a function over this entry's contents.
+    pub fn map<U, F>(self, f: F) -> MdCacheEntry<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        MdCacheEntry {
+            metadata: self.metadata,
+            contents: self.contents.map(f),
+        }
+    }
+
+    /// Maps a fallible function over this entry's contents.
+    pub fn and_then<U, F>(self, f: F) -> MdCacheEntry<U>
+    where
+        F: FnOnce(T) -> CacheEntry<U>,
+    {
+        MdCacheEntry {
+            metadata: self.metadata,
+            contents: self.contents.and_then(f),
+        }
+    }
+
+    /// Returns this entry's metadata.
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
+    }
+
+    /// Returns a reference to this entry's contents.
+    pub fn contents(&self) -> &CacheEntry<T> {
+        &self.contents
+    }
+
+    /// Consumes this entry and returns the contents.
+    pub fn into_contents(self) -> CacheEntry<T> {
+        self.contents
+    }
+}

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -14,14 +14,14 @@ pub struct Metadata {
 
 /// A cache entry with optional metadata.
 #[derive(Debug, Clone)]
-pub struct MdCacheEntry<T> {
+pub struct CacheEntry<T> {
     /// Metadata attached to this cache entry.
     pub(crate) metadata: Option<Metadata>,
     /// The cache entry itself.
     pub(crate) contents: CacheContents<T>,
 }
 
-impl<T> MdCacheEntry<T> {
+impl<T> CacheEntry<T> {
     /// Create a cache entry without attached metadata.
     pub(crate) fn without_metadata(contents: CacheContents<T>) -> Self {
         Self {
@@ -31,22 +31,22 @@ impl<T> MdCacheEntry<T> {
     }
 
     /// Maps a function over this entry's contents.
-    pub fn map<U, F>(self, f: F) -> MdCacheEntry<U>
+    pub fn map<U, F>(self, f: F) -> CacheEntry<U>
     where
         F: FnOnce(T) -> U,
     {
-        MdCacheEntry {
+        CacheEntry {
             metadata: self.metadata,
             contents: self.contents.map(f),
         }
     }
 
     /// Maps a fallible function over this entry's contents.
-    pub fn and_then<U, F>(self, f: F) -> MdCacheEntry<U>
+    pub fn and_then<U, F>(self, f: F) -> CacheEntry<U>
     where
         F: FnOnce(T) -> CacheContents<U>,
     {
-        MdCacheEntry {
+        CacheEntry {
             metadata: self.metadata,
             contents: self.contents.and_then(f),
         }

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -78,9 +78,9 @@
 //! configuration is done by providing a GCS bucket and `service_account_path`. A file-system based
 //! shared cache implementation exists for testing purposes.
 //!
-//! ## [`CacheEntry`] / [`CacheError`]
+//! ## [`CacheContents`] / [`CacheError`]
 //!
-//! The caching layer primarily deals with [`CacheEntry`]s, which are just an alias for a [`Result`]
+//! The caching layer primarily deals with [`CacheContents`]s, which are just an alias for a [`Result`]
 //! around a [`CacheError`].
 //!
 //! [`CacheError`] encodes opaque errors, most of which happen during downloading of files. These
@@ -135,7 +135,7 @@
 //! This file is a `&mut` reference, and one might use [`std::mem::swap`] to replace it with a
 //! newly created temporary file.
 //! Once the file is written, it is considered to be immutable, and loadable synchronously via the
-//! [`CacheItemRequest::load`] method. This function returns a [`CacheEntry`] and is theoretically
+//! [`CacheItemRequest::load`] method. This function returns a [`CacheContents`] and is theoretically
 //! fallible. However, failing to load a previously written cache file in most cases should be
 //! considered a [`CacheError::InternalError`], and is unexpected to occur.
 //!
@@ -167,7 +167,7 @@ mod shared_cache;
 #[cfg(test)]
 mod tests;
 
-pub use cache_error::{CacheEntry, CacheError};
+pub use cache_error::{CacheContents, CacheError};
 pub use cache_key::{CacheKey, CacheKeyBuilder};
 pub use cleanup::cleanup;
 pub use config::CacheName;

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -162,6 +162,7 @@ mod cleanup;
 mod config;
 mod fs;
 mod memory;
+mod metadata;
 mod shared_cache;
 #[cfg(test)]
 mod tests;
@@ -172,6 +173,7 @@ pub use cleanup::cleanup;
 pub use config::CacheName;
 pub use fs::{Cache, ExpirationStrategy, ExpirationTime};
 pub use memory::{CacheItemRequest, CacheVersions, Cacher};
+pub use metadata::{MdCacheEntry, Metadata};
 pub use shared_cache::{CacheStoreReason, SharedCacheConfig, SharedCacheRef, SharedCacheService};
 
 pub struct Caches {

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -173,7 +173,7 @@ pub use cleanup::cleanup;
 pub use config::CacheName;
 pub use fs::{Cache, ExpirationStrategy, ExpirationTime};
 pub use memory::{CacheItemRequest, CacheVersions, Cacher};
-pub use metadata::{MdCacheEntry, Metadata};
+pub use metadata::{CacheEntry, Metadata};
 pub use shared_cache::{CacheStoreReason, SharedCacheConfig, SharedCacheRef, SharedCacheService};
 
 pub struct Caches {

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -17,7 +17,7 @@ use crate::config::{
 };
 use crate::test;
 
-use super::cache_error::cache_entry_from_bytes;
+use super::cache_error::cache_contents_from_bytes;
 use super::shared_cache::config::SharedCacheBackendConfig;
 use super::*;
 
@@ -251,7 +251,7 @@ fn test_cleanup_cache_download() -> Result<()> {
 
 fn expiration_strategy(path: &Path) -> io::Result<ExpirationStrategy> {
     let bv = ByteView::open(path)?;
-    let cache_entry = cache_entry_from_bytes(bv);
+    let cache_entry = cache_contents_from_bytes(bv);
     Ok(super::fs::expiration_strategy(&cache_entry))
 }
 
@@ -685,20 +685,20 @@ fn test_shared_cache_config_gcs() {
 }
 
 #[test]
-fn test_cache_entry() {
-    fn read_cache_entry(bytes: &'static [u8]) -> CacheEntry<String> {
-        cache_entry_from_bytes(ByteView::from_slice(bytes))
+fn test_cache_contents() {
+    fn read_cache_contents(bytes: &'static [u8]) -> CacheContents<String> {
+        cache_contents_from_bytes(ByteView::from_slice(bytes))
             .map(|bv| String::from_utf8_lossy(bv.as_slice()).into_owned())
     }
 
     let not_found = b"";
 
-    assert_eq!(read_cache_entry(not_found), Err(CacheError::NotFound));
+    assert_eq!(read_cache_contents(not_found), Err(CacheError::NotFound));
 
     let malformed = b"malformedDoesn't look like anything to me";
 
     assert_eq!(
-        read_cache_entry(malformed),
+        read_cache_contents(malformed),
         Err(CacheError::Malformed(
             "Doesn't look like anything to me".into()
         ))
@@ -707,14 +707,14 @@ fn test_cache_entry() {
     let timeout = b"timeout4m33s";
 
     assert_eq!(
-        read_cache_entry(timeout),
+        read_cache_contents(timeout),
         Err(CacheError::Timeout(Duration::from_secs(273)))
     );
 
     let download_error = b"downloaderrorSomeone unplugged the internet";
 
     assert_eq!(
-        read_cache_entry(download_error),
+        read_cache_contents(download_error),
         Err(CacheError::DownloadError(
             "Someone unplugged the internet".into()
         ))
@@ -723,7 +723,7 @@ fn test_cache_entry() {
     let permission_denied = b"permissiondeniedI'm sorry Dave, I'm afraid I can't do that";
 
     assert_eq!(
-        read_cache_entry(permission_denied),
+        read_cache_contents(permission_denied),
         Err(CacheError::PermissionDenied(
             "I'm sorry Dave, I'm afraid I can't do that".into()
         ))
@@ -732,7 +732,7 @@ fn test_cache_entry() {
     let all_good = b"Not any of the error cases";
 
     assert_eq!(
-        read_cache_entry(all_good),
+        read_cache_contents(all_good),
         Ok("Not any of the error cases".into())
     );
 }
@@ -758,7 +758,7 @@ impl CacheItemRequest for TestCacheItem {
         fallbacks: &[1],
     };
 
-    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
         self.computations.fetch_add(1, Ordering::SeqCst);
 
         Box::pin(async move {
@@ -769,7 +769,7 @@ impl CacheItemRequest for TestCacheItem {
         })
     }
 
-    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
         Ok(std::str::from_utf8(data.as_slice()).unwrap().to_owned())
     }
 }
@@ -947,14 +947,14 @@ impl CacheItemRequest for FailingTestCacheItem {
         fallbacks: &[],
     };
 
-    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheEntry> {
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
         Box::pin(async move {
             fs::write(temp_file.path(), "garbage data")?;
             Err(self.0.clone())
         })
     }
 
-    fn load(&self, data: ByteView<'static>) -> CacheEntry<Self::Item> {
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
         Ok(std::str::from_utf8(data.as_slice()).unwrap().to_owned())
     }
 }

--- a/crates/symbolicator-service/src/download/fetch_file.rs
+++ b/crates/symbolicator-service/src/download/fetch_file.rs
@@ -6,7 +6,7 @@ use tempfile::NamedTempFile;
 
 use super::compression::maybe_decompress_file;
 use super::DownloadService;
-use crate::caching::{CacheEntry, CacheError};
+use crate::caching::{CacheContents, CacheError};
 
 /// Downloads the gives [`RemoteFile`] and decompresses it.
 ///
@@ -19,7 +19,7 @@ pub async fn fetch_file(
     downloader: Arc<DownloadService>,
     file_id: RemoteFile,
     temp_file: &mut NamedTempFile,
-) -> CacheEntry {
+) -> CacheContents {
     downloader
         .download(file_id, temp_file.path().to_owned())
         .await?;

--- a/crates/symbolicator-service/src/download/filesystem.rs
+++ b/crates/symbolicator-service/src/download/filesystem.rs
@@ -8,7 +8,7 @@ use tokio::fs::File;
 
 use symbolicator_sources::FilesystemRemoteFile;
 
-use crate::caching::{CacheEntry, CacheError};
+use crate::caching::{CacheContents, CacheError};
 
 /// Downloader implementation that supports the filesystem source.
 #[derive(Debug)]
@@ -24,7 +24,7 @@ impl FilesystemDownloader {
         &self,
         file_source: &FilesystemRemoteFile,
         destination: &mut File,
-    ) -> CacheEntry {
+    ) -> CacheContents {
         let path = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", path);
 

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -5,7 +5,7 @@ use reqwest::{header, Client};
 use symbolicator_sources::HttpRemoteFile;
 use tokio::fs::File;
 
-use crate::caching::{CacheEntry, CacheError};
+use crate::caching::{CacheContents, CacheError};
 use crate::utils::http::DownloadTimeouts;
 
 use super::USER_AGENT;
@@ -33,7 +33,7 @@ impl HttpDownloader {
         source_name: &str,
         file_source: &HttpRemoteFile,
         destination: &mut File,
-    ) -> CacheEntry {
+    ) -> CacheContents {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 
         tracing::debug!("Fetching debug file from `{}`", download_url);

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -15,7 +15,7 @@ use futures::TryStreamExt as _;
 use symbolicator_sources::{AwsCredentialsProvider, S3Region, S3RemoteFile, S3SourceKey};
 use tokio::fs::File;
 
-use crate::caching::{CacheEntry, CacheError};
+use crate::caching::{CacheContents, CacheError};
 use crate::utils::http::DownloadTimeouts;
 
 use super::content_length_timeout;
@@ -102,7 +102,7 @@ impl S3Downloader {
         source_name: &str,
         file_source: &S3RemoteFile,
         destination: &mut File,
-    ) -> CacheEntry {
+    ) -> CacheContents {
         let key = file_source.key();
         let bucket = file_source.bucket();
         tracing::debug!("Fetching from s3: {} (from {})", &key, &bucket);

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -17,7 +17,7 @@ use symbolicator_sources::{
 };
 
 use super::{FileType, USER_AGENT};
-use crate::caching::{CacheEntry, CacheError};
+use crate::caching::{CacheContents, CacheError};
 use crate::config::InMemoryCacheConfig;
 use crate::utils::futures::{m, measure, CancelOnDrop};
 use crate::utils::http::DownloadTimeouts;
@@ -82,7 +82,7 @@ pub struct SearchQuery {
 }
 
 /// An LRU Cache for Sentry DIF (Native Debug Files) lookups.
-type SentryDifCache = moka::future::Cache<SearchQuery, CacheEntry<Arc<[SearchResult]>>>;
+type SentryDifCache = moka::future::Cache<SearchQuery, CacheContents<Arc<[SearchResult]>>>;
 
 pub struct SentryDownloader {
     client: reqwest::Client,
@@ -129,7 +129,7 @@ impl SentryDownloader {
         client: &reqwest::Client,
         query: &SearchQuery,
         propagate_traces: bool,
-    ) -> CacheEntry<Arc<[T]>>
+    ) -> CacheContents<Arc<[T]>>
     where
         T: DeserializeOwned,
     {
@@ -164,7 +164,7 @@ impl SentryDownloader {
         source: Arc<SentrySourceConfig>,
         object_id: &ObjectId,
         file_types: &[FileType],
-    ) -> CacheEntry<Vec<RemoteFile>> {
+    ) -> CacheContents<Vec<RemoteFile>> {
         // There needs to be either a debug_id or a code_id filter in the query. Otherwise, this would
         // return a list of all debug files in the project.
         if object_id.debug_id.is_none() && object_id.code_id.is_none() {
@@ -257,7 +257,7 @@ impl SentryDownloader {
         source_name: &str,
         file_source: &SentryRemoteFile,
         destination: &mut File,
-    ) -> CacheEntry {
+    ) -> CacheContents {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);
 

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -107,7 +107,8 @@ impl FetchFileMetaRequest {
         let object_handle = self
             .data_cache
             .compute_memoized(FetchFileDataRequest(self.clone()), cache_key.clone())
-            .await?;
+            .await
+            .into_contents()?;
 
         let object = object_handle.object();
 

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -6,7 +6,7 @@ use sentry::{Hub, SentryFutureExt};
 
 use symbolicator_sources::{FileType, ObjectId, RemoteFile, RemoteFileUri, SourceConfig, SourceId};
 
-use crate::caching::{Cache, CacheEntry, CacheError, CacheKey, Cacher, SharedCacheRef};
+use crate::caching::{Cache, CacheContents, CacheError, CacheKey, Cacher, SharedCacheRef};
 use crate::download::DownloadService;
 use crate::types::Scope;
 
@@ -57,7 +57,7 @@ pub enum ObjectPurpose {
 #[derive(Debug, Clone)]
 pub struct FoundMeta {
     pub file_source: RemoteFile,
-    pub handle: CacheEntry<Arc<ObjectMetaHandle>>,
+    pub handle: CacheContents<Arc<ObjectMetaHandle>>,
 }
 
 /// The response for [`ObjectsActor::find`].
@@ -105,7 +105,7 @@ impl ObjectsActor {
     /// This fetches the requested object, re-downloading it from the source if it is no
     /// longer in the cache.
     #[tracing::instrument(skip_all, fields(file_source = ?file_handle.file_source))]
-    pub async fn fetch(&self, file_handle: Arc<ObjectMetaHandle>) -> CacheEntry<Arc<ObjectHandle>> {
+    pub async fn fetch(&self, file_handle: Arc<ObjectMetaHandle>) -> CacheContents<Arc<ObjectHandle>> {
         let cache_key = CacheKey::from_scoped_file(&file_handle.scope, &file_handle.file_source);
         let request = FetchFileDataRequest(FetchFileMetaRequest {
             scope: file_handle.scope.clone(),

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -105,7 +105,10 @@ impl ObjectsActor {
     /// This fetches the requested object, re-downloading it from the source if it is no
     /// longer in the cache.
     #[tracing::instrument(skip_all, fields(file_source = ?file_handle.file_source))]
-    pub async fn fetch(&self, file_handle: Arc<ObjectMetaHandle>) -> CacheContents<Arc<ObjectHandle>> {
+    pub async fn fetch(
+        &self,
+        file_handle: Arc<ObjectMetaHandle>,
+    ) -> CacheContents<Arc<ObjectHandle>> {
         let cache_key = CacheKey::from_scoped_file(&file_handle.scope, &file_handle.file_source);
         let request = FetchFileDataRequest(FetchFileMetaRequest {
             scope: file_handle.scope.clone(),

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -115,7 +115,10 @@ impl ObjectsActor {
             download_svc: self.download_svc.clone(),
         });
 
-        self.data_cache.compute_memoized(request, cache_key).await
+        self.data_cache
+            .compute_memoized(request, cache_key)
+            .await
+            .into_contents()
     }
 
     /// Fetches matching objects and returns the metadata of the most suitable object.
@@ -176,7 +179,11 @@ impl ObjectsActor {
             };
 
             async move {
-                let handle = self.meta_cache.compute_memoized(request, cache_key).await;
+                let handle = self
+                    .meta_cache
+                    .compute_memoized(request, cache_key)
+                    .await
+                    .into_contents();
                 FoundMeta {
                     file_source,
                     handle,

--- a/crates/symbolicator/src/endpoints/proxy.rs
+++ b/crates/symbolicator/src/endpoints/proxy.rs
@@ -6,14 +6,14 @@ use axum::body::Body;
 use axum::extract;
 use axum::http::{Method, Request, Response, StatusCode};
 
-use symbolicator_service::caching::{CacheEntry, CacheError};
+use symbolicator_service::caching::{CacheContents, CacheError};
 use symbolicator_sources::parse_symstore_path;
 
 use crate::service::{FindObject, ObjectHandle, ObjectPurpose, RequestService, Scope};
 
 use super::ResponseError;
 
-async fn load_object(service: RequestService, path: String) -> CacheEntry<Arc<ObjectHandle>> {
+async fn load_object(service: RequestService, path: String) -> CacheContents<Arc<ObjectHandle>> {
     let config = service.config();
     if !config.symstore_proxy {
         return Err(CacheError::NotFound);

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -32,7 +32,7 @@ use symbolicator_proguard::interface::{
     CompletedJvmSymbolicationResponse, SymbolicateJvmStacktraces,
 };
 use symbolicator_proguard::ProguardService;
-use symbolicator_service::caching::CacheEntry;
+use symbolicator_service::caching::CacheContents;
 use symbolicator_service::config::Config;
 use symbolicator_service::metric;
 use symbolicator_service::objects::ObjectsActor;
@@ -255,7 +255,7 @@ impl RequestService {
     pub async fn fetch_object(
         &self,
         handle: Arc<ObjectMetaHandle>,
-    ) -> CacheEntry<Arc<ObjectHandle>> {
+    ) -> CacheContents<Arc<ObjectHandle>> {
         self.inner.objects.fetch(handle).await
     }
 


### PR DESCRIPTION
This attaches an (optional) metadata struct to cache entries produced by `compute_memoized`. For now, this structure contains two pieces of data:
1. The scope (project ID or "global") of the request.
3. The creation time of the entry.

We may add more in the future.

We don't currently write or read the metadata at any point. When we create a `MdCacheEntry` we use the `without_md` constructor, and when we consume one, we always use `contents()` or `into_contents()` to get the data. Actually using the metadata is left for a future PR.

ETA: After discussion, this now also renames the former `CacheEntry` to `CacheContents` and uses the name `CacheEntry` for the new "cache contents + metadata" struct.