### PR TITLE
ref(symbolicator): Make cleanup job not mmap cache file contents

### DIFF
--- a/crates/symbolicator-service/src/caching/cache_error.rs
+++ b/crates/symbolicator-service/src/caching/cache_error.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::io;
+use std::io::{self, Read};
+use std::path::Path;
 use std::time::Duration;
 
 use humantime_serde::re::humantime::{format_duration, parse_duration};
@@ -75,6 +76,12 @@ impl CacheError {
     pub(super) const DOWNLOAD_ERROR_MARKER: &'static [u8] = b"downloaderror";
     pub(super) const UNSUPPORTED_MARKER: &'static [u8] = b"unsupported";
 
+    /// Maximum length of the error markers.
+    ///
+    /// This is the amount of bytes that need to be minimum read from a file to recover
+    /// the contained error.
+    const MAX_LEN_ERROR_MARKER: u64 = 32;
+
     /// Writes error markers and details to a file.
     ///
     /// * If `self` is [`InternalError`](Self::InternalError), it does nothing.
@@ -122,6 +129,18 @@ impl CacheError {
         file.set_len(new_len).await?;
 
         Ok(())
+    }
+
+    /// Reads an error from a cache file.
+    ///
+    /// Returns `None` if the file does not contain any known error.
+    pub(super) fn from_path(path: &Path) -> io::Result<Option<Self>> {
+        // No buffered reader, because we read a small fixed amount of bytes.
+        let file = std::fs::File::open(path)?;
+        let mut buffer = Vec::new();
+        file.take(Self::MAX_LEN_ERROR_MARKER)
+            .read_to_end(&mut buffer)?;
+        Ok(Self::from_bytes(&buffer))
     }
 
     /// Parses a `CacheError` from a byte slice.

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -218,7 +218,7 @@ impl Cache {
         anyhow::ensure!(metadata.is_file(), "not a file");
         let size = metadata.len();
 
-        if catch_not_found(|| self.check_expiry(path))?.is_none() {
+        if catch_not_found(|| self.check_expiry_no_contents(path))?.is_none() {
             tracing::debug!("Removing file `{}`", path.display());
             if !dry_run {
                 catch_not_found(|| remove_file(path))?;

--- a/crates/symbolicator-service/src/caching/fs.rs
+++ b/crates/symbolicator-service/src/caching/fs.rs
@@ -123,9 +123,37 @@ impl Cache {
 
         let bv = ByteView::open(path)?;
         let mtime = metadata.modified()?;
-        let mtime_elapsed = mtime.elapsed().unwrap_or_default();
 
         let cache_entry = cache_contents_from_bytes(bv);
+        self.check_expiry_inner(cache_entry, mtime)
+    }
+
+    /// Validate cache expiration of path.
+    ///
+    /// Like [`Self::check_expiry`] but it does not return the file contents.
+    pub(super) fn check_expiry_no_contents(
+        &self,
+        path: &Path,
+    ) -> io::Result<(CacheContents<()>, ExpirationTime)> {
+        let metadata = path.metadata()?;
+        tracing::trace!("File `{}` length: {}", path.display(), metadata.len());
+
+        let mtime = metadata.modified()?;
+        let cache_entry = match CacheError::from_path(path)? {
+            Some(error) => Err(error),
+            None => Ok(()),
+        };
+
+        self.check_expiry_inner(cache_entry, mtime)
+    }
+
+    fn check_expiry_inner<T>(
+        &self,
+        cache_entry: CacheContents<T>,
+        mtime: SystemTime,
+    ) -> io::Result<(CacheContents<T>, ExpirationTime)> {
+        let mtime_elapsed = mtime.elapsed().unwrap_or_default();
+
         let expiration_time = match expiration_strategy(&cache_entry) {
             ExpirationStrategy::None => {
                 let max_unused_for = self.cache_config.max_unused_for().unwrap_or(Duration::MAX);


### PR DESCRIPTION
The cleanup job does not need to `mmap` the entire cache file contents, we can just peek into the file, try to parse an error and immediately stop.

We've seen that this causes huge amounts of cache memory usage, which is not a problem in practice but may cause issues in containerized environments, specifically Kubernetes 1.30.