### PR TITLE
fix: rectify symsorter `--ignore-errors` handling for ZIP archives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Various fixes & improvements
+
+fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#11621](https://github.com/getsentry/symbolicator/pull/1621)
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.17 to v0.7.19 ([#1596](https://github.com/getsentry/symbolicator/pull/1596), [#1602](https://github.com/getsentry/symbolicator/pull/1602))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Various fixes & improvements
 
-fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#11621](https://github.com/getsentry/symbolicator/pull/1621)
+fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#1621](https://github.com/getsentry/symbolicator/pull/1621)
 
 ### Dependencies
 

--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -245,7 +245,7 @@ fn sort_files(sort_config: &SortConfig, paths: Vec<PathBuf>) -> Result<(usize, u
 
             // zip archive
             if bv.get(..2) == Some(b"PK") {
-                process_zip_archive(sort_config, bv, path.to_string_lossy().deref(),  &debug_ids)?;
+                process_zip_archive(sort_config, bv, path.to_string_lossy().deref(), &debug_ids)?;
 
             // object file directly
             } else if Archive::peek(&bv) != FileFormat::Unknown {


### PR DESCRIPTION
I recently observed a behavior in `symsorter` when running with `--ignore-errors` that is probably unintentional:

A ZIP archive it detected in the input path failed to read, leading to immediate termination, printing an error message in the top-level error logger, and unhelpful information that suggested I could use `--ignore-errors`.

Of course, what I really would expect in such a situation is the following:

* `symsorter` prints the error with the context of the ZIP archive path for which the error happens
* `symsorter` continues to process all other files
* `symsorter` does not suggest to use a flag which was already enabled
* `symsorter` returns a 0

This PR

* moves CLI parsing to `main()` so that the top-level error logger doesn't suggest using `--ignore-errors` when it is already in effect (because, in this case, it must have an error that cannot be ignored for some reason, because it shouldn't propagate to the top otherwise),
* extracts processing of ZIP archives into a separate function so it hides `--ignore-errors`-handling for ZIP archiving as an implementation detail,
* introduces a catch-all result scope for the ZIP archive processing (which has three ZIP-related function invocations that could fail besides `process_file()`) and 
* adds `--ignore-errors`-handling in that function analog to how the `maybe_ignore_error` macro handles it in `process_file()`