### PR TITLE
feat: Add retry_missing_after_public config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Various fixes & improvements
 
-fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#1621](https://github.com/getsentry/symbolicator/pull/1621)
+fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#1621](https://github.com/getsentry/symbolicator/pull/1621))
+feat: Added a setting `retry_missing_after_public` to downloaded and derived cache configs.
+      The effect of this setting is to control the time after which negative (missing, failed download, &c.)
+      cache entries from public sources. The default value is 24h. ([#1623](https://github.com/getsentry/symbolicator/pull/1623))
 
 ### Dependencies
 

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -382,7 +382,7 @@ mod tests {
             object_type: ObjectType::Macho,
             identifier,
             sources: Arc::new([source]),
-            scope: Scope::Global,
+            scope: Scope::Scoped("12345".into()),
         };
 
         let symcache_actor = symcache_actor(cache_dir.path().to_owned(), TIMEOUT).await;

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -27,12 +27,12 @@ fn tempdir() -> io::Result<tempfile::TempDir> {
     tempfile::tempdir_in(".")
 }
 
-fn write_file_and_metadata(path: &Path, contents: &[u8]) -> Result<()> {
+fn write_file_and_metadata(path: &Path, contents: &[u8], scope: Scope) -> Result<()> {
     let md_path = metadata_path(path);
     File::create(path)?.write_all(contents)?;
 
     let mut md = File::create(md_path)?;
-    serde_json::to_writer(&mut md, &Metadata::fresh_scoped(Scope::Global))?;
+    serde_json::to_writer(&mut md, &Metadata::fresh_scoped(scope))?;
     Ok(())
 }
 
@@ -115,15 +115,25 @@ fn test_max_unused_for() -> Result<()> {
         1024,
     )?;
 
+    let scope = Scope::Scoped("12345".into());
+
     // Will be deleted because it's OK and after the sleep the unused time will have passed.
-    write_file_and_metadata(&tempdir.path().join("objects/killthis"), b"hi")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/killthis"),
+        b"hi",
+        scope.clone(),
+    )?;
     // Will be kept because it's empty (not found) and the default "retry missing" time of 1h hasn't passed.
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis"), b"")?;
+    write_file_and_metadata(&tempdir.path().join("objects/keepthis"), b"", scope.clone())?;
 
     sleep(Duration::from_millis(100));
 
     // Will be deleted because it's OK and the unused time will not have passed.
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis2"), b"hi")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis2"),
+        b"hi",
+        scope.clone(),
+    )?;
 
     cache.cleanup(false)?;
 
@@ -166,30 +176,33 @@ fn test_retry_misses_after() -> Result<()> {
         1024,
     )?;
 
+    let scope = Scope::Scoped("12345".into());
+
     // Will be kept because it's OK and the default unused time of 7d hasn't passed.
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis"), b"hi")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis"),
+        b"hi",
+        scope.clone(),
+    )?;
+
+    // Will be kept because it's empty and public, and the "retry missing for public files" time hasn't passed.
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis2"),
+        b"",
+        Scope::Global,
+    )?;
+
     // Will be deleted because it's empty and after the sleep the "retry missing" time will have passed.
-    write_file_and_metadata(&tempdir.path().join("objects/killthis"), b"")?;
+    write_file_and_metadata(&tempdir.path().join("objects/killthis"), b"", scope.clone())?;
 
     sleep(Duration::from_secs(1));
 
-    // Create a file with a creation time 1 sec in the past. It should be deleted.
-    File::create(tempdir.path().join("objects/killthis2"))
-        .unwrap()
-        .write_all(b"")
-        .unwrap();
-    let metadata = Metadata {
-        scope: Scope::Global,
-        time_created: SystemTime::now()
-            .checked_sub(Duration::from_secs(1))
-            .unwrap(),
-    };
-    let md_path = metadata_path(tempdir.path().join("objects/killthis2"));
-    let mut md = File::create(md_path).unwrap();
-    serde_json::to_writer(&mut md, &metadata).unwrap();
-
     // Will be kept because it's empty and the "retry missing" time hasn't passed.
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis2"), b"")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis3"),
+        b"",
+        scope.clone(),
+    )?;
 
     cache.cleanup(false)?;
 
@@ -205,7 +218,9 @@ fn test_retry_misses_after() -> Result<()> {
             "keepthis",
             "keepthis.metadata",
             "keepthis2",
-            "keepthis2.metadata"
+            "keepthis2.metadata",
+            "keepthis3",
+            "keepthis3.metadata",
         ]
     );
 
@@ -221,16 +236,38 @@ fn test_cleanup_malformed() -> Result<()> {
     };
     fs::create_dir_all(tempdir.path().join("objects"))?;
 
+    let scope = Scope::Scoped("12345".into());
+
     // File has same amount of chars as "malformed", check that optimization works
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis"), b"addictive")?;
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis2"), b"hi")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis"),
+        b"addictive",
+        scope.clone(),
+    )?;
+
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis2"),
+        b"hi",
+        scope.clone(),
+    )?;
+
     write_file_and_metadata(
         &tempdir.path().join("objects/keepthis3"),
         b"honkhonkbeepbeep",
+        scope.clone(),
     )?;
 
-    write_file_and_metadata(&tempdir.path().join("objects/killthis"), b"malformed")?;
-    write_file_and_metadata(&tempdir.path().join("objects/killthis2"), b"malformedhonk")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/killthis"),
+        b"malformed",
+        scope.clone(),
+    )?;
+
+    write_file_and_metadata(
+        &tempdir.path().join("objects/killthis2"),
+        b"malformedhonk",
+        scope.clone(),
+    )?;
 
     sleep(Duration::from_millis(10));
 
@@ -279,25 +316,53 @@ fn test_cleanup_cache_download() -> Result<()> {
     };
     fs::create_dir_all(tempdir.path().join("objects"))?;
 
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis"), b"beeep")?;
-    write_file_and_metadata(&tempdir.path().join("objects/keepthis2"), b"hi")?;
+    let scope = Scope::Scoped("12345".into());
+
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis"),
+        b"beeep",
+        scope.clone(),
+    )?;
+
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis2"),
+        b"hi",
+        scope.clone(),
+    )?;
+
     write_file_and_metadata(
         &tempdir.path().join("objects/keepthis3"),
         b"honkhonkbeepbeep",
+        scope.clone(),
     )?;
 
-    write_file_and_metadata(&tempdir.path().join("objects/killthis"), b"downloaderror")?;
+    write_file_and_metadata(
+        &tempdir.path().join("objects/keepthis4"),
+        b"downloaderror",
+        Scope::Global,
+    )?;
+
+    write_file_and_metadata(
+        &tempdir.path().join("objects/killthis"),
+        b"downloaderror",
+        scope.clone(),
+    )?;
     write_file_and_metadata(
         &tempdir.path().join("objects/killthis2"),
         b"downloaderrorhonk",
+        scope.clone(),
     )?;
+
     write_file_and_metadata(
         &tempdir.path().join("objects/killthis3"),
         b"downloaderrormalformed",
+        scope.clone(),
     )?;
+
     write_file_and_metadata(
         &tempdir.path().join("objects/killthis4"),
         b"malformeddownloaderror",
+        scope.clone(),
     )?;
 
     let cache = Cache::from_config(
@@ -329,7 +394,9 @@ fn test_cleanup_cache_download() -> Result<()> {
             "keepthis2",
             "keepthis2.metadata",
             "keepthis3",
-            "keepthis3.metadata"
+            "keepthis3.metadata",
+            "keepthis4",
+            "keepthis4.metadata",
         ]
     );
 
@@ -481,41 +548,77 @@ fn test_open_cachefile() -> Result<()> {
 
 #[test]
 fn test_cleanup() {
+    test::setup();
     let tempdir = tempdir().unwrap();
 
     // Create entries in our caches that are an hour old.
-    let mtime = FileTime::from_system_time(SystemTime::now() - Duration::from_secs(3600));
+    let ctime = SystemTime::now() - Duration::from_secs(3600);
+    let mtime = FileTime::from_system_time(ctime);
 
-    let create = |cache_name: &str| {
-        let dir = tempdir.path().join(cache_name);
-        fs::create_dir(&dir).unwrap();
-        let entry = dir.join("entry");
-        write_file_and_metadata(&entry, b"contents").unwrap();
+    let create = |cache_name: &str, scope: Scope, status: &str| {
+        let dir = tempdir.path().join(cache_name).join(scope.as_ref());
+        let _ = fs::create_dir_all(&dir);
+        let entry = dir.join(status);
+        let path: &Path = &entry;
+        let md_path = metadata_path(path);
+        File::create(path)
+            .unwrap()
+            .write_all(status.as_bytes())
+            .unwrap();
+
+        let mut md_file = File::create(md_path).unwrap();
+        let md = Metadata {
+            scope,
+            time_created: ctime,
+        };
+        serde_json::to_writer(&mut md_file, &md).unwrap();
         filetime::set_file_mtime(&entry, mtime).unwrap();
         entry
     };
 
-    let object_entry = create("objects");
-    let object_meta_entry = create("object_meta");
-    let auxdifs_entry = create("auxdifs");
-    let symcaches_entry = create("symcaches");
-    let cficaches_entry = create("cficaches");
-    let diagnostics_entry = create("diagnostics");
+    let cache_names = [
+        "objects",
+        "object_meta",
+        "auxdifs",
+        "symcaches",
+        "cficaches",
+    ];
 
-    // Configure the caches to expire after 1 minute.
+    let positive_scoped: Vec<_> = cache_names
+        .iter()
+        .map(|cache_name| create(cache_name, Scope::Scoped("12345".into()), "positive"))
+        .collect();
+    let negative_scoped: Vec<_> = cache_names
+        .iter()
+        .map(|cache_name| create(cache_name, Scope::Scoped("12345".into()), "downloaderror"))
+        .collect();
+    let positive_global: Vec<_> = cache_names
+        .iter()
+        .map(|cache_name| create(cache_name, Scope::Global, "positive"))
+        .collect();
+    let negative_global: Vec<_> = cache_names
+        .iter()
+        .map(|cache_name| create(cache_name, Scope::Global, "downloaderror"))
+        .collect();
+
+    // Caches expire:
+    // * positive items after 1min
+    // * negative private itmes after 1min
+    // * negative public items after 2hr
     let caches = Caches::from_config(&Config {
         cache_dir: Some(tempdir.path().to_path_buf()),
         caches: CacheConfigs {
             downloaded: DownloadedCacheConfig {
                 max_unused_for: Some(Duration::from_secs(60)),
+                retry_misses_after: Some(Duration::from_secs(60)),
+                retry_misses_after_public: Some(Duration::from_secs(7200)),
                 ..Default::default()
             },
             derived: DerivedCacheConfig {
                 max_unused_for: Some(Duration::from_secs(60)),
+                retry_misses_after: Some(Duration::from_secs(60)),
+                retry_misses_after_public: Some(Duration::from_secs(7200)),
                 ..Default::default()
-            },
-            diagnostics: DiagnosticsCacheConfig {
-                retention: Some(Duration::from_secs(60)),
             },
             ..Default::default()
         },
@@ -524,21 +627,53 @@ fn test_cleanup() {
     .unwrap();
 
     // Finally do some testing
-    assert!(object_entry.is_file());
-    assert!(object_meta_entry.is_file());
-    assert!(auxdifs_entry.is_file());
-    assert!(symcaches_entry.is_file());
-    assert!(cficaches_entry.is_file());
-    assert!(diagnostics_entry.is_file());
+
+    for entry in positive_scoped
+        .iter()
+        .chain(positive_global.iter())
+        .chain(negative_scoped.iter())
+        .chain(negative_global.iter())
+    {
+        assert!(entry.is_file());
+    }
 
     caches.cleanup(false).unwrap();
 
-    assert!(!object_entry.is_file());
-    assert!(!object_meta_entry.is_file());
-    assert!(!auxdifs_entry.is_file());
-    assert!(!symcaches_entry.is_file());
-    assert!(!cficaches_entry.is_file());
-    assert!(!diagnostics_entry.is_file());
+    // All positive private files should've been cleaned up
+    for entry in positive_scoped.iter() {
+        assert!(
+            !entry.is_file(),
+            "{} should have been deleted",
+            entry.display()
+        );
+    }
+
+    // All positive global files should've been cleaned up
+    for entry in positive_global.iter() {
+        assert!(
+            !entry.is_file(),
+            "{} should have been deleted",
+            entry.display()
+        );
+    }
+
+    // All negative private files should've been cleaned up
+    for entry in negative_scoped.iter() {
+        assert!(
+            !entry.is_file(),
+            "{} should have been deleted",
+            entry.display()
+        );
+    }
+
+    // All negative global files should still be there
+    for entry in negative_global.iter() {
+        assert!(
+            entry.is_file(),
+            "{} should not have been deleted",
+            entry.display()
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -132,6 +132,13 @@ pub struct DownloadedCacheConfig {
     #[serde(with = "humantime_serde")]
     pub retry_misses_after: Option<Duration>,
 
+    /// Maximum duration since creation of negative cache item (item age).
+    ///
+    /// This setting is specific for items computed from "public" (non-project-specific)
+    /// sources.
+    #[serde(with = "humantime_serde")]
+    pub retry_misses_after_public: Option<Duration>,
+
     /// Maximum duration since creation of malformed cache item (item age).
     #[serde(with = "humantime_serde")]
     pub retry_malformed_after: Option<Duration>,
@@ -145,6 +152,7 @@ impl Default for DownloadedCacheConfig {
         Self {
             max_unused_for: Some(Duration::from_secs(3600 * 24)),
             retry_misses_after: Some(Duration::from_secs(3600)),
+            retry_misses_after_public: Some(Duration::from_secs(3600 * 24)),
             retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
             max_lazy_redownloads: 50,
         }
@@ -165,6 +173,13 @@ pub struct DerivedCacheConfig {
     #[serde(with = "humantime_serde")]
     pub retry_misses_after: Option<Duration>,
 
+    /// Maximum duration since creation of negative cache item (item age).
+    ///
+    /// This setting is specific for items computed from "public" (non-project-specific)
+    /// sources.
+    #[serde(with = "humantime_serde")]
+    pub retry_misses_after_public: Option<Duration>,
+
     /// Maximum duration since creation of malformed cache item (item age).
     #[serde(with = "humantime_serde")]
     pub retry_malformed_after: Option<Duration>,
@@ -178,6 +193,7 @@ impl Default for DerivedCacheConfig {
         Self {
             max_unused_for: Some(Duration::from_secs(3600 * 24 * 7)),
             retry_misses_after: Some(Duration::from_secs(3600)),
+            retry_misses_after_public: Some(Duration::from_secs(3600 * 24)),
             retry_malformed_after: Some(Duration::from_secs(3600 * 24)),
             max_lazy_recomputations: 20,
         }
@@ -222,6 +238,14 @@ impl CacheConfig {
         match self {
             Self::Downloaded(cfg) => cfg.retry_misses_after,
             Self::Derived(cfg) => cfg.retry_misses_after,
+            Self::Diagnostics(_cfg) => None,
+        }
+    }
+
+    pub fn retry_misses_after_public(&self) -> Option<Duration> {
+        match self {
+            Self::Downloaded(cfg) => cfg.retry_misses_after_public,
+            Self::Derived(cfg) => cfg.retry_misses_after_public,
             Self::Diagnostics(_cfg) => None,
         }
     }


### PR DESCRIPTION
This adds a setting `retry_missing_after_public` to downloaded and derived cache configs. The effect of this setting is to control the time after which negative (missing, failed download, &c.) cache entries from _public_ sources. Whether a file comes from a public source is determined by reading its metadata, which we added in #1617 and started writing in #1618.

The default value for this setting is 24h. This means that each Symbolicator only makes one request per day to public symbol sources for each missing debug file, as opposed to one per hour like before.

The bulk of this PR is test changes.