### PR TITLE
ref(caching): Remove debug .txt files

### DIFF
--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -95,7 +95,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
                 let object_meta = &self.object_meta;
                 tracing::error!(
                     scope = %object_meta.scope(),
-                    cache_key = object_meta.cache_key().metadata(),
+                    cache_key = object_meta.cache_key().data(),
                     debug_id = ?object_meta.object_id().debug_id,
                     code_id = ?object_meta.object_id().code_id,
                     error = %e

--- a/crates/symbolicator-native/tests/integration/e2e.rs
+++ b/crates/symbolicator-native/tests/integration/e2e.rs
@@ -503,6 +503,7 @@ async fn test_basic_windows() {
                             .debug
                             .as_ref()
                             .unwrap()
+                            .key_data
                             .starts_with(&expected_debug),
                         "{metadata:?} == {expected_debug:?}"
                     );
@@ -520,7 +521,10 @@ async fn test_basic_windows() {
                     let file = File::open(symcaches_dir.join(metadata_file)).unwrap();
                     let metadata: Metadata = serde_json::from_reader(&file).unwrap();
                     assert_eq!(metadata.scope.as_ref(), cached_scope);
-                    assert_eq!(&metadata.debug.as_ref().unwrap()[..], &expected_debug[..]);
+                    assert_eq!(
+                        &metadata.debug.as_ref().unwrap().key_data[..],
+                        &expected_debug[..]
+                    );
                 }
 
                 // our use of in-memory caching should make sure we only ever request each file once

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -15,7 +15,7 @@ use crate::types::Scope;
 #[derive(Debug, Clone, Eq)]
 pub struct CacheKey {
     scope: Scope,
-    daat: Arc<str>,
+    data: Arc<str>,
     hash: [u8; 32],
 }
 
@@ -54,7 +54,7 @@ impl CacheKey {
 
     /// Returns the human-readable data that forms the basis of the [`CacheKey`].
     pub fn data(&self) -> &str {
-        &self.daat
+        &self.data
     }
 
     /// Returns the relative path for this cache key.
@@ -79,7 +79,7 @@ impl CacheKey {
         let metadata = format!("scope: {scope}\n\n");
         CacheKeyBuilder {
             scope: scope.clone(),
-            metadata,
+            data: metadata,
         }
     }
 
@@ -87,7 +87,11 @@ impl CacheKey {
     pub fn for_testing(scope: Scope, key: impl Into<String>) -> Self {
         let metadata = key.into();
 
-        CacheKeyBuilder { scope, metadata }.build()
+        CacheKeyBuilder {
+            scope,
+            data: metadata,
+        }
+        .build()
     }
 }
 
@@ -99,13 +103,13 @@ impl CacheKey {
 /// the cache files to help debugging.
 pub struct CacheKeyBuilder {
     scope: Scope,
-    metadata: String,
+    data: String,
 }
 
 impl CacheKeyBuilder {
     /// Writes metadata about the [`RemoteFile`] into the [`CacheKey`].
     pub fn write_file_meta(&mut self, file: &RemoteFile) -> Result<(), fmt::Error> {
-        self.metadata.write_fmt(format_args!(
+        self.data.write_fmt(format_args!(
             "source: {}\nlocation: {}\n",
             file.source_id(),
             file.uri()
@@ -114,11 +118,11 @@ impl CacheKeyBuilder {
 
     /// Finalize the [`CacheKey`].
     pub fn build(self) -> CacheKey {
-        let hash = Sha256::digest(&self.metadata);
+        let hash = Sha256::digest(&self.data);
 
         CacheKey {
             scope: self.scope,
-            daat: self.metadata.into(),
+            data: self.data.into(),
             hash: hash.into(),
         }
     }
@@ -126,7 +130,7 @@ impl CacheKeyBuilder {
 
 impl fmt::Write for CacheKeyBuilder {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.metadata.write_str(s)
+        self.data.write_str(s)
     }
 }
 

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -15,7 +15,7 @@ use crate::types::Scope;
 #[derive(Debug, Clone, Eq)]
 pub struct CacheKey {
     scope: Scope,
-    metadata: Arc<str>,
+    pub(crate) metadata: Arc<str>,
     hash: [u8; 32],
 }
 

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -15,7 +15,7 @@ use crate::types::Scope;
 #[derive(Debug, Clone, Eq)]
 pub struct CacheKey {
     scope: Scope,
-    pub(crate) metadata: Arc<str>,
+    daat: Arc<str>,
     hash: [u8; 32],
 }
 
@@ -52,9 +52,9 @@ impl CacheKey {
         builder.build()
     }
 
-    /// Returns the human-readable metadata that forms the basis of the [`CacheKey`].
-    pub fn metadata(&self) -> &str {
-        &self.metadata
+    /// Returns the human-readable data that forms the basis of the [`CacheKey`].
+    pub fn data(&self) -> &str {
+        &self.daat
     }
 
     /// Returns the relative path for this cache key.
@@ -118,7 +118,7 @@ impl CacheKeyBuilder {
 
         CacheKey {
             scope: self.scope,
-            metadata: self.metadata.into(),
+            daat: self.metadata.into(),
             hash: hash.into(),
         }
     }
@@ -158,7 +158,7 @@ mod tests {
             "v0/f5/e08b92/a55c1357413b5e36547a8b534a014c3a00299e7622e4c4b022a96541"
         );
         assert_eq!(
-            key.metadata(),
+            key.data(),
             "scope: global\n\nsource: foo\nlocation: file://bar.baz\n"
         );
 
@@ -180,7 +180,7 @@ mod tests {
             "v0/d9/40ba75/07d18c0e9a1d884809670a1e32a72a85ed7563c52909507bf594880a"
         );
         assert_eq!(
-            key.metadata(),
+            key.data(),
             "scope: global\n\nsource: foo\nlocation: file://bar.baz\n\nsecond_source:\nsource: foo\nlocation: file://bar.quux\n"
         );
     }

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -31,13 +31,9 @@ impl Metadata {
         let time_created = SystemTime::now();
         let scope = cache_key.scope().clone();
 
-        #[cfg(debug_assertions)]
-        let debug = Some(Debug {
+        let debug = (cfg!(debug_assertions)).then(|| Debug {
             key_data: cache_key.data().to_owned(),
         });
-
-        #[cfg(not(debug_assertions))]
-        let debug = None;
 
         Self {
             scope,

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -29,7 +29,7 @@ impl Metadata {
     ///
     /// In debug mode, this adds the key's [`metadata`](CacheKey::metadata)
     /// in the `debug` field.
-    pub(crate) fn from_key(cache_key: &CacheKey) -> Self {
+    pub fn from_key(cache_key: &CacheKey) -> Self {
         let time_created = SystemTime::now();
         let scope = cache_key.scope().clone();
         #[cfg(debug_assertions)]

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::SystemTime};
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
@@ -19,9 +19,7 @@ pub struct Metadata {
     pub time_created: SystemTime,
 
     /// Optional data for debugging.
-    ///
-    /// See [Self::from_key] for how this is populated.
-    pub debug: Option<Arc<str>>,
+    pub debug: Option<Debug>,
 }
 
 impl Metadata {
@@ -34,10 +32,13 @@ impl Metadata {
         let scope = cache_key.scope().clone();
         #[cfg(debug_assertions)]
         {
+            let debug = Debug {
+                key_data: cache_key.metadata().to_owned(),
+            };
             Self {
                 scope,
                 time_created,
-                debug: Some(cache_key.metadata.clone()),
+                debug: Some(debug),
             }
         }
         #[cfg(not(debug_assertions))]
@@ -60,6 +61,12 @@ impl Metadata {
             debug: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Debug {
+    /// The data the cache key was generated from.
+    pub key_data: String,
 }
 
 /// Module for second-precision [`SystemTime`] de/serialization.

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -25,7 +25,7 @@ pub struct Metadata {
 impl Metadata {
     /// Creates metadata from a cache key.
     ///
-    /// In debug mode, this adds the key's [`metadata`](CacheKey::metadata)
+    /// In debug mode, this adds the key's [`data`](CacheKey::data)
     /// in the `debug` field.
     pub fn from_key(cache_key: &CacheKey) -> Self {
         let time_created = SystemTime::now();
@@ -33,7 +33,7 @@ impl Metadata {
         #[cfg(debug_assertions)]
         {
             let debug = Debug {
-                key_data: cache_key.metadata().to_owned(),
+                key_data: cache_key.data().to_owned(),
             };
             Self {
                 scope,

--- a/crates/symbolicator-service/src/caching/metadata.rs
+++ b/crates/symbolicator-service/src/caching/metadata.rs
@@ -30,24 +30,19 @@ impl Metadata {
     pub fn from_key(cache_key: &CacheKey) -> Self {
         let time_created = SystemTime::now();
         let scope = cache_key.scope().clone();
+
         #[cfg(debug_assertions)]
-        {
-            let debug = Debug {
-                key_data: cache_key.data().to_owned(),
-            };
-            Self {
-                scope,
-                time_created,
-                debug: Some(debug),
-            }
-        }
+        let debug = Some(Debug {
+            key_data: cache_key.data().to_owned(),
+        });
+
         #[cfg(not(debug_assertions))]
-        {
-            Self {
-                scope,
-                time_created,
-                debug: None,
-            }
+        let debug = None;
+
+        Self {
+            scope,
+            time_created,
+            debug,
         }
     }
 

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -209,6 +209,7 @@ fn test_retry_misses_after() -> Result<()> {
         time_created: SystemTime::now()
             .checked_sub(Duration::from_secs(1))
             .unwrap(),
+        debug: None,
     };
     write_file_and_metadata(&tempdir.path().join("objects/killthis2"), b"", &metadata)?;
 
@@ -577,6 +578,7 @@ fn test_cleanup() {
         let md = Metadata {
             scope,
             time_created: ctime,
+            debug: None,
         };
         write_file_and_metadata(&entry, status.as_bytes(), &md).unwrap();
         filetime::set_file_mtime(&entry, mtime).unwrap();


### PR DESCRIPTION
Previously we wrote .txt files with the human-readable contents of cache keys next to cache files, but only in debug mode. Since we now have JSON metadata files, we subsume these debug text files into a `debug` field in the `Metadata` struct that only gets written in debug mode.