### PR TITLE
feat(symbol sources): Add requires_checksum flag

### DIFF
--- a/crates/symbolicator-native/tests/integration/public_sources.rs
+++ b/crates/symbolicator-native/tests/integration/public_sources.rs
@@ -16,13 +16,15 @@ use crate::{assert_snapshot, make_symbolication_request, setup_service, source_c
 #[tokio::test]
 async fn test_nuget_source() {
     let (symbolication, _cache_dir) = setup_service(|_| ());
+    let mut files = source_config(DirectoryLayoutType::Symstore, vec![FileType::PortablePdb]);
+    files.filters.requires_checksum = true;
     let source = SourceConfig::Http(Arc::new(HttpSourceConfig {
         id: SourceId::new("nuget"),
         url: "https://symbols.nuget.org/download/symbols/"
             .parse()
             .unwrap(),
         headers: Default::default(),
-        files: source_config(DirectoryLayoutType::Symstore, vec![FileType::PortablePdb]),
+        files,
         accept_invalid_certs: false,
     }));
 
@@ -35,6 +37,43 @@ async fn test_nuget_source() {
           "debug_id": "4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc",
           "debug_file": "./TimeZoneConverter.pdb",
           "debug_checksum": "SHA256:87a82c4e5e82f386968f25b41ae1b5f3cc3f6d9e79cfb4464f8240400fc47dcd"
+        }]"#,
+        r#"[{
+          "frames":[{
+            "instruction_addr": "0x21",
+            "function_id": "0xc",
+            "addr_mode":"rel:0"
+          }]
+        }]"#,
+    );
+    let response = symbolication.symbolicate(request).await;
+
+    assert_snapshot!(response.unwrap());
+}
+
+#[tokio::test]
+async fn test_nuget_source_no_checksum() {
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let mut files = source_config(DirectoryLayoutType::Symstore, vec![FileType::PortablePdb]);
+    files.filters.requires_checksum = true;
+    let source = SourceConfig::Http(Arc::new(HttpSourceConfig {
+        id: SourceId::new("nuget"),
+        url: "https://symbols.nuget.org/download/symbols/"
+            .parse()
+            .unwrap(),
+        headers: Default::default(),
+        files,
+        accept_invalid_certs: false,
+    }));
+
+    let request = make_symbolication_request(
+        vec![source],
+        r#"[{
+          "type":"pe_dotnet",
+          "code_id": "efc9a199e000",
+          "code_file": "./TimeZoneConverter.dll",
+          "debug_id": "4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc",
+          "debug_file": "./TimeZoneConverter.pdb"
         }]"#,
         r#"[{
           "frames":[{

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__public_sources__nuget_source_no_checksum.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__public_sources__nuget_source_no_checksum.snap
@@ -1,0 +1,31 @@
+---
+source: crates/symbolicator-native/tests/integration/public_sources.rs
+expression: response.unwrap()
+---
+stacktraces:
+  - frames:
+      - status: missing
+        original_index: 0
+        addr_mode: "rel:0"
+        instruction_addr: "0x21"
+        function_id: "0xc"
+        package: "./TimeZoneConverter.dll"
+modules:
+  - debug_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe_dotnet
+    code_id: efc9a199e000
+    code_file: "./TimeZoneConverter.dll"
+    debug_id: 4e2ca887-825e-46f3-968f-25b41ae1b5f3-9e6d3fcc
+    debug_file: "./TimeZoneConverter.pdb"
+    image_addr: "0x0"
+    candidates:
+      - source: nuget
+        location: No object files listed on this source
+        download:
+          status: notfound

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -286,6 +286,7 @@ impl Server {
             filters: SourceFilters {
                 filetypes: vec![FileType::MachCode],
                 path_patterns: vec![],
+                requires_checksum: false,
             },
             layout: Default::default(),
             is_public: false,


### PR DESCRIPTION
The purpose of this is to not even attempt to download portable PDB files from sources that have this flag set if there is no debug_checksum. In practice the only source for which this is relevant is the public NuGet symbol source.