### PR TITLE
ref(caching): Reduce number of cache directories

### DIFF
--- a/crates/symbolicator-js/src/sourcemap_cache.rs
+++ b/crates/symbolicator-js/src/sourcemap_cache.rs
@@ -7,8 +7,8 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolic::debuginfo::sourcebundle::SourceFileDescriptor;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
 use symbolicator_service::caches::versions::SOURCEMAP_CACHE_VERSIONS;
-use symbolicator_service::caches::ByteViewString;
-use symbolicator_service::caching::{CacheContents, CacheError, CacheItemRequest, CacheVersions};
+use symbolicator_service::caches::{ByteViewString, CacheVersions};
+use symbolicator_service::caching::{CacheContents, CacheError, CacheItemRequest};
 use symbolicator_service::objects::ObjectHandle;
 use tempfile::NamedTempFile;
 

--- a/crates/symbolicator-native/src/caches/bitcode.rs
+++ b/crates/symbolicator-native/src/caches/bitcode.rs
@@ -13,9 +13,9 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::{ByteView, DebugId};
 use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use symbolicator_service::caches::versions::BITCODE_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
-    SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use symbolicator_service::download::{fetch_file, DownloadService};
 use symbolicator_service::metric;

--- a/crates/symbolicator-native/src/caches/cficaches.rs
+++ b/crates/symbolicator-native/src/caches/cficaches.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 use minidump_unwind::SymbolFile;
 use sentry::types::DebugId;
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::cfi::CfiCache;
@@ -12,7 +13,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::breakpad::BreakpadModuleRecord;
 use symbolicator_service::caches::versions::CFICACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-native/src/caches/il2cpp.rs
+++ b/crates/symbolicator-native/src/caches/il2cpp.rs
@@ -11,9 +11,9 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::{ByteView, DebugId};
 use symbolic::il2cpp::LineMapping;
 use symbolicator_service::caches::versions::IL2CPP_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
-    SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use symbolicator_service::download::{fetch_file, DownloadService};
 use symbolicator_service::metric;

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -3,6 +3,7 @@ use std::io::{self, BufWriter};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::common::{ByteView, SelfCell};
@@ -10,7 +11,7 @@ use symbolic::debuginfo::Object;
 use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_service::caches::versions::PPDB_CACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use sentry::{Hub, SentryFutureExt};
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::common::{ByteView, SelfCell};
 use symbolic::symcache::{SymCache, SymCacheConverter};
 use symbolicator_service::caches::versions::SYMCACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -5,8 +5,9 @@ use futures::future::BoxFuture;
 use proguard::ProguardCache;
 use symbolic::common::{AsSelf, ByteView, DebugId, SelfCell};
 use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher,
 };
 use symbolicator_service::download::{fetch_file, tempfile_in_parent, DownloadService};
 use symbolicator_service::objects::{

--- a/crates/symbolicator-service/src/caches/mod.rs
+++ b/crates/symbolicator-service/src/caches/mod.rs
@@ -4,3 +4,4 @@ mod sourcefiles;
 pub mod versions;
 
 pub use sourcefiles::{ByteViewString, SourceFilesCache};
+pub use versions::{CachePathFormat, CacheVersion, CacheVersions};

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -6,9 +6,10 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
+use crate::caches::CacheVersions;
 use crate::caching::{
-    Cache, CacheContents, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions,
-    Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher,
+    SharedCacheRef,
 };
 use crate::download::{fetch_file, DownloadService};
 use crate::types::Scope;

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -18,6 +18,8 @@ use crate::caching::CacheVersions;
 
 /// CFI cache, with the following versions:
 ///
+/// - `5`: Restructuring the cache directory format.
+///
 /// - `4`: Recomputation to use new `CacheKey` format.
 ///
 /// - `3`: Proactive bump, as a bug in shared cache could have potentially
@@ -29,12 +31,14 @@ use crate::caching::CacheVersions;
 ///
 /// - `0`: Initial version.
 pub const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 4,
-    fallbacks: &[],
+    current: 5,
+    fallbacks: &[4],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
 /// SymCache, with the following versions:
+///
+/// - `8`: Restructuring the cache directory format.
 ///
 /// - `7`: Fixes inlinee lookup. (<https://github.com/getsentry/symbolic/pull/883>)
 ///
@@ -60,32 +64,38 @@ static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 ///
 /// - `0`: Initial version.
 pub const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 7,
-    fallbacks: &[6],
+    current: 8,
+    fallbacks: &[6, 7],
 };
 static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 
 /// Data / Objects cache, with the following versions:
 ///
+/// - `2`: Restructuring the cache directory format.
+///
 /// - `1`: Recomputation to use new `CacheKey` format.
 ///
 /// - `0`: Initial version.
 pub const OBJECTS_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Objects Meta cache, with the following versions:
+///
+/// - `2`: Restructuring the cache directory format.
 ///
 /// - `1`: Recomputation to use new `CacheKey` format.
 ///
 /// - `0`: Initial version.
 pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Portable PDB cache, with the following versions:
+///
+/// - `4`: Restructuring the cache directory format.
 ///
 /// - `3`: Skips hidden SequencePoints, and thus avoids outputting `lineno: 0`.
 ///
@@ -93,59 +103,72 @@ pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `1`: Initial version.
 pub const PPDB_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 3,
-    fallbacks: &[2],
+    current: 4,
+    fallbacks: &[2, 3],
 };
 
 /// SourceMapCache, with the following versions:
 ///
+/// - `2`: Restructuring the cache directory format.
+///
 /// - `1`: Initial version.
 pub const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Il2cpp cache, with the following versions:
+///
+/// - `2`: Restructuring the cache directory format.
 ///
 /// - `1`: Recomputation to use new `CacheKey` format.
 ///
 /// - `0`: Initial version.
 pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Bitcode / Auxdif (plist / bcsymbolmap) cache, with the following versions:
+///
+/// - `2`: Restructuring the cache directory format.
 ///
 /// - `1`: Recomputation to use new `CacheKey` format.
 ///
 /// - `0`: Initial version.
 pub const BITCODE_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Source Files Cache, with the following versions:
 ///
+/// - `2`: Restructuring the cache directory format.
+///
 /// - `1`: Initial version.
 pub const SOURCEFILES_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Bundle Index Cache, with the following versions:
 ///
+/// - `2`: Restructuring the cache directory format.
+///
 /// - `1`: Initial version.
 pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
-    fallbacks: &[],
+    current: 2,
+    fallbacks: &[1],
 };
 
 /// Proguard Cache, with the following versions:
 ///
-/// - `1`: Initial version.
+/// - `3`: Restructuring the cache directory format.
+///
 /// - `2`: Use proguard cache format (<https://github.com/getsentry/symbolicator/pull/1491>).
+///
+/// - `1`: Initial version.
 pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 2,
-    fallbacks: &[],
+    current: 3,
+    fallbacks: &[2],
 };

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -61,7 +61,7 @@ impl CacheKey {
     ///
     /// The relative path is a sha-256 hash hex-formatted like so:
     /// `v$version/aa/bbccdd/eeff...`
-    pub fn cache_path(&self, version: u32) -> String {
+    pub fn cache_path_old(&self, version: u32) -> String {
         let mut path = format!("v{version}/{:02x}/", self.hash[0]);
         for b in &self.hash[1..4] {
             path.write_fmt(format_args!("{b:02x}")).unwrap();
@@ -173,7 +173,7 @@ mod tests {
         let key = CacheKey::from_scoped_file(&scope, &file);
 
         assert_eq!(
-            &key.cache_path(0),
+            &key.cache_path_old(0),
             "v0/f5/e08b92/a55c1357413b5e36547a8b534a014c3a00299e7622e4c4b022a96541"
         );
         assert_eq!(
@@ -187,7 +187,7 @@ mod tests {
 
         let built_key = CacheKey::from_scoped_file(&scope, &file);
 
-        assert_eq!(built_key.cache_path(0), key.cache_path(0));
+        assert_eq!(built_key.cache_path_old(0), key.cache_path_old(0));
 
         let mut builder = CacheKey::scoped_builder(&scope);
         builder.write_file_meta(&file).unwrap();
@@ -199,7 +199,7 @@ mod tests {
         let key = builder.build();
 
         assert_eq!(
-            &key.cache_path(0),
+            &key.cache_path_old(0),
             "v0/d9/40ba75/07d18c0e9a1d884809670a1e32a72a85ed7563c52909507bf594880a"
         );
         assert_eq!(

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -326,7 +326,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
             // Clean up old versions
             for version in 0..T::VERSIONS.current {
-                let item_path = key.cache_path(version);
+                let item_path = key.cache_path_old(version);
 
                 if let Err(e) = fs::remove_file(cache_dir.join(&item_path)) {
                     // `NotFound` errors are no cause for concern—it's likely that not all fallback versions exist anymore.
@@ -397,7 +397,7 @@ impl<T: CacheItemRequest> Cacher<T> {
                     let cache_path = if is_current_version {
                         cache_key.cache_path_new(version)
                     } else {
-                        cache_key.cache_path(version)
+                        cache_key.cache_path_old(version)
                     };
                     let in_memory_item = match lookup_local_cache(
                         &self.config,
@@ -501,7 +501,7 @@ impl<T: CacheItemRequest> Cacher<T> {
         tracing::trace!(
             "Spawning deduplicated {} computation for path {:?}",
             name,
-            cache_key.cache_path(T::VERSIONS.current)
+            cache_key.cache_path_new(T::VERSIONS.current)
         );
 
         let this = self.clone();

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -172,7 +172,7 @@ pub use cache_key::{CacheKey, CacheKeyBuilder};
 pub use cleanup::cleanup;
 pub use config::CacheName;
 pub use fs::{Cache, ExpirationStrategy, ExpirationTime};
-pub use memory::{CacheItemRequest, CacheVersions, Cacher};
+pub use memory::{CacheItemRequest, Cacher};
 pub use metadata::{CacheEntry, Metadata};
 pub use shared_cache::{CacheStoreReason, SharedCacheConfig, SharedCacheRef, SharedCacheService};
 

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -59,7 +59,7 @@
 //! It is divided into the categories "downloaded" and "derived". Both categories have settings
 //! related to cache expiration. Additionally, they allow configuring a limit on concurrent lazy
 //! re-downloads and re-computation. The limit applies to the whole category at once.
-//! See the section on [`CacheVersions`] for more details.
+//! See the section on [`CacheVersions`](crate::caches::CacheVersions) for more details.
 //!
 //! The `retry_X_after` options specify a time-to-live after which the cache expires and will be
 //! re-computed. The `max_unused_for` option is rather a time-to-idle value, after which the item
@@ -110,7 +110,7 @@
 //! **NOTE**: Care must be taken to make sure that this metadata is stable, as it would otherwise
 //! lead to bad cache reuse.
 //!
-//! ## Cache Fallback and [`CacheVersions`]
+//! ## Cache Fallback and [`CacheVersions`](crate::caches::CacheVersions)
 //!
 //! Each type of cache defines both a current cache version and a list of fallback versions. Different
 //! versions correspond to separate directories on the file system. When an item is looked up in a file
@@ -139,7 +139,7 @@
 //! fallible. However, failing to load a previously written cache file in most cases should be
 //! considered a [`CacheError::InternalError`], and is unexpected to occur.
 //!
-//! A [`CacheItemRequest`] also needs to specify [`CacheVersions`] which are used for cache fallback
+//! A [`CacheItemRequest`] also needs to specify [`CacheVersions`](crate::caches::CacheVersions) which are used for cache fallback
 //! as explained in detail above. Newly added caches should start with version `1`, and all the
 //! cache versions and their versioning history should be recorded in [`caches::versions`](crate::caches::versions).
 //!

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -1015,11 +1015,11 @@ async fn test_cache_fallback() {
     let request = TestCacheItem::new();
     let key = CacheKey::for_testing(Scope::Global, "global/some_cache_key");
 
-    let very_old_cache_file = cache_dir.path().join("objects").join(key.cache_path(0));
+    let very_old_cache_file = cache_dir.path().join("objects").join(key.cache_path_old(0));
     fs::create_dir_all(very_old_cache_file.parent().unwrap()).unwrap();
     fs::write(&very_old_cache_file, "some incompatible cached contents").unwrap();
 
-    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path(1));
+    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path_old(1));
     fs::create_dir_all(old_cache_file.parent().unwrap()).unwrap();
     fs::write(&old_cache_file, "some old cached contents").unwrap();
 
@@ -1076,7 +1076,7 @@ async fn test_cache_fallback_notfound() {
 
     {
         let cache_dir = cache_dir.path().join("objects");
-        let cache_file = cache_dir.join(key.cache_path(1));
+        let cache_file = cache_dir.join(key.cache_path_old(1));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
@@ -1133,7 +1133,7 @@ async fn test_lazy_computation_limit() {
         let request = request.clone();
         let key = CacheKey::for_testing(Scope::Global, *key);
 
-        let cache_file = cache_dir.join(key.cache_path(1));
+        let cache_file = cache_dir.join(key.cache_path_old(1));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -1080,7 +1080,7 @@ async fn test_cache_fallback_notfound() {
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
-        let cache_file = cache_dir.join(key.cache_path(2));
+        let cache_file = cache_dir.join(key.cache_path_new(2));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "").unwrap();
     }
@@ -1224,7 +1224,7 @@ async fn test_failing_cache_write() {
 
     // The computation returned `InternalError`, so the file should not have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path(1));
+    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path_new(1));
     assert!(!fs::exists(cache_file_path).unwrap());
 
     // Case 2: malformed error
@@ -1240,6 +1240,6 @@ async fn test_failing_cache_write() {
 
     // The computation returned `Malformed`, so the file should have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path(1));
+    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path_new(1));
     assert!(fs::exists(cache_file_path).unwrap());
 }

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -12,6 +12,7 @@ use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
+use crate::caches::{CachePathFormat, CacheVersion, CacheVersions};
 use crate::config::{CacheConfig, CacheConfigs, DerivedCacheConfig, DownloadedCacheConfig};
 use crate::test;
 use crate::types::Scope;
@@ -985,8 +986,12 @@ impl CacheItemRequest for TestCacheItem {
     type Item = String;
 
     const VERSIONS: CacheVersions = CacheVersions {
-        current: 2,
-        fallbacks: &[1],
+        current: CacheVersion::new(2, CachePathFormat::V2),
+        fallbacks: &[CacheVersion::new(1, CachePathFormat::V1)],
+        previous: &[
+            CacheVersion::new(0, CachePathFormat::V1),
+            CacheVersion::new(1, CachePathFormat::V1),
+        ],
     };
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
@@ -1015,11 +1020,20 @@ async fn test_cache_fallback() {
     let request = TestCacheItem::new();
     let key = CacheKey::for_testing(Scope::Global, "global/some_cache_key");
 
-    let very_old_cache_file = cache_dir.path().join("objects").join(key.cache_path_old(0));
+    let very_old_version = CacheVersion::new(0, CachePathFormat::V1);
+    let old_version = CacheVersion::new(1, CachePathFormat::V1);
+
+    let very_old_cache_file = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(very_old_version));
     fs::create_dir_all(very_old_cache_file.parent().unwrap()).unwrap();
     fs::write(&very_old_cache_file, "some incompatible cached contents").unwrap();
 
-    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path_old(1));
+    let old_cache_file = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(old_version));
     fs::create_dir_all(old_cache_file.parent().unwrap()).unwrap();
     fs::write(&old_cache_file, "some old cached contents").unwrap();
 
@@ -1076,11 +1090,11 @@ async fn test_cache_fallback_notfound() {
 
     {
         let cache_dir = cache_dir.path().join("objects");
-        let cache_file = cache_dir.join(key.cache_path_old(1));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.fallbacks[0]));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
-        let cache_file = cache_dir.join(key.cache_path_new(2));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.current));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "").unwrap();
     }
@@ -1133,7 +1147,7 @@ async fn test_lazy_computation_limit() {
         let request = request.clone();
         let key = CacheKey::for_testing(Scope::Global, *key);
 
-        let cache_file = cache_dir.join(key.cache_path_old(1));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.fallbacks[0]));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
@@ -1174,8 +1188,9 @@ impl CacheItemRequest for FailingTestCacheItem {
     type Item = String;
 
     const VERSIONS: CacheVersions = CacheVersions {
-        current: 1,
+        current: CacheVersion::new(2, CachePathFormat::V2),
         fallbacks: &[],
+        previous: &[CacheVersion::new(1, CachePathFormat::V1)],
     };
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
@@ -1224,7 +1239,10 @@ async fn test_failing_cache_write() {
 
     // The computation returned `InternalError`, so the file should not have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path_new(1));
+    let cache_file_path = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(FailingTestCacheItem::VERSIONS.current));
     assert!(!fs::exists(cache_file_path).unwrap());
 
     // Case 2: malformed error
@@ -1240,6 +1258,9 @@ async fn test_failing_cache_write() {
 
     // The computation returned `Malformed`, so the file should have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path_new(1));
+    let cache_file_path = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(FailingTestCacheItem::VERSIONS.current));
     assert!(fs::exists(cache_file_path).unwrap());
 }

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -19,8 +19,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
-use crate::caches::versions::OBJECTS_CACHE_VERSIONS;
-use crate::caching::CacheVersions;
+use crate::caches::versions::{CacheVersions, OBJECTS_CACHE_VERSIONS};
 use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey};
 use crate::download::{fetch_file, tempfile_in_parent, DownloadService};
 use crate::types::Scope;

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -16,9 +16,8 @@ use symbolicator_sources::{ObjectId, RemoteFile};
 use tempfile::NamedTempFile;
 
 use crate::caches::versions::META_CACHE_VERSIONS;
-use crate::caching::{
-    CacheContents, CacheItemRequest, CacheKey, CacheKeyBuilder, CacheVersions, Cacher,
-};
+use crate::caches::CacheVersions;
+use crate::caching::{CacheContents, CacheItemRequest, CacheKey, CacheKeyBuilder, Cacher};
 use crate::download::DownloadService;
 use crate::types::Scope;
 


### PR DESCRIPTION
Currently the path we compute for a cache key has the form `xx/xxxxxx/xxx…`, with `x` being a hex digit. This means that there is a two-level directory hierarchy where the outer layer has 256 possible entries and the inner has  2 ^ 24
= 16_777_216. This makes it infeasible to leave empty directories lying around and generally slows down the cleanup process.

Instead, we now format a key as `xx/xx/xxx…`. This means that there are 256 directories in both layers, for a total of 65536 directories per cache (and version, but under normal operation there is only one version per cache).

Switching the cache directory layout is obviously very disruptive. In order to accomplish this, we take the following steps:
* Bump all cache versions, with the previous version being marked as compatible so that existing caches can still be used.
* Rename the function `cache_path` to `cache_path_old` and introduce a new function `cache_path_new` that outputs the new format.
* Use `cache_path_new` whenever we compute a cache path for the current version and `cache_path_old` whenever we compute a cache path for a fallback version.

As a follow-up, once the new caches have replaced the old, we will remove `cache_key_old` and rename `cache_key_new` to `cache_key`.