### PR TITLE
feat(caches): Introduce cache path layouts

### DIFF
--- a/crates/symbolicator-js/src/sourcemap_cache.rs
+++ b/crates/symbolicator-js/src/sourcemap_cache.rs
@@ -7,8 +7,8 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolic::debuginfo::sourcebundle::SourceFileDescriptor;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
 use symbolicator_service::caches::versions::SOURCEMAP_CACHE_VERSIONS;
-use symbolicator_service::caches::ByteViewString;
-use symbolicator_service::caching::{CacheContents, CacheError, CacheItemRequest, CacheVersions};
+use symbolicator_service::caches::{ByteViewString, CacheVersions};
+use symbolicator_service::caching::{CacheContents, CacheError, CacheItemRequest};
 use symbolicator_service::objects::ObjectHandle;
 use tempfile::NamedTempFile;
 

--- a/crates/symbolicator-native/src/caches/bitcode.rs
+++ b/crates/symbolicator-native/src/caches/bitcode.rs
@@ -13,9 +13,9 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::{ByteView, DebugId};
 use symbolic::debuginfo::macho::{BcSymbolMap, UuidMapping};
 use symbolicator_service::caches::versions::BITCODE_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
-    SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use symbolicator_service::download::{fetch_file, DownloadService};
 use symbolicator_service::metric;

--- a/crates/symbolicator-native/src/caches/cficaches.rs
+++ b/crates/symbolicator-native/src/caches/cficaches.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 use minidump_unwind::SymbolFile;
 use sentry::types::DebugId;
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::cfi::CfiCache;
@@ -12,7 +13,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::breakpad::BreakpadModuleRecord;
 use symbolicator_service::caches::versions::CFICACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-native/src/caches/il2cpp.rs
+++ b/crates/symbolicator-native/src/caches/il2cpp.rs
@@ -11,9 +11,9 @@ use sentry::{Hub, SentryFutureExt};
 use symbolic::common::{ByteView, DebugId};
 use symbolic::il2cpp::LineMapping;
 use symbolicator_service::caches::versions::IL2CPP_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
-    SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher, SharedCacheRef,
 };
 use symbolicator_service::download::{fetch_file, DownloadService};
 use symbolicator_service::metric;

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -3,6 +3,7 @@ use std::io::{self, BufWriter};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::common::{ByteView, SelfCell};
@@ -10,7 +11,7 @@ use symbolic::debuginfo::Object;
 use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_service::caches::versions::PPDB_CACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use sentry::{Hub, SentryFutureExt};
+use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
 use symbolic::common::{ByteView, SelfCell};
 use symbolic::symcache::{SymCache, SymCacheConverter};
 use symbolicator_service::caches::versions::SYMCACHE_VERSIONS;
 use symbolicator_service::caching::{
-    Cache, CacheContents, CacheError, CacheItemRequest, CacheVersions, Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheError, CacheItemRequest, Cacher, SharedCacheRef,
 };
 use symbolicator_service::objects::{
     CandidateStatus, FindObject, ObjectHandle, ObjectMetaHandle, ObjectPurpose, ObjectsActor,

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -5,8 +5,9 @@ use futures::future::BoxFuture;
 use proguard::ProguardCache;
 use symbolic::common::{AsSelf, ByteView, DebugId, SelfCell};
 use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
+use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
-    CacheContents, CacheError, CacheItemRequest, CacheKey, CacheVersions, Cacher,
+    CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher,
 };
 use symbolicator_service::download::{fetch_file, tempfile_in_parent, DownloadService};
 use symbolicator_service::objects::{

--- a/crates/symbolicator-service/src/caches/mod.rs
+++ b/crates/symbolicator-service/src/caches/mod.rs
@@ -4,3 +4,4 @@ mod sourcefiles;
 pub mod versions;
 
 pub use sourcefiles::{ByteViewString, SourceFilesCache};
+pub use versions::{CachePathFormat, CacheVersion, CacheVersions};

--- a/crates/symbolicator-service/src/caches/sourcefiles.rs
+++ b/crates/symbolicator-service/src/caches/sourcefiles.rs
@@ -6,9 +6,10 @@ use symbolic::common::{ByteView, SelfCell};
 use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
+use crate::caches::CacheVersions;
 use crate::caching::{
-    Cache, CacheContents, CacheEntry, CacheError, CacheItemRequest, CacheKey, CacheVersions,
-    Cacher, SharedCacheRef,
+    Cache, CacheContents, CacheEntry, CacheError, CacheItemRequest, CacheKey, Cacher,
+    SharedCacheRef,
 };
 use crate::download::{fetch_file, DownloadService};
 use crate::types::Scope;

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -73,6 +73,9 @@ pub struct CacheVersions {
     /// in descending order of priority.
     pub fallbacks: &'static [CacheVersion],
     /// A list of all previous cache versions.
+    ///
+    /// This list includes both fallback and incompatible
+    /// versions.
     pub previous: &'static [CacheVersion],
 }
 

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -8,13 +8,73 @@
 //!
 //! * increase the `current` version.
 //! * prepend the `current` version to the `fallbacks`.
+//! * add the `current` version to the `previous` versions.
 //! * it is also possible to skip a version, in case a broken deploy needed to
 //!   be reverted which left behind broken cache files.
 //!
 //! Some of the versioned caches are also tied to format versions defined in [`symbolic`].
 //! For those cases, there are static assertions that are a reminder to also bump the cache version.
 
-use crate::caching::CacheVersions;
+use std::fmt;
+
+/// How to format cache keys into file paths.
+#[derive(Clone, Copy, Debug)]
+pub enum CachePathFormat {
+    /// Format cache keys as `xx/xxxxxx/xxx…`.
+    V1,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CacheVersion {
+    /// The version number.
+    pub number: u32,
+    /// The way in which cache keys should be formatted
+    /// into file paths for this version.
+    pub path_format: CachePathFormat,
+}
+
+impl CacheVersion {
+    /// Creates a new `CacheVersion` with the given number and path format.
+    pub const fn new(number: u32, path_format: CachePathFormat) -> Self {
+        Self {
+            number,
+            path_format,
+        }
+    }
+}
+
+impl fmt::Display for CacheVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.number)
+    }
+}
+
+impl PartialEq for CacheVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.number == other.number
+    }
+}
+
+impl Eq for CacheVersion {}
+
+/// Cache Version Configuration used during cache lookup and generation.
+///
+/// The `current` version is tried first, and written during cache generation.
+/// The `fallback` versions are tried next, in first to last order. They are used only for cache
+/// lookups, but never for writing.
+///
+/// The version `0` is special in the sense that it is not used as part of the resulting cache
+/// file path, and generates the same paths as "legacy" unversioned cache files.
+#[derive(Clone, Debug)]
+pub struct CacheVersions {
+    /// The current cache version that is being looked up, and used for writing
+    pub current: CacheVersion,
+    /// A list of fallback cache versions that are being tried on lookup,
+    /// in descending order of priority.
+    pub fallbacks: &'static [CacheVersion],
+    /// A list of all previous cache versions.
+    pub previous: &'static [CacheVersion],
+}
 
 /// CFI cache, with the following versions:
 ///
@@ -29,8 +89,13 @@ use crate::caching::CacheVersions;
 ///
 /// - `0`: Initial version.
 pub const CFICACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 4,
+    current: CacheVersion::new(4, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[
+        CacheVersion::new(1, CachePathFormat::V1),
+        CacheVersion::new(2, CachePathFormat::V1),
+        CacheVersion::new(3, CachePathFormat::V1),
+    ],
 };
 static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 
@@ -60,8 +125,16 @@ static_assert!(symbolic::cfi::CFICACHE_LATEST_VERSION == 2);
 ///
 /// - `0`: Initial version.
 pub const SYMCACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 7,
-    fallbacks: &[6],
+    current: CacheVersion::new(7, CachePathFormat::V1),
+    fallbacks: &[CacheVersion::new(6, CachePathFormat::V1)],
+    previous: &[
+        CacheVersion::new(1, CachePathFormat::V1),
+        CacheVersion::new(2, CachePathFormat::V1),
+        CacheVersion::new(3, CachePathFormat::V1),
+        CacheVersion::new(4, CachePathFormat::V1),
+        CacheVersion::new(5, CachePathFormat::V1),
+        CacheVersion::new(6, CachePathFormat::V1),
+    ],
 };
 static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 
@@ -71,8 +144,9 @@ static_assert!(symbolic::symcache::SYMCACHE_VERSION == 8);
 ///
 /// - `0`: Initial version.
 pub const OBJECTS_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Objects Meta cache, with the following versions:
@@ -81,8 +155,9 @@ pub const OBJECTS_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `0`: Initial version.
 pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Portable PDB cache, with the following versions:
@@ -93,16 +168,21 @@ pub const META_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `1`: Initial version.
 pub const PPDB_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 3,
-    fallbacks: &[2],
+    current: CacheVersion::new(3, CachePathFormat::V1),
+    fallbacks: &[CacheVersion::new(2, CachePathFormat::V1)],
+    previous: &[
+        CacheVersion::new(1, CachePathFormat::V1),
+        CacheVersion::new(2, CachePathFormat::V1),
+    ],
 };
 
 /// SourceMapCache, with the following versions:
 ///
 /// - `1`: Initial version.
 pub const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Il2cpp cache, with the following versions:
@@ -111,8 +191,9 @@ pub const SOURCEMAP_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `0`: Initial version.
 pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Bitcode / Auxdif (plist / bcsymbolmap) cache, with the following versions:
@@ -121,31 +202,36 @@ pub const IL2CPP_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `0`: Initial version.
 pub const BITCODE_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Source Files Cache, with the following versions:
 ///
 /// - `1`: Initial version.
 pub const SOURCEFILES_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Bundle Index Cache, with the following versions:
 ///
 /// - `1`: Initial version.
 pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 1,
+    current: CacheVersion::new(1, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[],
 };
 
 /// Proguard Cache, with the following versions:
 ///
-/// - `1`: Initial version.
 /// - `2`: Use proguard cache format (<https://github.com/getsentry/symbolicator/pull/1491>).
+///
+/// - `1`: Initial version.
 pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: 2,
+    current: CacheVersion::new(2, CachePathFormat::V1),
     fallbacks: &[],
+    previous: &[CacheVersion::new(1, CachePathFormat::V1)],
 };

--- a/crates/symbolicator-service/src/caching/cache_key.rs
+++ b/crates/symbolicator-service/src/caching/cache_key.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use sha2::{Digest, Sha256};
 use symbolicator_sources::RemoteFile;
 
+use crate::caches::{CachePathFormat, CacheVersion};
 use crate::types::Scope;
 
 /// The key of an item in an in-memory or on-disk
@@ -28,7 +29,11 @@ impl CacheKey {
 
 impl fmt::Display for CacheKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.cache_path(1234))
+        write!(
+            f,
+            "{}",
+            self.cache_path(CacheVersion::new(1234, CachePathFormat::V1))
+        )
     }
 }
 
@@ -59,18 +64,27 @@ impl CacheKey {
 
     /// Returns the relative path for this cache key.
     ///
-    /// The relative path is a sha-256 hash hex-formatted like so:
-    /// `v$version/aa/bbccdd/eeff...`
-    pub fn cache_path(&self, version: u32) -> String {
-        let mut path = format!("v{version}/{:02x}/", self.hash[0]);
-        for b in &self.hash[1..4] {
-            path.write_fmt(format_args!("{b:02x}")).unwrap();
+    /// The relative path depends on the `version`'s `path_format`
+    /// field. See the documentation of [`CachePathFormat`].
+    pub fn cache_path(&self, version: CacheVersion) -> String {
+        let CacheVersion {
+            number,
+            path_format,
+        } = version;
+
+        match path_format {
+            CachePathFormat::V1 => {
+                let mut path = format!("v{number}/{:02x}/", self.hash[0]);
+                for b in &self.hash[1..4] {
+                    path.write_fmt(format_args!("{b:02x}")).unwrap();
+                }
+                path.push('/');
+                for b in &self.hash[4..] {
+                    path.write_fmt(format_args!("{b:02x}")).unwrap();
+                }
+                path
+            }
         }
-        path.push('/');
-        for b in &self.hash[4..] {
-            path.write_fmt(format_args!("{b:02x}")).unwrap();
-        }
-        path
     }
 
     /// Create a [`CacheKeyBuilder`] that can be used to build a cache key consisting of all its
@@ -158,7 +172,7 @@ mod tests {
         let key = CacheKey::from_scoped_file(&scope, &file);
 
         assert_eq!(
-            &key.cache_path(0),
+            &key.cache_path(CacheVersion::new(0, CachePathFormat::V1)),
             "v0/f5/e08b92/a55c1357413b5e36547a8b534a014c3a00299e7622e4c4b022a96541"
         );
         assert_eq!(
@@ -168,7 +182,10 @@ mod tests {
 
         let built_key = CacheKey::from_scoped_file(&scope, &file);
 
-        assert_eq!(built_key.cache_path(0), key.cache_path(0));
+        assert_eq!(
+            built_key.cache_path(CacheVersion::new(0, CachePathFormat::V1)),
+            key.cache_path(CacheVersion::new(0, CachePathFormat::V1))
+        );
 
         let mut builder = CacheKey::scoped_builder(&scope);
         builder.write_file_meta(&file).unwrap();
@@ -180,7 +197,7 @@ mod tests {
         let key = builder.build();
 
         assert_eq!(
-            &key.cache_path(0),
+            &key.cache_path(CacheVersion::new(0, CachePathFormat::V1)),
             "v0/d9/40ba75/07d18c0e9a1d884809670a1e32a72a85ed7563c52909507bf594880a"
         );
         assert_eq!(

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -12,6 +12,7 @@ use tempfile::NamedTempFile;
 
 use super::metadata::CacheEntry;
 use super::shared_cache::{CacheStoreReason, SharedCacheRef};
+use crate::caches::CacheVersions;
 use crate::caching::Metadata;
 use crate::utils::futures::CallOnDrop;
 
@@ -152,23 +153,6 @@ impl<T: CacheItemRequest> Cacher<T> {
             shared_cache,
         }
     }
-}
-
-/// Cache Version Configuration used during cache lookup and generation.
-///
-/// The `current` version is tried first, and written during cache generation.
-/// The `fallback` versions are tried next, in first to last order. They are used only for cache
-/// lookups, but never for writing.
-///
-/// The version `0` is special in the sense that it is not used as part of the resulting cache
-/// file path, and generates the same paths as "legacy" unversioned cache files.
-#[derive(Clone, Debug)]
-pub struct CacheVersions {
-    /// The current cache version that is being looked up, and used for writing
-    pub current: u32,
-    /// A list of fallback cache versions that are being tried on lookup,
-    /// in descending order of priority.
-    pub fallbacks: &'static [u32],
 }
 
 pub trait CacheItemRequest: 'static + Send + Sync + Clone {
@@ -325,8 +309,8 @@ impl<T: CacheItemRequest> Cacher<T> {
             }
 
             // Clean up old versions
-            for version in 0..T::VERSIONS.current {
-                let item_path = key.cache_path(version);
+            for version in T::VERSIONS.previous {
+                let item_path = key.cache_path(*version);
 
                 if let Err(e) = fs::remove_file(cache_dir.join(&item_path)) {
                     // `NotFound` errors are no cause for concern—it's likely that not all fallback versions exist anymore.

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -59,7 +59,7 @@
 //! It is divided into the categories "downloaded" and "derived". Both categories have settings
 //! related to cache expiration. Additionally, they allow configuring a limit on concurrent lazy
 //! re-downloads and re-computation. The limit applies to the whole category at once.
-//! See the section on [`CacheVersions`] for more details.
+//! See the section on [`CacheVersions`](crate::caches::CacheVersions) for more details.
 //!
 //! The `retry_X_after` options specify a time-to-live after which the cache expires and will be
 //! re-computed. The `max_unused_for` option is rather a time-to-idle value, after which the item
@@ -110,7 +110,7 @@
 //! **NOTE**: Care must be taken to make sure that this metadata is stable, as it would otherwise
 //! lead to bad cache reuse.
 //!
-//! ## Cache Fallback and [`CacheVersions`]
+//! ## Cache Fallback and [`CacheVersions`](crate::caches::CacheVersions)
 //!
 //! Each type of cache defines both a current cache version and a list of fallback versions. Different
 //! versions correspond to separate directories on the file system. When an item is looked up in a file
@@ -139,7 +139,7 @@
 //! fallible. However, failing to load a previously written cache file in most cases should be
 //! considered a [`CacheError::InternalError`], and is unexpected to occur.
 //!
-//! A [`CacheItemRequest`] also needs to specify [`CacheVersions`] which are used for cache fallback
+//! A [`CacheItemRequest`] also needs to specify [`CacheVersions`](crate::caches::CacheVersions) which are used for cache fallback
 //! as explained in detail above. Newly added caches should start with version `1`, and all the
 //! cache versions and their versioning history should be recorded in [`caches::versions`](crate::caches::versions).
 //!
@@ -172,7 +172,7 @@ pub use cache_key::{CacheKey, CacheKeyBuilder};
 pub use cleanup::cleanup;
 pub use config::CacheName;
 pub use fs::{Cache, ExpirationStrategy, ExpirationTime};
-pub use memory::{CacheItemRequest, CacheVersions, Cacher};
+pub use memory::{CacheItemRequest, Cacher};
 pub use metadata::{CacheEntry, Metadata};
 pub use shared_cache::{CacheStoreReason, SharedCacheConfig, SharedCacheRef, SharedCacheService};
 

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -12,6 +12,7 @@ use symbolic::common::ByteView;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
+use crate::caches::{CachePathFormat, CacheVersion, CacheVersions};
 use crate::config::{CacheConfig, CacheConfigs, DerivedCacheConfig, DownloadedCacheConfig};
 use crate::test;
 use crate::types::Scope;
@@ -985,8 +986,12 @@ impl CacheItemRequest for TestCacheItem {
     type Item = String;
 
     const VERSIONS: CacheVersions = CacheVersions {
-        current: 2,
-        fallbacks: &[1],
+        current: CacheVersion::new(2, CachePathFormat::V1),
+        fallbacks: &[CacheVersion::new(1, CachePathFormat::V1)],
+        previous: &[
+            CacheVersion::new(0, CachePathFormat::V1),
+            CacheVersion::new(1, CachePathFormat::V1),
+        ],
     };
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
@@ -1015,11 +1020,20 @@ async fn test_cache_fallback() {
     let request = TestCacheItem::new();
     let key = CacheKey::for_testing(Scope::Global, "global/some_cache_key");
 
-    let very_old_cache_file = cache_dir.path().join("objects").join(key.cache_path(0));
+    let very_old_version = CacheVersion::new(0, CachePathFormat::V1);
+    let old_version = CacheVersion::new(1, CachePathFormat::V1);
+
+    let very_old_cache_file = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(very_old_version));
     fs::create_dir_all(very_old_cache_file.parent().unwrap()).unwrap();
     fs::write(&very_old_cache_file, "some incompatible cached contents").unwrap();
 
-    let old_cache_file = cache_dir.path().join("objects").join(key.cache_path(1));
+    let old_cache_file = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(old_version));
     fs::create_dir_all(old_cache_file.parent().unwrap()).unwrap();
     fs::write(&old_cache_file, "some old cached contents").unwrap();
 
@@ -1076,11 +1090,11 @@ async fn test_cache_fallback_notfound() {
 
     {
         let cache_dir = cache_dir.path().join("objects");
-        let cache_file = cache_dir.join(key.cache_path(1));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.fallbacks[0]));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
-        let cache_file = cache_dir.join(key.cache_path(2));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.current));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "").unwrap();
     }
@@ -1133,7 +1147,7 @@ async fn test_lazy_computation_limit() {
         let request = request.clone();
         let key = CacheKey::for_testing(Scope::Global, *key);
 
-        let cache_file = cache_dir.join(key.cache_path(1));
+        let cache_file = cache_dir.join(key.cache_path(TestCacheItem::VERSIONS.fallbacks[0]));
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(cache_file, "some old cached contents").unwrap();
 
@@ -1174,8 +1188,9 @@ impl CacheItemRequest for FailingTestCacheItem {
     type Item = String;
 
     const VERSIONS: CacheVersions = CacheVersions {
-        current: 1,
+        current: CacheVersion::new(2, CachePathFormat::V1),
         fallbacks: &[],
+        previous: &[CacheVersion::new(1, CachePathFormat::V1)],
     };
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
@@ -1224,7 +1239,10 @@ async fn test_failing_cache_write() {
 
     // The computation returned `InternalError`, so the file should not have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path(1));
+    let cache_file_path = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(FailingTestCacheItem::VERSIONS.current));
     assert!(!fs::exists(cache_file_path).unwrap());
 
     // Case 2: malformed error
@@ -1240,6 +1258,9 @@ async fn test_failing_cache_write() {
 
     // The computation returned `Malformed`, so the file should have been
     // persisted
-    let cache_file_path = cache_dir.path().join("objects").join(key.cache_path(1));
+    let cache_file_path = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(FailingTestCacheItem::VERSIONS.current));
     assert!(fs::exists(cache_file_path).unwrap());
 }

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -19,8 +19,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::{Archive, Object};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
-use crate::caches::versions::OBJECTS_CACHE_VERSIONS;
-use crate::caching::CacheVersions;
+use crate::caches::versions::{CacheVersions, OBJECTS_CACHE_VERSIONS};
 use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey};
 use crate::download::{fetch_file, tempfile_in_parent, DownloadService};
 use crate::types::Scope;

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -16,9 +16,8 @@ use symbolicator_sources::{ObjectId, RemoteFile};
 use tempfile::NamedTempFile;
 
 use crate::caches::versions::META_CACHE_VERSIONS;
-use crate::caching::{
-    CacheContents, CacheItemRequest, CacheKey, CacheKeyBuilder, CacheVersions, Cacher,
-};
+use crate::caches::CacheVersions;
+use crate::caching::{CacheContents, CacheItemRequest, CacheKey, CacheKeyBuilder, Cacher};
 use crate::download::DownloadService;
 use crate::types::Scope;
 


### PR DESCRIPTION
This is part 1 of a more principled/correct solution to #1630. It introduces a `CachePathFormat` enum (which for now only has 1 variant) that is attached to each cache version and determines how a cache key should be formatted into a cache file path for this version.