### PR TITLE
fix(cleanup): Use remove_dir_all

### DIFF
--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -180,6 +180,10 @@ impl Cache {
                 if dir_is_empty {
                     tracing::debug!("Removing directory `{}`", directory.display());
                     if !dry_run {
+                        // We use `remove_dir_all` here to make sure that the cleanup
+                        // succeeds even if the directory is not literally empty. We
+                        // have checked above that all cache files inside have been cleaned up,
+                        // but there might be orphaned metadata files or other broken data.
                         if let Err(e) = remove_dir_all(&path) {
                             sentry::with_scope(
                                 |scope| scope.set_extra("path", path.display().to_string().into()),

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsStr;
-use std::fs::{read_dir, remove_dir, remove_file};
+use std::fs::{read_dir, remove_dir_all, remove_file};
 use std::io;
 use std::path::Path;
 
@@ -180,7 +180,7 @@ impl Cache {
                 if dir_is_empty {
                     tracing::debug!("Removing directory `{}`", directory.display());
                     if !dry_run {
-                        if let Err(e) = remove_dir(&path) {
+                        if let Err(e) = remove_dir_all(&path) {
                             sentry::with_scope(
                                 |scope| scope.set_extra("path", path.display().to_string().into()),
                                 || tracing::error!("Failed to clean cache directory: {:?}", e),


### PR DESCRIPTION
This lets the cleanup remove directories that are "morally" empty but e.g. still contain leftover metadata files.