### PR TITLE
feat(release): Tag images with release version.

### DIFF
--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,0 +1,22 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/symbolicator:${{ github.ref_name }} \
+           ghcr.io/getsentry/symbolicator:${{ github.sha }}


### PR DESCRIPTION
This adds the same logic that is being added to Relay (https://github.com/getsentry/relay/pull/4532) to symbolicator.
That is, this PR adds the logic to tag  images we release to the Github Container Registry (ghcr) with the release version.

