### PR TITLE
ref: Log successful downloads from Electron

### DIFF
--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -396,6 +396,8 @@ impl DownloadService {
             metric!(counter("service.builtin_source.download") += 1, "source" => &source_metric_key, "status" => status);
         }
 
+        // Temporarily log successful downloads from Electron
+        // to see which files we can actually find there.
         if source_metric_key == "sentry:electron" && result.is_ok() {
             tracing::info!(
                 %uri,

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -328,6 +328,7 @@ impl DownloadService {
         destination: PathBuf,
     ) -> CacheContents {
         let host = source.host();
+        let uri = source.uri();
 
         let is_builtin_source = source.is_builtin();
         let source_metric_key = source.source_metric_key().to_string();
@@ -393,6 +394,13 @@ impl DownloadService {
                 Err(CacheError::InternalError) => "internalerror",
             };
             metric!(counter("service.builtin_source.download") += 1, "source" => &source_metric_key, "status" => status);
+        }
+
+        if source_metric_key == "sentry:electron" && result.is_ok() {
+            tracing::info!(
+                %uri,
+                "Successfully fetched from Electron symbol server"
+            );
         }
 
         result


### PR DESCRIPTION
Temporarily log whenever we successfully download a file from the Electron symbol server. These are few and far between, so the volume should be no problem.

The purpose of this is to validate that we only find files with very specific debug file names (my current assumption). If that is true, we can use path patterns to significantly limit what we request from Electron.