### PR TITLE
ref(caches): Mark certain caches as random access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Various fixes & improvements
+
+- Update `symbolic` dependency to `12.14.0`, which now skips not found frames instead of defaulting to the closest one. ([#1640](https://github.com/getsentry/symbolicator/pull/1640))
+- Mark certain caches as random access to improve cache performance. ([#1639](https://github.com/getsentry/symbolicator/pull/1639))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.20 to v0.8.1 ([#1634](https://github.com/getsentry/symbolicator/pull/1634))
@@ -12,8 +17,8 @@
 
 ### Various fixes & improvements
 
-fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#1621](https://github.com/getsentry/symbolicator/pull/1621))
-feat: Added a setting `retry_missing_after_public` to downloaded and derived cache configs.
+- fix: rectify symsorter `--ignore-errors` handling for ZIP archives. ([#1621](https://github.com/getsentry/symbolicator/pull/1621))
+- feat: Added a setting `retry_missing_after_public` to downloaded and derived cache configs.
       The effect of this setting is to control the time after which negative (missing, failed download, &c.)
       cache entries from public sources. The default value is 24h. ([#1623](https://github.com/getsentry/symbolicator/pull/1623))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "se
 # This only works for the very specific crate listed here, and not for its dependency tree.
 # Alternatively, the whole dependency tree can be changed at once by putting this line into
 # `crates/symbolicator/Cargo.toml`:
-# symbolic = { path = "../../../symbolic/symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
+# symbolic = { path = "../symbolic", features = ["common-serde", "debuginfo", "demangle", "minidump-serde", "symcache"] }
 # See also https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 # [patch.crates-io]
 # symbolic-debuginfo = { path = "../symbolic/symbolic-debuginfo" }

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -6,7 +6,7 @@ use futures::future::BoxFuture;
 use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
-use symbolic::common::{ByteView, SelfCell};
+use symbolic::common::{AccessPattern, ByteView, SelfCell};
 use symbolic::debuginfo::Object;
 use symbolic::ppdb::{PortablePdbCache, PortablePdbCacheConverter};
 use symbolicator_service::caches::versions::PPDB_CACHE_VERSIONS;
@@ -115,6 +115,9 @@ impl CacheItemRequest for FetchPortablePdbCacheInternal {
     }
 
     fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
+        let _result = data.hint(AccessPattern::Random);
+        debug_assert!(_result.is_ok(), "{_result:?}");
+
         parse_ppdb_cache_owned(data)
     }
 }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -8,7 +8,7 @@ use sentry::{Hub, SentryFutureExt};
 use symbolicator_service::caches::CacheVersions;
 use tempfile::NamedTempFile;
 
-use symbolic::common::{ByteView, SelfCell};
+use symbolic::common::{AccessPattern, ByteView, SelfCell};
 use symbolic::symcache::{SymCache, SymCacheConverter};
 use symbolicator_service::caches::versions::SYMCACHE_VERSIONS;
 use symbolicator_service::caching::{
@@ -91,6 +91,9 @@ impl CacheItemRequest for FetchSymCacheInternal {
     }
 
     fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
+        let _result = data.hint(AccessPattern::Random);
+        debug_assert!(_result.is_ok(), "{_result:?}");
+
         SelfCell::try_new(data, |p| unsafe {
             SymCache::parse(&*p).map_err(|e| {
                 let object_meta = &self.object_meta;

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use proguard::ProguardCache;
-use symbolic::common::{AsSelf, ByteView, DebugId, SelfCell};
+use symbolic::common::{AccessPattern, AsSelf, ByteView, DebugId, SelfCell};
 use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
 use symbolicator_service::caches::CacheVersions;
 use symbolicator_service::caching::{
@@ -185,6 +185,9 @@ impl CacheItemRequest for FetchProguard {
     }
 
     fn load(&self, byteview: ByteView<'static>) -> CacheContents<Self::Item> {
+        let _result = byteview.hint(AccessPattern::Random);
+        debug_assert!(_result.is_ok(), "{_result:?}");
+
         OwnedProguardCache::new(byteview)
     }
 


### PR DESCRIPTION
Marks the Sym- and SourceMap-Caches for random access to the byteview.

This is supposed to reduce the readahead of the operating system for data that is not actually needed. Running `symbolicli` with and without a patch to apply `MADV_RANDOM` revealed for  a single lookup we can reduce the amount of bytes read from `1628KiB` to just `84KiB`.