### PR TITLE
ref: Move Electron logging

### DIFF
--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -328,7 +328,6 @@ impl DownloadService {
         destination: PathBuf,
     ) -> CacheContents {
         let host = source.host();
-        let uri = source.uri();
 
         let is_builtin_source = source.is_builtin();
         let source_metric_key = source.source_metric_key().to_string();
@@ -394,15 +393,6 @@ impl DownloadService {
                 Err(CacheError::InternalError) => "internalerror",
             };
             metric!(counter("service.builtin_source.download") += 1, "source" => &source_metric_key, "status" => status);
-        }
-
-        // Temporarily log successful downloads from Electron
-        // to see which files we can actually find there.
-        if source_metric_key == "sentry:electron" && result.is_ok() {
-            tracing::info!(
-                %uri,
-                "Successfully fetched from Electron symbol server"
-            );
         }
 
         result

--- a/crates/symbolicator-service/src/objects/candidates.rs
+++ b/crates/symbolicator-service/src/objects/candidates.rs
@@ -260,6 +260,12 @@ impl AllObjectCandidates {
     pub fn into_inner(self) -> Vec<ObjectCandidate> {
         self.0
     }
+
+    /// Returns an iterator over the [`ObjectCandidates`](ObjectCandidate)
+    /// in this collection.
+    pub fn iter(&self) -> std::slice::Iter<ObjectCandidate> {
+        self.0.as_slice().iter()
+    }
 }
 
 impl From<Vec<ObjectCandidate>> for AllObjectCandidates {
@@ -268,6 +274,16 @@ impl From<Vec<ObjectCandidate>> for AllObjectCandidates {
             .sort_by_cached_key(|candidate| (candidate.source.clone(), candidate.location.clone()));
         source.dedup_by_key(|candidate| (candidate.source.clone(), candidate.location.clone()));
         Self(source)
+    }
+}
+
+impl<'a> IntoIterator for &'a AllObjectCandidates {
+    type Item = &'a ObjectCandidate;
+
+    type IntoIter = std::slice::Iter<'a, ObjectCandidate>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 


### PR DESCRIPTION
Move the logging of Electron downloads to a place where we have more useful metadata about the object.