### PR TITLE
ref: Introduce ProcessMinidump struct

### DIFF
--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -15,6 +15,7 @@ use symbolicator_service::types::{
 };
 use symbolicator_service::utils::hex::HexValue;
 use symbolicator_sources::SourceConfig;
+use tempfile::TempPath;
 use thiserror::Error;
 
 pub use crate::metrics::StacktraceOrigin;
@@ -57,6 +58,23 @@ pub struct SymbolicateStacktraces {
     /// Whether to apply source context for the stack frames.
     pub apply_source_context: bool,
 
+    /// Scraping configuration controling authenticated requests.
+    pub scraping: ScrapingConfig,
+}
+
+/// A request to process (stackwalk + symbolicate) a minidump.
+#[derive(Debug)]
+pub struct ProcessMinidump {
+    /// The minidump's platform.
+    ///
+    /// In practice this should mostly be "native".
+    pub platform: Option<Platform>,
+    /// The scope of this request which determines access to cached files.
+    pub scope: Scope,
+    /// The local temp path where the minidump file has been saved.
+    pub minidump_file: TempPath,
+    /// A list of external sources to load debug files.
+    pub sources: Arc<[SourceConfig]>,
     /// Scraping configuration controling authenticated requests.
     pub scraping: ScrapingConfig,
 }

--- a/crates/symbolicator-native/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-native/tests/integration/process_minidump.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use tempfile::NamedTempFile;
 
+use symbolicator_native::interface::ProcessMinidump;
 use symbolicator_service::types::Scope;
 
 use crate::{assert_snapshot, read_fixture, setup_service, symbol_server};
@@ -17,13 +18,13 @@ macro_rules! stackwalk_minidump {
             let mut minidump_file = NamedTempFile::new().unwrap();
             minidump_file.write_all(&minidump).unwrap();
             let response = symbolication
-                .process_minidump(
-                    None,
-                    Scope::Global,
-                    minidump_file.into_temp_path(),
-                    Arc::new([source]),
-                    Default::default(),
-                )
+                .process_minidump(ProcessMinidump {
+                    platform: None,
+                    scope: Scope::Global,
+                    minidump_file: minidump_file.into_temp_path(),
+                    sources: Arc::new([source]),
+                    scraping: Default::default(),
+                })
                 .await;
 
             assert_snapshot!(response.unwrap());

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use symbolicator_js::interface::{JsModule, JsStacktrace, SymbolicateJsStacktraces};
 use symbolicator_js::SourceMapService;
-use symbolicator_native::interface::{RawStacktrace, StacktraceOrigin, SymbolicateStacktraces};
+use symbolicator_native::interface::{
+    ProcessMinidump, RawStacktrace, StacktraceOrigin, SymbolicateStacktraces,
+};
 use symbolicator_native::SymbolicationActor;
 use symbolicator_service::download::SourceConfig;
 use symbolicator_service::types::{RawObjectInfo, Scope};
@@ -164,13 +166,13 @@ pub async fn process_payload(
 
             symbolication
                 .0
-                .process_minidump(
-                    None,
-                    scope.clone(),
-                    temp_path,
-                    Arc::clone(sources),
-                    Default::default(),
-                )
+                .process_minidump(ProcessMinidump {
+                    platform: None,
+                    scope: scope.clone(),
+                    minidump_file: temp_path,
+                    sources: Arc::clone(sources),
+                    scraping: Default::default(),
+                })
                 .await
                 .unwrap();
         }

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -2,6 +2,7 @@ use axum::extract;
 use axum::http::StatusCode;
 use axum::response::Json;
 use symbolic::common::ByteView;
+use symbolicator_native::interface::ProcessMinidump;
 use tokio::fs::File;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -75,12 +76,15 @@ pub async fn handle_minidump_request(
         )
             .into());
     }
+
     let request_id = service.process_minidump(
-        platform,
-        params.scope,
-        minidump_file,
-        sources,
-        scraping,
+        ProcessMinidump {
+            platform,
+            scope: params.scope,
+            minidump_file,
+            sources,
+            scraping,
+        },
         options,
     )?;
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -9,6 +9,7 @@ use remote::EventKey;
 
 use settings::Mode;
 use symbolicator_js::SourceMapService;
+use symbolicator_native::interface::ProcessMinidump;
 use symbolicator_native::SymbolicationActor;
 use symbolicator_service::config::Config;
 use symbolicator_service::services::SharedServices;
@@ -143,7 +144,13 @@ async fn main() -> Result<()> {
             let dsym_sources = prepare_dsym_sources(mode, &symbolicator_config, symbols);
             tracing::info!("symbolicating minidump");
             let res = native
-                .process_minidump(None, scope, minidump_path, dsym_sources, Default::default())
+                .process_minidump(ProcessMinidump {
+                    platform: None,
+                    scope,
+                    minidump_file: minidump_path,
+                    sources: dsym_sources,
+                    scraping: Default::default(),
+                })
                 .await?;
             CompletedResponse::NativeSymbolication(res)
         }


### PR DESCRIPTION
This introduces a `ProcessMinidump` request struct in analogy to `SymbolicateStacktraces` &c. This changes no functionality, it only bundles parameters together.
