### PR TITLE
feat(minidump): Introduce rewriting of debug file names for lookups

### DIFF
--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -61,6 +61,9 @@ pub struct SymbolicateStacktraces {
 
     /// Scraping configuration controling authenticated requests.
     pub scraping: ScrapingConfig,
+    /// Rules for rewriting the debug file of the first (lowest-address) module
+    /// in the request.
+    pub module_rewrite_rules: RewriteRules,
 }
 
 /// A request to process (stackwalk + symbolicate) a minidump.

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -78,6 +78,9 @@ pub struct ProcessMinidump {
     pub sources: Arc<[SourceConfig]>,
     /// Scraping configuration controling authenticated requests.
     pub scraping: ScrapingConfig,
+    /// Rules for rewriting the debug file of the first (lowest-address) module
+    /// in the request.
+    pub module_rewrite_rules: RewriteRules,
 }
 
 /// The symbolicated crash data.

--- a/crates/symbolicator-native/src/symbolication/apple.rs
+++ b/crates/symbolicator-native/src/symbolication/apple.rs
@@ -85,6 +85,7 @@ impl SymbolicationActor {
             stacktraces,
             apply_source_context: true,
             scraping,
+            module_rewrite_rules: Default::default(),
         };
 
         let mut system_info = SystemInfo {

--- a/crates/symbolicator-native/src/symbolication/module_lookup.rs
+++ b/crates/symbolicator-native/src/symbolication/module_lookup.rs
@@ -19,7 +19,9 @@ use crate::caches::ppdb_caches::{
     FetchPortablePdbCache, OwnedPortablePdbCache, PortablePdbCacheActor,
 };
 use crate::caches::symcaches::{FetchSymCache, OwnedSymCache, SymCacheActor};
-use crate::interface::{AddrMode, CompleteObjectInfo, CompleteStacktrace, RawFrame, RawStacktrace};
+use crate::interface::{
+    AddrMode, CompleteObjectInfo, CompleteStacktrace, RawFrame, RawStacktrace, RewriteRules,
+};
 
 fn object_id_from_object_info(object_info: &RawObjectInfo) -> ObjectId {
     ObjectId {
@@ -110,13 +112,24 @@ pub struct ModuleLookup {
     modules: Vec<ModuleEntry>,
     scope: Scope,
     sources: Arc<[SourceConfig]>,
+    original_first_debug_file: Option<String>,
 }
 
 type DebugSessions<'a> = HashMap<usize, Option<(&'a Scope, ObjectDebugSession<'a>)>>;
 
 impl ModuleLookup {
     /// Creates a new [`ModuleLookup`] out of the given module iterator.
-    pub fn new<I>(scope: Scope, sources: Arc<[SourceConfig]>, iter: I) -> Self
+    ///
+    /// The `module_rewrite_rules` will be used to rewrite the debug file name
+    /// of the first (by address) module. This is done because some debug files
+    /// may be found on a symbol source under another name. If such a renaming
+    /// is performed, the original name is restored in [`Self::into_inner`].
+    pub fn new<I>(
+        scope: Scope,
+        sources: Arc<[SourceConfig]>,
+        module_rewrite_rules: RewriteRules,
+        iter: I,
+    ) -> Self
     where
         I: IntoIterator<Item = CompleteObjectInfo>,
     {
@@ -156,10 +169,30 @@ impl ModuleLookup {
             }
         }
 
+        let mut original_first_debug_file = None;
+
+        // Rewrite the first (by address) module's debug file name according to the configured
+        // rewrite rules. If a rewrite ahppens, also save the original name so we can restore it
+        // after symbolication.
+        if let Some(first_module) = modules.first_mut() {
+            if let Some(new_debug_file) = first_module
+                .object_info
+                .raw
+                .debug_file
+                .as_ref()
+                .and_then(|debug_file| module_rewrite_rules.rewrite(debug_file))
+            {
+                original_first_debug_file =
+                    std::mem::take(&mut first_module.object_info.raw.debug_file);
+                first_module.object_info.raw.debug_file = Some(new_debug_file);
+            }
+        }
+
         Self {
             modules,
             scope,
             sources,
+            original_first_debug_file,
         }
     }
 
@@ -183,6 +216,15 @@ impl ModuleLookup {
                 }
             }
         }
+
+        // Restore the original name of the first module's debug file, if there
+        // was a replacement.
+        if let Some(original) = self.original_first_debug_file {
+            if let Some(entry) = self.modules.first_mut() {
+                entry.object_info.raw.debug_file = Some(original);
+            }
+        }
+
         self.modules.sort_by_key(|entry| entry.module_index);
         self.modules
             .into_iter()
@@ -534,6 +576,7 @@ mod tests {
         let modules = ModuleLookup::new(
             Scope::Global,
             Arc::new([]),
+            Default::default(),
             raw_modules.into_iter().map(From::from),
         );
 
@@ -570,6 +613,7 @@ mod tests {
         let modules = ModuleLookup::new(
             Scope::Global,
             Arc::new([]),
+            Default::default(),
             raw_modules.into_iter().map(From::from),
         );
 
@@ -601,7 +645,12 @@ mod tests {
             image_size: Some(0),
         });
 
-        let lookup = ModuleLookup::new(Scope::Global, Arc::new([]), std::iter::once(info.clone()));
+        let lookup = ModuleLookup::new(
+            Scope::Global,
+            Default::default(),
+            Default::default(),
+            std::iter::once(info.clone()),
+        );
 
         let lookup_result = lookup.lookup_cache(43, AddrMode::Abs).unwrap();
         assert_eq!(lookup_result.module_index, 0);

--- a/crates/symbolicator-native/src/symbolication/process_minidump.rs
+++ b/crates/symbolicator-native/src/symbolication/process_minidump.rs
@@ -546,7 +546,7 @@ impl SymbolicationActor {
             &minidump,
             scope.clone(),
             sources.clone(),
-            module_rewrite_rules,
+            module_rewrite_rules.clone(),
         );
 
         let result = match stackwalk_future.await {
@@ -584,6 +584,7 @@ impl SymbolicationActor {
             stacktraces,
             apply_source_context: true,
             scraping,
+            module_rewrite_rules,
         };
 
         Ok((request, minidump_state))

--- a/crates/symbolicator-native/src/symbolication/process_minidump.rs
+++ b/crates/symbolicator-native/src/symbolication/process_minidump.rs
@@ -7,12 +7,13 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use minidump::system_info::Os;
-use minidump::{MinidumpContext, MinidumpSystemInfo};
+use minidump::{MinidumpContext, MinidumpModuleList, MinidumpSystemInfo};
 use minidump::{MinidumpModule, Module};
 use minidump_processor::ProcessState;
 use minidump_unwind::{
     FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolProvider,
 };
+use sentry::types::DebugId;
 use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
 use symbolic::common::{Arch, ByteView};
@@ -26,7 +27,7 @@ use tokio::sync::Notify;
 use crate::caches::cficaches::{CfiCacheActor, CfiModuleInfo, FetchCfiCache, FetchedCfiCache};
 use crate::interface::{
     CompleteObjectInfo, CompletedSymbolicationResponse, ProcessMinidump, RawFrame, RawStacktrace,
-    Registers, SymbolicateStacktraces, SystemInfo,
+    Registers, RewriteRules, SymbolicateStacktraces, SystemInfo,
 };
 use crate::metrics::StacktraceOrigin;
 
@@ -155,6 +156,18 @@ struct SymbolicatorSymbolProvider {
     object_type: ObjectType,
     /// The actor used for fetching CFI.
     cficache_actor: CfiCacheActor,
+    /// The debug ID of the first module in the minidump
+    /// (by address).
+    ///
+    /// This is used in conjunction with `first_module_rewrite_rules`
+    /// to rewrite the first module's debug file.
+    first_module_debug_id: Option<DebugId>,
+    /// Rules to rewrite the first module's debug file.
+    ///
+    /// Note that the debug file is "rewritten" only for the
+    /// purpose of the lookup. The file name in the minidump itself
+    /// is unaffected.
+    first_module_rewrite_rules: RewriteRules,
     /// An internal database of loaded CFI.
     cficaches: Mutex<HashMap<LookupKey, LazyCfiCache>>,
 }
@@ -165,12 +178,16 @@ impl SymbolicatorSymbolProvider {
         sources: Arc<[SourceConfig]>,
         cficache_actor: CfiCacheActor,
         object_type: ObjectType,
+        first_module_debug_id: Option<DebugId>,
+        first_module_rewrite_rules: RewriteRules,
     ) -> Self {
         Self {
             scope,
             sources,
             cficache_actor,
             object_type,
+            first_module_debug_id,
+            first_module_rewrite_rules,
             cficaches: Default::default(),
         }
     }
@@ -205,7 +222,17 @@ impl SymbolicatorSymbolProvider {
         let scope = self.scope.clone();
 
         let code_file = non_empty_file_name(&module.code_file());
-        let debug_file = module.debug_file().as_deref().and_then(non_empty_file_name);
+        let mut debug_file = module.debug_file().as_deref().and_then(non_empty_file_name);
+
+        // Rewrite the first module's debug file according to the configured rewrite rules.
+        if module.debug_identifier() == self.first_module_debug_id {
+            if let Some(new_debug_file) = debug_file
+                .as_ref()
+                .and_then(|debug_file| self.first_module_rewrite_rules.rewrite(debug_file))
+            {
+                debug_file = Some(new_debug_file);
+            }
+        }
 
         let identifier = ObjectId {
             code_id: module.code_identifier(),
@@ -315,6 +342,7 @@ async fn stackwalk(
     minidump: &Minidump,
     scope: Scope,
     sources: Arc<[SourceConfig]>,
+    first_module_rewrite_rules: RewriteRules,
 ) -> Result<StackWalkMinidumpResult> {
     // Stackwalk the minidump.
     let duration = Instant::now();
@@ -327,7 +355,22 @@ async fn stackwalk(
         Os::Linux | Os::Solaris | Os::Android => ObjectType::Elf,
         _ => ObjectType::Unknown,
     };
-    let provider = SymbolicatorSymbolProvider::new(scope, sources, cficaches, ty);
+    let first_module_debug_id =
+        minidump
+            .get_stream::<MinidumpModuleList>()
+            .ok()
+            .and_then(|modules| {
+                let m = modules.by_addr().next()?;
+                m.debug_identifier()
+            });
+    let provider = SymbolicatorSymbolProvider::new(
+        scope,
+        sources,
+        cficaches,
+        ty,
+        first_module_debug_id,
+        first_module_rewrite_rules,
+    );
     let process_state = minidump_processor::process_minidump(minidump, &provider).await?;
     let duration = duration.elapsed();
 
@@ -482,6 +525,7 @@ impl SymbolicationActor {
             minidump_file,
             sources,
             scraping,
+            module_rewrite_rules,
         } = request;
         let len = minidump_file.metadata()?.len();
         tracing::debug!("Processing minidump ({} bytes)", len);
@@ -502,6 +546,7 @@ impl SymbolicationActor {
             &minidump,
             scope.clone(),
             sources.clone(),
+            module_rewrite_rules,
         );
 
         let result = match stackwalk_future.await {

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -101,10 +101,13 @@ impl SymbolicationActor {
             modules,
             apply_source_context,
             scraping,
+            module_rewrite_rules,
             ..
         } = request;
 
-        let mut module_lookup = ModuleLookup::new(scope.clone(), sources, modules);
+        let mut module_lookup =
+            ModuleLookup::new(scope.clone(), sources, module_rewrite_rules, modules);
+
         module_lookup
             .fetch_caches(
                 self.symcaches.clone(),

--- a/crates/symbolicator-native/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-native/tests/integration/process_minidump.rs
@@ -24,6 +24,7 @@ macro_rules! stackwalk_minidump {
                     minidump_file: minidump_file.into_temp_path(),
                     sources: Arc::new([source]),
                     scraping: Default::default(),
+                    module_rewrite_rules: Default::default(),
                 })
                 .await;
 

--- a/crates/symbolicator-native/tests/integration/utils.rs
+++ b/crates/symbolicator-native/tests/integration/utils.rs
@@ -61,6 +61,7 @@ pub fn make_symbolication_request(
         scope: Default::default(),
         apply_source_context: true,
         scraping: Default::default(),
+        module_rewrite_rules: Default::default(),
     }
 }
 

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -172,6 +172,7 @@ pub async fn process_payload(
                     minidump_file: temp_path,
                     sources: Arc::clone(sources),
                     scraping: Default::default(),
+                    module_rewrite_rules: Default::default(),
                 })
                 .await
                 .unwrap();

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -88,6 +88,7 @@ pub fn prepare_payload(
                 scraping: Default::default(),
                 stacktraces,
                 modules,
+                module_rewrite_rules: Default::default(),
             })
         }
         Payload::Js { source, event } => {

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -84,6 +84,8 @@ pub async fn handle_minidump_request(
             minidump_file,
             sources,
             scraping,
+            // TODO
+            module_rewrite_rules: Default::default(),
         },
         options,
     )?;

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -27,6 +27,7 @@ pub async fn handle_minidump_request(
     let mut scraping = Default::default();
     let mut options = RequestOptions::default();
     let mut platform = None;
+    let mut module_rewrite_rules = Default::default();
 
     while let Some(field) = multipart.next_field().await? {
         match field.name() {
@@ -59,6 +60,10 @@ pub async fn handle_minidump_request(
                 let data = read_multipart_data(field, 1024 * 1024).await?; // 1Mb
                 platform = serde_json::from_slice(&data)?
             }
+            Some("rewrite_first_module") => {
+                let data = read_multipart_data(field, 1024 * 1024).await?; // 1Mb
+                module_rewrite_rules = serde_json::from_slice(&data)?
+            }
             _ => (), // Always ignore unknown fields.
         }
     }
@@ -84,8 +89,7 @@ pub async fn handle_minidump_request(
             minidump_file,
             sources,
             scraping,
-            // TODO
-            module_rewrite_rules: Default::default(),
+            module_rewrite_rules,
         },
         options,
     )?;

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -78,6 +78,7 @@ pub async fn symbolicate_frames(
             modules: body.modules.into_iter().map(From::from).collect(),
             apply_source_context: body.options.apply_source_context,
             scraping: body.scraping,
+            module_rewrite_rules: Default::default(),
         },
         body.options,
     )?;

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -614,6 +614,7 @@ mod tests {
             scope: Default::default(),
             apply_source_context: true,
             scraping: Default::default(),
+            module_rewrite_rules: Default::default(),
         };
 
         let request_id = service
@@ -656,6 +657,7 @@ mod tests {
             })],
             apply_source_context: true,
             scraping: Default::default(),
+            module_rewrite_rules: Default::default(),
         }
     }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -567,6 +567,7 @@ mod event {
             modules,
             apply_source_context: true,
             scraping: Default::default(),
+            module_rewrite_rules: Default::default(),
         })
     }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> Result<()> {
                     minidump_file: minidump_path,
                     sources: dsym_sources,
                     scraping: Default::default(),
+                    module_rewrite_rules: Default::default(),
                 })
                 .await?;
             CompletedResponse::NativeSymbolication(res)

--- a/docs/api/minidump.md
+++ b/docs/api/minidump.md
@@ -27,6 +27,13 @@ Content-Disposition: form-data; name="sources"
 Content-Disposition: form-data; name="platform"
 "native"
 
+--xxx
+Content-Disposition: form-data; name="rewrite_first_module"
+[
+  ["([^/]+) (?<suffix>Framework|Helper( \\(.+\\))?)$", "Electron $suffix"],
+  ["([^/]+).exe.pdb$", "electron.exe.pdb"],
+  ["([^/]+)$", "electron"]
+]
 --xxx--
 ```
 
@@ -46,6 +53,9 @@ sources to pull symbols from.
 - `sources`: A list of descriptors for internal or external symbol sources. See
   [Sources](index.md).
 - `upload_file_minidump`: The minidump file to be analyzed.
+- `rewrite_first_module`: Rewriting rules for rewriting the debug file name
+  of the first (by address) module in the minidump. This is used because that debug
+  file may be found on a symbol source under another name.
 
 ## Response
 


### PR DESCRIPTION
# Rationale
In order to stackwalk and symbolicate minidumps from Electron, we have to
look up symbol files on the official Electron symbol server. The lookup of a module
involves the module's debug file name. Debug file names that can be found on
the Electron symbol server include "Electron Framework", "electron.exe.pdb",
and others.

The problem is that when an Electron application is bundled, the main executable
can be renamed, and this renaming affects minidumps. Specifically, the debug file name
of the first loaded module follows the executable name. For example, crashing a simple
test application may produce a minidump in which the first module has debug file "Electron".
But bundling the test app as "My Awesome Crasher" causes the first module's debug file to
also be called "My Awesome Crasher".

This renaming causes the debug file not to be found on the Electron source under the modified
name, even though it is available under the original name. This is obviously unsatisfactory.

# Solution
This PR adds a new optional parameter `rewrite_first_module` to the minidump
endpoint. This can be used to pass Symbolicator a list of _rewrite rules_
in the form of a regex and a replacement string. These rewrite rules will be used
during minidump stackwalking and symbolication to perform a name replacement on the
debug file of the first loaded module.

Note that this renaming of the debug file is transient—it's only used for lookups and
reverted before we return the symbolication response.
