### PR TITLE
feat(electron): Log successful and failed candidates

### DIFF
--- a/crates/symbolicator-native/src/symbolication/module_lookup.rs
+++ b/crates/symbolicator-native/src/symbolication/module_lookup.rs
@@ -217,19 +217,20 @@ impl ModuleLookup {
 
                 // Log not found candidates for the first module
                 if let Some(original) = self.original_first_debug_file.as_ref() {
-                    let failed_candidates = info
+                    let (successful_candidates, failed_candidates): (Vec<_>, Vec<_>) = info
                         .candidates
                         .iter()
-                        .filter(|c| {
-                            c.source.as_str() == "sentry:electron"
-                                && matches!(c.download, ObjectDownloadInfo::NotFound)
-                        })
+                        .filter(|c| c.source.as_str() == "sentry:electron")
                         .cloned()
-                        .collect::<Vec<_>>();
+                        .partition(|c| matches!(c.download, ObjectDownloadInfo::Ok { .. }));
 
                     let mut electron_context = BTreeMap::new();
                     electron_context.insert(
-                        "candidates".into(),
+                        "successful candidates".into(),
+                        serde_json::to_value(successful_candidates).unwrap(),
+                    );
+                    electron_context.insert(
+                        "failed candidates".into(),
                         serde_json::to_value(failed_candidates).unwrap(),
                     );
                     electron_context.insert(


### PR DESCRIPTION
Slight modification to #1653: log the successful candidates as well as the unsuccessful ones.