### PR TITLE
fix(caching): Don't error on broken metadata files

### DIFF
--- a/crates/symbolicator-service/src/caching/fs.rs
+++ b/crates/symbolicator-service/src/caching/fs.rs
@@ -113,7 +113,12 @@ impl Cache {
         tracing::trace!("File `{}` length: {}", path.display(), fs_metadata.len());
 
         // Open the metadata file if possible
-        let external_metadata: Option<Metadata> = self.read_metadata(path)?;
+        let external_metadata = self
+            .read_metadata(path)
+            .inspect_err(|e| {
+                tracing::error!(path, "Failed to parse cache metadata file");
+            })
+            .ok();
 
         let (atime, ctime) = {
             // If the `ctime` from the external metadata is available, we use it. Otherwise


### PR DESCRIPTION
Previously we would early return in check_expiry if parsing a metadata file failed. Now we log an error and carry on as if the cache file didn't exist. This lets the cleanup job remove files for which it can't open the metadata file.