### PR TITLE
ref: Make download_source functions generic

### DIFF
--- a/crates/symbolicator-service/src/download/filesystem.rs
+++ b/crates/symbolicator-service/src/download/filesystem.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 
-use tokio::fs::File;
+use tokio::{fs::File, io::AsyncWrite};
 
 use symbolicator_sources::FilesystemRemoteFile;
 
@@ -23,7 +23,7 @@ impl FilesystemDownloader {
     pub async fn download_source(
         &self,
         file_source: &FilesystemRemoteFile,
-        destination: &mut File,
+        mut destination: impl AsyncWrite + Unpin,
     ) -> CacheContents {
         let path = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", path);
@@ -32,7 +32,7 @@ impl FilesystemDownloader {
             io::ErrorKind::NotFound => CacheError::NotFound,
             _ => e.into(),
         })?;
-        tokio::io::copy(&mut file, destination).await?;
+        tokio::io::copy(&mut file, &mut destination).await?;
         Ok(())
     }
 }

--- a/crates/symbolicator-service/src/download/filesystem.rs
+++ b/crates/symbolicator-service/src/download/filesystem.rs
@@ -23,7 +23,7 @@ impl FilesystemDownloader {
     pub async fn download_source(
         &self,
         file_source: &FilesystemRemoteFile,
-        mut destination: impl AsyncWrite + Unpin,
+        mut destination: impl AsyncWrite,
     ) -> CacheContents {
         let path = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", path);
@@ -32,6 +32,7 @@ impl FilesystemDownloader {
             io::ErrorKind::NotFound => CacheError::NotFound,
             _ => e.into(),
         })?;
+        let mut destination = std::pin::pin!(destination);
         tokio::io::copy(&mut file, &mut destination).await?;
         Ok(())
     }

--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use symbolicator_sources::{GcsRemoteFile, GcsSourceKey};
-use tokio::fs::File;
+use tokio::io::AsyncWrite;
 
 use crate::caching::{CacheContents, CacheError};
 use crate::utils::gcs::{self, GcsToken};
@@ -58,7 +58,7 @@ impl GcsDownloader {
         &self,
         source_name: &str,
         file_source: &GcsRemoteFile,
-        destination: &mut File,
+        destination: impl AsyncWrite + Unpin,
     ) -> CacheContents {
         let key = file_source.key();
         let bucket = &file_source.source.bucket;

--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -58,7 +58,7 @@ impl GcsDownloader {
         &self,
         source_name: &str,
         file_source: &GcsRemoteFile,
-        destination: impl AsyncWrite + Unpin,
+        destination: impl AsyncWrite,
     ) -> CacheContents {
         let key = file_source.key();
         let bucket = &file_source.source.bucket;

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -3,7 +3,7 @@
 use reqwest::{header, Client};
 
 use symbolicator_sources::HttpRemoteFile;
-use tokio::fs::File;
+use tokio::io::AsyncWrite;
 
 use crate::caching::{CacheContents, CacheError};
 use crate::utils::http::DownloadTimeouts;
@@ -32,7 +32,7 @@ impl HttpDownloader {
         &self,
         source_name: &str,
         file_source: &HttpRemoteFile,
-        destination: &mut File,
+        destination: impl AsyncWrite + Unpin,
     ) -> CacheContents {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -32,7 +32,7 @@ impl HttpDownloader {
         &self,
         source_name: &str,
         file_source: &HttpRemoteFile,
-        destination: impl AsyncWrite + Unpin,
+        destination: impl AsyncWrite,
     ) -> CacheContents {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -12,8 +12,7 @@ use std::time::{Duration, Instant, SystemTime};
 use ::sentry::SentryFutureExt;
 use futures::prelude::*;
 use reqwest::StatusCode;
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 pub use symbolicator_sources::{
     DirectoryLayout, FileType, ObjectId, ObjectType, RemoteFile, RemoteFileUri, SourceConfig,
@@ -509,7 +508,7 @@ where
 async fn download_stream(
     source_name: &str,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, CacheError>>,
-    destination: &mut File,
+    mut destination: impl AsyncWrite + Unpin,
 ) -> CacheContents {
     futures::pin_mut!(stream);
 
@@ -536,7 +535,7 @@ async fn download_reqwest(
     source_name: &str,
     builder: reqwest::RequestBuilder,
     timeouts: &DownloadTimeouts,
-    destination: &mut File,
+    destination: impl AsyncWrite + Unpin,
 ) -> CacheContents {
     let (client, request) = builder.build_split();
     let request = request?;

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -508,9 +508,10 @@ where
 async fn download_stream(
     source_name: &str,
     stream: impl Stream<Item = Result<impl AsRef<[u8]>, CacheError>>,
-    mut destination: impl AsyncWrite + Unpin,
+    mut destination: impl AsyncWrite,
 ) -> CacheContents {
     futures::pin_mut!(stream);
+    let mut destination = std::pin::pin!(destination);
 
     let mut throughput_recorder =
         MeasureSourceDownloadGuard::new("source.download.stream", source_name);
@@ -535,7 +536,7 @@ async fn download_reqwest(
     source_name: &str,
     builder: reqwest::RequestBuilder,
     timeouts: &DownloadTimeouts,
-    destination: impl AsyncWrite + Unpin,
+    destination: impl AsyncWrite,
 ) -> CacheContents {
     let (client, request) = builder.build_split();
     let request = request?;

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -101,7 +101,7 @@ impl S3Downloader {
         &self,
         source_name: &str,
         file_source: &S3RemoteFile,
-        destination: impl AsyncWrite + Unpin,
+        destination: impl AsyncWrite,
     ) -> CacheContents {
         let key = file_source.key();
         let bucket = file_source.bucket();

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -13,7 +13,7 @@ use aws_sdk_s3::Client;
 pub use aws_sdk_s3::Error as S3Error;
 use futures::TryStreamExt as _;
 use symbolicator_sources::{AwsCredentialsProvider, S3Region, S3RemoteFile, S3SourceKey};
-use tokio::fs::File;
+use tokio::io::AsyncWrite;
 
 use crate::caching::{CacheContents, CacheError};
 use crate::utils::http::DownloadTimeouts;
@@ -101,7 +101,7 @@ impl S3Downloader {
         &self,
         source_name: &str,
         file_source: &S3RemoteFile,
-        destination: &mut File,
+        destination: impl AsyncWrite + Unpin,
     ) -> CacheContents {
         let key = file_source.key();
         let bucket = file_source.bucket();

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use sentry::SentryFutureExt;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use tokio::fs::File;
+use tokio::io::AsyncWrite;
 use url::Url;
 
 use symbolicator_sources::{
@@ -256,7 +256,7 @@ impl SentryDownloader {
         &self,
         source_name: &str,
         file_source: &SentryRemoteFile,
-        destination: &mut File,
+        destination: impl AsyncWrite + Unpin,
     ) -> CacheContents {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -256,7 +256,7 @@ impl SentryDownloader {
         &self,
         source_name: &str,
         file_source: &SentryRemoteFile,
-        destination: impl AsyncWrite + Unpin,
+        destination: impl AsyncWrite,
     ) -> CacheContents {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);


### PR DESCRIPTION
The downloaders for the various source types each have a `download_source` method that currently takes a `tokio::fs::File` as its destination. We can instead target `tokio::io::AsyncWrite`, which also lets us download into e.g. an in-memory buffer instead of a file.