### PR TITLE
ref(caching): Split up `Cacher` methods

### DIFF
--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -168,10 +168,6 @@ pub trait CacheItemRequest: 'static + Send + Sync + Clone {
     /// Loads an existing element from the cache.
     fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item>;
 
-    fn refresh(&self, _contents: &CacheContents<Self::Item>) -> Option<Self::Item> {
-        None
-    }
-
     /// The "cost" of keeping this item in the in-memory cache.
     fn weight(item: &Self::Item) -> u32 {
         std::mem::size_of_val(item) as u32

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -313,7 +313,7 @@ impl<T: CacheItemRequest> Cacher<T> {
             }
         };
 
-        self.write_cache_file(&entry, is_refresh, temp_file, key);
+        self.write_cache_file(key, &entry, temp_file, is_refresh);
 
         if !shared_cache_hit {
             self.store_in_shared_cache(&request, key, &entry, CacheStoreReason::New);
@@ -329,10 +329,10 @@ impl<T: CacheItemRequest> Cacher<T> {
     /// exist.
     fn write_cache_file(
         &self,
-        entry: &CacheEntry<ByteView<'_>>,
-        is_refresh: bool,
-        temp_file: NamedTempFile,
         key: &CacheKey,
+        entry: &CacheEntry<ByteView<'_>>,
+        temp_file: NamedTempFile,
+        is_refresh: bool,
     ) {
         if let Some(cache_dir) = self.config.cache_dir() {
             // Cache is enabled, write it!


### PR DESCRIPTION
This splits some very long and complicated methods on `Cacher` apart (compute, compute_memoized). This should make the logic more understandable, but the diff is unfortunately not easy to grasp.