### PR TITLE
feat(download): Parallelize downloading large files with multiple independent partial streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,15 +2414,16 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.39.0"
+version = "1.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "pest",
  "pest_derive",
+ "pin-project",
  "serde",
  "similar",
 ]
@@ -3019,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -4912,6 +4913,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "bytes",
  "cadence",
  "chrono",
  "crossbeam-utils",
@@ -4922,6 +4924,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "idna 1.0.2",
+ "insta",
  "ipnetwork",
  "jsonwebtoken",
  "moka",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -15,6 +15,7 @@ aws-credential-types = { version = "1.0.1", features = [
     "hardcoded-credentials",
 ] }
 aws-sdk-s3 = "1.4.0"
+bytes = "1.6.0"
 cadence = "1.0.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 crossbeam-utils = "0.8.19"
@@ -71,3 +72,4 @@ zstd = "0.13.0"
 [dev-dependencies]
 sha-1 = "0.10.0"
 symbolicator-test = { path = "../symbolicator-test" }
+insta = "1.42"

--- a/crates/symbolicator-service/src/download/destination.rs
+++ b/crates/symbolicator-service/src/download/destination.rs
@@ -1,0 +1,232 @@
+use bytes::Bytes;
+use std::{convert::Infallible, future::Future, io, sync::Arc};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+/// A simplified version of [`AsyncWrite`] which only supports
+/// [`write_all`](AsyncWriteExt::write_all).
+///
+/// The interface here could be replaced with [`AsyncWrite`],
+/// but currently Symbolicator only needs this minimized interface,
+/// the full implementation of [`AsyncWrite`] is significantly harder
+/// to implement and get right.
+pub trait WriteStream: Send {
+    /// Attempts to write an entire buffer into this writer.
+    ///
+    /// See also: [`AsyncWriteExt::write_buf`].
+    fn write_buf(&mut self, buf: Bytes) -> impl Future<Output = io::Result<()>> + Send;
+}
+
+impl<T> WriteStream for T
+where
+    T: AsyncWrite + Unpin + Send,
+{
+    async fn write_buf(&mut self, mut buf: Bytes) -> io::Result<()> {
+        AsyncWriteExt::write_buf(self, &mut buf).await.map(|_| ())
+    }
+}
+
+/// A generic destination for downloads.
+///
+/// The destination can be simply converted into a [`AsyncWrite`],
+/// but some destinations can choose to implement [`Destination::try_into_streams`],
+/// to support concurrent partial downloads.
+pub trait Destination: Sized + Send {
+    /// Type returned from [`Destination::try_into_streams`].
+    type Streams: MultiStreamDestination;
+    /// Type returned from [`Destination::into_write`].
+    type Write: AsyncWrite + Send;
+
+    /// Attempts to convert this `Destination` into a destination which
+    /// supports parallelized downloads through the [`MultiStreamDestination`] interface.
+    ///
+    /// Destinations which do not support parallelized downloads will return `Err` here.
+    ///
+    fn try_into_streams(self) -> impl Future<Output = Result<Self::Streams, Self>> + Send;
+
+    /// Converts the destination into a generic [`AsyncWrite`].
+    fn into_write(self) -> Self::Write;
+}
+
+/// A destination which supports multiple concurrent streams writing to it.
+pub trait MultiStreamDestination: Send {
+    /// Type returned from [`MultiStreamDestination::stream`].
+    type Stream<'a>: WriteStream
+    where
+        Self: 'a;
+    /// Type returned from [`MultiStreamDestination::into_write`].
+    type Write: AsyncWrite + Send;
+
+    /// Configures the amount of bytes that will be written total.
+    ///
+    /// By contract a size must be set before acquiring any
+    /// [streams](`MultiStreamDestination::stream`).
+    ///
+    /// The specified `size` is the size of the fully downloaded file.
+    /// Some underlying storages first need to resize to support concurrent writes.
+    fn set_size(&mut self, size: u64) -> impl Future<Output = io::Result<()>> + Send;
+
+    /// Creates a new stream starting at `offset`.
+    ///
+    /// Writing to the stream will write to the underlying destination with the specified offset.
+    ///
+    /// Multiple streams can be opened at once. The returned streams can be overlapping
+    /// but the caller must take care not to write overlapping data.
+    ///
+    /// The `offset` specified here may not be validated against the `size` this multi-destination
+    /// was opened with, requesting an offset past the maximum size of the destination may result
+    /// in data corruption.
+    ///
+    /// The amount of bytes written to that stream must be specified accurately.
+    /// An implementation is free to ignore these constraints and writing past the end of the
+    /// returned stream may lead to data corruption.
+    fn stream(&self, offset: u64, size: u64) -> Self::Stream<'_>;
+
+    /// Converts the destination into a generic [`AsyncWrite`].
+    fn into_write(self) -> Self::Write;
+}
+
+impl MultiStreamDestination for Infallible {
+    type Stream<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+    type Write = Vec<u8>;
+
+    async fn set_size(&mut self, _size: u64) -> io::Result<()> {
+        match *self {}
+    }
+
+    fn stream(&self, _offset: u64, _len: u64) -> Self::Stream<'_> {
+        match *self {}
+    }
+
+    fn into_write(self) -> Self::Write {
+        match self {}
+    }
+}
+
+impl<'a> Destination for &'a mut tokio::fs::File {
+    #[cfg(unix)]
+    type Streams = FileMultiStreamDestination<'a>;
+    #[cfg(not(unix))]
+    type Streams = Infallible;
+    type Write = Self;
+
+    #[cfg(unix)]
+    async fn try_into_streams(self) -> Result<Self::Streams, Self> {
+        let dup = match self.try_clone().await {
+            Ok(file) => file.into_std().await,
+            Err(_) => return Err(self),
+        };
+
+        Ok(FileMultiStreamDestination {
+            original: self,
+            std: Arc::new(dup),
+        })
+    }
+
+    #[cfg(not(unix))]
+    async fn try_into_streams(self, _size: u64) -> Result<Self::Streams, Self> {
+        Err(self)
+    }
+
+    fn into_write(self) -> Self::Write {
+        self
+    }
+}
+
+/// File based multi stream destination.
+pub struct FileMultiStreamDestination<'a> {
+    original: &'a mut tokio::fs::File,
+    std: Arc<std::fs::File>,
+}
+
+#[cfg(unix)]
+impl<'file> MultiStreamDestination for FileMultiStreamDestination<'file> {
+    type Stream<'a>
+        = OffsetFileWriteStream
+    where
+        Self: 'a;
+    type Write = &'file mut tokio::fs::File;
+
+    async fn set_size(&mut self, size: u64) -> io::Result<()> {
+        // While not strictly necessary for the implementation using `pwrite`,
+        // we can already resize the file to prevent sparse files.
+        self.original.set_len(size).await
+    }
+
+    fn stream(&self, offset: u64, size: u64) -> Self::Stream<'_> {
+        OffsetFileWriteStream {
+            file: Arc::clone(&self.std),
+            offset,
+            end: offset + size + 1,
+        }
+    }
+
+    fn into_write(self) -> Self::Write {
+        self.original
+    }
+}
+
+/// A [`WriteStream`] for a file with an arbitrary offset.
+#[cfg(unix)]
+pub struct OffsetFileWriteStream {
+    file: Arc<std::fs::File>,
+    offset: u64,
+    end: u64,
+}
+
+#[cfg(unix)]
+impl WriteStream for OffsetFileWriteStream {
+    async fn write_buf(&mut self, buf: Bytes) -> io::Result<()>
+    where
+        Self: Unpin,
+    {
+        use std::os::unix::fs::FileExt;
+
+        let offset = self.offset;
+        let length = buf.len() as u64;
+
+        debug_assert!(
+            offset + length < self.end,
+            "attempt to write past end of stream"
+        );
+
+        let file = Arc::clone(&self.file);
+        tokio::task::spawn_blocking(move || file.write_all_at(&buf, offset)).await??;
+
+        // Update the offset for the next write.
+        //
+        // There are no concurrent writes, because we have an exclusive reference here.
+        self.offset += length;
+
+        Ok(())
+    }
+}
+
+/// Turns a [`AsyncWrite`] into a [`Destination`].
+///
+/// The resulting destination will not support concurrent streaming writes.
+pub struct AsyncWriteDestination<T>(pub T);
+
+impl<T> Destination for AsyncWriteDestination<T>
+where
+    T: AsyncWrite + Send,
+{
+    type Streams = Infallible;
+    type Write = T;
+
+    async fn try_into_streams(self) -> Result<Self::Streams, Self> {
+        Err(self)
+    }
+
+    fn into_write(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for AsyncWriteDestination<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}

--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -3,11 +3,12 @@
 use std::sync::Arc;
 
 use symbolicator_sources::{GcsRemoteFile, GcsSourceKey};
-use tokio::io::AsyncWrite;
 
 use crate::caching::{CacheContents, CacheError};
 use crate::utils::gcs::{self, GcsToken};
 use crate::utils::http::DownloadTimeouts;
+
+use super::Destination;
 
 /// An LRU cache for GCS OAuth tokens.
 type GcsTokenCache = moka::future::Cache<Arc<GcsSourceKey>, CacheContents<GcsToken>>;
@@ -58,7 +59,7 @@ impl GcsDownloader {
         &self,
         source_name: &str,
         file_source: &GcsRemoteFile,
-        destination: impl AsyncWrite,
+        destination: impl Destination,
     ) -> CacheContents {
         let key = file_source.key();
         let bucket = &file_source.source.bucket;

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -3,12 +3,11 @@
 use reqwest::{header, Client};
 
 use symbolicator_sources::HttpRemoteFile;
-use tokio::io::AsyncWrite;
 
 use crate::caching::{CacheContents, CacheError};
 use crate::utils::http::DownloadTimeouts;
 
-use super::USER_AGENT;
+use super::{Destination, USER_AGENT};
 
 /// Downloader implementation that supports the HTTP source.
 #[derive(Debug)]
@@ -32,7 +31,7 @@ impl HttpDownloader {
         &self,
         source_name: &str,
         file_source: &HttpRemoteFile,
-        destination: impl AsyncWrite,
+        destination: impl Destination,
     ) -> CacheContents {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -755,7 +755,13 @@ impl<'a> SymRequest<'a> {
 
     /// Applies a [`partial::Range`] to the request.
     fn with_range(mut self, range: partial::Range) -> Self {
-        range.apply_to(&mut self.request);
+        let header = reqwest::header::HeaderValue::from_str(&range.to_string())
+            .expect("the range header to be a always valid");
+
+        self.request
+            .headers_mut()
+            .insert(reqwest::header::RANGE, header);
+
         self
     }
 
@@ -1045,6 +1051,10 @@ mod tests {
     }
 
     /// Another download, but this time the server does not respond with a `Content-Range` header.
+    ///
+    /// This test is using the `garbage_data/` endpoint provided by the test framework,
+    /// which is just a simple axum handler, which does not implement `Range` requests,
+    /// unlike the `symbols/` endpoint.
     #[tokio::test]
     async fn test_download_missing_content_range() {
         test::setup();

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -6,14 +6,16 @@
 use std::collections::VecDeque;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use ::sentry::SentryFutureExt;
-use futures::prelude::*;
+use bytes::Bytes;
+use futures::{future::Either, prelude::*};
 use reqwest::StatusCode;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
 
+use stream::FuturesUnordered;
 pub use symbolicator_sources::{
     DirectoryLayout, FileType, ObjectId, ObjectType, RemoteFile, RemoteFileUri, SourceConfig,
     SourceFilters, SourceLocation,
@@ -25,22 +27,25 @@ use symbolicator_sources::{
 use crate::caching::{CacheContents, CacheError};
 use crate::config::Config;
 use crate::types::Scope;
-use crate::utils::futures::{m, measure, CancelOnDrop};
+use crate::utils::futures::{m, measure, CancelOnDrop, SendFuture as _};
 use crate::utils::gcs::GcsError;
 use crate::utils::http::DownloadTimeouts;
 use crate::utils::sentry::ConfigureScope;
 
 mod compression;
+mod destination;
 mod fetch_file;
 mod filesystem;
 mod gcs;
 mod http;
 mod index;
+mod partial;
 mod s3;
 pub mod sentry;
 
-pub use compression::tempfile_in_parent;
-pub use fetch_file::fetch_file;
+pub use self::compression::tempfile_in_parent;
+pub use self::destination::{Destination, MultiStreamDestination, WriteStream};
+pub use self::fetch_file::fetch_file;
 pub use index::SourceIndexService;
 
 impl ConfigureScope for RemoteFile {
@@ -517,69 +522,186 @@ where
 /// This is common functionality used by many downloaders.
 async fn download_stream(
     source_name: &str,
-    stream: impl Stream<Item = Result<impl AsRef<[u8]>, CacheError>>,
-    mut destination: impl AsyncWrite,
+    stream: impl Stream<Item = Result<Bytes, CacheError>>,
+    mut destination: impl WriteStream,
 ) -> CacheContents {
-    futures::pin_mut!(stream);
-    let mut destination = std::pin::pin!(destination);
+    let mut stream = std::pin::pin!(stream);
 
-    let mut throughput_recorder =
+    let throughput_recorder =
         MeasureSourceDownloadGuard::new("source.download.stream", source_name);
     let result: CacheContents = async {
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
-            let chunk = chunk.as_ref();
             throughput_recorder.add_bytes_transferred(chunk.len() as u64);
-            destination.write_all(chunk).await?;
+            destination.write_buf(chunk).await?;
         }
         Ok(())
     }
     .await;
     throughput_recorder.done(&result);
-    result?;
 
-    destination.flush().await?;
-    Ok(())
+    result
 }
 
+/// Download the source with a HTTP request.
+///
+/// This is common functionality used by many downloaders.
 async fn download_reqwest(
     source_name: &str,
     builder: reqwest::RequestBuilder,
     timeouts: &DownloadTimeouts,
-    destination: impl AsyncWrite,
+    destination: impl Destination,
 ) -> CacheContents {
     let (client, request) = builder.build_split();
     let request = request?;
-    let source = request.url().to_string();
-    let request = client.execute(request);
 
-    let timeout = timeouts.head;
-    let request = tokio::time::timeout(timeout, request);
-    let request = measure_download_time(source_name, request);
+    // A non-get request or a request with a body is not supported for partial downloads.
+    let destination = match request.method() == reqwest::Method::GET && request.body().is_none() {
+        true => destination.try_into_streams().await,
+        false => Err(destination),
+    };
 
-    let response = request.await.map_err(|_| CacheError::Timeout(timeout))??;
+    let measure = MeasureSourceDownloadGuard::new("source.download.body", source_name);
+    let request = SymRequest {
+        source_name,
+        request,
+        client,
+        timeouts,
+        measure: &measure,
+    };
+
+    let result = match destination {
+        Ok(destination) => do_download_reqwest_range(request, destination).send().await,
+        Err(destination) => {
+            let destination = std::pin::pin!(destination.into_write());
+            do_download_reqwest(request, destination).send().await
+        }
+    };
+
+    measure.done(&result);
+
+    result
+}
+
+/// Downloads a remote resource into `destination` using multiple concurrent range requests.
+///
+/// If the server does not support range requests, the function will fallback to a normal
+/// non-concurrent download of the resource.
+///
+/// Invariant: the passed `request` must be cloneable (contain no body).
+async fn do_download_reqwest_range(
+    request: SymRequest<'_>,
+    mut destination: impl MultiStreamDestination,
+) -> CacheContents {
+    let source = request.to_source();
+
+    let response = request
+        .try_clone()
+        // Cloning should never fail, it is an invariant of the function,
+        // which was validated before.
+        .ok_or(CacheError::InternalError)?
+        // Supply the initial range.
+        //
+        // If the server does not support range requests it will give us the full file contents.
+        .with_range(partial::initial_range())
+        .execute()
+        .await?;
+
+    // Server supports range requests and just sent us the first batch.
+    match response.content_range() {
+        // Server does not know about ranges and returns us the full contents.
+        None if response.status().is_success() => {
+            tracing::trace!(
+                "Success hitting `{source}`, but server does not support range requests"
+            );
+            let destination = std::pin::pin!(destination.into_write());
+            response.download(destination).await
+        }
+        None if response.status() == StatusCode::RANGE_NOT_SATISFIABLE => {
+            // This case should never happen, since our initial request is always a valid request,
+            // when this happens, just retry without a range header and log the error for investigation.
+            tracing::error!("initial partial request was rejected with 416, range not satisfiable");
+            drop(response);
+
+            let destination = std::pin::pin!(destination.into_write());
+            do_download_reqwest(request, destination).await
+        }
+        // Server returned some generic error, we need to bubble it up.
+        None => Err(status_to_error(&source, response.status())),
+        // Malformed range header.
+        Some(Err(err)) => {
+            // This case can happen if the server returns an invalid header or a header which does
+            // not specify the total length of the resource, in which case we cancel the original
+            // request and just retry without a range request.
+            //
+            // Either way, we do not expect this to happen.
+            tracing::error!(
+                error = &err as &dyn std::error::Error,
+                "server returned an invalid range"
+            );
+            drop(response);
+
+            let destination = std::pin::pin!(destination.into_write());
+            do_download_reqwest(request, destination).await
+        }
+        // Server indicates it supports ranges.
+        Some(Ok(content_range)) => {
+            tracing::trace!(
+                "Successfully requested an initial range {content_range:?} from `{source}`"
+            );
+
+            destination.set_size(content_range.total_size).await?;
+
+            let mut futures = FuturesUnordered::new();
+
+            let head = response.download(destination.stream(0, content_range.range().size()));
+            futures.push(Either::Left(head.send()));
+
+            for range in partial::split(content_range) {
+                let request = request
+                    .try_clone()
+                    .ok_or(CacheError::InternalError)?
+                    .with_range(range);
+
+                let destination = destination.stream(range.start, range.size());
+                let partial = do_download_reqwest(request, destination).send();
+                futures.push(Either::Right(partial));
+            }
+
+            request.measure.set_streams(futures.len());
+
+            while futures.try_next().await?.is_some() {}
+
+            Ok(())
+        }
+    }
+}
+
+/// Downloads the requested resource with a single download request into the `destination`.
+async fn do_download_reqwest(
+    request: SymRequest<'_>,
+    destination: impl WriteStream,
+) -> CacheContents {
+    let source = request.to_source();
+    let response = request.execute().await?;
 
     let status = response.status();
     if status.is_success() {
-        tracing::trace!("Success hitting `{}`", source);
+        tracing::trace!("Success hitting `{source}`");
+        response.download(destination).await
+    } else {
+        Err(status_to_error(&source, status))
+    }
+}
 
-        let content_length = response
-            .headers()
-            .get(reqwest::header::CONTENT_LENGTH)
-            .and_then(|hv| hv.to_str().ok())
-            .and_then(|s| s.parse::<i64>().ok());
+/// Converts a status code to an error.
+///
+/// Any status code will be converted to an error, callers must ensure success cases
+/// are handled before turning the status code into an error using this function.
+fn status_to_error(source: &str, status: StatusCode) -> CacheError {
+    debug_assert!(!status.is_success());
 
-        let timeout = content_length.map(|cl| content_length_timeout(cl, timeouts.streaming));
-        let stream = response.bytes_stream().map_err(CacheError::from);
-        let future = download_stream(source_name, stream, destination);
-
-        match timeout {
-            Some(timeout) => tokio::time::timeout(timeout, future)
-                .await
-                .map_err(|_| CacheError::Timeout(timeout))?,
-            None => future.await,
-        }
-    } else if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
+    if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
         tracing::debug!(
             "Insufficient permissions to download `{}`: {}",
             source,
@@ -590,16 +712,16 @@ async fn download_reqwest(
         // let details = response.text().await?;
         let details = status.to_string();
 
-        Err(CacheError::PermissionDenied(details))
-        // If it's a client error, chances are it's a 404.
+        CacheError::PermissionDenied(details)
     } else if status.is_client_error() {
+        // If it's a client error, chances are it's a 404.
         tracing::debug!(
             "Unexpected client error status code from `{}`: {}",
             source,
             status
         );
 
-        Err(CacheError::NotFound)
+        CacheError::NotFound
     } else if status == StatusCode::FOUND {
         tracing::debug!(
             "Potential login page detected when downloading from `{}`: {}",
@@ -607,14 +729,112 @@ async fn download_reqwest(
             status
         );
 
-        Err(CacheError::PermissionDenied(
-            "Potential login page detected".to_string(),
-        ))
+        CacheError::PermissionDenied("Potential login page detected".to_string())
     } else {
         tracing::debug!("Unexpected status code from `{}`: {}", source, status);
 
         let details = status.to_string();
-        Err(CacheError::DownloadError(details))
+        CacheError::DownloadError(details)
+    }
+}
+
+/// A HTTP request Symbolicator wants to make.
+struct SymRequest<'a> {
+    source_name: &'a str,
+    request: reqwest::Request,
+    client: reqwest::Client,
+    timeouts: &'a DownloadTimeouts,
+    measure: &'a MeasureSourceDownloadGuard<'a>,
+}
+
+impl<'a> SymRequest<'a> {
+    /// Returns the source location for debugging purposes.
+    fn to_source(&self) -> String {
+        self.request.url().to_string()
+    }
+
+    /// Applies a [`partial::Range`] to the request.
+    fn with_range(mut self, range: partial::Range) -> Self {
+        range.apply_to(&mut self.request);
+        self
+    }
+
+    /// Attempts to clone the request.
+    ///
+    /// This will fail if the request contains a body which cannot be cloned.
+    /// See also: [`reqwest::Request::try_clone`].
+    fn try_clone(&self) -> Option<Self> {
+        Some(Self {
+            source_name: self.source_name,
+            request: self.request.try_clone()?,
+            client: self.client.clone(),
+            timeouts: self.timeouts,
+            measure: self.measure,
+        })
+    }
+
+    /// Executes the request and returns the corresponding [`SymResponse`].
+    async fn execute(self) -> CacheContents<SymResponse<'a>> {
+        let request = self.client.execute(self.request);
+        let request = tokio::time::timeout(self.timeouts.head, request);
+        // Use a separate measure for the head request.
+        //
+        // We're only interested in the total combined throughput of all concurrent requests.
+        // The head requests can still be tracked individually.
+        let request = measure_download_time(self.source_name, request);
+
+        let response = request
+            .await
+            .map_err(|_| CacheError::Timeout(self.timeouts.head))??;
+
+        Ok(SymResponse {
+            timeouts: self.timeouts,
+            measure: self.measure,
+            response,
+        })
+    }
+}
+
+/// A HTTP response Symbolicator received.
+struct SymResponse<'a> {
+    timeouts: &'a DownloadTimeouts,
+    measure: &'a MeasureSourceDownloadGuard<'a>,
+    response: reqwest::Response,
+}
+
+impl SymResponse<'_> {
+    /// Returns the [`StatusCode`] of the response.
+    fn status(&self) -> StatusCode {
+        self.response.status()
+    }
+
+    /// Returns the content range, the server replied with.
+    fn content_range(
+        &self,
+    ) -> Option<Result<partial::BytesContentRange, partial::InvalidBytesRange>> {
+        partial::BytesContentRange::from_response(&self.response)
+    }
+
+    /// Downloads the resource into `destination`, applying timeouts.
+    async fn download(self, mut destination: impl WriteStream) -> CacheContents {
+        let timeout = self
+            .response
+            .content_length()
+            .map(|cl| content_length_timeout(cl, self.timeouts.streaming))
+            .unwrap_or(self.timeouts.max_download);
+
+        let mut stream = self.response.bytes_stream().map_err(CacheError::from);
+        // Transfer the contents, into the destination and track progress.
+        tokio::time::timeout(timeout, async move {
+            while let Some(chunk) = stream.next().await.transpose()? {
+                self.measure.add_bytes_transferred(chunk.len() as u64);
+                destination.write_buf(chunk).await?;
+            }
+
+            Ok(())
+        })
+        .await
+        .map_err(|_| CacheError::Timeout(timeout))?
     }
 }
 
@@ -641,7 +861,8 @@ pub struct MeasureSourceDownloadGuard<'a> {
     task_name: &'a str,
     source_name: &'a str,
     creation_time: Instant,
-    bytes_transferred: Option<u64>,
+    bytes_transferred: AtomicU64,
+    streams: AtomicUsize,
 }
 
 impl<'a> MeasureSourceDownloadGuard<'a> {
@@ -651,17 +872,26 @@ impl<'a> MeasureSourceDownloadGuard<'a> {
             state: MeasureState::Pending,
             task_name,
             source_name,
-            bytes_transferred: None,
+            bytes_transferred: AtomicU64::new(0),
             creation_time: Instant::now(),
+            streams: AtomicUsize::new(0),
         }
+    }
+
+    /// Sets the amount of concurrent streams used for the download.
+    ///
+    /// This value will be used as a tag for the emitted metrics.
+    pub fn set_streams(&self, num_streams: usize) {
+        self.streams
+            .store(num_streams, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// A checked add to the amount of bytes transferred during the download.
     ///
     /// This value will be emitted when the download's future is completed or cancelled.
-    pub fn add_bytes_transferred(&mut self, additional_bytes: u64) {
-        let bytes = self.bytes_transferred.get_or_insert(0);
-        *bytes = bytes.saturating_add(additional_bytes);
+    pub fn add_bytes_transferred(&self, additional_bytes: u64) {
+        self.bytes_transferred
+            .fetch_add(additional_bytes, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Marks the download as terminated.
@@ -677,15 +907,19 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
             MeasureState::Done(status) => status,
         };
 
+        let streams = (*self.streams.get_mut()).to_string();
+
         let duration = self.creation_time.elapsed();
         metric!(
             timer("download_duration") = duration,
             "task_name" => self.task_name,
             "status" => status,
             "source" => self.source_name,
+            "streams" => &streams,
         );
 
-        if let Some(bytes_transferred) = self.bytes_transferred {
+        let bytes_transferred = *self.bytes_transferred.get_mut();
+        if bytes_transferred > 0 {
             // Times are recorded in milliseconds, so match that unit when calculating throughput,
             // recording a byte / ms value.
             // This falls back to the throughput being equivalent to the amount of bytes transferred
@@ -694,11 +928,21 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
                 .checked_div(duration.as_millis())
                 .and_then(|t| t.try_into().ok())
                 .unwrap_or(bytes_transferred);
+
             metric!(
                 histogram("download_throughput") = throughput,
                 "task_name" => self.task_name,
                 "status" => status,
                 "source" => self.source_name,
+                "streams" => &streams,
+            );
+
+            metric!(
+                histogram("download_size") = bytes_transferred,
+                "task_name" => self.task_name,
+                "status" => status,
+                "source" => self.source_name,
+                "streams" => &streams,
             );
         }
     }
@@ -729,7 +973,7 @@ where
 /// Computes a download timeout based on a content length in bytes and a per-gigabyte timeout.
 ///
 /// Returns `content_length / 2^30 * timeout_per_gb`, with a minimum value of 10s.
-fn content_length_timeout(content_length: i64, timeout_per_gb: Duration) -> Duration {
+fn content_length_timeout(content_length: u64, timeout_per_gb: Duration) -> Duration {
     let gb = content_length as f64 / (1024.0 * 1024.0 * 1024.0);
     timeout_per_gb.mul_f64(gb).max(Duration::from_secs(10))
 }
@@ -739,6 +983,9 @@ mod tests {
     // Actual implementation is tested in the sub-modules, this only needs to
     // ensure the service interface works correctly.
 
+    use symbolicator_sources::{HttpSourceConfig, SourceId};
+    use symbolicator_test::fixture;
+
     use super::*;
 
     use crate::{
@@ -746,34 +993,83 @@ mod tests {
         test,
     };
 
-    #[tokio::test]
-    async fn test_download() {
-        test::setup();
+    fn config() -> Config {
+        Config {
+            connect_to_reserved_ips: true,
+            ..Config::default()
+        }
+    }
 
+    async fn download(location: &'static str) -> tempfile::NamedTempFile {
         let (_srv, source) = test::symbol_server();
         let file_source = match source {
             SourceConfig::Http(source) => {
-                HttpRemoteFile::new(source, SourceLocation::new("hello.txt")).into()
+                HttpRemoteFile::new(source, SourceLocation::new(location)).into()
             }
             _ => panic!("unexpected source"),
         };
 
-        let config = Config {
-            connect_to_reserved_ips: true,
-            ..Config::default()
-        };
+        let service = DownloadService::new(&config(), tokio::runtime::Handle::current());
 
-        let service = DownloadService::new(&config, tokio::runtime::Handle::current());
-
-        // Jump through some hoops here, to prove that we can .await the service.
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         service
             .download(file_source, temp_file.path().to_owned())
             .await
             .unwrap();
 
-        let content = std::fs::read_to_string(temp_file.path()).unwrap();
+        temp_file
+    }
+
+    #[tokio::test]
+    async fn test_download_small() {
+        test::setup();
+
+        let file = download("hello.txt").await;
+        let content = std::fs::read_to_string(file.path()).unwrap();
         assert_eq!(content, "hello world\n")
+    }
+
+    /// This test requests a much larger file than [`test_download`], which will initiate a
+    /// concurrent download on platforms which support it.
+    #[tokio::test]
+    async fn test_download_large() {
+        test::setup();
+
+        let file = download("7f/883fcdc55336d0a809b0150f09500b.debug").await;
+        let content = std::fs::read(file.path()).unwrap();
+
+        let expected =
+            std::fs::read(fixture("symbols/7f/883fcdc55336d0a809b0150f09500b.debug")).unwrap();
+
+        assert_eq!(content, expected);
+    }
+
+    /// Another download, but this time the server does not respond with a `Content-Range` header.
+    #[tokio::test]
+    async fn test_download_missing_content_range() {
+        test::setup();
+
+        let server = test::Server::new();
+
+        let source = Arc::new(HttpSourceConfig {
+            id: SourceId::new("local"),
+            url: server.url("/garbage_data/"),
+            headers: Default::default(),
+            files: Default::default(),
+            accept_invalid_certs: false,
+        });
+        let file_source = HttpRemoteFile::new(source, SourceLocation::new("hello_world")).into();
+
+        let service = DownloadService::new(&config(), tokio::runtime::Handle::current());
+        let file = tempfile::NamedTempFile::new().unwrap();
+        service
+            .download(file_source, file.path().to_owned())
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(file.path()).unwrap();
+
+        assert_eq!(content, "hello_world");
     }
 
     #[tokio::test]

--- a/crates/symbolicator-service/src/download/partial.rs
+++ b/crates/symbolicator-service/src/download/partial.rs
@@ -1,0 +1,309 @@
+use std::{fmt, str::FromStr};
+
+use reqwest::StatusCode;
+
+/// The maximum amount of partial requests per download.
+const MAX_PARTIAL_RANGES: u64 = 4;
+
+/// The amount of bytes when a download should split into multiple parts,
+/// this essentially means the minimum split size is `PARTIAL_SPLIT_SIZE / 2`.
+#[cfg(not(test))]
+const PARTIAL_SPLIT_SIZE: u64 = 128 * 1024 * 1024;
+#[cfg(test)]
+const PARTIAL_SPLIT_SIZE: u64 = 100;
+
+/// The initial range request sent to the server.
+///
+/// It must start at `0`.
+///
+/// The smaller the total initially requested range, the more requests will
+/// be streamed.
+const INITIAL_RANGE: Range = Range {
+    start: 0,
+    end: PARTIAL_SPLIT_SIZE - 1, // Ranges are inclusive.
+};
+
+/// Prepares a `request` for partially streamed downloads.
+pub const fn initial_range() -> Range {
+    INITIAL_RANGE
+}
+
+/// Splits the remainder of the remote file into multiple smaller ranges.
+pub fn split(r: BytesContentRange) -> impl Iterator<Item = Range> {
+    // Ranges are inclusive. This range represents the correct
+    // bounds of the remainder of the supplied content range.
+    let remainder = Range {
+        start: r.end + 1,
+        end: r.total_size - 1,
+    };
+
+    if remainder.size() == 0 {
+        return None.into_iter().flatten();
+    }
+
+    // Infer the amount of partial requests we want to make,
+    // making sure each request is split at `PARTIAL_SPLIT_SIZE` bytes,
+    // but there are not more partial requests than `MAX_PARTIAL_RANGES`.
+    let ranges = remainder
+        .size()
+        .div_ceil(PARTIAL_SPLIT_SIZE)
+        .min(MAX_PARTIAL_RANGES);
+
+    // Divide the remaining bytes into individual ranges.
+    let range_size = remainder.size() / ranges;
+
+    // Emit the ranges.
+    Some((0..ranges).map(move |i| {
+        let is_last = i + 1 == ranges;
+        let start = remainder.start + i * range_size;
+        let end = match is_last {
+            false => start + range_size,
+            true => remainder.end,
+        };
+        Range { start, end }
+    }))
+    .into_iter()
+    .flatten()
+}
+
+/// Represents an HTTP Range header.
+///
+/// The string representation can be used as a range header.
+///
+/// Unlike the specification, this range cannot be open ended.
+#[derive(Copy, Clone)]
+pub struct Range {
+    /// Start of the range, inclusive.
+    pub start: u64,
+    /// End of the range, inclusive.
+    pub end: u64,
+}
+
+impl Range {
+    /// Returns the amount of bytes the range contains.
+    pub fn size(&self) -> u64 {
+        if self.start > self.end {
+            return 0;
+        }
+        // +1 because the end of the range is inclusive,
+        // A 0-0 range is 1 byte in size.
+        self.end - self.start + 1
+    }
+
+    /// Applies this range to a request.
+    pub fn apply_to(&self, request: &mut reqwest::Request) {
+        let header = reqwest::header::HeaderValue::from_str(&self.to_string());
+        let header = header.expect("the range header to be a valid");
+        request.headers_mut().insert(reqwest::header::RANGE, header);
+    }
+}
+
+impl fmt::Debug for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl fmt::Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "bytes={}-{}", self.start, self.end)
+    }
+}
+
+/// A parsed `Content-Range` header for `bytes`.
+///
+/// This implementation only supports the very basic format
+/// where all values are present: `bytes <start>-<end>/<size>`.
+///
+/// All other variations like `bytes */<size>` are not supported.
+#[derive(Debug, Clone, Copy)]
+pub struct BytesContentRange {
+    /// Start of the returned range, offset in bytes.
+    pub start: u64,
+    /// End of the returned range, offset in bytes.
+    pub end: u64,
+    /// The total size of the resource on the server.
+    pub total_size: u64,
+}
+
+impl BytesContentRange {
+    /// Extracts the contained range into a [`Range`].
+    pub fn range(self) -> Range {
+        Range {
+            start: self.start,
+            end: self.end,
+        }
+    }
+
+    /// Parses a [`BytesContentRange`] from a [`reqwest::Response`].
+    ///
+    /// Returns `None` if the response is not a partial response.
+    pub fn from_response(response: &reqwest::Response) -> Option<Result<Self, InvalidBytesRange>> {
+        if response.status() != StatusCode::PARTIAL_CONTENT {
+            return None;
+        }
+
+        response
+            .headers()
+            .get(reqwest::header::CONTENT_RANGE)
+            .and_then(|hv| hv.to_str().ok())
+            .map(|s| s.parse())
+    }
+}
+
+/// An error which can be returned when parsing a [`BytesContentRange`].
+#[derive(thiserror::Error, Debug)]
+pub enum InvalidBytesRange {
+    /// The header is malformed.
+    #[error("content range header is malformed")]
+    Malformed,
+    /// The specified unit is not `bytes`.
+    #[error("content range unit is not bytes")]
+    NotBytes,
+    /// The header indicates the requested range is not satisfiable.
+    #[error("the requested range is not satisfiable")]
+    RangeNotSatisfiable,
+    /// The header indicates the total length of the resource is unknown.
+    #[error("the total length of the resource is not known")]
+    UnknownLength,
+}
+
+impl FromStr for BytesContentRange {
+    type Err = InvalidBytesRange;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some(("bytes", s)) = s.trim().split_once(' ') else {
+            return Err(InvalidBytesRange::NotBytes);
+        };
+
+        let (range, total_size) = s
+            .trim()
+            .split_once('/')
+            .ok_or(InvalidBytesRange::Malformed)?;
+        if range.trim() == "*" {
+            return Err(InvalidBytesRange::RangeNotSatisfiable);
+        }
+
+        let (start, end) = range.split_once('-').ok_or(InvalidBytesRange::Malformed)?;
+        let start = start
+            .trim()
+            .parse()
+            .map_err(|_| InvalidBytesRange::Malformed)?;
+        let end = end
+            .trim()
+            .parse()
+            .map_err(|_| InvalidBytesRange::Malformed)?;
+
+        if end < start {
+            return Err(InvalidBytesRange::Malformed);
+        }
+
+        let total_size = match total_size.trim() {
+            "*" => Err(InvalidBytesRange::UnknownLength),
+            size => size.parse().map_err(|_| InvalidBytesRange::Malformed),
+        }?;
+
+        Ok(Self {
+            start,
+            end,
+            total_size,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_split {
+        ($r:expr, @$expected:literal) => {{
+            let s = split($r).collect::<Vec<_>>();
+            insta::assert_debug_snapshot!(s, @$expected);
+
+            if let Some(x) = s.last() {
+                assert_eq!($r.total_size, x.end + 1);
+            }
+
+            s
+        }};
+    }
+
+    #[test]
+    fn test_split_nothing_to_do() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 11,
+            total_size: 12,
+        };
+
+        assert_split!(r, @"[]");
+    }
+
+    #[test]
+    fn test_split_too_small() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 9,
+            total_size: 10 + PARTIAL_SPLIT_SIZE,
+        };
+
+        let s = split(r).collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(s, @r###"
+        [
+            bytes=10-109,
+        ]
+        "###);
+    }
+
+    #[test]
+    fn test_split_two_parts() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 9,
+            // 10 bytes for the original range, in order to split, we need to fit at least
+            // two partial ranges into the remainder.
+            total_size: 10 + PARTIAL_SPLIT_SIZE * 2,
+        };
+
+        assert_split!(r, @r###"
+        [
+            bytes=10-110,
+            bytes=110-209,
+        ]
+        "###);
+    }
+
+    #[test]
+    fn test_split_two_parts_not_exact() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 9,
+            total_size: 10 + PARTIAL_SPLIT_SIZE * 2 - 1,
+        };
+
+        assert_split!(r, @r###"
+        [
+            bytes=10-109,
+            bytes=109-208,
+        ]
+        "###);
+    }
+
+    #[test]
+    fn test_split_too_many_parts() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 9,
+            total_size: 10 + PARTIAL_SPLIT_SIZE * (MAX_PARTIAL_RANGES + 10),
+        };
+
+        assert_split!(r, @r###"
+        [
+            bytes=10-360,
+            bytes=360-710,
+            bytes=710-1060,
+            bytes=1060-1409,
+        ]
+        "###);
+    }
+}

--- a/crates/symbolicator-service/src/download/partial.rs
+++ b/crates/symbolicator-service/src/download/partial.rs
@@ -32,6 +32,10 @@ pub const fn initial_range() -> Range {
 
 /// Splits the remainder of the remote file into multiple smaller ranges.
 pub fn split(r: BytesContentRange) -> impl Iterator<Item = Range> {
+    if r.total_size == 0 {
+        return None.into_iter().flatten();
+    }
+
     // Ranges are inclusive. This range represents the correct
     // bounds of the remainder of the supplied content range.
     let remainder = Range {
@@ -146,6 +150,12 @@ impl BytesContentRange {
     }
 }
 
+impl fmt::Display for BytesContentRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "bytes {}-{}/{}", self.start, self.end, self.total_size)
+    }
+}
+
 /// An error which can be returned when parsing a [`BytesContentRange`].
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum InvalidBytesRange {
@@ -229,6 +239,17 @@ mod tests {
             start: 0,
             end: 11,
             total_size: 12,
+        };
+
+        assert_split!(r, @"[]");
+    }
+
+    #[test]
+    fn test_split_empty() {
+        let r = BytesContentRange {
+            start: 0,
+            end: 0,
+            total_size: 0,
         };
 
         assert_split!(r, @"[]");

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -9,14 +9,13 @@ use std::time::Duration;
 use sentry::SentryFutureExt;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use tokio::io::AsyncWrite;
 use url::Url;
 
 use symbolicator_sources::{
     ObjectId, RemoteFile, SentryFileId, SentryRemoteFile, SentrySourceConfig,
 };
 
-use super::{FileType, USER_AGENT};
+use super::{Destination, FileType, USER_AGENT};
 use crate::caching::{CacheContents, CacheError};
 use crate::config::InMemoryCacheConfig;
 use crate::utils::futures::{m, measure, CancelOnDrop};
@@ -256,7 +255,7 @@ impl SentryDownloader {
         &self,
         source_name: &str,
         file_source: &SentryRemoteFile,
-        destination: impl AsyncWrite,
+        destination: impl Destination,
     ) -> CacheContents {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);

--- a/crates/symbolicator-service/src/utils/futures.rs
+++ b/crates/symbolicator-service/src/utils/futures.rs
@@ -197,3 +197,18 @@ pub mod m {
         }
     }
 }
+
+/// Extension trait to workaround a compiler bug: <https://github.com/rust-lang/rust/issues/96865>.
+///
+/// This extension trait can be used to force `Send` bounds on futures to help the compiler
+/// prove send bounds through multiple nested futures.
+pub trait SendFuture: std::future::Future {
+    fn send(self) -> impl std::future::Future<Output = Self::Output> + Send
+    where
+        Self: Sized + Send,
+    {
+        self
+    }
+}
+
+impl<T: std::future::Future> SendFuture for T {}

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -72,6 +72,7 @@ pub fn tempdir() -> TempDir {
 /// # Panics
 ///
 /// Panics if the fixture path does not exist on the file system.
+#[track_caller]
 pub fn fixture(path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
 


### PR DESCRIPTION
Parallelize large downloads with multiple parallel streams using [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests).

Symbolicator after this PR will make the first request to a resource with a `Range` header containing a large initial range, which should already satisfy most small files.

If the server responds with a `Content-Range` which is not already covered by the initial `Range`, symbolicator will split the remaining bytes into multiple smaller ranges and request them concurrently. A response which does not contain a `Content-Range` header in the response is treated as previously and is assumed to contain the fully requested file (as per spec).

The concurrent streams are written concurrently into the `Destination`, this is currently only supported for `Unix` platforms, using the `pwrite` syscall. In theory this could easily be supported for in memory buffers (e.g. `Vec`) as well. If the chosen destination does not support writing multiple concurrent streams at different offsets, Symbolicator will fallback to the old behaviour without range requests.

Fixes: #1646