### PR TITLE
ref(HTTP sources): Set user agent before custom headers

### DIFF
--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -45,6 +45,7 @@ impl HttpDownloader {
             self.client.get(download_url)
         };
 
+        builder = builder.header(header::USER_AGENT, USER_AGENT);
         let headers = file_source
             .source
             .headers
@@ -55,7 +56,6 @@ impl HttpDownloader {
                 builder = builder.header(key, value.as_str());
             }
         }
-        builder = builder.header(header::USER_AGENT, USER_AGENT);
 
         super::download_reqwest(source_name, builder, &self.timeouts, destination).await
     }


### PR DESCRIPTION
By itself, this change is inert: the only headers we actually get from Sentry are basic auth, so setting the user agent before or after makes no difference. However, this allows us to override the user agent for individual source configs.