### PR TITLE
feat(symsorter): Save separate metadata for each file

### DIFF
--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -147,7 +147,7 @@ fn process_file(
         };
 
         fs::write(
-            new_filename.parent().unwrap().join("meta"),
+            new_filename.with_extension("meta"),
             serde_json::to_vec(&meta)?,
         )?;
 


### PR DESCRIPTION
In cases where multiple input files are sorted into the same folder, e.g. app.exe and the corresponding app.pdb, the meta file only contains information of the last file written.  Add a `--keep-meta` option which causes new metadata entries to be appended instead, resulting in jsonl files instead.