### PR TITLE
fix(download): Correct failed merge, accessing a renamed field

### DIFF
--- a/crates/symbolicator-service/src/download/destination.rs
+++ b/crates/symbolicator-service/src/download/destination.rs
@@ -176,7 +176,7 @@ impl<'file> MultiStreamDestination for FileMultiStreamDestination<'file> {
         }
     }
     async fn flush(&mut self) -> io::Result<()> {
-        let mut file = Arc::clone(&self.std);
+        let mut file = Arc::clone(&self.file);
         tokio::task::spawn_blocking(move || file.flush()).await?
     }
 


### PR DESCRIPTION
Renamed field `std` to `file` in PR 1, used field `std` in PR 2 and merged both -> now it's broken.