### PR TITLE
feat(js): Error when failing to query Sentry

### DIFF
--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -1030,8 +1030,12 @@ impl ArtifactFetcher {
             .await
         {
             Ok(results) => results,
-            Err(_err) => {
-                // TODO(sourcemap): handle errors
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    lookup_url = %self.source.url,
+                    "Failed to query Sentry for files",
+                );
                 return false;
             }
         };


### PR DESCRIPTION
This adds a `tracing::error` in JS symbolication if querying Sentry for files/artifact bundles fails.

This is intended less for SaaS and more for self-hosted, where there may be communication problems between Sentry and Symbolicator.