### PR TITLE
fix(index): Avoid creating duplicate index service

### DIFF
--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -4,7 +4,6 @@ use symbolic::common::Name;
 use symbolic::demangle::Demangle;
 use symbolicator_service::caches::SourceFilesCache;
 use symbolicator_service::caching::{Cache, CacheError};
-use symbolicator_service::download::SourceIndexService;
 use symbolicator_service::objects::ObjectsActor;
 use symbolicator_service::services::SharedServices;
 
@@ -44,11 +43,7 @@ impl SymbolicationActor {
         let shared_cache = services.shared_cache.clone();
         let objects = services.objects.clone();
         let download_svc = services.download_svc.clone();
-        let source_index_svc = Arc::new(SourceIndexService::new(
-            caches.source_index.clone(),
-            Arc::clone(&shared_cache),
-            Arc::clone(&download_svc),
-        ));
+        let source_index_svc = services.source_index_svc.clone();
         let sourcefiles_cache = services.sourcefiles_cache.clone();
 
         let bitcode = BitcodeService::new(


### PR DESCRIPTION
By mistake, the `SymbolicationActor` created a new SourceIndexService instead of cloning the one passed to it through `SharedServices`.