### PR TITLE
fix(ci): Bump ubuntu to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   linux:
     name: Build Binary on Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   linux:
     name: Build Binary on Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -48,8 +48,8 @@ jobs:
 
     runs-on: |-
       ${{fromJson('{
-        "amd64": "ubuntu-24.04",
-        "arm64": "ubuntu-24.04-arm"
+        "amd64": "ubuntu-22.04",
+        "arm64": "ubuntu-22.04-arm"
       }')[matrix.arch] }}
 
     env:
@@ -159,7 +159,7 @@ jobs:
     if: "needs.build-setup.outputs.full_ci == 'true'"
 
     name: Assemble for Github Container Registry
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     env:
       TARGET_IMAGE: ghcr.io/getsentry/symbolicator

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -48,8 +48,8 @@ jobs:
 
     runs-on: |-
       ${{fromJson('{
-        "amd64": "ubuntu-20.04",
-        "arm64": "ubuntu-22.04-arm"
+        "amd64": "ubuntu-24.04",
+        "arm64": "ubuntu-24.04-arm"
       }')[matrix.arch] }}
 
     env:
@@ -159,7 +159,7 @@ jobs:
     if: "needs.build-setup.outputs.full_ci == 'true'"
 
     name: Assemble for Github Container Registry
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       TARGET_IMAGE: ghcr.io/getsentry/symbolicator


### PR DESCRIPTION
See https://github.com/getsentry/symbolicator/actions/runs/14475232477/job/40600459400


``` 
--
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
 

<br class="Apple-interchange-newline">
```

#skip-changelog