### PR TITLE
ref: Unify download timeout configuration

### DIFF
--- a/crates/symbolicator-js/src/api_lookup.rs
+++ b/crates/symbolicator-js/src/api_lookup.rs
@@ -12,9 +12,8 @@ use symbolicator_service::metric;
 use url::Url;
 
 use symbolicator_service::caching::{CacheContents, CacheError};
-use symbolicator_service::config::InMemoryCacheConfig;
+use symbolicator_service::config::{DownloadTimeouts, InMemoryCacheConfig};
 use symbolicator_service::utils::futures::{CancelOnDrop, m, measure};
-use symbolicator_service::utils::http::DownloadTimeouts;
 use symbolicator_sources::{RemoteFile, SentryFileId, SentryRemoteFile, SentrySourceConfig};
 
 use crate::interface::ResolvedWith;

--- a/crates/symbolicator-native/tests/integration/source_errors.rs
+++ b/crates/symbolicator-native/tests/integration/source_errors.rs
@@ -9,7 +9,7 @@ use crate::{Server, example_request, setup_service};
 #[tokio::test]
 async fn test_download_errors() {
     let (symbolication, _cache_dir) = setup_service(|config| {
-        config.max_download_timeout = Duration::from_millis(200);
+        config.timeouts.max_download = Duration::from_millis(200);
     });
 
     let hitcounter = Server::new();
@@ -127,7 +127,7 @@ async fn test_deny_list() {
         config.caches.derived.retry_misses_after = Some(Duration::ZERO);
         // FIXME: `object_meta` caches treat download errors as `malformed`
         config.caches.derived.retry_malformed_after = Some(Duration::ZERO);
-        config.max_download_timeout = Duration::from_millis(200);
+        config.timeouts.max_download = Duration::from_millis(200);
         config.deny_list_time_window = Duration::from_millis(500);
         config.deny_list_bucket_size = Duration::from_millis(100);
         config.deny_list_threshold = 2;

--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use symbolicator_sources::{GcsRemoteFile, GcsSourceAuthorization, GcsSourceKey, GcsSourceToken};
 
 use crate::caching::{CacheContents, CacheError};
+use crate::config::DownloadTimeouts;
 use crate::utils::gcs::{self, CacheableToken};
-use crate::utils::http::DownloadTimeouts;
 
 use super::Destination;
 

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -4,8 +4,10 @@ use reqwest::{Client, header};
 
 use symbolicator_sources::HttpRemoteFile;
 
-use crate::caching::{CacheContents, CacheError};
-use crate::utils::http::DownloadTimeouts;
+use crate::{
+    caching::{CacheContents, CacheError},
+    config::DownloadTimeouts,
+};
 
 use super::{Destination, USER_AGENT};
 

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -17,11 +17,10 @@ use partial::BytesContentRange;
 use reqwest::StatusCode;
 
 use crate::caching::{CacheContents, CacheError};
-use crate::config::Config;
+use crate::config::{Config, DownloadTimeouts};
 use crate::types::Scope;
 use crate::utils::futures::{CancelOnDrop, SendFuture as _, m, measure};
 use crate::utils::gcs::GcsError;
-use crate::utils::http::DownloadTimeouts;
 use crate::utils::sentry::ConfigureScope;
 use stream::FuturesUnordered;
 pub use symbolicator_sources::{
@@ -243,7 +242,7 @@ pub struct DownloadService {
 impl DownloadService {
     /// Creates a new downloader that runs all downloads in the given remote thread.
     pub fn new(config: &Config, runtime: tokio::runtime::Handle) -> Arc<Self> {
-        let timeouts = DownloadTimeouts::from_config(config);
+        let timeouts = config.timeouts;
 
         // |   client   | can connect to reserved IPs | accepts invalid SSL certs |
         // | -----------| ----------------------------|---------------------------|

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -16,7 +16,7 @@ use symbolicator_sources::{AwsCredentialsProvider, S3Region, S3RemoteFile, S3Sou
 use tokio::io::AsyncWriteExt as _;
 
 use crate::caching::{CacheContents, CacheError};
-use crate::utils::http::DownloadTimeouts;
+use crate::config::DownloadTimeouts;
 
 use super::{Destination, content_length_timeout};
 

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -17,9 +17,8 @@ use symbolicator_sources::{
 
 use super::{Destination, FileType, USER_AGENT};
 use crate::caching::{CacheContents, CacheError};
-use crate::config::InMemoryCacheConfig;
+use crate::config::{DownloadTimeouts, InMemoryCacheConfig};
 use crate::utils::futures::{CancelOnDrop, m, measure};
-use crate::utils::http::DownloadTimeouts;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -245,7 +245,7 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::caching::{Cache, CacheName};
-    use crate::config::{CacheConfig, CacheConfigs, Config};
+    use crate::config::{CacheConfig, CacheConfigs, Config, DownloadTimeouts};
     use crate::download::SourceIndexService;
     use crate::objects::{FindObject, ObjectPurpose, ObjectsActor};
     use crate::test::{self, tempdir};
@@ -255,7 +255,10 @@ mod tests {
     async fn make_objects_actor(tempdir: &TempDir) -> ObjectsActor {
         let config = Config {
             connect_to_reserved_ips: true,
-            max_download_timeout: Duration::from_millis(100),
+            timeouts: DownloadTimeouts {
+                max_download: Duration::from_millis(100),
+                ..Default::default()
+            },
             cache_dir: Some(tempdir.path().to_path_buf()),
             ..Default::default()
         };

--- a/crates/symbolicator-service/src/utils/http.rs
+++ b/crates/symbolicator-service/src/utils/http.rs
@@ -6,7 +6,7 @@ use ipnetwork::Ipv4Network;
 use once_cell::sync::Lazy;
 use reqwest::{StatusCode, Url, redirect};
 
-use crate::config::Config;
+use crate::config::DownloadTimeouts;
 
 static RESERVED_IP_BLOCKS: Lazy<Vec<Ipv4Network>> = Lazy::new(|| {
     [
@@ -51,41 +51,6 @@ fn is_external_ip(ip: std::net::IpAddr) -> bool {
     }
 
     true
-}
-
-/// Various timeouts for all the Downloaders
-#[derive(Copy, Clone, Debug)]
-pub struct DownloadTimeouts {
-    /// The timeout for establishing a connection.
-    pub connect: Duration,
-    /// The timeout for receiving the first headers.
-    pub head: Duration,
-    /// An adaptive timeout per 1GB of content.
-    pub streaming: Duration,
-    /// Global timeout for one download.
-    pub max_download: Duration,
-}
-
-impl DownloadTimeouts {
-    pub fn from_config(config: &Config) -> Self {
-        Self {
-            connect: config.connect_timeout,
-            head: config.head_timeout,
-            streaming: config.streaming_timeout,
-            max_download: config.max_download_timeout,
-        }
-    }
-}
-
-impl Default for DownloadTimeouts {
-    fn default() -> Self {
-        Self {
-            connect: Duration::from_millis(500),
-            head: Duration::from_secs(5),
-            streaming: Duration::from_secs(250),
-            max_download: Duration::from_secs(315),
-        }
-    }
 }
 
 /// Creates a [`reqwest::Client`] with the provided options.


### PR DESCRIPTION
Previously we had individual download timeout settings in the config and then a struct bundling them in the `utils` module. The default values were inconsistent between them (meaning the ones on the struct didn't matter) and this was just unnecessary duplication in general.

This moves the `DownloadTimeouts` struct into the config. No changes to config parsing.