### PR TITLE
ref(symbolicator): move `Bearer` prefix into request code

### DIFF
--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -83,7 +83,7 @@ impl GcsDownloader {
         let builder = self
             .client
             .get(url)
-            .header("authorization", token.bearer_token());
+            .header("authorization", format!("Bearer {}", token.bearer_token()));
 
         super::download_reqwest(source_name, builder, &self.timeouts, destination).await
     }

--- a/crates/symbolicator-service/src/utils/gcs.rs
+++ b/crates/symbolicator-service/src/utils/gcs.rs
@@ -138,10 +138,9 @@ pub async fn request_new_token(
         .json::<GcsTokenResponse>()
         .await
         .map_err(GcsError::Auth)?;
-    let bearer_token = format!("Bearer {}", token.access_token).into();
 
     Ok(CacheableToken {
-        bearer_token,
+        bearer_token: token.access_token.into(),
         expires_at,
     })
 }


### PR DESCRIPTION
This PR moves the prepending of `Bearer` into the http client code. This enables us to pass down the bearer token from external sources without having to specify the `Bearer` prefix in the request