### PR TITLE
ci: push nightly images to dockerhub

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           IMAGE_URL="ghcr.io/getsentry/symbolicator:${{ github.sha }}"
           docker pull "$IMAGE_URL"
-          docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+          docker login --username=sentrybuilder --password-stdin <<< "${{ secrets.DOCKER_HUB_RW_TOKEN }}"
 
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -241,7 +241,6 @@ jobs:
         shell: bash
         run: |
           IMAGE_URL="ghcr.io/getsentry/symbolicator:${{ github.sha }}"
-          docker pull "$IMAGE_URL"
           docker login --username=sentrybuilder --password-stdin <<< "${{ secrets.DOCKER_HUB_RW_TOKEN }}"
 
           # We push 3 tags to Dockerhub:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -232,7 +232,7 @@ jobs:
   publish-to-dockerhub:
     name: Publish Symbolicator to DockerHub
     runs-on: ubuntu-latest
-    if: ${{ (github.ref_name == 'master') }}
+    if: ${{ (github.ref_name == 'master' && github.event_name == 'push') }}
     needs:
       - assemble
     steps:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -232,7 +232,7 @@ jobs:
   publish-to-dockerhub:
     name: Publish Symbolicator to DockerHub
     runs-on: ubuntu-latest
-    if: ${{ (github.ref_name == 'main') }}
+    if: ${{ (github.ref_name == 'master') }}
     needs:
       - assemble
     steps:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -228,3 +228,29 @@ jobs:
           docker buildx imagetools create -t "${TARGET_IMAGE}:latest" \
             "${GHCR_IMAGE}:arm64-${{ github.sha }}" \
             "${GHCR_IMAGE}:amd64-${{ github.sha }}"
+
+  publish-to-dockerhub:
+    name: Publish Symbolicator to DockerHub
+    runs-on: ubuntu-latest
+    if: ${{ (github.ref_name == 'main') }}
+    needs:
+      - assemble
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push built docker image
+        shell: bash
+        run: |
+          IMAGE_URL="ghcr.io/getsentry/symbolicator:${{ github.sha }}"
+          docker pull "$IMAGE_URL"
+          docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+
+          # We push 3 tags to Dockerhub:
+          # first, the full sha of the commit
+          docker buildx imagetools create --tag getsentry/symbolicator:${GITHUB_SHA} ghcr.io/getsentry/symbolicator:${{ github.sha }}
+
+          # second, the short sha of the commit
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          docker buildx imagetools create --tag getsentry/symbolicator:${SHORT_SHA} ghcr.io/getsentry/symbolicator:${{ github.sha }}
+
+          # finally, nightly
+          docker buildx imagetools create --tag getsentry/symbolicator:nightly ghcr.io/getsentry/symbolicator:${{ github.sha }}


### PR DESCRIPTION
Nightly images should be pushed to DockerHub. This is the only repository that don't do that.

#skip-changelog