### PR TITLE
ci: push nightly to ghcr

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -181,6 +181,10 @@ jobs:
             "${TARGET_IMAGE}:arm64-${{ github.sha }}" \
             "${TARGET_IMAGE}:amd64-${{ github.sha }}"
 
+          docker buildx imagetools create -t "${TARGET_IMAGE}:nightly" \
+            "${TARGET_IMAGE}:arm64-${{ github.sha }}" \
+            "${TARGET_IMAGE}:amd64-${{ github.sha }}"
+
   assemble-ar:
     needs: [build-setup, build-image]
     if: "needs.build-setup.outputs.full_ci == 'true'"


### PR DESCRIPTION
This is the only one that is missing from all repositories.