### PR TITLE
fix(metrics): Validate statsd port

### DIFF
--- a/crates/symbolicator-service/src/metrics.rs
+++ b/crates/symbolicator-service/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Provides access to the metrics sytem.
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
-use std::net::ToSocketAddrs;
+use std::net::SocketAddr;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
@@ -394,8 +394,7 @@ impl LocalAggregator {
 }
 
 /// Tell the metrics system to report to statsd.
-pub fn configure_statsd<A: ToSocketAddrs>(prefix: &str, host: A, tags: BTreeMap<String, String>) {
-    let addrs: Vec<_> = host.to_socket_addrs().unwrap().collect();
+pub fn configure_statsd(prefix: &str, addrs: Vec<SocketAddr>, tags: BTreeMap<String, String>) {
     if !addrs.is_empty() {
         tracing::info!("Reporting metrics to statsd at {}", addrs[0]);
     }

--- a/crates/symbolicator-stress/src/logging.rs
+++ b/crates/symbolicator-stress/src/logging.rs
@@ -86,14 +86,14 @@ pub unsafe fn init(config: Config) -> Guard {
             }
         }));
 
-        let host = format!("127.0.0.1:{}", socket.port());
+        let addrs = vec![([127, 0, 0, 1], socket.port()).into()];
 
         // have some default tags, just to be closer to the real world config
         let mut tags = BTreeMap::new();
         tags.insert("host".into(), "stresstest".into());
         tags.insert("env".into(), "stresstest".into());
 
-        metrics::configure_statsd("symbolicator", host, tags);
+        metrics::configure_statsd("symbolicator", addrs, tags);
     }
 
     guard


### PR DESCRIPTION
The statsd port was previously totally unvalidated, Symbolicator simply panicked if you passed an invalid value.