### PR TITLE
fix(ci): Update from windows 2019 to windows 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
 
   windows:
     name: Build Tools on Windows
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
 
   windows:
     name: Build Tools on Windows
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Seems like symbolicator release is failing due to deprecated windows version: https://github.com/getsentry/symbolicator/actions/runs/16299649338/job/46030635724

