### PR TITLE
ci: Upload ARM debug files

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -102,8 +102,8 @@ jobs:
         run: |
           mkdir -p "artifacts/${{ matrix.arch }}"
 
-          docker run --rm --entrypoint cat "${BUILDER_IMG_CACHE}" /opt/symbolicator-debug.zip > artifacts/symbolicator-debug.zip
-          docker run --rm --entrypoint cat "${BUILDER_IMG_CACHE}" /opt/symbolicator.src.zip > artifacts/symbolicator.src.zip
+          docker run --rm --entrypoint cat "${BUILDER_IMG_CACHE}" /opt/symbolicator-debug.zip > artifacts/symbolicator-${{ matrix.arch }}-debug.zip
+          docker run --rm --entrypoint cat "${BUILDER_IMG_CACHE}" /opt/symbolicator.src.zip > artifacts/symbolicator-${{ matrix.arch }}.src.zip
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -148,7 +148,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: "image-amd64"
+          pattern: "image-*"
           merge-multiple: true
 
       - name: Upload gocd deployment assets

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -22,8 +22,7 @@ sentry-cli --version
 
 echo 'Pulling debug information...'
 gsutil cp \
-  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-*-debug.zip" \
-  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-*.src.zip" \
+  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-*.zip" \
   .
 
 echo 'Uploading debug information and source bundle...'

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -22,12 +22,12 @@ sentry-cli --version
 
 echo 'Pulling debug information...'
 gsutil cp \
-  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-debug.zip" \
-  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator.src.zip" \
+  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-*-debug.zip" \
+  "gs://dicd-team-devinfra-cd--symbolicator/difs/${VERSION}/symbolicator-*.src.zip" \
   .
 
 echo 'Uploading debug information and source bundle...'
-sentry-cli upload-dif ./symbolicator-debug.zip ./symbolicator.src.zip
+sentry-cli upload-dif ./symbolicator-*-debug.zip ./symbolicator-*.src.zip
 
 echo 'Creating a new deploy in Sentry...'
 sentry-cli releases new "${VERSION}"

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -27,7 +27,7 @@ gsutil cp \
   .
 
 echo 'Uploading debug information and source bundle...'
-sentry-cli upload-dif ./symbolicator-*-debug.zip ./symbolicator-*.src.zip
+sentry-cli upload-dif ./symbolicator-*.zip
 
 echo 'Creating a new deploy in Sentry...'
 sentry-cli releases new "${VERSION}"


### PR DESCRIPTION
At the moment we only upload amd64 debug files into Sentry which causes Symbolication to fail.
This changes it such that we also upload the debug files for arm64