### PR TITLE
fix(proguard): Update proguard to 5.6.2 to fix a panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,9 +3683,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.6.1"
+version = "5.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a199b2f766cfc8f351e1dfcb9974ed0e27f6d22bdbf000230c90e1da6200b39"
+checksum = "e40a6553b04a87f8efa9b559356dc9d6342b255307c8cf052ea09e93cd53a1bb"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "se
 
 
 [workspace.dependencies]
-proguard = "5.6.1"
+proguard = "5.6.2"
 reqwest = "0.12.15"
 serde-vars = "0.2.0"
 symbolic = "12.15.5"


### PR DESCRIPTION
See https://github.com/getsentry/rust-proguard/pull/57.