### PR TITLE
ref: Turn some `error!`s into `debug!`s

### DIFF
--- a/crates/symbolicator-native/src/caches/cficaches.rs
+++ b/crates/symbolicator-native/src/caches/cficaches.rs
@@ -185,7 +185,7 @@ fn write_cficache(file: &mut File, object_handle: &ObjectHandle) -> CacheContent
 
     let cficache = CfiCache::from_object(object_handle.object()).map_err(|e| {
         let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
-        tracing::error!(error = dynerr, "Could not process CFI Cache");
+        tracing::debug!(error = dynerr, "Could not process CFI Cache");
 
         CacheError::Malformed(e.to_string())
     })?;

--- a/crates/symbolicator-native/src/caches/ppdb_caches.rs
+++ b/crates/symbolicator-native/src/caches/ppdb_caches.rs
@@ -146,7 +146,7 @@ fn write_ppdb_cache(file: &mut File, object_handle: &ObjectHandle) -> CacheConte
         .process_portable_pdb(ppdb_obj.portable_pdb())
         .map_err(|e| {
             let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
-            tracing::error!(error = dynerr, "Could not process PortablePDB Cache");
+            tracing::debug!(error = dynerr, "Could not process PortablePDB Cache");
 
             CacheError::Malformed(e.to_string())
         })?;

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -268,7 +268,7 @@ fn write_symcache(
 
     converter.process_object(symbolic_object).map_err(|e| {
         let dynerr: &dyn std::error::Error = &e; // tracing expects a `&dyn Error`
-        tracing::error!(error = dynerr, "Could not process SymCache");
+        tracing::debug!(error = dynerr, "Could not process SymCache");
 
         CacheError::Malformed(e.to_string())
     })?;


### PR DESCRIPTION
Errors for malformed or unprocessable debug files aren't really actionable and in practice we just ignore them.

ref: #1727. ref: SYMBOLI-25.