### PR TITLE
fix(logging): Reduce breakpad-symbols warning spam

### DIFF
--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -16,10 +16,12 @@ fn get_rust_log(level: LevelFilter) -> &'static str {
         LevelFilter::ERROR => "ERROR",
         LevelFilter::WARN => {
             "WARN,\
+             breakpad_symbols=ERROR,\
              minidump=ERROR"
         }
         LevelFilter::INFO => {
             "INFO,\
+             breakpad_symbols=ERROR,\
              minidump=ERROR,\
              trust_dns_proto=WARN"
         }


### PR DESCRIPTION
We are seeing tons of warning-level logs of the form `"STACK WIN entry had bad intersections, dropping it"` in production. Therefore, we now only emit `error`-level logs from `breakpad-symbols` when the log level is `info` or above.

ref: SYMBOLI-25