### PR TITLE
fix(ci): Align image/assemble and assemble-ar jobs

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -234,8 +234,8 @@ jobs:
             "${GHCR_IMAGE}:amd64-${{ github.sha }}"
 
           docker buildx imagetools create -t "${TARGET_IMAGE}:nightly" \
-            "${TARGET_IMAGE}:arm64-${{ github.sha }}" \
-            "${TARGET_IMAGE}:amd64-${{ github.sha }}"
+            "${GHCR_IMAGE}:arm64-${{ github.sha }}" \
+            "${GHCR_IMAGE}:amd64-${{ github.sha }}"
 
   self-hosted-end-to-end:
     needs: [assemble]

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -159,7 +159,7 @@ jobs:
     if: "needs.build-setup.outputs.full_ci == 'true'"
 
     name: Assemble for Github Container Registry
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     env:
       TARGET_IMAGE: ghcr.io/getsentry/symbolicator
@@ -232,6 +232,10 @@ jobs:
           docker buildx imagetools create -t "${TARGET_IMAGE}:latest" \
             "${GHCR_IMAGE}:arm64-${{ github.sha }}" \
             "${GHCR_IMAGE}:amd64-${{ github.sha }}"
+
+          docker buildx imagetools create -t "${TARGET_IMAGE}:nightly" \
+            "${TARGET_IMAGE}:arm64-${{ github.sha }}" \
+            "${TARGET_IMAGE}:amd64-${{ github.sha }}"
 
   self-hosted-end-to-end:
     needs: [assemble]


### PR DESCRIPTION
This changes the `assemble` job to run on `ubuntu-latest` (same as `assemble-ar`) and the `assemble-ar` job to also push the image as `:nightly` (same as `assemble`).

The latter part in particular is important because the `devservices` config expects the current image to be found at
`us-central1-docker.pkg.dev/sentryio/symbolicator/image:nightly`, and that image was last pushed on 2025-01-17.