### PR TITLE
Sebastian/cleanup loop

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -466,6 +466,13 @@ pub struct Config {
     /// Fine-tune cache expiry
     pub caches: CacheConfigs,
 
+    /// The interval between runs of the `cleanup`
+    /// command (if run with `--loop`).
+    ///
+    /// Defaults to 15min.
+    #[serde(with = "humantime_serde")]
+    pub cache_cleanup_interval: Duration,
+
     /// Enables symbol proxy mode.
     pub symstore_proxy: bool,
 
@@ -595,6 +602,7 @@ impl Default for Config {
             metrics: Metrics::default(),
             sentry_dsn: None,
             caches: CacheConfigs::default(),
+            cache_cleanup_interval: Duration::from_secs(900),
             symstore_proxy: true,
             sources: Arc::from(vec![]),
             connect_to_reserved_ips: false,

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -40,6 +40,13 @@ enum Command {
         /// Only simulate the cleanup without deleting any files.
         #[arg(long)]
         dry_run: bool,
+        /// Instead of exiting immediately, perform the cleanup
+        /// periodically.
+        ///
+        /// The interval between runs is controlled by the
+        /// `cache_cleanup_interval` config option.
+        #[arg(long)]
+        repeat: bool,
     },
 }
 
@@ -166,8 +173,8 @@ pub fn execute() -> Result<()> {
 
     match cli.command {
         Command::Run => server::run(config).context("failed to start the server")?,
-        Command::Cleanup { dry_run } => {
-            caching::cleanup(config, dry_run).context("failed to clean up caches")?
+        Command::Cleanup { dry_run, repeat } => {
+            caching::cleanup(config, dry_run, repeat).context("failed to clean up caches")?
         }
     }
 


### PR DESCRIPTION
This adds a `--repeat` flag to the `cleanup` command that will cause it to loop indefinitely instead of exiting after the first run. The time between runs is controlled by a new config option `cache_cleanup_interval` which defaults to 15min.

Alternatively we could also pass the interval to the command as a parameter. I thought it might be nice as a config option because then there is a uniform place to set it when we also allow running the cleanup from within Symbolicator in the future.

ref: #1758. ref: SYMBOLI-34.