### PR TITLE
fix(logging): Reduce goblin warning spam

### DIFF
--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -17,11 +17,13 @@ fn get_rust_log(level: LevelFilter) -> &'static str {
         LevelFilter::WARN => {
             "WARN,\
              breakpad_symbols=ERROR,\
+             goblin=ERROR,\
              minidump=ERROR"
         }
         LevelFilter::INFO => {
             "INFO,\
              breakpad_symbols=ERROR,\
+             goblin=ERROR,\
              minidump=ERROR,\
              trust_dns_proto=WARN"
         }


### PR DESCRIPTION
Similar to #1755. `"section #1 size 27167680 out of bounds"` from `goblin` is another very common warning-level log message that isn't actionable for us. Therefore we limit logs from `goblin` to errors.

ref: SYMBOLI-25