### PR TITLE
feat(cleanup): Allow running cleanup from within Symbolicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   - The `cleanup` command has gained a `--repeat [INTERVAL]` option that will
     cause it to loop with a pause of length `INTERVAL` between runs. If no
     `INTERVAL` is passed the value of `cache_cleanup_interval` is used.
+- Caches can now be periodically cleaned up from within Symbolicator. The new
+  `enable_cache_cleanup` config option (defaults to `false`) causes Symbolicator
+  to start a cleanup background thread. The time between cleanup runs is determined
+  by the `cache_cleanup_interval` config option. ([#1761](https://github.com/getsentry/symbolicator/pull/1761))
 
 ## 25.7.0
 

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -466,6 +466,12 @@ pub struct Config {
     /// Fine-tune cache expiry
     pub caches: CacheConfigs,
 
+    /// Whether to enable automatic periodic cache cleanup.
+    ///
+    /// The time between cleaning runs is determined
+    /// by the value of `cache_cleanup_interval`.
+    pub enable_cache_cleanup: bool,
+
     /// The interval between runs of the `cleanup`
     /// command (if run with `--loop`).
     ///
@@ -602,6 +608,7 @@ impl Default for Config {
             metrics: Metrics::default(),
             sentry_dsn: None,
             caches: CacheConfigs::default(),
+            enable_cache_cleanup: false,
             cache_cleanup_interval: Duration::from_secs(900),
             symstore_proxy: true,
             sources: Arc::from(vec![]),


### PR DESCRIPTION
This adds a new config option `enable_cache_cleanup` (default `false`) that causes the `run` command to also start a periodic cache cleanup background thread. The time between cleanup runs is determined by the `cache_cleanup_interval` config option.

Implements https://github.com/getsentry/symbolicator/issues/1758. Implements SYMBOLI-34.