### PR TITLE
ref(symbolicator): Mask credentials in debug representation

### DIFF
--- a/crates/symbolicator-js/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-js/tests/integration/sourcemap.rs
@@ -5,7 +5,7 @@ use reqwest::Url;
 use serde_json::json;
 use symbolicator_js::interface::{JsFrame, JsModule, JsStacktrace, SymbolicateJsStacktraces};
 use symbolicator_service::types::{Scope, ScrapingConfig};
-use symbolicator_sources::{SentrySourceConfig, SourceId};
+use symbolicator_sources::{SentrySourceConfig, SentryToken, SourceId};
 
 use crate::{assert_snapshot, setup_service};
 
@@ -774,7 +774,7 @@ async fn test_manual_processing() {
             "https://sentry.io/api/0/projects/{org}/{project}/artifact-lookup/"
         ))
         .unwrap(),
-        token: token.to_string(),
+        token: SentryToken(token.to_string()),
     };
 
     let request = make_js_request(source, frames, modules, release, dist);

--- a/crates/symbolicator-native/tests/integration/e2e.rs
+++ b/crates/symbolicator-native/tests/integration/e2e.rs
@@ -9,7 +9,7 @@ use symbolicator_service::objects::ObjectDownloadInfo;
 use symbolicator_service::types::{ObjectFileStatus, Scope};
 use symbolicator_sources::{
     CommonSourceConfig, DirectoryLayout, DirectoryLayoutType, FileType, FilesystemSourceConfig,
-    HttpSourceConfig, RemoteFileUri, SentrySourceConfig, SourceConfig, SourceId,
+    HttpSourceConfig, RemoteFileUri, SentrySourceConfig, SentryToken, SourceConfig, SourceId,
 };
 use symbolicator_test::read_fixture;
 use tempfile::NamedTempFile;
@@ -404,7 +404,7 @@ async fn test_unreachable_bucket() {
                 SourceConfig::Sentry(Arc::new(SentrySourceConfig {
                     id: SourceId::new(format!("broken-{ty}-{code}")),
                     url: hitcounter.url(&format!("respond_statuscode/{code}")),
-                    token: "123abc".into(),
+                    token: SentryToken("123abc".to_owned()),
                 }))
             };
 

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -62,7 +62,7 @@ impl S3Downloader {
                     self.create_s3_client(
                         Credentials::from_keys(
                             key.access_key.clone(),
-                            key.secret_key.clone(),
+                            key.secret_key.0.as_ref(),
                             None,
                         ),
                         &key.region,
@@ -214,8 +214,8 @@ mod tests {
     use std::path::Path;
 
     use symbolicator_sources::{
-        CommonSourceConfig, DirectoryLayoutType, RemoteFileUri, S3SourceConfig, SourceId,
-        SourceLocation,
+        CommonSourceConfig, DirectoryLayoutType, RemoteFileUri, S3SecretKey, S3SourceConfig,
+        SourceId, SourceLocation,
     };
 
     use crate::test;
@@ -237,7 +237,7 @@ mod tests {
                 region: S3Region::from("us-east-1"),
                 aws_credentials_provider: AwsCredentialsProvider::Static,
                 access_key,
-                secret_key,
+                secret_key: S3SecretKey(secret_key.into()),
             })
         }
     }
@@ -340,7 +340,7 @@ mod tests {
     async fn setup_bucket(source_key: S3SourceKey) {
         let provider = Credentials::from_keys(
             source_key.access_key.clone(),
-            source_key.secret_key.clone(),
+            source_key.secret_key.0.as_ref(),
             None,
         );
         let shared_config = aws_config::from_env()
@@ -420,7 +420,7 @@ mod tests {
             region: S3Region::from("us-east-1"),
             aws_credentials_provider: AwsCredentialsProvider::Static,
             access_key: "".into(),
-            secret_key: "".into(),
+            secret_key: S3SecretKey("".into()),
         };
         let source = s3_source(broken_key);
         let downloader = S3Downloader::new(Default::default(), 100);
@@ -448,7 +448,7 @@ mod tests {
             region: S3Region::from("us-east-1"),
             aws_credentials_provider: AwsCredentialsProvider::Static,
             access_key: String::from("abc"),
-            secret_key: String::from("123"),
+            secret_key: S3SecretKey("123".into()),
         });
         let source = Arc::new(S3SourceConfig {
             id: SourceId::new("s3-id"),

--- a/crates/symbolicator-sources/src/sources/gcs.rs
+++ b/crates/symbolicator-sources/src/sources/gcs.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
@@ -76,33 +76,43 @@ pub enum GcsSourceAuthorization {
 /// GCS authorization credentials.
 ///
 /// These are used to obtain a token which is then used for GCS communication.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct GcsSourceKey {
     /// Gcs authorization key.
-    pub private_key: String,
+    pub private_key: GcsPrivateKey,
 
     /// The client email.
     pub client_email: String,
 }
 
+/// A GCS private key.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct GcsPrivateKey(pub Arc<str>);
+
+impl fmt::Debug for GcsPrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<gcs private key>")
+    }
+}
+
 /// GCS authorization token.
 ///
 /// This token will be used directly to authorize against GCS.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct GcsSourceToken {
-    /// Gcs bearer token.
-    bearer_token: Arc<str>,
+    /// GCS bearer token.
+    pub bearer_token: GcsBearerToken,
 }
 
-impl GcsSourceToken {
-    /// Constructs a new bearer token.
-    pub fn new(bearer_token: Arc<str>) -> Self {
-        Self { bearer_token }
-    }
+/// A GCS bearer token.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct GcsBearerToken(pub Arc<str>);
 
-    /// The token in the HTTP Bearer-header format, header value only.
-    pub fn bearer_token(&self) -> &str {
-        &self.bearer_token
+impl fmt::Debug for GcsBearerToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<gcs bearer token>")
     }
 }
 

--- a/crates/symbolicator-sources/src/sources/s3.rs
+++ b/crates/symbolicator-sources/src/sources/s3.rs
@@ -132,9 +132,8 @@ where
 ///
 /// For details on the AWS side, see:
 /// <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-#[derive(Default)]
 pub enum AwsCredentialsProvider {
     /// Static Credentials
     #[default]
@@ -144,7 +143,7 @@ pub enum AwsCredentialsProvider {
 }
 
 /// Amazon S3 authorization information.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct S3SourceKey {
     /// The region of the S3 bucket.
     #[serde(
@@ -163,7 +162,7 @@ pub struct S3SourceKey {
 
     /// S3 secret key.
     #[serde(default)]
-    pub secret_key: String,
+    pub secret_key: S3SecretKey,
 }
 
 /// A wrapper around an S3 region that allows using custom regions.
@@ -203,6 +202,17 @@ impl std::hash::Hash for S3SourceKey {
     }
 }
 
+/// A S3 secret key.
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct S3SecretKey(pub Arc<str>);
+
+impl fmt::Debug for S3SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<s3 secret key>")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,7 +239,7 @@ mod tests {
                 assert_eq!(cfg.bucket, "my-supermarket-bucket");
                 assert_eq!(cfg.source_key.region, S3Region::from("us-east-1"));
                 assert_eq!(cfg.source_key.access_key, "the-access-key");
-                assert_eq!(cfg.source_key.secret_key, "the-secret-key");
+                assert_eq!(cfg.source_key.secret_key.0.as_ref(), "the-secret-key");
             }
             _ => unreachable!(),
         }

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -16,7 +16,7 @@ pub struct SentrySourceConfig {
     pub url: Url,
 
     /// Bearer authorization token.
-    pub token: String,
+    pub token: SentryToken,
 }
 
 /// The Sentry-specific [`RemoteFile`].
@@ -93,5 +93,16 @@ pub struct SentryFileId(pub Arc<str>);
 impl fmt::Display for SentryFileId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// A sentry authentication token.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct SentryToken(pub String);
+
+impl fmt::Debug for SentryToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<sentry token>")
     }
 }

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -36,7 +36,8 @@ use tracing_subscriber::fmt::fmt;
 
 use symbolicator_sources::{
     CommonSourceConfig, DirectoryLayout, DirectoryLayoutType, FileType, FilesystemSourceConfig,
-    GcsSourceKey, HttpSourceConfig, SentrySourceConfig, SourceConfig, SourceFilters, SourceId,
+    GcsPrivateKey, GcsSourceKey, HttpSourceConfig, SentrySourceConfig, SentryToken, SourceConfig,
+    SourceFilters, SourceId,
 };
 
 pub use tempfile::TempDir;
@@ -392,7 +393,7 @@ where
     let source = SentrySourceConfig {
         id: SourceId::new("sentry:project"),
         url: server.url("/lookup"),
-        token: String::new(),
+        token: SentryToken(String::new()),
     };
 
     (server, source)
@@ -433,7 +434,7 @@ where
     let source = SentrySourceConfig {
         id: SourceId::new("sentry:project"),
         url: server.url("/files/dsyms/"),
-        token: String::new(),
+        token: SentryToken(String::new()),
     };
 
     (server, source)
@@ -450,7 +451,7 @@ pub fn gcs_source_key_from_env() -> Option<GcsSourceKey> {
         None
     } else {
         Some(GcsSourceKey {
-            private_key,
+            private_key: GcsPrivateKey(private_key.into()),
             client_email,
         })
     }

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -16,7 +16,7 @@ use symbolicator_service::services::SharedServices;
 use symbolicator_service::types::Scope;
 use symbolicator_sources::{
     CommonSourceConfig, DirectoryLayout, DirectoryLayoutType, FilesystemSourceConfig,
-    SentrySourceConfig, SourceConfig, SourceId,
+    SentrySourceConfig, SentryToken, SourceConfig, SourceId,
 };
 
 use anyhow::{Context, Result};
@@ -118,7 +118,7 @@ async fn main() -> Result<()> {
 
             let source = Arc::new(SentrySourceConfig {
                 id: SourceId::new("sentry:project"),
-                token: auth_token.clone(),
+                token: SentryToken(auth_token.clone()),
                 url: base_url
                     .join(&format!("projects/{org}/{project}/artifact-lookup/"))
                     .unwrap(),
@@ -195,7 +195,7 @@ fn prepare_dsym_sources(
     {
         let project_source = SourceConfig::Sentry(Arc::new(SentrySourceConfig {
             id: SourceId::new("sentry:project"),
-            token: auth_token.clone(),
+            token: SentryToken(auth_token.clone()),
             url: base_url
                 .join(&format!("projects/{org}/{project}/files/dsyms/"))
                 .unwrap(),


### PR DESCRIPTION
It's possible that credentials leak due to the tracing integration when errors occur. This masks all source credentials with a newtype which implements a Debug implementation which masks out the credentials.