### PR TITLE
feat(devservices): Use ghcr instead of artifact registry

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -9,7 +9,7 @@ x-sentry-service-config:
 
 services:
   symbolicator:
-    image: us-central1-docker.pkg.dev/sentryio/symbolicator/image:nightly
+    image: ghcr.io/getsentry/symbolicator:nightly
     volumes:
       - symbolicator-data:/data
       - type: bind


### PR DESCRIPTION
We're trying to move over to using ghcr for CI, and it looks like artifact registry is failing in CI for us so trying to switch this over now

https://github.com/getsentry/sentry/actions/runs/16942340945/job/48014467794

#skip-changelog