### PR TITLE
docs: python 3.13.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.13.7
 
       - name: Setup python dependencies
         run: pip install --upgrade mkdocs mkdocs-material pygments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13.7
+          python-version: 3.13.5
 
       - name: Setup python dependencies
         run: pip install --upgrade mkdocs mkdocs-material pygments

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13.7
+          python-version: 3.13.5
 
       - name: Setup python dependencies
         run: pip install --upgrade mkdocs mkdocs-material pygments

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.13.7
 
       - name: Setup python dependencies
         run: pip install --upgrade mkdocs mkdocs-material pygments


### PR DESCRIPTION
prerequisite to https://github.com/getsentry/symbolicator/pull/1770

we need python >= 3.11 since that's what our internal pypi supports