### PR TITLE
Add extra characters to Symsorter allowed bundle ID characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - [diff](https://github.com/getsentry/sentry-native/compare/0.9.1...0.10.0)
 
 ### Various fixes & improvements
-- Added support for + in SymSorter Bundle ID's
+- Added support for + in SymSorter Bundle ID's. ([#1772](https://github.com/getsentry/symbolicator/pull/1772))
 
 ## 25.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0100)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.9.1...0.10.0)
 
+### Various fixes & improvements
+- Added support for + in SymSorter Bundle ID's
+
 ## 25.8.0
 
 ### Dependencies
@@ -93,7 +96,7 @@
 ### Various fixes & improvements
 
 - Speed up large file downloads, by using multiple concurrent http range requests. ([#1670](https://github.com/getsentry/symbolicator/pull/1670))
-- Validate stack scanned candidate frames against available CFI unwind information. 
+- Validate stack scanned candidate frames against available CFI unwind information.
   This reduces hallucinated frames when relying on stack scanning. ([#1651](https://github.com/getsentry/symbolicator/pull/1651))
 - Logic for setting the in-app property on frames has been removed from JavaScript symbolication. ([#1656](https://github.com/getsentry/symbolicator/pull/1656))
 - Added support for indexes for symbol sources.

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -10,7 +10,7 @@ use symbolic::common::ByteView;
 use symbolic::debuginfo::sourcebundle::{SourceBundleWriter, SourceFileDescriptor};
 use symbolic::debuginfo::{Archive, FileEntry, FileFormat, Object, ObjectKind};
 
-static BAD_CHARS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^a-zA-Z0-9.,-]+").unwrap());
+static BAD_CHARS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^a-zA-Z0-9.,+-]+").unwrap());
 
 /// Console logging for the symsorter app.
 #[macro_export]

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -120,3 +120,20 @@ pub fn create_source_bundle(path: &Path, unified_id: &str) -> Result<Option<Byte
     }
     Ok(None)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_bundle_id_checks() {
+        let good_input_id = "10.3_ABCD";
+        assert_eq!(is_bundle_id(good_input_id), true);
+
+        let bad_input_id = "10.3.*";
+        assert_eq!(is_bundle_id(bad_input_id), false);
+
+        let unreal_bundle_id = "++lyra+main-CL-12345";
+        assert_eq!(is_bundle_id(unreal_bundle_id), true);
+    }
+}

--- a/crates/symsorter/src/utils.rs
+++ b/crates/symsorter/src/utils.rs
@@ -128,12 +128,12 @@ mod tests {
     #[test]
     fn is_bundle_id_checks() {
         let good_input_id = "10.3_ABCD";
-        assert_eq!(is_bundle_id(good_input_id), true);
+        assert!(is_bundle_id(good_input_id));
 
         let bad_input_id = "10.3.*";
-        assert_eq!(is_bundle_id(bad_input_id), false);
+        assert!(!is_bundle_id(bad_input_id));
 
         let unreal_bundle_id = "++lyra+main-CL-12345";
-        assert_eq!(is_bundle_id(unreal_bundle_id), true);
+        assert!(is_bundle_id(unreal_bundle_id));
     }
 }


### PR DESCRIPTION
Hi again,
long time no see.

We build unreal engine applications which use Perforce, and use a "nice" encoding of the p4 format - .e.g. if you were working on the main stream of project Lyra at CL 12345, your "depot path" would be //lyra/main and your CL is 12345. Unreal combines these together and replaces / with + to give you paths that can be stored, so you can uniquely identify a build by ++lyra+main-CL-12345 (There's more for shelves etc but out of scope). I'm playing with SymSorter, and I noticed that it didn't accept this format so I modified the regex to allow for a + character. 

I'm unsure of the implication this has on the storage formats, but I wanted to suggest it.