### PR TITLE
fix(docker): Experimentally unpin openssl/libssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN sentry-cli --version \
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends 'openssl=3.0.16-1~deb12u1' 'libssl3=3.0.16-1~deb12u1' ca-certificates gosu curl cabextract \
+    && apt-get install -y --no-install-recommends openssl ca-certificates gosu curl cabextract \
     && rm -rf /var/lib/apt/lists/*
 
 ENV \


### PR DESCRIPTION
This reverts commit d7d5b57c7b39ce9ce8f498c1839bc451003bdc9f (#1753).

The version of `libssl3` pinned in that PR is no longer available in the debian bookworm repos. It's possible that `libssl3` 3.0.17 has been fixed by now, so we experimentally remove the pin. This may get reverted.