### PR TITLE
Symsorter always prints "Created 0 source bundles"

### DIFF
--- a/crates/symsorter/src/app.rs
+++ b/crates/symsorter/src/app.rs
@@ -357,7 +357,7 @@ fn execute(cli: Cli) -> Result<()> {
             let (debug_files_sorted, source_bundles_created) =
                 sort_files(&sort_config, vec![path])?;
             debug_files += debug_files_sorted;
-            source_bundles *= source_bundles_created;
+            source_bundles += source_bundles_created;
         }
     } else {
         if let Some(bundle_id) = cli.bundle_id {
@@ -366,7 +366,7 @@ fn execute(cli: Cli) -> Result<()> {
         }
         let (debug_files_sorted, source_bundles_created) = sort_files(&sort_config, cli.input)?;
         debug_files += debug_files_sorted;
-        source_bundles *= source_bundles_created;
+        source_bundles += source_bundles_created;
     }
 
     log!();


### PR DESCRIPTION
... the original implementation would collect partial sums by multiplying them, instead of adding them together.

This resulted in a series of multiplications by 0 -- and therefore, it would always print "Created 0 source bundles" at the end.

Here's a fix for that. This does not affect the functionality of the tool in any other way; just the stdout message at the end.