### PR TITLE
ref(crash): Send sentry-native crashes via Rust SDK transport 

### DIFF
--- a/crates/symbolicator-crash/build.rs
+++ b/crates/symbolicator-crash/build.rs
@@ -9,8 +9,6 @@ fn main() {
         _ => return, // allow building with --all-features, fail during runtime
     }
 
-    println!("cargo:rustc-link-lib=curl");
-
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
@@ -22,11 +20,16 @@ fn main() {
         .profile("RelWithDebInfo")
         // always build breakpad regardless of platform defaults
         .define("SENTRY_BACKEND", "breakpad")
+        // inject a custom transport instead of curl
+        .define("SENTRY_TRANSPORT", "none")
         // build a static library
         .define("BUILD_SHARED_LIBS", "OFF")
         // disable additional targets
         .define("SENTRY_BUILD_TESTS", "OFF")
         .define("SENTRY_BUILD_EXAMPLES", "OFF")
+        // cmake sets the install dir to `lib64` on some platforms, since we are not installing to
+        // `/usr` or `/usr/local`, we can choose a stable directory for the link-search below.
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .build();
 
     println!(


### PR DESCRIPTION
Uses the Sentry Rust SDK for the sentry-native transport. This is exactly how Relay does it as well.