### PR TITLE
feat(symbolicator): Healthcheck command for self-hosted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.3+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3405,7 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,15 +3389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.3+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,7 +3396,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -40,10 +40,10 @@ tower-service = { workspace = true}
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
+reqwest = { workspace = true, features = ["multipart", "gzip", "native-tls-vendored"] }
 
 [dev-dependencies]
 insta = { workspace = true }
-reqwest = { workspace = true, features = ["multipart"] }
 symbolicator-test = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -40,10 +40,11 @@ tower-service = { workspace = true}
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
-reqwest = { workspace = true, features = ["multipart", "gzip", "native-tls-vendored"] }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+reqwest = { workspace = true, features = ["multipart"] }
 symbolicator-test = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -55,8 +55,8 @@ enum Command {
     Healthcheck {
         /// Timeout for the healthcheck request.
         /// Defaults to 30 seconds.
-        #[arg(long)]
-        timeout: Option<Duration>,
+        #[arg(long, default_value_t = 30)]
+        timeout: u64,
 
         /// Host to check. Defaults to `localhost`.
         #[arg(long, default_value_t = String::from("localhost"))]
@@ -214,7 +214,7 @@ pub fn execute() -> Result<()> {
             port,
         } => {
             let client = reqwest::blocking::Client::builder()
-                .timeout(timeout.into())
+                .timeout(std::time::Duration::from_secs(timeout))
                 .build()
                 .unwrap_or_default();
             let url = format!("http://{host}:{port}/healthcheck");

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -49,14 +49,20 @@ enum Command {
         #[arg(long, value_name = "INTERVAL")]
         repeat: Option<Option<Duration>>,
     },
+
+    /// Checks the health of the symbolicator server.
     #[command(name = "healthcheck")]
     Healthcheck {
-        #[arg(long, default_value_t = 30)]
+        /// Timeout for the healthcheck request.
+        /// Defaults to 30 seconds.
+        #[arg(long)]
         timeout: Option<Duration>,
 
+        /// Host to check. Defaults to `localhost`.
         #[arg(long, default_value_t = String::from("localhost"))]
         host: String,
 
+        /// Port to check. Defaults to `3021`.
         #[arg(long, default_value_t = String::from("3021"))]
         port: String,
     },
@@ -220,7 +226,7 @@ pub fn execute() -> Result<()> {
                         println!("OK");
                     } else {
                         println!("ERROR");
-                        Err(anyhow!(
+                        Err(anyhow::anyhow!(
                             "Symbolicator is unhealthy. Status: {}",
                             response.status()
                         ))
@@ -228,7 +234,9 @@ pub fn execute() -> Result<()> {
                 }
                 Err(error) => {
                     println!("ERROR");
-                    Err(anyhow!("Failed to check Symbolicator health: {error}"))
+                    Err(anyhow::anyhow!(
+                        "Failed to check Symbolicator health: {error}"
+                    ))
                 }
             }
         }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -214,7 +214,7 @@ pub fn execute() -> Result<()> {
             port,
         } => {
             let client = reqwest::blocking::Client::builder()
-                .timeout(timeout)
+                .timeout(timeout.into())
                 .build()
                 .unwrap_or_default();
             let url = format!("http://{host}:{port}/healthcheck");
@@ -226,17 +226,17 @@ pub fn execute() -> Result<()> {
                         println!("OK");
                     } else {
                         println!("ERROR");
-                        Err(anyhow::anyhow!(
+                        return Err(anyhow::anyhow!(
                             "Symbolicator is unhealthy. Status: {}",
                             response.status()
-                        ))
+                        ));
                     }
                 }
                 Err(error) => {
                     println!("ERROR");
-                    Err(anyhow::anyhow!(
+                    return Err(anyhow::anyhow!(
                         "Failed to check Symbolicator health: {error}"
-                    ))
+                    ));
                 }
             }
         }

--- a/crates/symbolicator/src/healthcheck.rs
+++ b/crates/symbolicator/src/healthcheck.rs
@@ -1,0 +1,39 @@
+use std::net::SocketAddr;
+
+use crate::config::Config;
+
+pub fn healthcheck(config: Config, addr: Option<SocketAddr>, timeout: u64) -> anyhow::Result<()> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout))
+        .build()?;
+
+    let addr = match addr {
+        Some(addr) => addr,
+        None => config.bind.parse()?,
+    };
+
+    let url = format!("http://{addr}/healthcheck");
+    tracing::debug!("Sending request to: {url}");
+
+    let response = client.get(url).send();
+
+    match response {
+        Ok(response) if response.status().is_success() => {
+            println!("OK");
+            Ok(())
+        }
+        Ok(response) => {
+            println!("ERROR");
+            Err(anyhow::anyhow!(
+                "Symbolicator ({addr}) is unhealthy. Status: {}",
+                response.status()
+            ))
+        }
+        Err(error) => {
+            println!("ERROR");
+            Err(anyhow::anyhow!(
+                "Failed to check Symbolicator ({addr}) health: {error}"
+            ))
+        }
+    }
+}

--- a/crates/symbolicator/src/logging.rs
+++ b/crates/symbolicator/src/logging.rs
@@ -62,7 +62,8 @@ pub unsafe fn init_logging(config: &Config) {
     let fmt_layer = {
         let layer = tracing_subscriber::fmt::layer()
             .with_timer(UtcTime::rfc_3339())
-            .with_target(true);
+            .with_target(true)
+            .with_writer(std::io::stderr);
 
         match (config.logging.format, console::user_attended()) {
             (LogFormat::Auto, true) | (LogFormat::Pretty, _) => layer.pretty().boxed(),

--- a/crates/symbolicator/src/main.rs
+++ b/crates/symbolicator/src/main.rs
@@ -23,6 +23,7 @@ pub use symbolicator_service::{config, metric, utils};
 
 mod cli;
 mod endpoints;
+mod healthcheck;
 mod logging;
 mod server;
 mod service;


### PR DESCRIPTION
Similar work to https://github.com/getsentry/relay/pull/5044 due to distroless migration

This works on relay and this is making CI's red right now.

Changes made:
- Adds a new `healthcheck` sub-command
- Defaults to the values from the config
- Changes logger to use `stderr` to still allow for logging and parsing of the healthcheck output (Relay uses the same mechanism here)