### PR TITLE
fix(download): Add dartsymbolmap to sentry file types

### DIFF
--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -46,6 +46,7 @@ enum SentryFileType {
     BcSymbolMap,
     Il2cpp,
     Proguard,
+    DartSymbolMap,
 }
 
 impl From<FileType> for SentryFileType {


### PR DESCRIPTION
Symbolicator fails to parse a list of files from the Sentry symbol source when they contain a dartsymbolmap, which was added in this PR: https://github.com/getsentry/sentry/pull/97076.

Symbolicator is not supposed to do anything with this symbol map, it is used in sentry preprocessing. Adding the enum variant should fix the parsing error.

Fixes [SYMBOLICATOR-1KKQR](https://sentry.my.sentry.io/organizations/sentry/issues/2347462/).