### PR TITLE
cd: add github check to deployment

### DIFF
--- a/gocd/templates/bash/github-checks.sh
+++ b/gocd/templates/bash/github-checks.sh
@@ -5,4 +5,5 @@ checks-githubactions-checkruns \
   ${GO_REVISION_SYMBOLICATOR_REPO} \
   'Tests' \
   'Sentry-Symbolicator Tests' \
+  'Assemble' \
   'Upload gocd artifacts'


### PR DESCRIPTION
this follows up to #1805 and adds this github check as a prerequisite to deployment as we should make sure the image has been built and uploaded to GAR by Assemble before deploying (otherwise can crashloop on imagepullbackoff)