### PR TITLE
chore(self-hosted): Clean up symbolicator tar after building image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -235,7 +235,7 @@ jobs:
           docker image ls
 
       - name: Clean up Docker tar file
-        run: rm -rf /tmp/symbolicator-amd64.tar /tmp/docker-ctx/binaries/linux/amd64 /tmp/docker-ctx/symbolicator
+        run: rm -rf /tmp/symbolicator-amd64.tar /tmp/docker-ctx
 
       - name: Run Sentry self-hosted e2e CI
         uses: getsentry/self-hosted@master


### PR DESCRIPTION
Encountering no space left on device errors: https://github.com/getsentry/symbolicator/actions/runs/19392892888/job/55627721751

Hopefully this fixes