### PR TITLE
fix(ci): Start Sentry in symbolicator-tests mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         uses: ./.github/actions/setup-sentry
         with:
           workdir: sentry
-          mode: minimal
+          mode: symbolicator-tests
 
       - name: Do the localhost docker dance
         run: echo "$DJANGO_LIVE_TEST_SERVER_ADDRESS host.docker.internal" | sudo tee --append /etc/hosts


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/103959 added a new mode `symbolicator-tests` to Sentry devservices. This starts the `objectstore` service, which is required for Sentry/Symbolicator integration tests.

Fixes #1831. Fixes SYMBOLI-40.