### PR TITLE
ref(s3): Capture signature mismatch errors

### DIFF
--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -147,7 +147,7 @@ impl S3Downloader {
                         // <https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList>
                         let response = service_err.raw();
                         let status = response.status();
-                        let code = service_err.err().to_owned().code();
+                        let code = service_err.err().code();
 
                         // Capturing signature mismatch errors for issue #1850/SYMBOLI-44
                         if code == Some("SignatureDoesNotMatch") {


### PR DESCRIPTION
This updates the AWS dependencies and adds an error log for S3 signature mismatch errors.

ref: #1850. ref: SYMBOLI-44.