### PR TITLE
fix(s3): Don't log entire S3 errors

### DIFF
--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -151,10 +151,7 @@ impl S3Downloader {
 
                         // Capturing signature mismatch errors for issue #1850/SYMBOLI-44
                         if code == Some("SignatureDoesNotMatch") {
-                            tracing::error!(
-                                error = &err as &dyn std::error::Error,
-                                "S3 signature mismatch",
-                            )
+                            tracing::error!("S3 signature mismatch")
                         }
 
                         // NOTE: leaving the credentials empty as our unit / integration tests do


### PR DESCRIPTION
S3 error payloads contain request IDs which will cause the errors to not be grouped properly.