### PR TITLE
fix: Revert "ref(gocd): Bump gocd lib version to v2.18.0 (#1857)"

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.18.0"
+      "version": "v2.13.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "3b7e3b151fb20d21d66c2f04d17a740ba0b09ac0",
-      "sum": "cgfkKWTz+bBKHa8WVji1v4Ke5JM3bTeMnqPtYZuy9VM="
+      "version": "6ddc943ae87444b48e16995639dfe89f33a0f444",
+      "sum": "NH9U5jQ8oCSPXLuBw27OqAaPLBUDqMGHvRLxfo84hNQ="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This reverts commit 6ea1f4a3ae515cdc13025d635a7ea8de44cb162c. The pipeline doesn't work correctly in the updated gocd lib version.