### PR TITLE
ci(gocd): Switch debug file uploads to s4s2

### DIFF
--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -13,11 +13,9 @@ local deploy_canary_stage(region) =
           jobs: {
             create_sentry_release: {
               environment_variables: {
-                SENTRY_URL: 'https://sentry.my.sentry.io/',
-                ENVIRONMENT: 'canary',
-                // Temporary; self-service encrypted secrets aren't implemented yet.
-                // This should really be rotated to an internal integration token.
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}',
+                SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
+                // We use the Relay token, it is named in S4S2 to indicate usage for Relay and Symbolicator.
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
               },
               timeout: 1200,
               elastic_profile_id: 'symbolicator',
@@ -82,11 +80,9 @@ function(region) {
         jobs: {
           create_sentry_release: {
             environment_variables: {
-              SENTRY_URL: 'https://sentry.my.sentry.io/',
-              ENVIRONMENT: 'production',
-              // Temporary; self-service encrypted secrets aren't implemented yet.
-              // This should really be rotated to an internal integration token.
-              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][symbolicator_sentry_auth_token]}}',
+              SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
+              // We use the Relay token, it is named in S4S2 to indicate usage for Relay and Symbolicator.
+              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
             },
             timeout: 1200,
             elastic_profile_id: 'symbolicator',

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -32,6 +32,8 @@ echo 'Creating a new deploy in Sentry...'
 sentry-cli releases new "${VERSION}"
 # NOTE: linking commits requires a valid GitHub integration in Sentry4Sentry, which we don't have.
 # sentry-cli releases set-commits "${VERSION}" --commit "${GITHUB_PROJECT}@${VERSION}"
-sentry-cli releases deploys "${VERSION}" new -e "${ENVIRONMENT}"
+if [ ! -z "${ENVIRONMENT:-}" ]; then
+  sentry-cli releases deploys "${VERSION}" new -e "${ENVIRONMENT}"
+fi
 sentry-cli releases finalize "${VERSION}"
 echo 'Deploy created.'


### PR DESCRIPTION
Removed the environment stuff, because that's not how we use environments. Keeping the variable around as it may become useful again if we set it to the customer names instead.