### PR TITLE
fix(gocd): More sentry-cli/gocd script fixes

### DIFF
--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -13,9 +13,11 @@ local deploy_canary_stage(region) =
           jobs: {
             create_sentry_release: {
               environment_variables: {
-                SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
+                SENTRY_URL: 'https://sentry.io',
                 // We use the Relay token, it is named in S4S2 to indicate usage for Relay and Symbolicator.
                 SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
+                SENTRY_ORG: 'sentry-s4s2',
+                SENTRY_PROJECT: 'symbolicator',
               },
               timeout: 1200,
               elastic_profile_id: 'symbolicator',
@@ -80,9 +82,11 @@ function(region) {
         jobs: {
           create_sentry_release: {
             environment_variables: {
-              SENTRY_URL: 'https://sentry-s4s2.sentry.io/',
+              SENTRY_URL: 'https://sentry.io',
               // We use the Relay token, it is named in S4S2 to indicate usage for Relay and Symbolicator.
               SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-temp][relay_sentry_s4s2_auth_token]}}',
+              SENTRY_ORG: 'sentry-s4s2',
+              SENTRY_PROJECT: 'symbolicator',
             },
             timeout: 1200,
             elastic_profile_id: 'symbolicator',

--- a/scripts/create-sentry-release
+++ b/scripts/create-sentry-release
@@ -6,16 +6,17 @@ set -eu
 VERSION="${1:-}"
 ENVIRONMENT="${2:-}"
 # GITHUB_PROJECT="getsentry/symbolicator"
-export SENTRY_ORG="sentry"
-export SENTRY_PROJECT="symbolicator"
 
 if [ -z "${VERSION}" ]; then
   echo 'No version specified' && exit 1
 fi
 
-
 if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
   echo 'No Sentry auth token found' && exit 1
+fi
+
+if [ -z "${SENTRY_ORG:-}" ] || [ -z "${SENTRY_PROJECT:-}" ]; then
+  echo 'No SENTRY_ORG or SENTRY_PROJECT provided' && exit 1
 fi
 
 sentry-cli --version


### PR DESCRIPTION
Eliminates some warnings in the scripts:

```
WARN    2026-01-20 09:23:19.931220 +01:00 Using https://sentry.io (embedded in token) rather than manually-configured URL https://sentry-s4s2.sentry.io/. To use https://sentry-s4s2.sentry.io/, please provide an  auth token for https://sentry-s4s2.sentry.io/.
```

And configures org/project correctly.