### PR TITLE
ref(symbolicator): Enable stacktraces for sentry issues when backtraces are enabled

### DIFF
--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -119,6 +119,7 @@ pub fn execute() -> Result<()> {
         release,
         session_mode: sentry::SessionMode::Request,
         auto_session_tracking: false,
+        attach_stacktrace: config.logging.enable_backtraces,
         traces_sampler: Some(Arc::new(move |ctx| {
             if Some(true) == ctx.sampled() && config.propagate_traces {
                 1.0


### PR DESCRIPTION
Follows what Relay does: https://github.com/getsentry/relay/blob/bafc2a05fad8906144822774c9dfb56d6debcb4c/relay-log/src/setup.rs#L364