### PR TITLE
build(gocd): Enable canary deployment for DE

### DIFF
--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -11,7 +11,7 @@ local sentry_create_env_vars(region) = {
 
 // Only the US and DE regions has a canary deployment.
 local deploy_canary_stage(region) =
-  if region != 'us' and region != 'de' then
+  if region != 'us' && region != 'de' then
     []
   else
     [


### PR DESCRIPTION
DE has canary pods, but we can't indepently deploy them.