### PR TITLE
fix: Do not double write `user-agent`

### DIFF
--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -9,7 +9,7 @@ use crate::{
     config::DownloadTimeouts,
 };
 
-use super::{Destination, USER_AGENT};
+use super::Destination;
 
 /// Downloader implementation that supports the HTTP source.
 #[derive(Debug)]
@@ -45,19 +45,6 @@ impl HttpDownloader {
         } else {
             self.client.get(download_url)
         };
-
-        // Only set `symbolicator` as the user agent if the `file_source` does not have a custom
-        // user agent that should be used.
-        let has_custom_user_agent = file_source
-            .source
-            .headers
-            .0
-            .keys()
-            .any(|k| k.eq_ignore_ascii_case("user-agent"));
-
-        if !has_custom_user_agent {
-            builder = builder.header(header::USER_AGENT, USER_AGENT);
-        }
 
         let headers = file_source
             .source

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -57,9 +57,6 @@ impl ConfigureScope for RemoteFile {
     }
 }
 
-/// HTTP User-Agent string to use.
-const USER_AGENT: &str = concat!("symbolicator/", env!("CARGO_PKG_VERSION"));
-
 impl CacheError {
     fn download_error(mut error: &dyn Error) -> Self {
         while let Some(src) = error.source() {

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -15,7 +15,7 @@ use symbolicator_sources::{
     ObjectId, RemoteFile, SentryFileId, SentryRemoteFile, SentrySourceConfig, SentryToken,
 };
 
-use super::{Destination, FileType, USER_AGENT};
+use super::{Destination, FileType};
 use crate::caching::{CacheContents, CacheError};
 use crate::config::{DownloadTimeouts, InMemoryCacheConfig};
 use crate::utils::futures::{CancelOnDrop, m, measure};
@@ -135,8 +135,7 @@ impl SentryDownloader {
         let mut request = client
             .get(query.index_url.clone())
             .bearer_auth(&query.token.0)
-            .header("Accept-Encoding", "identity")
-            .header("User-Agent", USER_AGENT);
+            .header("Accept-Encoding", "identity");
 
         if propagate_traces && let Some(span) = sentry::configure_scope(|scope| scope.get_span()) {
             for (k, v) in span.iter_headers() {
@@ -258,7 +257,7 @@ impl SentryDownloader {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);
 
-        let mut builder = self.client.get(url).header("User-Agent", USER_AGENT);
+        let mut builder = self.client.get(url);
         if file_source.use_credentials() {
             builder = builder.bearer_auth(&file_source.source.token.0);
         }


### PR DESCRIPTION
With the logic introduced here https://github.com/getsentry/sentry/pull/88892 certain symbol sources might be associated with certain user-agents. For these sources symbolicator currently double writes the user-agent which is undesirable. This changes the logic such that we either write symolicator as the user-agent or the custom one but not both. 