### PR TITLE
fix(playstation): Prospero symbol uploader is using uppercase for IDs

### DIFF
--- a/crates/symbolicator-sources/src/paths.rs
+++ b/crates/symbolicator-sources/src/paths.rs
@@ -758,10 +758,13 @@ mod tests {
             FileType::ElfCode,
             &ELF_OBJECT_ID,
         );
-        assert_eq!(&paths, &[
-            "libm-2.23.so/dfb85de42daffd09640c8fe377d572de3e168920/symbols",
-            "libm-2.23.so/DFB85DE42DAFFD09640C8FE377D572DE3E168920/symbols",
-        ]);
+        assert_eq!(
+            &paths,
+            &[
+                "libm-2.23.so/dfb85de42daffd09640c8fe377d572de3e168920/symbols",
+                "libm-2.23.so/DFB85DE42DAFFD09640C8FE377D572DE3E168920/symbols",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
* Prospero symbol uploader is using uppercase for IDs