### PR TITLE
ref(crash): Switch to Sentry's native crash backend

### DIFF
--- a/crates/symbolicator-crash/build.rs
+++ b/crates/symbolicator-crash/build.rs
@@ -2,13 +2,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    // sentry-native dependencies
-    match std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
-        "macos" => println!("cargo:rustc-link-lib=dylib=c++"),
-        "linux" => println!("cargo:rustc-link-lib=dylib=stdc++"),
-        _ => return, // allow building with --all-features, fail during runtime
-    }
-
     if !Path::new("sentry-native/.git").exists() {
         let _ = Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
@@ -18,8 +11,8 @@ fn main() {
     let destination = cmake::Config::new("sentry-native")
         // we never need a debug build of sentry-native
         .profile("RelWithDebInfo")
-        // always build breakpad regardless of platform defaults
-        .define("SENTRY_BACKEND", "breakpad")
+        // use the sentry native crash reporting backend
+        .define("SENTRY_BACKEND", "native")
         // inject a custom transport instead of curl
         .define("SENTRY_TRANSPORT", "none")
         // build a static library
@@ -36,7 +29,9 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         destination.join("lib").display()
     );
-    println!("cargo:rustc-link-lib=static=breakpad_client");
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "linux" {
+        println!("cargo:rustc-link-lib=static=unwind");
+    }
     println!("cargo:rustc-link-lib=static=sentry");
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Based on https://github.com/getsentry/relay/pull/5789.