### PR TITLE
fix(proguard): Support Compose group-key mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.10.1"
+version = "5.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8229689975f1a875da21896b99d7cdd0dc6acecd54e9a37c7faf59e27d2add2"
+checksum = "8ba7d8586f6b54127ec445fd643091dd2b2f956548df692c82572611a9396957"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ minidump-processor = "0.26.1"
 minidump-unwind = "0.26.1"
 moka = { version = "0.12.8", features = ["future", "sync"] }
 prettytable-rs = "0.10.0"
-proguard = "5.10.1"
+proguard = "5.10.2"
 rand = "0.9.4"
 rayon = "1.10.0"
 regex = "1.5.5"

--- a/crates/symbolicator-proguard/tests/integration/proguard.rs
+++ b/crates/symbolicator-proguard/tests/integration/proguard.rs
@@ -603,3 +603,57 @@ async fn test_no_line_info_mapping() {
 
     assert_snapshot!(response);
 }
+
+#[tokio::test]
+async fn test_compose_stacktrace_group_keys() {
+    symbolicator_test::setup();
+    let (symbolication, _cache_dir) = setup_service(|_| ());
+    let (_srv, source) = proguard_server("compose_stacktrace_group_keys", |_url, _query| {
+        json!([{
+            "id":"proguard.txt",
+            "uuid":"246fb328-fc4e-406a-87ff-fc35f6149d8f",
+            "debugId":"246fb328-fc4e-406a-87ff-fc35f6149d8f",
+            "codeId":null,
+            "cpuName":"any",
+            "objectName":"proguard-mapping",
+            "symbolType":"proguard",
+            "headers": {
+                "Content-Type":"text/x-proguard+plain"
+            },
+            "size":1000,
+            "sha1":"0000000000000000000000000000000000000000",
+            "dateCreated":"2024-02-14T10:49:38.770116Z",
+            "data":{
+                "features":["mapping"]
+            }
+        }])
+    });
+
+    let source = SourceConfig::Sentry(Arc::new(source));
+
+    let frames = r#"[{
+        "function": "m$1125598679",
+        "module": "$$compose",
+        "filename": "SourceFile",
+        "lineno": 1,
+        "index": 0
+    }, {
+        "function": "m$1125708605",
+        "module": "$$compose",
+        "filename": "SourceFile",
+        "lineno": 1,
+        "index": 1
+    }]"#;
+
+    let request = make_jvm_request(
+        source,
+        r#"{"type": "DiagnosticComposeException", "module": "androidx.compose.runtime.tooling"}"#,
+        frames,
+        r#"[{"uuid": "246fb328-fc4e-406a-87ff-fc35f6149d8f", "type": "proguard"}]"#,
+        None,
+    );
+
+    let response = symbolication.symbolicate_jvm(request).await;
+
+    assert_snapshot!(response);
+}

--- a/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__compose_stacktrace_group_keys.snap
+++ b/crates/symbolicator-proguard/tests/integration/snapshots/integration__proguard__compose_stacktrace_group_keys.snap
@@ -1,0 +1,26 @@
+---
+source: crates/symbolicator-proguard/tests/integration/proguard.rs
+expression: response
+---
+exceptions:
+  - type: DiagnosticComposeException
+    module: androidx.compose.runtime.tooling
+stacktraces:
+  - exception:
+      type: DiagnosticComposeException
+      module: androidx.compose.runtime.tooling
+    frames:
+      - function: animateFloatAsState
+        filename: AnimateAsState.kt
+        module: androidx.compose.animation.core.AnimateAsStateKt
+        abs_path: AnimateAsState.kt
+        lineno: 71
+        index: 0
+      - function: animateFloatAsState
+        filename: AnimateAsState.kt
+        module: androidx.compose.animation.core.AnimateAsStateKt
+        abs_path: AnimateAsState.kt
+        lineno: 73
+        index: 1
+classes: {}
+errors: []

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -283,6 +283,9 @@ pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
 
 /// Proguard Cache, with the following versions:
 ///
+/// - `7`: Recompute caches after starting to support Compose
+///   mappings with two-space indentation.
+///
 /// - `6`: Information about whether a method has rewrite rules is now part
 ///   of the cache format.
 ///
@@ -298,7 +301,7 @@ pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
 ///
 /// - `1`: Initial version.
 pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
-    current: CacheVersion::new(6, CachePathFormat::V2),
+    current: CacheVersion::new(7, CachePathFormat::V2),
     fallbacks: &[],
     previous: &[
         CacheVersion::new(1, CachePathFormat::V1),
@@ -306,6 +309,7 @@ pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
         CacheVersion::new(3, CachePathFormat::V2),
         CacheVersion::new(4, CachePathFormat::V2),
         CacheVersion::new(5, CachePathFormat::V2),
+        CacheVersion::new(6, CachePathFormat::V2),
     ],
 };
 static_assert!(proguard::PRGCACHE_VERSION == 4);

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -283,7 +283,7 @@ pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
 
 /// Proguard Cache, with the following versions:
 ///
-/// - `7`: Recompute caches after starting to support Compose
+/// - `7`: Caches now support Compose
 ///   mappings with two-space indentation.
 ///
 /// - `6`: Information about whether a method has rewrite rules is now part

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -302,7 +302,7 @@ pub const BUNDLE_INDEX_CACHE_VERSIONS: CacheVersions = CacheVersions {
 /// - `1`: Initial version.
 pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
     current: CacheVersion::new(7, CachePathFormat::V2),
-    fallbacks: &[],
+    fallbacks: &[CacheVersion::new(6, CachePathFormat::V2)],
     previous: &[
         CacheVersion::new(1, CachePathFormat::V1),
         CacheVersion::new(2, CachePathFormat::V1),

--- a/tests/fixtures/proguard/compose_stacktrace_group_keys/proguard.txt
+++ b/tests/fixtures/proguard/compose_stacktrace_group_keys/proguard.txt
@@ -1,0 +1,3 @@
+ComposeStackTrace -> $$compose:
+  1:1:androidx.compose.runtime.State androidx.compose.animation.core.AnimateAsStateKt.animateFloatAsState(float,androidx.compose.animation.core.AnimationSpec,float,java.lang.String,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,int,int):71:71 -> m$1125598679
+  1:1:androidx.compose.runtime.State androidx.compose.animation.core.AnimateAsStateKt.animateFloatAsState(float,androidx.compose.animation.core.AnimationSpec,float,java.lang.String,kotlin.jvm.functions.Function1,androidx.compose.runtime.Composer,int,int):73:73 -> m$1125708605


### PR DESCRIPTION
Support Compose group-key mappings in symbolicator

Symbolicator caches ProGuard mappings through rust-proguard before JVM symbolication. `ComposeStackTrace` -> `$$compose` sections emitted by recent Android builds can use two-space member indentation, which caused older cached mappings to keep only the class-level remap and leave frames as `ComposeStackTrace.m$...` instead of resolving them to the original Compose methods.

This bumps proguard to 5.10.2, adds an integration test with a raw two-space `$$compose` mapping fixture, and bumps symbolicator's own ProGuard cache version so previously truncated caches are recomputed with the fixed parser.

Closes getsentry/sentry-android-gradle-plugin#1065