### PR TITLE
fix(proguard): Remap root-package exception classes

### DIFF
--- a/crates/symbolicator-proguard/src/interface.rs
+++ b/crates/symbolicator-proguard/src/interface.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::{collections::HashMap, fmt};
 
@@ -123,6 +124,20 @@ pub struct JvmException {
     pub ty: String,
     /// The module in which the exception is defined.
     pub module: String,
+}
+
+impl JvmException {
+    /// Returns the exception's fully-qualified class name.
+    ///
+    /// R8 aggressive mode can rename classes into the root package, in which
+    /// case `module` is empty and the bare `ty` is the full name.
+    pub fn full_class_name(&self) -> Cow<'_, str> {
+        if self.module.is_empty() {
+            Cow::Borrowed(&self.ty)
+        } else {
+            Cow::Owned(format!("{}.{}", self.module, self.ty))
+        }
+    }
 }
 
 /// A JVM stacktrace.

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -634,8 +634,7 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
     /// prepend a bogus `.` to the lookup key.
     #[test]
     fn remap_exception_root_package() {
-        let proguard_source =
-            b"androidx.compose.runtime.tooling.DiagnosticComposeException -> kj:
+        let proguard_source = b"androidx.compose.runtime.tooling.DiagnosticComposeException -> kj:
     1:3:void <init>(androidx.compose.runtime.tooling.ComposeStackTrace):18:18 -> <init>
 ";
 

--- a/crates/symbolicator-proguard/src/symbolication.rs
+++ b/crates/symbolicator-proguard/src/symbolication.rs
@@ -220,11 +220,8 @@ impl ProguardService {
         let mut carried_outline_pos = vec![None; mappers.len()];
         let mut remapped_frames = Vec::new();
 
-        // Compute exception descriptor for rewrite rules
-        let exception_descriptor = exception.map(|exc| {
-            let full_class = format!("{}.{}", exc.module, exc.ty);
-            proguard::class_name_to_descriptor(&full_class)
-        });
+        let exception_descriptor =
+            exception.map(|exc| proguard::class_name_to_descriptor(&exc.full_class_name()));
 
         // Track whether the next frame can have rewrite rules applied
         // (only the first non-outline frame after an exception)
@@ -383,20 +380,11 @@ impl ProguardService {
             return None;
         }
 
-        let key = format!("{}.{}", exception.module, exception.ty);
-
+        let key = exception.full_class_name();
         let mapped = mappers.iter().find_map(|mapper| mapper.remap_class(&key))?;
 
-        // In the Python implementation, we just split by `.` here with no check. I assume
-        // this error can not actually occur.
-        let Some((new_module, new_ty)) = mapped.rsplit_once('.') else {
-            tracing::error!(
-                original = key,
-                remapped = mapped,
-                "Invalid remapped class name"
-            );
-            return None;
-        };
+        // Root-package classes remap to a bare class name with no dot.
+        let (new_module, new_ty) = mapped.rsplit_once('.').unwrap_or(("", mapped));
 
         Some(JvmException {
             ty: new_ty.into(),
@@ -638,6 +626,34 @@ org.slf4j.helpers.Util$ClassContext -> org.a.b.g$b:
 
         assert_eq!(exception.ty, "Util$ClassContextSecurityManager");
         assert_eq!(exception.module, "org.slf4j.helpers");
+    }
+
+    /// Regression test for root-package obfuscated exception classes
+    /// (e.g. R8 aggressive mode renaming `DiagnosticComposeException` to `kj`).
+    /// The SDK sends these with an empty `module`, so remapping must not
+    /// prepend a bogus `.` to the lookup key.
+    #[test]
+    fn remap_exception_root_package() {
+        let proguard_source =
+            b"androidx.compose.runtime.tooling.DiagnosticComposeException -> kj:
+    1:3:void <init>(androidx.compose.runtime.tooling.ComposeStackTrace):18:18 -> <init>
+";
+
+        let exception = JvmException {
+            ty: "kj".into(),
+            module: "".into(),
+        };
+
+        let mapping = ProguardMapping::new(proguard_source);
+        let mut cache = Vec::new();
+        ProguardCache::write(&mapping, &mut cache).unwrap();
+        let cache = ProguardCache::parse(&cache).unwrap();
+        cache.test();
+
+        let exception = ProguardService::map_exception(&[&cache], &exception).unwrap();
+
+        assert_eq!(exception.ty, "DiagnosticComposeException");
+        assert_eq!(exception.module, "androidx.compose.runtime.tooling");
     }
 
     // based on the Python test `test_resolving_inline`


### PR DESCRIPTION
## Summary

When R8 renames a Java class into the root package (no dots), the SDK sends the exception with an empty `module` and a bare `ty` such as `kj`. `map_exception` was building the lookup key as `format!("{}.{}", module, ty)`, producing `.kj`, which never matches the mapping's class key `kj` — so `exception.type` stayed obfuscated even though the same class, when seen as a stack frame's `module`, was remapped fine.

Concretely, Compose now ships `androidx.compose.runtime.tooling.DiagnosticComposeException`, which R8 aggressive mode can rename to `kj`. Frames on `kj` were symbolicating; `exception.type` wasn't.

This PR:
- Adds `JvmException::full_class_name()` returning `Cow<str>` — borrows `ty` when `module` is empty, formats `module.ty` otherwise.
- Uses it for both the `map_exception` lookup key and the rewrite-rule `exception_descriptor` in `map_stacktrace` (two identical copies before).
- Tolerates a remapped class without a dot, since a root-package obfuscated class can in principle map back to another root-package class. Replaces the `tracing::error!` branch (which was treating this as "can not actually occur") with a graceful empty-module fallback.

Companion fix on the Sentry side: https://github.com/getsentry/sentry/pull/113691 — sentry's current filter drops module-less exceptions before they reach symbolicator, so this change by itself has no user-visible effect until that ships too.

## Test plan

- [x] New unit test `remap_exception_root_package` covering `kj` → `androidx.compose.runtime.tooling.DiagnosticComposeException`
- [x] Existing `remap_exception_simple` still passes
- [x] Full `symbolicator-proguard` test suite: 13/13 pass