### PR TITLE
ref(sentry): Remove release health integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,158 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags 2.9.4",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cceded2fb55f3c4b67068fa64962e2ca59614edc5b03167de9ff82ae803da0"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "base64",
- "bitflags 2.9.4",
- "bytes",
- "bytestring",
- "derive_more",
- "encoding_rs",
- "foldhash 0.1.5",
- "futures-core",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.9.4",
- "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio 1.0.4",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "bytes",
- "bytestring",
- "cfg-if",
- "derive_more",
- "encoding_rs",
- "foldhash 0.1.5",
- "futures-core",
- "futures-util",
- "impl-more",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2 0.5.10",
- "time",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,15 +892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytestring"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "bzip2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,27 +1368,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2520,12 +2338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
-name = "impl-more"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-
-[[package]]
 name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,12 +2552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,23 +2607,6 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
-
-[[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -3076,7 +2865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -4200,7 +3988,6 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
- "sentry-actix",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
@@ -4212,19 +3999,6 @@ dependencies = [
  "sentry-tracing",
  "tokio",
  "ureq",
-]
-
-[[package]]
-name = "sentry-actix"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c675bdf6118764a8e265c3395c311b4d905d12866c92df52870c0223d2ffc1"
-dependencies = [
- "actix-http",
- "actix-web",
- "bytes",
- "futures-util",
- "sentry-core",
 ]
 
 [[package]]
@@ -5476,7 +5250,6 @@ dependencies = [
  "io-uring",
  "libc",
  "mio 1.0.4",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -5805,12 +5578,6 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ sentry = { version = "0.42.0", default-features = false, features = [
     "debug-images",
     "panic",
     "transport",
+    "logs",
     # additional features
     "anyhow",
     "tracing",

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { workspace = true, features = [
     "hickory-dns",
     "socks",
 ] }
-sentry = { workspace = true, features = ["logs"] }
+sentry = { workspace = true }
 serde = { workspace = true }
 serde-vars = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/symbolicator-stress/Cargo.toml
+++ b/crates/symbolicator-stress/Cargo.toml
@@ -10,7 +10,7 @@ axum = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
-sentry = { workspace = true, features = ["logs"] }
+sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -16,7 +16,7 @@ futures = { workspace = true}
 hostname = { workspace = true}
 humantime =  { workspace = true }
 rustls = { workspace = true }
-sentry = { workspace = true, features = ["release-health", "tower", "tower-http"] }
+sentry = { workspace = true, features = ["tower", "tower-http"] }
 serde = { workspace = true }
 serde_json = { workspace = true}
 symbolic = { workspace = true }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -117,8 +117,6 @@ pub fn execute() -> Result<()> {
     let sentry = sentry::init(sentry::ClientOptions {
         dsn: config.sentry_dsn.clone(),
         release,
-        session_mode: sentry::SessionMode::Request,
-        auto_session_tracking: false,
         attach_stacktrace: config.logging.enable_backtraces,
         traces_sampler: Some(Arc::new(move |ctx| {
             if Some(true) == ctx.sampled() && config.propagate_traces {

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -16,8 +16,6 @@ pub async fn handle_apple_crash_report_request(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     mut multipart: extract::Multipart,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let mut report = None;

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -18,8 +18,6 @@ pub async fn handle_minidump_request(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     mut multipart: extract::Multipart,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let mut minidump = None;

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -58,8 +58,6 @@ pub async fn symbolicate_frames(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     extract::Json(body): extract::Json<SymbolicationRequestBody>,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let sources = match body.sources {

--- a/crates/symbolicator/src/endpoints/symbolicate_any.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_any.rs
@@ -55,8 +55,6 @@ pub async fn symbolicate_any(
     extract::Query(params): extract::Query<RequestQueryParams>,
     extract::Json(body): extract::Json<SymbolicateAnyRequestBody>,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let request_id = match body.symbolicate {

--- a/crates/symbolicator/src/endpoints/symbolicate_js.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_js.rs
@@ -63,8 +63,6 @@ pub async fn handle_symbolication_request(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     extract::Json(body): extract::Json<JsSymbolicationRequestBody>,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let JsSymbolicationRequestBody {

--- a/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_jvm.rs
@@ -55,8 +55,6 @@ pub async fn handle_symbolication_request(
     extract::Query(params): extract::Query<SymbolicationRequestQueryParams>,
     extract::Json(body): extract::Json<JvmSymbolicationRequestBody>,
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
-    sentry::start_session();
-
     params.configure_scope();
 
     let JvmSymbolicationRequestBody {

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -20,7 +20,6 @@ use anyhow::Result;
 use futures::future;
 use futures::{FutureExt as _, channel::oneshot};
 use sentry::SentryFutureExt;
-use sentry::protocol::SessionStatus;
 use serde::{Deserialize, Deserializer, Serialize};
 use symbolicator_js::SourceMapService;
 use symbolicator_js::interface::{CompletedJsSymbolicationResponse, SymbolicateJsStacktraces};
@@ -432,12 +431,8 @@ impl RequestService {
             .unwrap()
             .insert(request_id, receiver.shared());
         current_requests.fetch_add(1, Ordering::Relaxed);
-        let drop_hub = hub.clone();
         let token = CallOnDrop::new(move || {
             requests.lock().unwrap().remove(&request_id);
-            // we consider every premature drop of the future as fatal crash, which works fine
-            // since ending a session consumes it and its not possible to double-end.
-            drop_hub.end_session_with_status(SessionStatus::Crashed);
         });
 
         let spawn_time = Instant::now();
@@ -469,7 +464,6 @@ impl RequestService {
                     {
                         clear_dif_candidates(res)
                     }
-                    sentry::end_session_with_status(SessionStatus::Exited);
                     SymbolicationResponse::Completed(Box::new(response))
                 }
                 Ok(Err(err)) => {
@@ -481,15 +475,12 @@ impl RequestService {
                     let error: &dyn std::error::Error = err.as_ref();
                     tracing::warn!(error, "Symbolication failed");
 
-                    sentry::end_session_with_status(SessionStatus::Crashed);
                     SymbolicationResponse::Failed {
                         message: err.to_string(),
                     }
                 }
                 Err(_) => {
                     tracing::error!("Symbolication timed out after {timeout:?}");
-                    // a timeout is an abnormal session exit, all other errors are considered "crashed"
-                    sentry::end_session_with_status(SessionStatus::Abnormal);
                     SymbolicationResponse::Timeout
                 }
             };


### PR DESCRIPTION
Removes the release health integration which we never really used and it drops the actix dependency from Sentry.

Up for debate if we should merge this, maybe this could still be useful to us.