### PR TITLE
chore(deps): Bump proguard to 5.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.10.2"
+version = "5.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba7d8586f6b54127ec445fd643091dd2b2f956548df692c82572611a9396957"
+checksum = "a1000670719a375fcecd479087740ad350d217e761c135436c06c16e0e4307ee"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ minidump-processor = "0.26.1"
 minidump-unwind = "0.26.1"
 moka = { version = "0.12.8", features = ["future", "sync"] }
 prettytable-rs = "0.10.0"
-proguard = "5.10.2"
+proguard = "5.10.3"
 rand = "0.9.4"
 rayon = "1.10.0"
 regex = "1.5.5"


### PR DESCRIPTION
Bumps `proguard` from 5.10.2 to 5.10.3 to pick up the `ComposableSingletons$FileKt` source-file synthesis fix from [getsentry/rust-proguard#94](https://github.com/getsentry/rust-proguard/pull/94).

When a Compose-generated `ComposableSingletons$MainActivityKt` class is inlined through an R8 synthetic lambda and no top-level class declaration exists for it in the mapping (common in Android builds), the previous `synthesize_source_file` truncated at the first `$` and produced `ComposableSingletons.java`. 5.10.3 scans every `$`-segment for a `Kt` marker and now resolves to `MainActivity.kt`.

No symbolicator-side changes are needed — the fix is entirely inside the leaf utility. Upstream carries unit tests (7 cases in `src/utils.rs`) and an integration test (`tests/r8-source-file-edge-cases.rs::test_composable_singletons_inlined_lambda_stacktrace`). Skipping an end-to-end integration test here since there's no new data flow or wiring to exercise on this side; happy to add one if reviewers prefer.