### PR TITLE
fix(download): Force identity encoding on range requests

### DIFF
--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__add_bucket-2.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__add_bucket-2.snap
@@ -41,12 +41,17 @@ modules:
             has_unwind_info: false
             has_symbols: true
             has_sources: false
-        debug:
-          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
-          status: notfound
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: false
+            has_symbols: true
+            has_sources: false
+        debug:
+          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.src.zip"
         download:

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__remove_bucket.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__remove_bucket.snap
@@ -41,12 +41,17 @@ modules:
             has_unwind_info: false
             has_symbols: true
             has_sources: false
-        debug:
-          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
-          status: notfound
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: false
+            has_symbols: true
+            has_sources: false
+        debug:
+          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.src.zip"
         download:

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -697,9 +697,12 @@ impl<'a> SymRequest<'a> {
         let header = reqwest::header::HeaderValue::from_str(&range.to_string())
             .expect("the range header to be a always valid");
 
-        self.request
-            .headers_mut()
-            .insert(reqwest::header::RANGE, header);
+        let headers = self.request.headers_mut();
+        headers.insert(reqwest::header::RANGE, header);
+        headers.insert(
+            reqwest::header::ACCEPT_ENCODING,
+            reqwest::header::HeaderValue::from_static("identity"),
+        );
 
         self
     }


### PR DESCRIPTION
This is effectively already happening with the current version of reqwest, the update to 0.13 in #1942 changes the behaviour and we need to explicitly force it.

The better solution is to implement proper support for compressed ranges as described in #1891 

Test snapshots updated because of a `tower-http` bug serving files without extensions with the `identity` encoding: https://github.com/tower-rs/tower-http/issues/664