### PR TITLE
feat(proxy): serve Microsoft-style compressed symbol files (.pd_, .dl_, .ex_)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-server",
+ "cab",
  "clap",
  "console 0.16.1",
  "futures",

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -331,6 +331,9 @@ mod tests {
         let objects = ObjectsActor::new(
             caches.object_meta,
             caches.objects,
+            caches.raw_compressed,
+            caches.cab_synth,
+            false,
             shared_cache.clone(),
             downloader.clone(),
             source_index_svc.clone(),

--- a/crates/symbolicator-service/src/caches/versions.rs
+++ b/crates/symbolicator-service/src/caches/versions.rs
@@ -318,6 +318,28 @@ pub const PROGUARD_CACHE_VERSIONS: CacheVersions = CacheVersions {
 };
 static_assert!(proguard::PRGCACHE_VERSION == 4);
 
+/// Raw-compressed object mirror, with the following versions:
+///
+/// - `1`: Initial version. Stores upstream-compressed bytes (CAB / gzip / zstd / zlib / zip)
+///   tee'd during download, used to serve `.pd_` / `.dl_` / `.ex_` byte-identical responses
+///   on the proxy endpoint.
+pub const RAW_COMPRESSED_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: CacheVersion::new(1, CachePathFormat::V2),
+    fallbacks: &[],
+    previous: &[],
+};
+
+/// Synthesized CAB cache, with the following versions:
+///
+/// - `1`: Initial version. CAB (MSZIP) envelopes built on demand from decompressed objects
+///   when no upstream raw-compressed copy is available, used as fallback for `.pd_`/`.dl_`
+///   /`.ex_` proxy responses.
+pub const CAB_SYNTH_CACHE_VERSIONS: CacheVersions = CacheVersions {
+    current: CacheVersion::new(1, CachePathFormat::V2),
+    fallbacks: &[],
+    previous: &[],
+};
+
 /// Symstore index cache, with the following versions:
 ///
 /// - `1`: Initial version.

--- a/crates/symbolicator-service/src/caching/cleanup.rs
+++ b/crates/symbolicator-service/src/caching/cleanup.rs
@@ -65,6 +65,8 @@ impl Caches {
             diagnostics,
             proguard,
             source_index,
+            raw_compressed,
+            cab_synth,
         } = &self;
 
         let mut caches = vec![
@@ -80,6 +82,8 @@ impl Caches {
             diagnostics,
             proguard,
             source_index,
+            raw_compressed,
+            cab_synth,
         ];
         let mut rng = rand::rng();
 

--- a/crates/symbolicator-service/src/caching/config.rs
+++ b/crates/symbolicator-service/src/caching/config.rs
@@ -15,6 +15,13 @@ pub enum CacheName {
     Diagnostics,
     Proguard,
     SourceIndex,
+    /// Mirror of upstream-compressed object bytes (CAB/gzip/zstd/...), tee'd during download
+    /// so the `/proxy` endpoint can serve `.pd_`/`.dl_`/`.ex_` byte-identically when the
+    /// upstream source delivered a compressed payload.
+    RawCompressed,
+    /// CAB (MSZIP) envelopes synthesized from cached decompressed objects, used as the
+    /// fallback for compressed-proxy responses when no upstream raw copy is available.
+    CabSynth,
 }
 
 impl CacheName {
@@ -32,6 +39,8 @@ impl CacheName {
             Self::Diagnostics => "diagnostics",
             Self::Proguard => "proguard",
             Self::SourceIndex => "source_index",
+            Self::RawCompressed => "raw_compressed",
+            Self::CabSynth => "cab_synth",
         }
     }
 }

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -491,6 +491,39 @@ impl<T: CacheItemRequest> Cacher<T> {
     ///
     /// Cache computation can fail, in which case [`T::compute`](CacheItemRequest::compute)
     /// will return an `Err`. This err may be persisted in the cache for a time.
+    /// Persists a pre-computed [`NamedTempFile`] directly into the on-disk cache for the given
+    /// `cache_key`, bypassing the normal [`CacheItemRequest::compute`] flow.
+    ///
+    /// This is used for caches that are populated as a side effect of other work -- for
+    /// example, the `raw_compressed` cache that tee's upstream-compressed bytes during a
+    /// download of the corresponding decompressed object.
+    ///
+    /// If no cache directory is configured (e.g. in some test setups), this is a no-op.
+    /// The in-memory cache is *not* updated; subsequent calls to [`Self::compute_memoized`]
+    /// will discover the newly persisted file via the on-disk lookup path.
+    pub fn store_externally(
+        &self,
+        cache_key: &CacheKey,
+        temp_file: NamedTempFile,
+    ) -> std::io::Result<()> {
+        let Some(cache_dir) = self.config.cache_dir() else {
+            return Ok(());
+        };
+        let cache_path = cache_dir.join(cache_key.cache_path(T::VERSIONS.current));
+        persist_tempfile(temp_file, &cache_path)?;
+
+        let metadata = Metadata::from_key(cache_key);
+        if let Err(e) = super::fs::write_metadata(&cache_path, &metadata) {
+            tracing::error!(
+                error = &e as &dyn std::error::Error,
+                path = %cache_path.display(),
+                "Failed to write metadata file for externally-stored cache entry",
+            );
+        }
+
+        Ok(())
+    }
+
     pub async fn compute_memoized(&self, request: T, cache_key: CacheKey) -> CacheEntry<T::Item> {
         let name = self.config.name();
         metric!(counter("caches.access") += 1, "cache" => name.as_str());

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -491,6 +491,22 @@ impl<T: CacheItemRequest> Cacher<T> {
     ///
     /// Cache computation can fail, in which case [`T::compute`](CacheItemRequest::compute)
     /// will return an `Err`. This err may be persisted in the cache for a time.
+    pub async fn compute_memoized(&self, request: T, cache_key: CacheKey) -> CacheEntry<T::Item> {
+        let name = self.config.name();
+        metric!(counter("caches.access") += 1, "cache" => name.as_str());
+
+        let entry = self
+            .cache
+            .entry_by_ref(&cache_key)
+            .or_insert_with(Box::pin(self.lookup_or_compute(request, &cache_key)))
+            .await;
+
+        if !entry.is_fresh() {
+            metric!(counter("caches.memory.hit") += 1, "cache" => name.as_str());
+        }
+        entry.into_value().data
+    }
+
     /// Persists a pre-computed [`NamedTempFile`] directly into the on-disk cache for the given
     /// `cache_key`, bypassing the normal [`CacheItemRequest::compute`] flow.
     ///
@@ -522,22 +538,6 @@ impl<T: CacheItemRequest> Cacher<T> {
         }
 
         Ok(())
-    }
-
-    pub async fn compute_memoized(&self, request: T, cache_key: CacheKey) -> CacheEntry<T::Item> {
-        let name = self.config.name();
-        metric!(counter("caches.access") += 1, "cache" => name.as_str());
-
-        let entry = self
-            .cache
-            .entry_by_ref(&cache_key)
-            .or_insert_with(Box::pin(self.lookup_or_compute(request, &cache_key)))
-            .await;
-
-        if !entry.is_fresh() {
-            metric!(counter("caches.memory.hit") += 1, "cache" => name.as_str());
-        }
-        entry.into_value().data
     }
 
     /// Looks a cache entry up or computes it.

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -507,6 +507,38 @@ impl<T: CacheItemRequest> Cacher<T> {
         entry.into_value().data
     }
 
+    /// Looks up a cache entry without ever running [`CacheItemRequest::compute`].
+    ///
+    /// Checks the in-memory cache first, then the on-disk cache. A true miss returns
+    /// [`CacheError::NotFound`] but is NOT inserted into the in-memory cache, so a
+    /// subsequent call will re-check disk. This is the right primitive for caches that
+    /// are populated by external side effects (e.g. the `raw_compressed` mirror written
+    /// from the data-cache download): a stale negative would otherwise mask a legitimate
+    /// later population for the duration of `retry_misses_after`.
+    ///
+    /// Positive disk hits ARE inserted into the in-memory cache with the normal TTL, so
+    /// hot symbols don't re-stat the filesystem on every request.
+    pub async fn lookup_only(&self, request: T, cache_key: CacheKey) -> CacheEntry<T::Item> {
+        let name = self.config.name();
+        metric!(counter("caches.access") += 1, "cache" => name.as_str());
+
+        if let Some(item) = self.cache.get(&cache_key).await {
+            metric!(counter("caches.memory.hit") += 1, "cache" => name.as_str());
+            return item.data;
+        }
+
+        match self.lookup_local_cache(request, &cache_key) {
+            Some(item) => {
+                self.cache.insert(cache_key, item.clone()).await;
+                item.data
+            }
+            None => {
+                metric!(counter("caches.file.miss") += 1, "cache" => name.as_str());
+                CacheEntry::from_err(CacheError::NotFound)
+            }
+        }
+    }
+
     /// Persists a pre-computed [`NamedTempFile`] directly into the on-disk cache for the given
     /// `cache_key`, bypassing the normal [`CacheItemRequest::compute`] flow.
     ///

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -202,6 +202,12 @@ pub struct Caches {
     pub proguard: Cache,
     /// Source index files.
     pub source_index: Cache,
+    /// Upstream-compressed object bytes preserved during download, used by the
+    /// compressed-proxy mode.
+    pub raw_compressed: Cache,
+    /// CAB envelopes synthesized on demand from decompressed objects, used as the
+    /// compressed-proxy fallback when no raw upstream copy is available.
+    pub cab_synth: Cache,
 }
 
 impl Caches {
@@ -278,7 +284,7 @@ impl Caches {
                 CacheName::SourceMapCaches,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations,
+                max_lazy_recomputations.clone(),
                 default_cap,
             )?,
             sourcefiles: Cache::from_config(
@@ -306,8 +312,22 @@ impl Caches {
                 CacheName::SourceIndex,
                 config,
                 config.caches.index.into(),
-                max_lazy_redownloads,
+                max_lazy_redownloads.clone(),
                 in_memory.source_index_capacity,
+            )?,
+            raw_compressed: Cache::from_config(
+                CacheName::RawCompressed,
+                config,
+                config.caches.downloaded.into(),
+                max_lazy_redownloads,
+                default_cap,
+            )?,
+            cab_synth: Cache::from_config(
+                CacheName::CabSynth,
+                config,
+                config.caches.derived.into(),
+                max_lazy_recomputations,
+                default_cap,
             )?,
         })
     }

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -1264,3 +1264,61 @@ async fn test_failing_cache_write() {
         .join(key.cache_path(FailingTestCacheItem::VERSIONS.current));
     assert!(fs::exists(cache_file_path).unwrap());
 }
+
+/// Regression test for the `raw_compressed` stale-negative caching bug.
+///
+/// `lookup_only` must NOT cache a `NotFound` result in the in-memory cache, so an entry
+/// that is populated externally between two lookups is picked up by the second one.
+#[tokio::test]
+async fn test_lookup_only_does_not_cache_negatives() {
+    test::setup();
+    let cache_dir = test::tempdir();
+
+    let request = TestCacheItem::new();
+    let key = CacheKey::for_testing(Scope::Global, "global/raw-compressed-key");
+
+    let config = Config {
+        cache_dir: Some(cache_dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let cache = Cache::from_config(
+        CacheName::Objects,
+        &config,
+        CacheConfig::from(CacheConfigs::default().downloaded),
+        Arc::new(AtomicIsize::new(1)),
+        1024,
+    )
+    .unwrap();
+    let cacher = Cacher::new(cache, Default::default());
+
+    // 1. Cold cache: lookup_only returns NotFound.
+    let entry = cacher
+        .lookup_only(request.clone(), key.clone())
+        .await
+        .into_contents();
+    assert_eq!(entry, Err(CacheError::NotFound));
+    // No `compute` was invoked.
+    assert_eq!(request.computations.load(Ordering::SeqCst), 0);
+
+    // 2. Simulate a side-effect population: write the cache file directly to disk,
+    //    bypassing `compute`. This mimics what `store_externally` does after a
+    //    successful data-cache tee.
+    let cache_path = cache_dir
+        .path()
+        .join("objects")
+        .join(key.cache_path(TestCacheItem::VERSIONS.current));
+    fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+    fs::write(&cache_path, "externally populated bytes").unwrap();
+
+    // 3. Second lookup_only finds the freshly persisted file. If the first call had
+    //    cached the NotFound in moka, this would also return NotFound and the bug
+    //    would manifest as expensive fallback on every request for `retry_misses_after`.
+    let entry = cacher
+        .lookup_only(request.clone(), key)
+        .await
+        .into_contents()
+        .unwrap();
+    assert_eq!(entry, "externally populated bytes");
+    // Still no `compute` invocations.
+    assert_eq!(request.computations.load(Ordering::SeqCst), 0);
+}

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -454,11 +454,11 @@ pub struct Config {
     /// When enabled, the `/proxy` endpoint will additionally answer requests for
     /// Microsoft-style compressed symbol filenames (`.pd_`, `.dl_`, `.ex_`) by either:
     ///
-    /// * returning the upstream-compressed bytes byte-identically, when the source delivered
-    ///   the file as a CAB/gzip/zstd/zlib/zip payload (these are tee'd into the
-    ///   `raw_compressed` cache during download); or
+    /// * returning the upstream CAB payload byte-identically, when the source delivered
+    ///   the file as a CAB (tee'd into the `raw_compressed` cache during download); or
     /// * synthesizing a fresh CAB (MSZIP) on demand from the decompressed cached object
-    ///   when no upstream compressed copy is available (cached in `cab_synth`).
+    ///   in all other cases (gzip/zstd/zlib/zip upstreams, plain uncompressed uploads).
+    ///   Results are cached in `cab_synth`.
     ///
     /// Off by default -- existing deployments are bit-for-bit unchanged.
     pub compressed_proxy: bool,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -449,6 +449,20 @@ pub struct Config {
     /// Enables symbol proxy mode.
     pub symstore_proxy: bool,
 
+    /// Enables compressed symbol output on the symstore proxy.
+    ///
+    /// When enabled, the `/proxy` endpoint will additionally answer requests for
+    /// Microsoft-style compressed symbol filenames (`.pd_`, `.dl_`, `.ex_`) by either:
+    ///
+    /// * returning the upstream-compressed bytes byte-identically, when the source delivered
+    ///   the file as a CAB/gzip/zstd/zlib/zip payload (these are tee'd into the
+    ///   `raw_compressed` cache during download); or
+    /// * synthesizing a fresh CAB (MSZIP) on demand from the decompressed cached object
+    ///   when no upstream compressed copy is available (cached in `cab_synth`).
+    ///
+    /// Off by default -- existing deployments are bit-for-bit unchanged.
+    pub compressed_proxy: bool,
+
     /// Default list of sources and the sources used for proxy mode.
     pub sources: Arc<[SourceConfig]>,
 
@@ -594,6 +608,7 @@ impl Default for Config {
             enable_cache_cleanup: false,
             cache_cleanup_interval: Duration::from_secs(900),
             symstore_proxy: true,
+            compressed_proxy: false,
             sources: Arc::from(vec![]),
             connect_to_reserved_ips: false,
             deny_list_enabled: true,

--- a/crates/symbolicator-service/src/download/compression.rs
+++ b/crates/symbolicator-service/src/download/compression.rs
@@ -6,7 +6,7 @@ use tempfile::NamedTempFile;
 
 /// The compression format that was detected on a downloaded file.
 ///
-/// Returned by [`maybe_decompress_file`] so callers know whether (and how) the
+/// Returned by `maybe_decompress_file` so callers know whether (and how) the
 /// original bytes were compressed before decompression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompressionKind {
@@ -17,7 +17,7 @@ pub enum CompressionKind {
     Cab,
 }
 
-/// Outcome of a [`maybe_decompress_file`] call.
+/// Outcome of a `maybe_decompress_file` call.
 #[derive(Debug, Default)]
 pub struct DecompressOutcome {
     /// The detected compression kind, or `None` if the file was already uncompressed.

--- a/crates/symbolicator-service/src/download/compression.rs
+++ b/crates/symbolicator-service/src/download/compression.rs
@@ -50,11 +50,13 @@ fn allocate_raw_sink(src: &NamedTempFile) -> io::Result<NamedTempFile> {
 /// The passed [`NamedTempFile`] might be swapped with a fresh one in case decompression happens.
 /// That new temp file will be created in the same directory as the original one.
 ///
-/// When `want_raw_sink` is `true` and the file is detected as compressed, the original
-/// (still-compressed) bytes are copied into a fresh sibling tempfile and returned as
-/// [`DecompressOutcome::raw_sink`]. This lets callers preserve the upstream-compressed
-/// payload without paying for the allocation when no compression is detected (e.g. raw PDB
-/// downloads, which are the common case).
+/// When `want_raw_sink` is `true` *and* the file is detected as a **CAB** payload, the
+/// original (still-compressed) bytes are copied into a fresh sibling tempfile and returned
+/// as [`DecompressOutcome::raw_sink`]. Other compression formats (gzip / zstd / zlib / zip)
+/// are decompressed normally but the original bytes are not preserved: the proxy serves
+/// the raw-compressed mirror under `Content-Type: application/vnd.ms-cab-compressed`, so
+/// it would be incorrect to return non-CAB bytes from it. For those formats the fallback
+/// path synthesizes a fresh CAB on demand instead.
 pub fn maybe_decompress_file(
     src: &mut NamedTempFile,
     want_raw_sink: bool,
@@ -80,10 +82,11 @@ pub fn maybe_decompress_file(
     file.rewind()?;
 
     let mut raw_sink: Option<NamedTempFile> = None;
-    // Allocate the tee sink lazily -- only when we know a compressed magic was matched.
-    // This avoids creating a sibling tempfile on every uncompressed download (the common
-    // case) even when `compressed_proxy` is enabled.
-    let mut tee = |src: &NamedTempFile| -> io::Result<()> {
+    // Allocate the tee sink lazily -- only when we know a CAB magic was matched. Other
+    // compression formats are decompressed normally but their original bytes are
+    // discarded because the proxy serves the mirror under `vnd.ms-cab-compressed` and
+    // cannot honestly label a gzip / zstd / zlib / zip body as CAB.
+    let mut tee_cab = |src: &NamedTempFile| -> io::Result<()> {
         if want_raw_sink {
             raw_sink = Some(allocate_raw_sink(src)?);
         }
@@ -102,7 +105,6 @@ pub fn maybe_decompress_file(
         // https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2.1.1
         [0x28, 0xb5, 0x2f, 0xfd] => {
             metric!(counter("compression") += 1, "type" => "zstd");
-            tee(src)?;
 
             let mut dst = tempfile_in_parent(src)?;
             zstd::stream::copy_decode(file, &mut dst)?;
@@ -114,7 +116,6 @@ pub fn maybe_decompress_file(
         // https://tools.ietf.org/html/rfc1952#section-2.3.1
         [0x1f, 0x8b, _, _] => {
             metric!(counter("compression") += 1, "type" => "gz");
-            tee(src)?;
 
             // We assume MultiGzDecoder accepts a strict superset of input
             // values compared to GzDecoder.
@@ -128,7 +129,6 @@ pub fn maybe_decompress_file(
         // Magic bytes for zlib
         [0x78, 0x01, _, _] | [0x78, 0x9c, _, _] | [0x78, 0xda, _, _] => {
             metric!(counter("compression") += 1, "type" => "zlib");
-            tee(src)?;
 
             let mut dst = tempfile_in_parent(src)?;
             let mut reader = ZlibDecoder::new(file);
@@ -142,7 +142,6 @@ pub fn maybe_decompress_file(
         // Section: 4.3.7  Local file header
         [0x50, 0x4b, 0x03, 0x04] => {
             metric!(counter("compression") += 1, "type" => "zip");
-            tee(src)?;
 
             let mut dst = {
                 let mut archive = zip::ZipArchive::new(file)?;
@@ -167,7 +166,7 @@ pub fn maybe_decompress_file(
         // Magic bytes for CAB
         [77, 83, 67, 70] => {
             metric!(counter("compression") += 1, "type" => "cab");
-            tee(src)?;
+            tee_cab(src)?;
 
             let mut cab_file = Cabinet::new(file)?;
 
@@ -203,7 +202,7 @@ pub fn maybe_decompress_file(
             None
         }
     };
-    drop(tee);
+    drop(tee_cab);
 
     Ok(DecompressOutcome { kind, raw_sink })
 }
@@ -249,7 +248,10 @@ mod tests {
     }
 
     #[test]
-    fn test_gzip_decompresses_and_tees_raw() {
+    fn test_gzip_decompresses_but_does_not_tee() {
+        // Non-CAB compression must NOT populate `raw_sink` even when `want_raw_sink: true`.
+        // The proxy serves the mirror as `vnd.ms-cab-compressed`; returning gzip bytes
+        // under that content-type would break clients (WinDbg etc.).
         let payload = b"the original symbol bytes";
         let mut gz = Vec::new();
         {
@@ -262,9 +264,8 @@ mod tests {
         let outcome = maybe_decompress_file(&mut src, true).unwrap();
 
         assert_eq!(outcome.kind, Some(CompressionKind::Gzip));
+        assert!(outcome.raw_sink.is_none(), "gzip bytes must not enter the CAB mirror");
         assert_eq!(read_to_vec(&mut src), payload);
-        let mut sink = outcome.raw_sink.expect("sink allocated for compressed input");
-        assert_eq!(read_to_vec(&mut sink), gz);
     }
 
     #[test]
@@ -280,6 +281,34 @@ mod tests {
         let outcome = maybe_decompress_file(&mut src, false).unwrap();
         assert_eq!(outcome.kind, Some(CompressionKind::Gzip));
         assert!(outcome.raw_sink.is_none());
+        assert_eq!(read_to_vec(&mut src), payload);
+    }
+
+    #[test]
+    fn test_cab_decompresses_and_tees_raw() {
+        // CAB is the only format whose original bytes are preserved -- those bytes ARE
+        // valid `vnd.ms-cab-compressed` content and can be served verbatim by the proxy.
+        let payload = b"hello world, fake PDB bytes inside a CAB";
+        let mut cab_bytes = Vec::new();
+        {
+            let mut builder = cab::CabinetBuilder::new();
+            builder
+                .add_folder(cab::CompressionType::MsZip)
+                .add_file("foo.pdb".to_owned());
+            let mut w = builder.build(std::io::Cursor::new(&mut cab_bytes)).unwrap();
+            while let Some(mut fw) = w.next_file().unwrap() {
+                let mut src = std::io::Cursor::new(payload);
+                io::copy(&mut src, &mut fw).unwrap();
+            }
+            w.finish().unwrap();
+        }
+
+        let mut src = tempfile_with(&cab_bytes);
+        let outcome = maybe_decompress_file(&mut src, true).unwrap();
+
+        assert_eq!(outcome.kind, Some(CompressionKind::Cab));
+        let mut sink = outcome.raw_sink.expect("CAB tee must populate raw_sink");
+        assert_eq!(read_to_vec(&mut sink), cab_bytes);
         assert_eq!(read_to_vec(&mut src), payload);
     }
 }

--- a/crates/symbolicator-service/src/download/compression.rs
+++ b/crates/symbolicator-service/src/download/compression.rs
@@ -4,11 +4,61 @@ use cab::Cabinet;
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
 use tempfile::NamedTempFile;
 
+/// The compression format that was detected on a downloaded file.
+///
+/// Returned by [`maybe_decompress_file`] so callers know whether (and how) the
+/// original bytes were compressed before decompression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressionKind {
+    Zstd,
+    Gzip,
+    Zlib,
+    Zip,
+    Cab,
+}
+
+/// Outcome of a [`maybe_decompress_file`] call.
+#[derive(Debug, Default)]
+pub struct DecompressOutcome {
+    /// The detected compression kind, or `None` if the file was already uncompressed.
+    pub kind: Option<CompressionKind>,
+    /// The original (still-compressed) payload. `Some` only when the caller requested
+    /// preservation via `want_raw_sink` *and* a compressed magic was actually detected.
+    pub raw_sink: Option<NamedTempFile>,
+}
+
+/// Creates a sibling tempfile and copies the still-compressed contents of `src` into it,
+/// rewinding both. Returns the populated sink.
+///
+/// Called from each decompression branch *before* the source tempfile is swapped, so the
+/// caller can preserve the upstream-compressed payload (used by the `raw_compressed` cache
+/// to answer `.pd_` / `.dl_` / `.ex_` proxy requests byte-identically).
+fn allocate_raw_sink(src: &NamedTempFile) -> io::Result<NamedTempFile> {
+    let mut sink = tempfile_in_parent(src)?;
+    let mut reader = src.as_file();
+    reader.rewind()?;
+    io::copy(&mut reader, sink.as_file_mut())?;
+    sink.as_file_mut().sync_all()?;
+    sink.as_file_mut().rewind()?;
+    // Leave `src` rewound so the subsequent decompressor reads from the start.
+    src.as_file().rewind()?;
+    Ok(sink)
+}
+
 /// Decompresses a downloaded file.
 ///
 /// The passed [`NamedTempFile`] might be swapped with a fresh one in case decompression happens.
 /// That new temp file will be created in the same directory as the original one.
-pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
+///
+/// When `want_raw_sink` is `true` and the file is detected as compressed, the original
+/// (still-compressed) bytes are copied into a fresh sibling tempfile and returned as
+/// [`DecompressOutcome::raw_sink`]. This lets callers preserve the upstream-compressed
+/// payload without paying for the allocation when no compression is detected (e.g. raw PDB
+/// downloads, which are the common case).
+pub fn maybe_decompress_file(
+    src: &mut NamedTempFile,
+    want_raw_sink: bool,
+) -> io::Result<DecompressOutcome> {
     // Ensure that both meta data and file contents are available to the
     // subsequent reads of the file metadata and reads from other threads.
     let mut file = src.as_file();
@@ -22,12 +72,23 @@ pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
     file.rewind()?;
     if metadata.len() < 4 {
         // we don’t want to error for empty files here
-        return Ok(());
+        return Ok(DecompressOutcome::default());
     }
 
     let mut magic_bytes: [u8; 4] = [0, 0, 0, 0];
     file.read_exact(&mut magic_bytes)?;
     file.rewind()?;
+
+    let mut raw_sink: Option<NamedTempFile> = None;
+    // Allocate the tee sink lazily -- only when we know a compressed magic was matched.
+    // This avoids creating a sibling tempfile on every uncompressed download (the common
+    // case) even when `compressed_proxy` is enabled.
+    let mut tee = |src: &NamedTempFile| -> io::Result<()> {
+        if want_raw_sink {
+            raw_sink = Some(allocate_raw_sink(src)?);
+        }
+        Ok(())
+    };
 
     // For a comprehensive list also refer to
     // https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -36,21 +97,24 @@ pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
     // wrapper around a Write. Only zstd doesn't. If we can get this into
     // zstd we could save one tempfile and especially avoid the io::copy
     // for downloads that were not compressed.
-    match magic_bytes {
+    let kind = match magic_bytes {
         // Magic bytes for zstd
         // https://tools.ietf.org/id/draft-kucherawy-dispatch-zstd-00.html#rfc.section.2.1.1
         [0x28, 0xb5, 0x2f, 0xfd] => {
             metric!(counter("compression") += 1, "type" => "zstd");
+            tee(src)?;
 
             let mut dst = tempfile_in_parent(src)?;
             zstd::stream::copy_decode(file, &mut dst)?;
 
             std::mem::swap(src, &mut dst);
+            Some(CompressionKind::Zstd)
         }
         // Magic bytes for gzip
         // https://tools.ietf.org/html/rfc1952#section-2.3.1
         [0x1f, 0x8b, _, _] => {
             metric!(counter("compression") += 1, "type" => "gz");
+            tee(src)?;
 
             // We assume MultiGzDecoder accepts a strict superset of input
             // values compared to GzDecoder.
@@ -59,22 +123,26 @@ pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
             io::copy(&mut reader, &mut dst)?;
 
             std::mem::swap(src, &mut dst);
+            Some(CompressionKind::Gzip)
         }
         // Magic bytes for zlib
         [0x78, 0x01, _, _] | [0x78, 0x9c, _, _] | [0x78, 0xda, _, _] => {
             metric!(counter("compression") += 1, "type" => "zlib");
+            tee(src)?;
 
             let mut dst = tempfile_in_parent(src)?;
             let mut reader = ZlibDecoder::new(file);
             io::copy(&mut reader, &mut dst)?;
 
             std::mem::swap(src, &mut dst);
+            Some(CompressionKind::Zlib)
         }
         // Magic bytes for ZipArchive
         // https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.10.TXT
         // Section: 4.3.7  Local file header
         [0x50, 0x4b, 0x03, 0x04] => {
             metric!(counter("compression") += 1, "type" => "zip");
+            tee(src)?;
 
             let mut dst = {
                 let mut archive = zip::ZipArchive::new(file)?;
@@ -94,10 +162,12 @@ pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
             };
 
             std::mem::swap(src, &mut dst);
+            Some(CompressionKind::Zip)
         }
         // Magic bytes for CAB
         [77, 83, 67, 70] => {
             metric!(counter("compression") += 1, "type" => "cab");
+            tee(src)?;
 
             let mut cab_file = Cabinet::new(file)?;
 
@@ -125,14 +195,17 @@ pub fn maybe_decompress_file(src: &mut NamedTempFile) -> io::Result<()> {
             let mut reader = cab_file.read_file(&first_file)?;
             std::io::copy(&mut reader, &mut dst)?;
             std::mem::swap(src, &mut dst);
+            Some(CompressionKind::Cab)
         }
         // Probably not compressed
         _ => {
             metric!(counter("compression") += 1, "type" => "none");
+            None
         }
-    }
+    };
+    drop(tee);
 
-    Ok(())
+    Ok(DecompressOutcome { kind, raw_sink })
 }
 
 // FIXME(swatinem): this fn needs a better place
@@ -142,4 +215,71 @@ pub fn tempfile_in_parent(file: &NamedTempFile) -> io::Result<NamedTempFile> {
         .parent()
         .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
     NamedTempFile::new_in(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    fn tempfile_with(contents: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(contents).unwrap();
+        f.as_file_mut().sync_all().unwrap();
+        f.as_file_mut().rewind().unwrap();
+        f
+    }
+
+    fn read_to_vec(f: &mut NamedTempFile) -> Vec<u8> {
+        f.as_file_mut().rewind().unwrap();
+        let mut out = Vec::new();
+        f.as_file_mut().read_to_end(&mut out).unwrap();
+        out
+    }
+
+    #[test]
+    fn test_uncompressed_returns_none() {
+        let mut src = tempfile_with(b"hello world, not compressed at all");
+        let outcome = maybe_decompress_file(&mut src, true).unwrap();
+        assert_eq!(outcome.kind, None);
+        // No tee allocation for uncompressed input -- this is the lazy-allocation contract.
+        assert!(outcome.raw_sink.is_none());
+        assert_eq!(read_to_vec(&mut src), b"hello world, not compressed at all");
+    }
+
+    #[test]
+    fn test_gzip_decompresses_and_tees_raw() {
+        let payload = b"the original symbol bytes";
+        let mut gz = Vec::new();
+        {
+            let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::default());
+            enc.write_all(payload).unwrap();
+            enc.finish().unwrap();
+        }
+
+        let mut src = tempfile_with(&gz);
+        let outcome = maybe_decompress_file(&mut src, true).unwrap();
+
+        assert_eq!(outcome.kind, Some(CompressionKind::Gzip));
+        assert_eq!(read_to_vec(&mut src), payload);
+        let mut sink = outcome.raw_sink.expect("sink allocated for compressed input");
+        assert_eq!(read_to_vec(&mut sink), gz);
+    }
+
+    #[test]
+    fn test_gzip_no_sink_still_decompresses() {
+        let payload = b"abc";
+        let mut gz = Vec::new();
+        {
+            let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::default());
+            enc.write_all(payload).unwrap();
+            enc.finish().unwrap();
+        }
+        let mut src = tempfile_with(&gz);
+        let outcome = maybe_decompress_file(&mut src, false).unwrap();
+        assert_eq!(outcome.kind, Some(CompressionKind::Gzip));
+        assert!(outcome.raw_sink.is_none());
+        assert_eq!(read_to_vec(&mut src), payload);
+    }
 }

--- a/crates/symbolicator-service/src/download/fetch_file.rs
+++ b/crates/symbolicator-service/src/download/fetch_file.rs
@@ -5,7 +5,7 @@ use symbolicator_sources::RemoteFile;
 use tempfile::NamedTempFile;
 
 use super::DownloadService;
-use super::compression::maybe_decompress_file;
+use super::compression::{DecompressOutcome, maybe_decompress_file};
 use crate::caching::{CacheContents, CacheError};
 
 /// Downloads the gives [`RemoteFile`] and decompresses it.
@@ -20,6 +20,26 @@ pub async fn fetch_file(
     file_id: RemoteFile,
     temp_file: &mut NamedTempFile,
 ) -> CacheContents {
+    fetch_file_with_raw_sink(downloader, file_id, temp_file, false)
+        .await
+        .map(|_| ())
+}
+
+/// Like [`fetch_file`], but additionally preserves the upstream-compressed payload (if any)
+/// when `want_raw_sink` is `true`.
+///
+/// Returns a [`DecompressOutcome`] indicating which compression was detected (if any) and,
+/// when applicable, a sibling tempfile containing the original compressed bytes.
+///
+/// This is used to populate the `raw_compressed` cache so the `/proxy` endpoint can serve
+/// byte-identical responses for `.pd_` / `.dl_` / `.ex_` requests.
+#[tracing::instrument(skip(downloader, temp_file), fields(%file_id))]
+pub async fn fetch_file_with_raw_sink(
+    downloader: Arc<DownloadService>,
+    file_id: RemoteFile,
+    temp_file: &mut NamedTempFile,
+    want_raw_sink: bool,
+) -> CacheContents<DecompressOutcome> {
     downloader
         .download(file_id, temp_file.path().to_owned())
         .await?;
@@ -27,7 +47,9 @@ pub async fn fetch_file(
 
     // Treat decompression errors as malformed files. It is more likely that
     // the error comes from a corrupt file than a local file system error.
-    maybe_decompress_file(temp_file).map_err(|e| CacheError::Malformed(e.to_string()))?;
+    let outcome = maybe_decompress_file(temp_file, want_raw_sink)
+        .map_err(|e| CacheError::Malformed(e.to_string()))?;
 
-    Ok(temp_file.as_file().rewind()?)
+    temp_file.as_file().rewind()?;
+    Ok(outcome)
 }

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -43,9 +43,9 @@ mod partial;
 mod s3;
 pub mod sentry;
 
-pub use self::compression::tempfile_in_parent;
+pub use self::compression::{CompressionKind, DecompressOutcome, tempfile_in_parent};
 pub use self::destination::{Destination, MultiStreamDestination, WriteStream};
-pub use self::fetch_file::fetch_file;
+pub use self::fetch_file::{fetch_file, fetch_file_with_raw_sink};
 pub use index::SourceIndexService;
 
 impl ConfigureScope for RemoteFile {

--- a/crates/symbolicator-service/src/objects/cab_synth_cache.rs
+++ b/crates/symbolicator-service/src/objects/cab_synth_cache.rs
@@ -1,0 +1,175 @@
+//! Cache of CAB (MSZIP) envelopes synthesized on demand from decompressed objects.
+//!
+//! When the proxy receives a request for a Microsoft-style compressed filename
+//! (`.pd_`, `.dl_`, `.ex_`) and the `raw_compressed` mirror has no upstream copy, the
+//! proxy falls back to this cache, which wraps the cached decompressed object in a
+//! single-folder, single-file CAB using the `cab` crate's MSZIP writer.
+
+use std::fmt::Write as _;
+use std::io::{Cursor, Seek, Write};
+use std::sync::Arc;
+
+use cab::{CabinetBuilder, CompressionType};
+use futures::future::BoxFuture;
+use symbolic::common::ByteView;
+use symbolicator_sources::{ObjectId, RemoteFile};
+use tempfile::NamedTempFile;
+
+use crate::caches::CacheVersions;
+use crate::caches::versions::CAB_SYNTH_CACHE_VERSIONS;
+use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher};
+use crate::download::DownloadService;
+use crate::types::Scope;
+
+use super::data_cache::FetchFileDataRequest;
+use super::meta_cache::FetchFileMetaRequest;
+use super::role_scoped_cache_key;
+
+const CAB_SYNTH_DISCRIMINATOR: &str = "\nrole: cab_synth\n";
+
+/// Builds the [`CacheKey`] for a synthesized CAB envelope wrapping the given object under
+/// `inner_filename`. The filename is part of the key because it is embedded in the CAB
+/// header and must invalidate the cached envelope if it changes.
+pub(super) fn cab_synth_cache_key(
+    scope: &Scope,
+    file_source: &RemoteFile,
+    inner_filename: &str,
+) -> CacheKey {
+    let mut builder = role_scoped_cache_key(scope, file_source, CAB_SYNTH_DISCRIMINATOR);
+    builder
+        .write_fmt(format_args!("inner_filename: {inner_filename}\n"))
+        .unwrap();
+    builder.build()
+}
+
+/// Wraps `data` in a single-folder, single-file CAB (MSZIP) and writes it to `out`.
+///
+/// The `inner_filename` is what tools like WinDbg / `expand.exe` will see when they
+/// extract the cabinet — it must be the **uncompressed** form (e.g. `foo.pdb`, never
+/// `foo.pd_`).
+pub fn synthesize_cab<W: Write + Seek>(
+    data: &[u8],
+    inner_filename: &str,
+    out: W,
+) -> std::io::Result<()> {
+    let mut builder = CabinetBuilder::new();
+    builder
+        .add_folder(CompressionType::MsZip)
+        .add_file(inner_filename.to_owned());
+
+    let mut writer = builder.build(out)?;
+    while let Some(mut fw) = writer.next_file()? {
+        let mut src = Cursor::new(data);
+        std::io::copy(&mut src, &mut fw)?;
+    }
+    writer.finish()?;
+    Ok(())
+}
+
+/// [`CacheItemRequest`] that materializes a CAB envelope around a decompressed object.
+#[derive(Clone, Debug)]
+pub(crate) struct CabSynthRequest {
+    pub(super) scope: Scope,
+    pub(super) file_source: RemoteFile,
+    pub(super) object_id: ObjectId,
+    pub(super) inner_filename: String,
+    pub(super) data_cache: Arc<Cacher<FetchFileDataRequest>>,
+    pub(super) download_svc: Arc<DownloadService>,
+}
+
+impl CabSynthRequest {
+    async fn compute_inner(&self, temp_file: &mut NamedTempFile) -> CacheContents {
+        // Fetch the underlying decompressed object exactly the way `ObjectsActor::fetch`
+        // does (data-cache compute_memoized + FetchFileDataRequest).
+        let data_cache_key = CacheKey::from_scoped_file(&self.scope, &self.file_source);
+        let meta_request = FetchFileMetaRequest {
+            scope: self.scope.clone(),
+            file_source: self.file_source.clone(),
+            object_id: self.object_id.clone(),
+            data_cache: self.data_cache.clone(),
+            download_svc: self.download_svc.clone(),
+            // Don't tee raw bytes here: the data_cache is being consulted to retrieve an
+            // already-cached object. If it does happen to re-download, the upstream-bytes
+            // mirror was either already populated by a prior fetch or wasn't requested for
+            // this object type.
+            raw_compressed_cache: None,
+        };
+        let object_handle = self
+            .data_cache
+            .compute_memoized(FetchFileDataRequest(meta_request), data_cache_key)
+            .await
+            .into_contents()?;
+
+        // MSZIP compression of a multi-GB PDB takes tens of seconds of CPU on one thread,
+        // so run it on the blocking pool to avoid starving other tokio tasks.
+        let bytes = object_handle.data().clone();
+        let inner_filename = self.inner_filename.clone();
+        let temp_path = temp_file.path().to_owned();
+        tokio::task::spawn_blocking(move || -> CacheContents {
+            let mut f = std::fs::File::create(&temp_path)?;
+            synthesize_cab(bytes.as_ref(), &inner_filename, &mut f)
+                .map_err(|e| CacheError::Malformed(format!("CAB synthesis failed: {e}")))?;
+            f.sync_all()?;
+            Ok(())
+        })
+        .await
+        .map_err(CacheError::from_std_error)??;
+
+        temp_file.as_file_mut().rewind()?;
+        Ok(())
+    }
+}
+
+impl CacheItemRequest for CabSynthRequest {
+    type Item = ByteView<'static>;
+
+    const VERSIONS: CacheVersions = CAB_SYNTH_CACHE_VERSIONS;
+
+    fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
+        Box::pin(self.compute_inner(temp_file))
+    }
+
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
+        Ok(data)
+    }
+
+    fn use_shared_cache(&self) -> bool {
+        // Synthesized envelopes can be regenerated cheaply from the cached object;
+        // no point burning shared-cache bandwidth on them.
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read};
+
+    use super::*;
+
+    #[test]
+    fn test_synthesize_cab_roundtrip() {
+        let payload = b"hello world, this is fake PDB content".repeat(64);
+        let mut out = Cursor::new(Vec::new());
+        synthesize_cab(&payload, "foo.pdb", &mut out).unwrap();
+
+        let cab_bytes = out.into_inner();
+        assert!(cab_bytes.starts_with(b"MSCF"), "must be a CAB envelope");
+
+        let mut cabinet = cab::Cabinet::new(Cursor::new(&cab_bytes)).unwrap();
+        // Collect entries first to drop the iterator borrow before we call read_file.
+        let entries: Vec<String> = cabinet
+            .folder_entries()
+            .flat_map(|f| f.file_entries())
+            .map(|f| f.name().to_owned())
+            .collect();
+        assert_eq!(entries, vec!["foo.pdb".to_owned()]);
+
+        let mut extracted = Vec::new();
+        cabinet
+            .read_file("foo.pdb")
+            .unwrap()
+            .read_to_end(&mut extracted)
+            .unwrap();
+        assert_eq!(extracted, payload);
+    }
+}

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -20,12 +20,13 @@ use symbolic::debuginfo::{Archive, Object};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
 use crate::caches::versions::{CacheVersions, OBJECTS_CACHE_VERSIONS};
-use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey};
-use crate::download::{DownloadService, fetch_file, tempfile_in_parent};
+use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher};
+use crate::download::{DownloadService, fetch_file_with_raw_sink, tempfile_in_parent};
 use crate::types::Scope;
 use crate::utils::sentry::ConfigureScope;
 
 use super::meta_cache::FetchFileMetaRequest;
+use super::raw_compressed_cache::{RawCompressedRequest, raw_compressed_cache_key};
 
 /// This requests the file content of a single file at a specific path/url.
 /// The attributes for this are the same as for `FetchFileMetaRequest`, hence the newtype
@@ -110,22 +111,49 @@ impl fmt::Display for ObjectHandle {
 /// debug ID of our request is extracted first.  Finally the object is parsed with
 /// symbolic to ensure it is not malformed.
 ///
+/// When `raw_compressed_cache` is provided (compressed-proxy mode), the upstream
+/// payload -- if it was actually compressed -- is tee'd into the raw-compressed mirror so
+/// the `/proxy` endpoint can later serve `.pd_` / `.dl_` / `.ex_` byte-identically.
+///
 /// This is the actual implementation of [`CacheItemRequest::compute`] for
 /// [`FetchFileDataRequest`] but outside of the trait so it can be written as async/await
 /// code.
-#[tracing::instrument(skip(downloader, temp_file), fields(object_id, %file_id))]
+#[tracing::instrument(
+    skip(downloader, temp_file, scope, raw_compressed_cache),
+    fields(object_id, %file_id),
+)]
 async fn fetch_object_file(
     object_id: &ObjectId,
     file_id: RemoteFile,
     downloader: Arc<DownloadService>,
     temp_file: &mut NamedTempFile,
+    scope: &Scope,
+    raw_compressed_cache: Option<Arc<Cacher<RawCompressedRequest>>>,
 ) -> CacheContents {
     sentry::configure_scope(|scope| {
         file_id.to_scope(scope);
         object_id.to_scope(scope);
     });
 
-    fetch_file(downloader, file_id, temp_file).await?;
+    // The sink is allocated lazily inside `maybe_decompress_file` only when a compressed
+    // magic is actually detected -- see `compression::allocate_raw_sink`.
+    let want_raw_sink = raw_compressed_cache.is_some();
+    let outcome =
+        fetch_file_with_raw_sink(downloader, file_id.clone(), temp_file, want_raw_sink).await?;
+
+    // If the upstream payload was compressed, persist the tee'd raw bytes into the mirror
+    // cache so subsequent `.pd_` / `.dl_` / `.ex_` proxy requests can be answered
+    // byte-identically.
+    if let (Some(cache), Some(sink)) = (raw_compressed_cache, outcome.raw_sink) {
+        let key = raw_compressed_cache_key(scope, &file_id);
+        if let Err(e) = cache.store_externally(&key, sink) {
+            tracing::warn!(
+                error = &e as &dyn std::error::Error,
+                "failed to persist raw-compressed mirror entry; proxy will fall back to CAB synthesis",
+            );
+        }
+    }
+
 
     // Since objects in Sentry (and potentially also other sources) might be
     // multi-arch files (e.g. FatMach), we parse as Archive and try to
@@ -209,6 +237,8 @@ impl CacheItemRequest for FetchFileDataRequest {
             self.0.file_source.clone(),
             self.0.download_svc.clone(),
             temp_file,
+            &self.0.scope,
+            self.0.raw_compressed_cache.clone(),
         ))
     }
 
@@ -280,6 +310,24 @@ mod tests {
         )
         .unwrap();
 
+        let raw_compressed_cache = Cache::from_config(
+            CacheName::RawCompressed,
+            &config,
+            CacheConfig::from(CacheConfigs::default().downloaded),
+            Default::default(),
+            1024,
+        )
+        .unwrap();
+
+        let cab_synth_cache = Cache::from_config(
+            CacheName::CabSynth,
+            &config,
+            CacheConfig::from(CacheConfigs::default().derived),
+            Default::default(),
+            1024,
+        )
+        .unwrap();
+
         let source_index_cache = Cache::from_config(
             CacheName::SourceIndex,
             &config,
@@ -299,6 +347,9 @@ mod tests {
         ObjectsActor::new(
             meta_cache,
             data_cache,
+            raw_compressed_cache,
+            cab_synth_cache,
+            false,
             Default::default(),
             download_svc,
             source_index_svc,

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -112,8 +112,11 @@ impl fmt::Display for ObjectHandle {
 /// symbolic to ensure it is not malformed.
 ///
 /// When `raw_compressed_cache` is provided (compressed-proxy mode), the upstream
-/// payload -- if it was actually compressed -- is tee'd into the raw-compressed mirror so
-/// the `/proxy` endpoint can later serve `.pd_` / `.dl_` / `.ex_` byte-identically.
+/// payload -- if it was an actual CAB -- is tee'd into the raw-compressed mirror so the
+/// `/proxy` endpoint can later serve `.pd_` / `.dl_` / `.ex_` byte-identically. Other
+/// compression formats (gzip, zstd, zlib, zip) are decompressed normally and the
+/// raw-compressed mirror is left empty for those entries; the proxy falls back to CAB
+/// synthesis instead.
 ///
 /// This is the actual implementation of [`CacheItemRequest::compute`] for
 /// [`FetchFileDataRequest`] but outside of the trait so it can be written as async/await

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -23,6 +23,7 @@ use crate::types::Scope;
 
 use super::FetchFileDataRequest;
 use super::candidates::{ObjectFeatures, SrcSrvVcs};
+use super::raw_compressed_cache::RawCompressedRequest;
 
 /// This requests metadata of a single file at a specific path/url.
 #[derive(Clone, Debug)]
@@ -38,6 +39,9 @@ pub(super) struct FetchFileMetaRequest {
     // state for computing.
     pub(super) data_cache: Arc<Cacher<FetchFileDataRequest>>,
     pub(super) download_svc: Arc<DownloadService>,
+    /// `Some` when the compressed-proxy feature is enabled: the data-cache compute will tee
+    /// the upstream-compressed bytes (if any) into this cache during download.
+    pub(super) raw_compressed_cache: Option<Arc<Cacher<RawCompressedRequest>>>,
 }
 
 /// Handle to local metadata file of an object.

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -4,22 +4,43 @@ use std::sync::Arc;
 use futures::future;
 use sentry::{Hub, SentryFutureExt};
 
+use symbolic::common::ByteView;
 use symbolicator_sources::{FileType, ObjectId, RemoteFile, RemoteFileUri, SourceConfig, SourceId};
 
-use crate::caching::{Cache, CacheContents, CacheError, CacheKey, Cacher, SharedCacheRef};
+use crate::caching::{Cache, CacheContents, CacheError, CacheKey, CacheKeyBuilder, Cacher, SharedCacheRef};
 use crate::download::{self, DownloadService, SourceIndexService};
 use crate::types::Scope;
 
+mod cab_synth_cache;
 mod candidates;
 mod data_cache;
 mod meta_cache;
+mod raw_compressed_cache;
 
+use cab_synth_cache::{CabSynthRequest, cab_synth_cache_key};
 use data_cache::FetchFileDataRequest;
 use meta_cache::FetchFileMetaRequest;
+use raw_compressed_cache::{RawCompressedRequest, raw_compressed_cache_key};
 
 pub use candidates::*;
 pub use data_cache::ObjectHandle;
 pub use meta_cache::ObjectMetaHandle;
+
+/// Builds a [`CacheKeyBuilder`] scoped to `(scope, file_source)` with a trailing
+/// `discriminator` line, used to namespace per-role caches that share an underlying
+/// `RemoteFile` identity with the primary `objects` cache (raw-compressed mirror,
+/// synthesized CAB envelopes, etc.).
+fn role_scoped_cache_key(
+    scope: &Scope,
+    file_source: &RemoteFile,
+    discriminator: &str,
+) -> CacheKeyBuilder {
+    use std::fmt::Write as _;
+    let mut builder = CacheKey::scoped_builder(scope);
+    builder.write_file_meta(file_source).unwrap();
+    builder.write_str(discriminator).unwrap();
+    builder
+}
 
 /// Wrapper around [`CacheError`] to also pass the file information along.
 ///
@@ -83,14 +104,28 @@ pub struct ObjectsActor {
     // appropriate at some point.
     meta_cache: Arc<Cacher<FetchFileMetaRequest>>,
     data_cache: Arc<Cacher<FetchFileDataRequest>>,
+    /// Mirror of the upstream-compressed payload tee'd during downloads. Populated as a side
+    /// effect of `data_cache` compute when `compressed_proxy` is on; used by the proxy to
+    /// serve `.pd_`/`.dl_`/`.ex_` byte-identically.
+    raw_compressed_cache: Arc<Cacher<RawCompressedRequest>>,
+    /// On-demand CAB (MSZIP) envelopes built from the decompressed object. Fallback for the
+    /// compressed-proxy mode when no upstream raw copy is available.
+    cab_synth_cache: Arc<Cacher<CabSynthRequest>>,
+    /// Whether the compressed-proxy feature is enabled. Gates raw-bytes tee'ing during
+    /// downloads and the proxy's compressed lookup path.
+    compressed_proxy: bool,
     download_svc: Arc<DownloadService>,
     source_index_svc: Arc<SourceIndexService>,
 }
 
 impl ObjectsActor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         meta_cache: Cache,
         data_cache: Cache,
+        raw_compressed_cache: Cache,
+        cab_synth_cache: Cache,
+        compressed_proxy: bool,
         shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
         source_index_svc: Arc<SourceIndexService>,
@@ -98,6 +133,12 @@ impl ObjectsActor {
         ObjectsActor {
             meta_cache: Arc::new(Cacher::new(meta_cache, Arc::clone(&shared_cache))),
             data_cache: Arc::new(Cacher::new(data_cache, Arc::clone(&shared_cache))),
+            raw_compressed_cache: Arc::new(Cacher::new(
+                raw_compressed_cache,
+                Arc::clone(&shared_cache),
+            )),
+            cab_synth_cache: Arc::new(Cacher::new(cab_synth_cache, Arc::clone(&shared_cache))),
+            compressed_proxy,
             download_svc,
             source_index_svc,
         }
@@ -113,18 +154,101 @@ impl ObjectsActor {
         file_handle: Arc<ObjectMetaHandle>,
     ) -> CacheContents<Arc<ObjectHandle>> {
         let cache_key = CacheKey::from_scoped_file(&file_handle.scope, &file_handle.file_source);
-        let request = FetchFileDataRequest(FetchFileMetaRequest {
-            scope: file_handle.scope.clone(),
-            file_source: file_handle.file_source.clone(),
-            object_id: file_handle.object_id.clone(),
-            data_cache: self.data_cache.clone(),
-            download_svc: self.download_svc.clone(),
-        });
+        let request = FetchFileDataRequest(self.make_meta_request(
+            file_handle.scope.clone(),
+            file_handle.file_source.clone(),
+            file_handle.object_id.clone(),
+        ));
 
         self.data_cache
             .compute_memoized(request, cache_key)
             .await
             .into_contents()
+    }
+
+    /// Returns a compressed (CAB-wrapped) form of the requested object file.
+    ///
+    /// Resolution order:
+    ///
+    /// 1. If [`Self::compressed_proxy`] is `false`, returns [`CacheError::NotFound`].
+    /// 2. Otherwise, ensures the underlying object has been downloaded (which populates the
+    ///    `raw_compressed` cache as a side effect when the upstream payload was compressed).
+    /// 3. Looks up the `raw_compressed` mirror; on hit, returns those bytes byte-identically.
+    /// 4. On miss, falls back to synthesizing a CAB envelope around the cached decompressed
+    ///    object, caching it under `cab_synth` for subsequent requests.
+    ///
+    /// `inner_filename` is what tools extracting the CAB will see (must be the
+    /// uncompressed name like `foo.pdb`).
+    #[tracing::instrument(skip_all, fields(file_source = ?file_handle.file_source, inner_filename))]
+    pub async fn fetch_compressed(
+        &self,
+        file_handle: Arc<ObjectMetaHandle>,
+        inner_filename: &str,
+    ) -> CacheContents<ByteView<'static>> {
+        if !self.compressed_proxy {
+            return Err(CacheError::NotFound);
+        }
+
+        // Ensure the underlying object has been fetched so that, if the source delivered a
+        // compressed payload, it has been tee'd into the raw_compressed cache. Errors here
+        // propagate so callers see the same NotFound the regular proxy path would return.
+        self.fetch(file_handle.clone()).await?;
+
+        // Try the upstream-bytes mirror first (cheap + byte-identical).
+        let raw_key = raw_compressed_cache_key(&file_handle.scope, &file_handle.file_source);
+        match self
+            .raw_compressed_cache
+            .compute_memoized(RawCompressedRequest, raw_key)
+            .await
+            .into_contents()
+        {
+            Ok(bytes) => return Ok(bytes),
+            Err(CacheError::NotFound) => {
+                // fall through to CAB synthesis
+            }
+            Err(other) => return Err(other),
+        }
+
+        // Fallback: synthesize a CAB envelope from the decompressed object.
+        let synth_key = cab_synth_cache_key(
+            &file_handle.scope,
+            &file_handle.file_source,
+            inner_filename,
+        );
+        let synth_request = CabSynthRequest {
+            scope: file_handle.scope.clone(),
+            file_source: file_handle.file_source.clone(),
+            object_id: file_handle.object_id.clone(),
+            inner_filename: inner_filename.to_owned(),
+            data_cache: self.data_cache.clone(),
+            download_svc: self.download_svc.clone(),
+        };
+        self.cab_synth_cache
+            .compute_memoized(synth_request, synth_key)
+            .await
+            .into_contents()
+    }
+
+    /// Builds a [`FetchFileMetaRequest`] with this actor's shared state plumbed in.
+    fn make_meta_request(
+        &self,
+        scope: Scope,
+        file_source: RemoteFile,
+        object_id: ObjectId,
+    ) -> FetchFileMetaRequest {
+        let raw_compressed_cache = if self.compressed_proxy {
+            Some(self.raw_compressed_cache.clone())
+        } else {
+            None
+        };
+        FetchFileMetaRequest {
+            scope,
+            file_source,
+            object_id,
+            data_cache: self.data_cache.clone(),
+            download_svc: self.download_svc.clone(),
+            raw_compressed_cache,
+        }
     }
 
     /// Fetches matching objects and returns the metadata of the most suitable object.
@@ -180,13 +304,7 @@ impl ObjectsActor {
                 scope.clone()
             };
             let cache_key = CacheKey::from_scoped_file(&scope, &file_source);
-            let request = FetchFileMetaRequest {
-                scope,
-                file_source: file_source.clone(),
-                object_id: identifier.clone(),
-                data_cache: self.data_cache.clone(),
-                download_svc: self.download_svc.clone(),
-            };
+            let request = self.make_meta_request(scope, file_source.clone(), identifier.clone());
 
             async move {
                 let handle = self

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -170,7 +170,7 @@ impl ObjectsActor {
     ///
     /// Resolution order:
     ///
-    /// 1. If [`Self::compressed_proxy`] is `false`, returns [`CacheError::NotFound`].
+    /// 1. If the `compressed_proxy` feature is disabled, returns [`CacheError::NotFound`].
     /// 2. Otherwise, ensures the underlying object has been downloaded (which populates the
     ///    `raw_compressed` cache as a side effect when the upstream payload was compressed).
     /// 3. Looks up the `raw_compressed` mirror; on hit, returns those bytes byte-identically.

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -194,11 +194,14 @@ impl ObjectsActor {
         // propagate so callers see the same NotFound the regular proxy path would return.
         self.fetch(file_handle.clone()).await?;
 
-        // Try the upstream-bytes mirror first (cheap + byte-identical).
+        // Try the upstream-bytes mirror first (cheap + byte-identical). Use `lookup_only`
+        // rather than `compute_memoized` so a miss does not get cached: this cache is
+        // populated as a side effect of the data-cache tee, and the next request might
+        // find the entry on disk even when an earlier request did not.
         let raw_key = raw_compressed_cache_key(&file_handle.scope, &file_handle.file_source);
         match self
             .raw_compressed_cache
-            .compute_memoized(RawCompressedRequest, raw_key)
+            .lookup_only(RawCompressedRequest, raw_key)
             .await
             .into_contents()
         {

--- a/crates/symbolicator-service/src/objects/raw_compressed_cache.rs
+++ b/crates/symbolicator-service/src/objects/raw_compressed_cache.rs
@@ -1,0 +1,64 @@
+//! Cache mirror of upstream-compressed object bytes.
+//!
+//! When `compressed_proxy` is enabled and a downloaded object turns out to be compressed
+//! (CAB/gzip/zstd/zlib/zip), the data cache tee's the still-compressed payload into a
+//! sibling tempfile and persists it here via [`Cacher::store_externally`]. The `/proxy`
+//! endpoint can then serve `.pd_`/`.dl_`/`.ex_` requests byte-identically by looking up
+//! this cache before falling back to synthesizing a fresh CAB.
+//!
+//! [`Cacher::store_externally`]: crate::caching::Cacher::store_externally
+
+use futures::future::BoxFuture;
+use symbolic::common::ByteView;
+use symbolicator_sources::RemoteFile;
+
+use crate::caches::CacheVersions;
+use crate::caches::versions::RAW_COMPRESSED_CACHE_VERSIONS;
+use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey};
+use crate::types::Scope;
+
+use super::role_scoped_cache_key;
+
+const RAW_COMPRESSED_DISCRIMINATOR: &str = "\nrole: raw_compressed\n";
+
+/// Builds the [`CacheKey`] for the raw-compressed mirror of the given `(scope, file_source)`.
+pub(super) fn raw_compressed_cache_key(scope: &Scope, file_source: &RemoteFile) -> CacheKey {
+    role_scoped_cache_key(scope, file_source, RAW_COMPRESSED_DISCRIMINATOR).build()
+}
+
+/// [`CacheItemRequest`] for the raw-compressed mirror.
+///
+/// Carries no state — all cache identity lives in the [`CacheKey`] built by
+/// [`raw_compressed_cache_key`]. `compute` always returns [`CacheError::NotFound`]: this
+/// cache is populated as a side effect of downloading the corresponding decompressed object
+/// (see [`Cacher::store_externally`]), never on demand. A miss signals the caller to fall
+/// back to CAB synthesis.
+///
+/// [`Cacher::store_externally`]: crate::caching::Cacher::store_externally
+#[derive(Clone, Debug)]
+pub(crate) struct RawCompressedRequest;
+
+impl CacheItemRequest for RawCompressedRequest {
+    type Item = ByteView<'static>;
+
+    const VERSIONS: CacheVersions = RAW_COMPRESSED_CACHE_VERSIONS;
+
+    fn compute<'a>(
+        &'a self,
+        _temp_file: &'a mut tempfile::NamedTempFile,
+    ) -> BoxFuture<'a, CacheContents> {
+        // Populated as a side effect of the data-cache download. On a true miss, signal the
+        // caller to fall back to CAB synthesis rather than caching a negative result.
+        Box::pin(async { Err(CacheError::NotFound) })
+    }
+
+    fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
+        Ok(data)
+    }
+
+    fn use_shared_cache(&self) -> bool {
+        // Raw compressed mirrors are local-only — the shared cache is reserved for the
+        // primary decompressed objects.
+        false
+    }
+}

--- a/crates/symbolicator-service/src/objects/raw_compressed_cache.rs
+++ b/crates/symbolicator-service/src/objects/raw_compressed_cache.rs
@@ -28,12 +28,13 @@ pub(super) fn raw_compressed_cache_key(scope: &Scope, file_source: &RemoteFile) 
 
 /// [`CacheItemRequest`] for the raw-compressed mirror.
 ///
-/// Carries no state — all cache identity lives in the [`CacheKey`] built by
-/// [`raw_compressed_cache_key`]. `compute` always returns [`CacheError::NotFound`]: this
-/// cache is populated as a side effect of downloading the corresponding decompressed object
-/// (see [`Cacher::store_externally`]), never on demand. A miss signals the caller to fall
-/// back to CAB synthesis.
+/// Carries no state -- all cache identity lives in the [`CacheKey`] built by
+/// [`raw_compressed_cache_key`]. This cache is queried only via
+/// [`Cacher::lookup_only`], which never invokes `compute`; it is populated as a side
+/// effect of downloading the corresponding decompressed object (see
+/// [`Cacher::store_externally`]).
 ///
+/// [`Cacher::lookup_only`]: crate::caching::Cacher::lookup_only
 /// [`Cacher::store_externally`]: crate::caching::Cacher::store_externally
 #[derive(Clone, Debug)]
 pub(crate) struct RawCompressedRequest;
@@ -47,8 +48,9 @@ impl CacheItemRequest for RawCompressedRequest {
         &'a self,
         _temp_file: &'a mut tempfile::NamedTempFile,
     ) -> BoxFuture<'a, CacheContents> {
-        // Populated as a side effect of the data-cache download. On a true miss, signal the
-        // caller to fall back to CAB synthesis rather than caching a negative result.
+        // Unreachable: we only access this cache via `Cacher::lookup_only`. If anyone
+        // ever calls `compute_memoized` on us, returning NotFound is the right
+        // defensive behaviour -- the caller's fallback handles it.
         Box::pin(async { Err(CacheError::NotFound) })
     }
 

--- a/crates/symbolicator-service/src/services.rs
+++ b/crates/symbolicator-service/src/services.rs
@@ -52,6 +52,9 @@ impl SharedServices {
         let objects = ObjectsActor::new(
             caches.object_meta.clone(),
             caches.objects.clone(),
+            caches.raw_compressed.clone(),
+            caches.cab_synth.clone(),
+            config.compressed_proxy,
             shared_cache.clone(),
             download_svc.clone(),
             source_index_svc.clone(),

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { workspace = true }
 reqwest = { workspace = true }
 
 [dev-dependencies]
+cab = { workspace = true }
 insta = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
 symbolicator-test = { workspace = true }

--- a/crates/symbolicator/src/endpoints/proxy.rs
+++ b/crates/symbolicator/src/endpoints/proxy.rs
@@ -40,7 +40,12 @@ fn uncompress_leaf(leaf: &str) -> Option<String> {
         .find(|(suffix, _)| suffix.eq_ignore_ascii_case(ext))?;
 
     let mut out = leaf[..leaf.len() - 1].to_owned();
-    if ext.chars().any(|c| c.is_ascii_uppercase()) {
+    // Match Microsoft's case convention: uppercase only when the entire extension is
+    // uppercase (`EX_` -> `EXE`). Mixed-case stays canonical lowercase to match the
+    // form Microsoft uses on the symbol server (`Cmd.Ex_` -> `Cmd.Exe`).
+    let ext_letters = ext.trim_end_matches('_');
+    let all_upper = !ext_letters.is_empty() && ext_letters.chars().all(|c| c.is_ascii_uppercase());
+    if all_upper {
         out.push(replacement.to_ascii_uppercase());
     } else {
         out.push(*replacement);
@@ -213,7 +218,11 @@ mod tests {
             ),
             (
                 "Cmd.Ex_/FOO/Cmd.Ex_",
-                Some(("Cmd.ExE/FOO/Cmd.ExE", "Cmd.ExE")),
+                Some(("Cmd.Exe/FOO/Cmd.Exe", "Cmd.Exe")),
+            ),
+            (
+                "KERNEL32.DL_/AAA/KERNEL32.DL_",
+                Some(("KERNEL32.DLL/AAA/KERNEL32.DLL", "KERNEL32.DLL")),
             ),
             ("integration.pdb/abc/integration.pdb", None),
             ("integration.bin/abc/integration.bin", None),

--- a/crates/symbolicator/src/endpoints/proxy.rs
+++ b/crates/symbolicator/src/endpoints/proxy.rs
@@ -6,14 +6,73 @@ use axum::body::Body;
 use axum::extract;
 use axum::http::{Method, Request, Response, StatusCode};
 
+use symbolic::common::ByteView;
 use symbolicator_service::caching::{CacheContents, CacheError};
 use symbolicator_sources::parse_symstore_path;
 
-use crate::service::{FindObject, ObjectHandle, ObjectPurpose, RequestService, Scope};
+use crate::service::{FindObject, ObjectMetaHandle, ObjectPurpose, RequestService, Scope};
 
 use super::ResponseError;
 
-async fn load_object(service: RequestService, path: String) -> CacheContents<Arc<ObjectHandle>> {
+/// Builds an empty 404 response. Inlined into 4 different match arms otherwise.
+fn not_found() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::empty())
+        .expect("404 builder is infallible")
+}
+
+/// Microsoft-style compressed-extension suffix -> uncompressed last char.
+///
+/// Symbolicator's path generator (`paths.rs:475-485`) already requests both forms on ingress;
+/// this table reverses the mapping for inbound proxy requests.
+const COMPRESSED_EXTENSIONS: &[(&str, char)] = &[("pd_", 'b'), ("dl_", 'l'), ("ex_", 'e')];
+
+/// If `leaf` looks like `<name>.{pd_,dl_,ex_}` (case-insensitive), returns the uncompressed
+/// form with the trailing `_` replaced by `b`/`l`/`e`. Casing of the replacement matches the
+/// casing of the original extension (lowercase input -> lowercase replacement, otherwise
+/// uppercase). Returns `None` for any other input.
+fn uncompress_leaf(leaf: &str) -> Option<String> {
+    let dot = leaf.rfind('.')?;
+    let ext = &leaf[dot + 1..];
+    let (_, replacement) = COMPRESSED_EXTENSIONS
+        .iter()
+        .find(|(suffix, _)| suffix.eq_ignore_ascii_case(ext))?;
+
+    let mut out = leaf[..leaf.len() - 1].to_owned();
+    if ext.chars().any(|c| c.is_ascii_uppercase()) {
+        out.push(replacement.to_ascii_uppercase());
+    } else {
+        out.push(*replacement);
+    }
+    Some(out)
+}
+
+/// If `path` looks like a symstore path whose last filename component ends in `_`
+/// (`.pd_` / `.dl_` / `.ex_`), returns the path rewritten to the uncompressed form along with
+/// the uncompressed leaf filename. Returns `None` for any other path.
+///
+/// Both the leading and trailing filename components of a symstore path
+/// (`<filename>/<id>/<filename>`) are rewritten, matching the convention enforced by
+/// [`parse_symstore_path`].
+fn rewrite_compressed_path(path: &str) -> Option<(String, String)> {
+    let first_slash = path.find('/')?;
+    let last_slash = path.rfind('/')?;
+    let trailing_uncompressed = uncompress_leaf(&path[last_slash + 1..])?;
+    let leading = &path[..first_slash];
+    let leading_uncompressed = uncompress_leaf(leading).unwrap_or_else(|| leading.to_owned());
+
+    let middle = &path[first_slash..=last_slash];
+    let rewritten = format!("{leading_uncompressed}{middle}{trailing_uncompressed}");
+    Some((rewritten, trailing_uncompressed))
+}
+
+/// Resolves a (possibly rewritten) symstore path to an [`ObjectMetaHandle`] for the
+/// requested object.
+async fn find_meta(
+    service: &RequestService,
+    path: &str,
+) -> CacheContents<Arc<ObjectMetaHandle>> {
     let config = service.config();
     if !config.symstore_proxy {
         return Err(CacheError::NotFound);
@@ -21,7 +80,7 @@ async fn load_object(service: RequestService, path: String) -> CacheContents<Arc
 
     tracing::trace!("Resolving symstore proxy path `{path:?}`");
 
-    let (filetypes, object_id) = parse_symstore_path(&path).ok_or(CacheError::NotFound)?;
+    let (filetypes, object_id) = parse_symstore_path(path).ok_or(CacheError::NotFound)?;
 
     tracing::debug!("Searching for {:?} ({:?})", object_id, filetypes);
 
@@ -39,7 +98,7 @@ async fn load_object(service: RequestService, path: String) -> CacheContents<Arc
         return Err(CacheError::NotFound);
     };
 
-    service.fetch_object(meta.handle?).await
+    meta.handle
 }
 
 pub async fn proxy_symstore_request(
@@ -51,13 +110,54 @@ pub async fn proxy_symstore_request(
         scope.set_transaction(Some("GET /proxy"));
     });
 
-    let object_handle = match load_object(service, path).await {
-        Ok(handle) => handle,
-        Err(CacheError::NotFound) => {
-            return Ok(Response::builder()
-                .status(StatusCode::NOT_FOUND)
-                .body(Body::empty())?);
+    // Detect a Microsoft-style compressed request (`.pd_` / `.dl_` / `.ex_`). When the
+    // feature is enabled, `inner_filename` is `Some(<uncompressed leaf>)` -- its presence
+    // is the sole signal that we should emit a CAB envelope instead of raw bytes.
+    let (resolve_path, inner_filename) =
+        match (rewrite_compressed_path(&path), service.config().compressed_proxy) {
+            (Some((rewritten, leaf)), true) => (rewritten, Some(leaf)),
+            (Some(_), false) => {
+                // Compressed-proxy disabled: 404 the underscore form so we don't accidentally
+                // expose unrelated decompressed bytes under a misleading filename.
+                return Ok(not_found());
+            }
+            (None, _) => (path, None),
+        };
+
+    let meta = match find_meta(&service, &resolve_path).await {
+        Ok(meta) => meta,
+        Err(CacheError::NotFound) => return Ok(not_found()),
+        Err(e) => {
+            return Err(e)
+                .context("failed to locate object")
+                .map_err(|e| e.into());
         }
+    };
+
+    if let Some(inner_filename) = inner_filename {
+        let bytes = match service
+            .fetch_compressed_object(meta, &inner_filename)
+            .await
+        {
+            Ok(b) => b,
+            Err(CacheError::NotFound) => return Ok(not_found()),
+            Err(e) => {
+                return Err(e)
+                    .context("failed to materialize compressed object")
+                    .map_err(|e| e.into());
+            }
+        };
+
+        return Ok(build_response(
+            bytes,
+            "application/vnd.ms-cab-compressed",
+            request.method(),
+        )?);
+    }
+
+    let object_handle = match service.fetch_object(meta).await {
+        Ok(handle) => handle,
+        Err(CacheError::NotFound) => return Ok(not_found()),
         Err(e) => {
             return Err(e)
                 .context("failed to download object")
@@ -66,16 +166,28 @@ pub async fn proxy_symstore_request(
     };
 
     let data = object_handle.data().clone();
-    let response = Response::builder()
-        .header("content-length", data.len())
-        .header("content-type", "application/octet-stream");
+    Ok(build_response(
+        data,
+        "application/octet-stream",
+        request.method(),
+    )?)
+}
 
-    if *request.method() == Method::HEAD {
-        return Ok(response.body(Body::empty())?);
+fn build_response(
+    bytes: ByteView<'static>,
+    content_type: &'static str,
+    method: &Method,
+) -> Result<Response<Body>, axum::http::Error> {
+    let response = Response::builder()
+        .header("content-length", bytes.len())
+        .header("content-type", content_type);
+
+    if *method == Method::HEAD {
+        return response.body(Body::empty());
     }
 
-    let bytes = Cursor::new(data);
-    Ok(response.body(Body::from_stream(tokio_util::io::ReaderStream::new(bytes)))?)
+    let cursor = Cursor::new(bytes);
+    response.body(Body::from_stream(tokio_util::io::ReaderStream::new(cursor)))
 }
 
 #[cfg(test)]
@@ -85,6 +197,40 @@ mod tests {
     use reqwest::{Client, StatusCode};
 
     use crate::test;
+
+    use super::rewrite_compressed_path;
+
+    #[test]
+    fn test_rewrite_compressed_path() {
+        let cases = [
+            (
+                "integration.pd_/ABC123/integration.pd_",
+                Some(("integration.pdb/ABC123/integration.pdb", "integration.pdb")),
+            ),
+            (
+                "kernel32.dl_/DEADBEEF/kernel32.dl_",
+                Some(("kernel32.dll/DEADBEEF/kernel32.dll", "kernel32.dll")),
+            ),
+            (
+                "Cmd.Ex_/FOO/Cmd.Ex_",
+                Some(("Cmd.ExE/FOO/Cmd.ExE", "Cmd.ExE")),
+            ),
+            ("integration.pdb/abc/integration.pdb", None),
+            ("integration.bin/abc/integration.bin", None),
+            ("integration.zz_/abc/integration.zz_", None),
+        ];
+        for (input, expected) in cases {
+            let actual = rewrite_compressed_path(input);
+            match (actual, expected) {
+                (None, None) => {}
+                (Some((path, leaf)), Some((expected_path, expected_leaf))) => {
+                    assert_eq!(path, expected_path, "rewriting {input}");
+                    assert_eq!(leaf, expected_leaf, "leaf for {input}");
+                }
+                (a, e) => panic!("mismatch for {input}: got {a:?}, expected {e:?}"),
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_proxy_works() {
@@ -111,5 +257,124 @@ mod tests {
             "symbols/integration.pdb/0C1033F78632492E91C6C314B72E1920ffffffff/integration.pdb",
         );
         assert_eq!(bytes, file_contents);
+    }
+
+    /// `.pd_` is 404 when `compressed_proxy` is disabled, even if the underlying `.pdb` exists.
+    #[tokio::test]
+    async fn test_proxy_compressed_off_returns_404() {
+        test::setup();
+
+        let (_srv, source) = test::symbol_server();
+        let server = test::server_with_config(|config| {
+            config.symstore_proxy = true;
+            config.compressed_proxy = false;
+            config.sources = Arc::from([source]);
+        });
+
+        let response = Client::new()
+            .get(server.url(
+                "/proxy/integration.pd_/0C1033F78632492E91C6C314B72E1920ffffffff/integration.pd_",
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// `.pd_` is served as a freshly-synthesized CAB when `compressed_proxy` is enabled and
+    /// the source only has the decompressed `.pdb`.
+    #[tokio::test]
+    async fn test_proxy_compressed_synthesized() {
+        use std::io::{Cursor, Read};
+
+        test::setup();
+
+        let (_srv, source) = test::symbol_server();
+        let server = test::server_with_config(|config| {
+            config.symstore_proxy = true;
+            config.compressed_proxy = true;
+            config.sources = Arc::from([source]);
+        });
+
+        let response = Client::new()
+            .get(server.url(
+                "/proxy/integration.pd_/0C1033F78632492E91C6C314B72E1920ffffffff/integration.pd_",
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|h| h.to_str().ok()),
+            Some("application/vnd.ms-cab-compressed"),
+        );
+
+        let body = response.bytes().await.unwrap();
+        assert!(body.starts_with(b"MSCF"), "expected a CAB envelope");
+
+        // The CAB should contain the original PDB under its uncompressed name.
+        let mut cab = cab::Cabinet::new(Cursor::new(&body[..])).unwrap();
+        let entries: Vec<String> = cab
+            .folder_entries()
+            .flat_map(|f| f.file_entries())
+            .map(|f| f.name().to_owned())
+            .collect();
+        assert_eq!(entries, vec!["integration.pdb".to_owned()]);
+
+        let mut extracted = Vec::new();
+        cab.read_file("integration.pdb")
+            .unwrap()
+            .read_to_end(&mut extracted)
+            .unwrap();
+        let expected = test::read_fixture(
+            "symbols/integration.pdb/0C1033F78632492E91C6C314B72E1920ffffffff/integration.pdb",
+        );
+        assert_eq!(extracted, expected);
+    }
+
+    /// HEAD on `.pd_` returns the right headers without a body.
+    #[tokio::test]
+    async fn test_proxy_compressed_head() {
+        test::setup();
+
+        let (_srv, source) = test::symbol_server();
+        let server = test::server_with_config(|config| {
+            config.symstore_proxy = true;
+            config.compressed_proxy = true;
+            config.sources = Arc::from([source]);
+        });
+
+        let response = Client::new()
+            .head(server.url(
+                "/proxy/integration.pd_/0C1033F78632492E91C6C314B72E1920ffffffff/integration.pd_",
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|h| h.to_str().ok()),
+            Some("application/vnd.ms-cab-compressed"),
+        );
+        let len: usize = response
+            .headers()
+            .get("content-length")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(len > 0);
+        let body = response.bytes().await.unwrap();
+        assert!(body.is_empty(), "HEAD response must have empty body");
     }
 }

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -277,6 +277,31 @@ impl RequestService {
         self.inner.objects.fetch(handle).await
     }
 
+    /// Fetches the object given by the [`ObjectMetaHandle`] in a Microsoft-style compressed
+    /// (CAB-wrapped) form, suitable for direct return on `.pd_` / `.dl_` / `.ex_` proxy
+    /// requests.
+    ///
+    /// Returns the upstream-compressed bytes byte-identically when available
+    /// (`raw_compressed` cache), otherwise synthesizes a fresh CAB (MSZIP) envelope around
+    /// the cached decompressed object (`cab_synth` cache). Returns
+    /// [`CacheError::NotFound`] when the `compressed_proxy` feature is not enabled or
+    /// when the underlying object can't be located.
+    ///
+    /// `inner_filename` is the uncompressed filename embedded in the CAB header (e.g.
+    /// `foo.pdb`).
+    ///
+    /// [`CacheError::NotFound`]: symbolicator_service::caching::CacheError::NotFound
+    pub async fn fetch_compressed_object(
+        &self,
+        handle: Arc<ObjectMetaHandle>,
+        inner_filename: &str,
+    ) -> CacheContents<symbolic::common::ByteView<'static>> {
+        self.inner
+            .objects
+            .fetch_compressed(handle, inner_filename)
+            .await
+    }
+
     /// Creates a new request to symbolicate stacktraces.
     ///
     /// Returns an `Err` if the [`RequestService`] is already processing the


### PR DESCRIPTION
Symbolicator can ingest Microsoft style compressed symbol files (`.pd_`, `.dl_`, `.ex_`) from upstream symbol servers but cannot serve them on the `/proxy` endpoint. Tools that speak the symsrv protocol (WinDbg, Visual Studio, symchk) request the underscore form and expect a CAB body. This PR adds optional CAB output behind a new `compressed_proxy` config flag, defaulting to off so existing deployments are unchanged.

When the flag is enabled, the proxy serves the underscore form in two ways. If the upstream source delivered a CAB, the bytes are preserved byte for byte in a new `raw_compressed` cache and returned as is. Otherwise a fresh MSZIP CAB is synthesized from the cached object and stored in a new `cab_synth` cache for reuse.

## Changes

- Wire up the new request shape in the proxy handler. Detect the `.pd_` / `.dl_` / `.ex_` leaf, rewrite to the uncompressed form for object lookup, attach the `vnd.ms-cab-compressed` content type on the way out. With the flag off, the underscore form returns 404 so we never accidentally serve decompressed bytes under a misleading filename. (`endpoints/proxy.rs`)

- Preserve upstream CAB bytes during download. `maybe_decompress_file` returns a `DecompressOutcome` that includes the original payload as a sibling tempfile when the source is CAB. The allocation happens only after the CAB magic is matched, so non CAB downloads pay nothing extra. Other compressed formats (gzip, zstd, zlib, zip) are decompressed as before but not preserved, because their bytes cannot honestly be served as `vnd.ms-cab-compressed`. (`download/compression.rs`, `download/fetch_file.rs`, `objects/data_cache.rs`)

- Synthesize CAB on demand for uploads and non CAB upstreams. The new `cab_synth_cache.rs` wraps the cached object in a single folder, single file MSZIP CAB using the `cab` crate writer. The compression runs inside `tokio::task::spawn_blocking` so multi GB inputs do not stall async workers. Results are cached so the cost is paid once per symbol. (`objects/cab_synth_cache.rs`)

- Compose the two paths in `ObjectsActor::fetch_compressed`. Ensure the underlying object is fetched (which populates the upstream mirror as a side effect), look in `raw_compressed` first, fall back to `cab_synth`. Plumb the new caches and the config flag through `ObjectsActor::new` and `RequestService::fetch_compressed_object`. (`objects/mod.rs`, `objects/raw_compressed_cache.rs`, `service.rs`)

- Extend the cache layer with two primitives needed for the above. `Cacher::store_externally` persists a tempfile into the on disk cache from outside the normal `compute` flow, used by the tee path. `Cacher::lookup_only` checks the cache without ever invoking `compute` and without caching negatives, used by the proxy so a `raw_compressed` entry that appears after a first lookup is picked up by the second. (`caching/memory.rs`)

- Register the new caches alongside the existing ones (`raw_compressed`, `cab_synth`) with their version constants, cleanup wiring, and config plumbing. Add the `compressed_proxy: bool` field with a default of false. (`caching/mod.rs`, `caching/config.rs`, `caches/versions.rs`, `caching/cleanup.rs`, `config.rs`, `services.rs`)

## Benchmark

CAB synthesis is the only added per request CPU cost. The other paths are filesystem rename or mmap and stay in the microsecond range. Numbers below come from a single threaded run of the cab 0.6 MSZIP writer on Apple Silicon, release build.

| Input size | PDB realistic content | High entropy (worst case) |
| --- | --- | --- |
| 10 MB | 0.17 s (60 MB/s) | 0.29 s (34 MB/s) |
| 100 MB | 1.70 s (59 MB/s) | 2.91 s (34 MB/s) |
| 500 MB | 9.26 s (54 MB/s) | 13.31 s (38 MB/s) |
| 1 GB (extrapolated) | 19 s | 27 s |
| 5 GB (extrapolated) | 95 s | 135 s |

Cost is paid once per `(scope, symbol)` pair on first cache miss. Subsequent hits read from the `cab_synth` mmap in single digit milliseconds. Concurrent requests for the same symbol deduplicate to one compression via `Cacher::compute_memoized`. Memory footprint stays bounded: input is a kernel demand paged mmap, output streams through the writer to a tempfile, DEFLATE state fits in a few hundred KB. With the flag off, the codepath is bit for bit identical to before.