### PR TITLE
feat(native): Allow limiting size of compressed debug file sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- (native) Added a config setting `object_file_max_decompressed_section_size` to limit
+  the decompressed sizes of compressed sections during debug file parsing. The default
+  value is 4GiB. ([#1965](https://github.com/getsentry/symbolicator/pull/1965))
+
 ## 26.5.2
 
 ### Internal Changes 🔧

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728ee0b430d939eebd0c80ae35af32d8bd85fc8352dc6def44f5d432945f9c4e"
+checksum = "4d09200f6dedc8ec17cad4c67744035010c93da8337a6bc88086b423239523d5"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4655,9 +4655,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e195bf5ac1cb706a184abbe677d6c761880dce1b90e6aaa469fff4494bee799b"
+checksum = "f15118d9c452e9e00101ce8a8f63d9d89083350321d89e9274e5a8c99c35983a"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4666,9 +4666,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c30da69ccd7ab2780ce5309791f3cd2ef9716262c07a0a29096226d4235a979"
+checksum = "48ecf78a590c8c47816b4a3208200b3c810805c4e1cdfcab50dcdca321f6127e"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4679,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798d435a1b31dad4b5e7e82a6d9463cd3aaa508d70f3a7366eaf5d58ca2ef2fc"
+checksum = "c311b4e0b7b76c6915969198ca60c24d1ba5a4e503edc128e2fe4fcedd66a222"
 dependencies = [
  "debugid",
  "elementtree",
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1245acf80236b4a0d99e9216532102a1670950e79c70b980b607c2040966e83d"
+checksum = "3b6ca44d5562961fb4dc6883a2c308feda65a55c3b2e8db52baa073f9d28de04"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -4725,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111bd3b91a9c4bf40f358d16fbe78b1345911b2dc80fa3fdca3d360019e0e637"
+checksum = "6a9d46acccec5746a61f575d3cf65a98d9f79330e10a7d5043e90e5a0b43c1db"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4737,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456cc8f7fce011b397d20ab686939ce9d98dfc763cc54ea9a8f489f1968454e7"
+checksum = "947106c8838d2c8cac3b7bfc88b53b69c3e233c0af0072d833f5300446bb87c9"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4753,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d50334f89f8a265994f40f629403e857ea26046fd69c1c42e104994cbf4eb3"
+checksum = "f92f7131d6192d1e823a78d754f5f7e63764b5063cb81bb5287250aed9e6dcbb"
 dependencies = [
  "itertools 0.14.0",
  "js-source-scopes",
@@ -4768,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "13.1.1"
+version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e091ef4476cb9322d1f96cb69499848c20d31da3128ed609dfc3f71170c14"
+checksum = "304289acb70387bb78fc40c986174967505b6ef885888f259e96a0af43265bc3"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ serde_yaml = "0.9.14"
 sha-1 = "0.10.0"
 sha2 = "0.10.6"
 sketches-ddsketch = "0.3.0"
-symbolic = "13.1.1"
+symbolic = "13.2.0"
 symbolicator-crash = { path = "crates/symbolicator-crash" }
 symbolicator-js = { path = "crates/symbolicator-js" }
 symbolicator-native = { path = "crates/symbolicator-native" }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -334,6 +334,7 @@ mod tests {
             shared_cache.clone(),
             downloader.clone(),
             source_index_svc.clone(),
+            Default::default(),
         );
         let bitcode = BitcodeService::new(
             caches.auxdifs,

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use sentry::types::Dsn;
 use serde::{Deserialize, Deserializer, de};
+use symbolic::debuginfo::ParseObjectOptions;
 use tracing::level_filters::LevelFilter;
 
 use symbolicator_sources::SourceConfig;
@@ -532,6 +533,11 @@ pub struct Config {
     /// This applies to the `/symbolicate`, `/symbolicate-any`, `/symbolicate-js`,
     /// and `/symbolicate-jvm` endpoints.
     pub symbolicate_body_max_bytes: usize,
+
+    /// Maximum decompressed size of compressed sections in debug files.
+    ///
+    /// Defaults to 4GiB
+    pub object_file_max_decompressed_section_size: Option<usize>,
 }
 
 impl Config {
@@ -548,6 +554,12 @@ impl Config {
 
     pub fn default_sources(&self) -> Arc<[SourceConfig]> {
         self.sources.clone()
+    }
+
+    pub fn parse_object_options(&self) -> ParseObjectOptions {
+        let mut opts = ParseObjectOptions::default();
+        opts.max_decompressed_section_size = self.object_file_max_decompressed_section_size;
+        opts
     }
 }
 
@@ -620,10 +632,11 @@ impl Default for Config {
             propagate_traces: true,
             // We currently accept 200MiB minidumps in Sentry. This allows for that size
             // plus some extra for the rest of the request.
-            crash_file_body_max_bytes: 250 * 1024 * 1024,
+            crash_file_body_max_bytes: 250 << 20,
             // We allow profiles up to 50MiB in through Relay, This allows for that size
             // plus some extra for the rest of the request.
-            symbolicate_body_max_bytes: 55 * 1024 * 1024,
+            symbolicate_body_max_bytes: 55 << 20,
+            object_file_max_decompressed_section_size: Some(4 << 30),
         }
     }
 }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -632,11 +632,11 @@ impl Default for Config {
             propagate_traces: true,
             // We currently accept 200MiB minidumps in Sentry. This allows for that size
             // plus some extra for the rest of the request.
-            crash_file_body_max_bytes: 250 << 20,
+            crash_file_body_max_bytes: 250 * 1024 * 1024,
             // We allow profiles up to 50MiB in through Relay, This allows for that size
             // plus some extra for the rest of the request.
-            symbolicate_body_max_bytes: 55 << 20,
-            object_file_max_decompressed_section_size: Some(4 << 30),
+            symbolicate_body_max_bytes: 55 * 1024 * 1024,
+            object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
         }
     }
 }

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -9,7 +9,7 @@
 use std::cmp;
 use std::fmt;
 use std::io;
-use std::sync::{LazyLock, Arc};
+use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use symbolic::common::SelfCell;
@@ -27,34 +27,33 @@ use crate::utils::sentry::ConfigureScope;
 
 use super::meta_cache::FetchFileMetaRequest;
 
-static PARSE_OBJECT_OPTIONS: LazyLock<ParseObjectOptions> = LazyLock::new(|| {
-    let mut options = ParseObjectOptions::default();
-    // Limit decompressed debug file section size to 4GiB.
-    options.max_decompressed_section_size = Some(4 << 30);
-    options
-});
-
 /// This requests the file content of a single file at a specific path/url.
 /// The attributes for this are the same as for `FetchFileMetaRequest`, hence the newtype
 #[derive(Clone, Debug)]
 pub(super) struct FetchFileDataRequest(pub(super) FetchFileMetaRequest);
 
 #[derive(Debug)]
-pub struct OwnedObject(SelfCell<ByteView<'static>, Object<'static>>);
+pub struct OwnedObject {
+    inner: SelfCell<ByteView<'static>, Object<'static>>,
+    opts: ParseObjectOptions,
+}
 
 impl OwnedObject {
-    fn parse(byteview: ByteView<'static>) -> CacheContents<OwnedObject> {
-        let obj = SelfCell::try_new(byteview, |p| unsafe {
-            Object::parse_with_opts(&*p, *PARSE_OBJECT_OPTIONS).map_err(CacheError::from_std_error)
+    fn parse(byteview: ByteView<'static>, opts: ParseObjectOptions) -> CacheContents<OwnedObject> {
+        let object = SelfCell::try_new(byteview, |p| unsafe {
+            Object::parse_with_opts(&*p, opts).map_err(CacheError::from_std_error)
         })?;
-        Ok(OwnedObject(obj))
+        Ok(OwnedObject {
+            inner: object,
+            opts,
+        })
     }
 }
 
 impl Clone for OwnedObject {
     fn clone(&self) -> Self {
-        let byteview = self.0.owner().clone();
-        Self::parse(byteview).unwrap()
+        let byteview = self.inner.owner().clone();
+        Self::parse(byteview, self.opts).unwrap()
     }
 }
 
@@ -77,12 +76,12 @@ pub struct ObjectHandle {
 impl ObjectHandle {
     /// Get a reference to the parsed [`Object`].
     pub fn object(&self) -> &Object<'_> {
-        self.object.0.get()
+        self.object.inner.get()
     }
 
     /// Get a reference to the underlying data.
     pub fn data(&self) -> &ByteView<'static> {
-        self.object.0.owner()
+        self.object.inner.owner()
     }
 }
 
@@ -125,6 +124,7 @@ async fn fetch_object_file(
     object_id: &ObjectId,
     file_id: RemoteFile,
     downloader: Arc<DownloadService>,
+    opts: ParseObjectOptions,
     temp_file: &mut NamedTempFile,
 ) -> CacheContents {
     sentry::configure_scope(|scope| {
@@ -138,7 +138,7 @@ async fn fetch_object_file(
     // multi-arch files (e.g. FatMach), we parse as Archive and try to
     // extract the wanted file.
     let view = ByteView::map_file_ref(temp_file.as_file())?;
-    let archive = match Archive::parse_with_opts(&view, *PARSE_OBJECT_OPTIONS) {
+    let archive = match Archive::parse_with_opts(&view, opts) {
         Ok(archive) => archive,
         Err(e) => return Err(CacheError::Malformed(e.to_string())),
     };
@@ -207,26 +207,45 @@ impl CacheItemRequest for FetchFileDataRequest {
     const VERSIONS: CacheVersions = OBJECTS_CACHE_VERSIONS;
 
     fn compute<'a>(&'a self, temp_file: &'a mut NamedTempFile) -> BoxFuture<'a, CacheContents> {
+        let Self(FetchFileMetaRequest {
+            scope,
+            file_source,
+            object_id,
+            opts,
+            data_cache: _,
+            download_svc,
+        }) = self;
+
         tracing::trace!(
             "Fetching file data for {}",
-            CacheKey::from_scoped_file(&self.0.scope, &self.0.file_source)
+            CacheKey::from_scoped_file(scope, file_source)
         );
         Box::pin(fetch_object_file(
-            &self.0.object_id,
-            self.0.file_source.clone(),
-            self.0.download_svc.clone(),
+            object_id,
+            file_source.clone(),
+            download_svc.clone(),
+            *opts,
             temp_file,
         ))
     }
 
     fn load(&self, data: ByteView<'static>) -> CacheContents<Self::Item> {
-        let object = OwnedObject::parse(data)?;
+        let Self(FetchFileMetaRequest {
+            scope,
+            file_source,
+            object_id,
+            opts,
+            data_cache: _,
+            download_svc: _,
+        }) = self;
+
+        let object = OwnedObject::parse(data, *opts)?;
         let object_handle = ObjectHandle {
-            object_id: self.0.object_id.clone(),
+            object_id: object_id.clone(),
             object,
 
-            scope: self.0.scope.clone(),
-            cache_key: CacheKey::from_scoped_file(&self.0.scope, &self.0.file_source),
+            scope: scope.clone(),
+            cache_key: CacheKey::from_scoped_file(scope, file_source),
         };
 
         // FIXME(swatinem): This `configure_scope` call happens in a spawned/deduplicated
@@ -309,6 +328,7 @@ mod tests {
             Default::default(),
             download_svc,
             source_index_svc,
+            Default::default(),
         )
     }
 

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -40,13 +40,10 @@ pub struct OwnedObject {
 
 impl OwnedObject {
     fn parse(byteview: ByteView<'static>, opts: ParseObjectOptions) -> CacheContents<OwnedObject> {
-        let object = SelfCell::try_new(byteview, |p| unsafe {
+        let inner = SelfCell::try_new(byteview, |p| unsafe {
             Object::parse_with_opts(&*p, opts).map_err(CacheError::from_std_error)
         })?;
-        Ok(OwnedObject {
-            inner: object,
-            opts,
-        })
+        Ok(OwnedObject { inner, opts })
     }
 }
 

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -9,14 +9,14 @@
 use std::cmp;
 use std::fmt;
 use std::io;
-use std::sync::Arc;
+use std::sync::{LazyLock, Arc};
 
 use futures::future::BoxFuture;
 use symbolic::common::SelfCell;
 use tempfile::NamedTempFile;
 
 use symbolic::common::ByteView;
-use symbolic::debuginfo::{Archive, Object};
+use symbolic::debuginfo::{Archive, Object, ParseObjectOptions};
 use symbolicator_sources::{ObjectId, RemoteFile};
 
 use crate::caches::versions::{CacheVersions, OBJECTS_CACHE_VERSIONS};
@@ -26,6 +26,13 @@ use crate::types::Scope;
 use crate::utils::sentry::ConfigureScope;
 
 use super::meta_cache::FetchFileMetaRequest;
+
+static PARSE_OBJECT_OPTIONS: LazyLock<ParseObjectOptions> = LazyLock::new(|| {
+    let mut options = ParseObjectOptions::default();
+    // Limit decompressed debug file section size to 4GiB.
+    options.max_decompressed_section_size = Some(4 << 30);
+    options
+});
 
 /// This requests the file content of a single file at a specific path/url.
 /// The attributes for this are the same as for `FetchFileMetaRequest`, hence the newtype
@@ -38,7 +45,7 @@ pub struct OwnedObject(SelfCell<ByteView<'static>, Object<'static>>);
 impl OwnedObject {
     fn parse(byteview: ByteView<'static>) -> CacheContents<OwnedObject> {
         let obj = SelfCell::try_new(byteview, |p| unsafe {
-            Object::parse(&*p).map_err(CacheError::from_std_error)
+            Object::parse_with_opts(&*p, *PARSE_OBJECT_OPTIONS).map_err(CacheError::from_std_error)
         })?;
         Ok(OwnedObject(obj))
     }
@@ -131,7 +138,7 @@ async fn fetch_object_file(
     // multi-arch files (e.g. FatMach), we parse as Archive and try to
     // extract the wanted file.
     let view = ByteView::map_file_ref(temp_file.as_file())?;
-    let archive = match Archive::parse(&view) {
+    let archive = match Archive::parse_with_opts(&view, *PARSE_OBJECT_OPTIONS) {
         Ok(archive) => archive,
         Err(e) => return Err(CacheError::Malformed(e.to_string())),
     };

--- a/crates/symbolicator-service/src/objects/meta_cache.rs
+++ b/crates/symbolicator-service/src/objects/meta_cache.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 
 use symbolic::common::ByteView;
+use symbolic::debuginfo::ParseObjectOptions;
 use symbolicator_sources::{ObjectId, RemoteFile};
 use tempfile::NamedTempFile;
 
@@ -32,6 +33,7 @@ pub(super) struct FetchFileMetaRequest {
     /// Source-type specific attributes.
     pub(super) file_source: RemoteFile,
     pub(super) object_id: ObjectId,
+    pub(super) opts: ParseObjectOptions,
 
     // XXX: This kind of state is not request data. We should find a different way to get this into
     // `<FetchFileMetaRequest as CacheItemRequest>::compute`, e.g. make the Cacher hold arbitrary

--- a/crates/symbolicator-service/src/objects/mod.rs
+++ b/crates/symbolicator-service/src/objects/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use futures::future;
 use sentry::{Hub, SentryFutureExt};
 
+use symbolic::debuginfo::ParseObjectOptions;
 use symbolicator_sources::{FileType, ObjectId, RemoteFile, RemoteFileUri, SourceConfig, SourceId};
 
 use crate::caching::{Cache, CacheContents, CacheError, CacheKey, Cacher, SharedCacheRef};
@@ -85,6 +86,7 @@ pub struct ObjectsActor {
     data_cache: Arc<Cacher<FetchFileDataRequest>>,
     download_svc: Arc<DownloadService>,
     source_index_svc: Arc<SourceIndexService>,
+    opts: ParseObjectOptions,
 }
 
 impl ObjectsActor {
@@ -94,12 +96,14 @@ impl ObjectsActor {
         shared_cache: SharedCacheRef,
         download_svc: Arc<DownloadService>,
         source_index_svc: Arc<SourceIndexService>,
+        opts: ParseObjectOptions,
     ) -> Self {
         ObjectsActor {
             meta_cache: Arc::new(Cacher::new(meta_cache, Arc::clone(&shared_cache))),
             data_cache: Arc::new(Cacher::new(data_cache, Arc::clone(&shared_cache))),
             download_svc,
             source_index_svc,
+            opts,
         }
     }
 
@@ -119,6 +123,7 @@ impl ObjectsActor {
             object_id: file_handle.object_id.clone(),
             data_cache: self.data_cache.clone(),
             download_svc: self.download_svc.clone(),
+            opts: self.opts,
         });
 
         self.data_cache
@@ -186,6 +191,7 @@ impl ObjectsActor {
                 object_id: identifier.clone(),
                 data_cache: self.data_cache.clone(),
                 download_svc: self.download_svc.clone(),
+                opts: self.opts,
             };
 
             async move {

--- a/crates/symbolicator-service/src/services.rs
+++ b/crates/symbolicator-service/src/services.rs
@@ -55,6 +55,7 @@ impl SharedServices {
             shared_cache.clone(),
             download_svc.clone(),
             source_index_svc.clone(),
+            config.parse_object_options(),
         );
 
         Ok(Self {


### PR DESCRIPTION
This bumps `symbolic` to 13.2.0, giving us the ability to limit the sizes of decompressed sections in ELF files. It adds a new config setting `object_file_max_decompressed_section_size` to configure this behavior. The default is 4GiB.

Closes INGEST-949.