### PR TITLE
ci: Switch to gcloud storage for gocd uploads

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload gocd deployment assets
         run: |
-          gsutil -m cp /tmp/debug-info/symbolicator*.zip "gs://dicd-team-devinfra-cd--symbolicator/difs/${{ github.sha }}/"
+          gcloud storage cp /tmp/debug-info/symbolicator*.zip "gs://dicd-team-devinfra-cd--symbolicator/difs/${{ github.sha }}/"
 
   prepare-self-hosted-end-to-end:
     needs: [build-binaries]

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -195,6 +195,10 @@ jobs:
           merge-multiple: true
 
       - name: Upload gocd deployment assets
+        env:
+          # the upload SA has no delete perms; disable parallel composite uploads
+          # since their chunk cleanup would fail on delete
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: false
         run: |
           gcloud storage cp /tmp/debug-info/symbolicator*.zip "gs://dicd-team-devinfra-cd--symbolicator/difs/${{ github.sha }}/"
 


### PR DESCRIPTION
Adapted from https://github.com/getsentry/relay/pull/6103.