### PR TITLE
fix(api): Reduce inflight requests on panic

### DIFF
--- a/crates/symbolicator-service/src/caching/fs.rs
+++ b/crates/symbolicator-service/src/caching/fs.rs
@@ -1,8 +1,6 @@
 use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::AtomicIsize;
 use std::time::{Duration, Instant, SystemTime};
 
 use filetime::FileTime;
@@ -11,6 +9,7 @@ use tempfile::NamedTempFile;
 
 use crate::config::{CacheConfig, Config};
 use crate::types::Scope;
+use crate::utils::defer::MaxDeferCounter;
 
 use super::cache_error::cache_contents_from_bytes;
 use super::{CacheContents, CacheEntry, CacheError, CacheName, Metadata};
@@ -55,8 +54,8 @@ pub struct Cache {
     /// Options intended to be user-configurable.
     cache_config: CacheConfig,
 
-    /// The maximum number of lazy refreshes of this cache.
-    max_lazy_refreshes: Arc<AtomicIsize>,
+    /// Limits the maximum number of concurrent lazy refreshes of this cache.
+    lazy_refreshes: MaxDeferCounter,
 
     /// The capacity (in bytes) of the in-memory cache.
     pub(super) in_memory_capacity: u64,
@@ -67,7 +66,7 @@ impl Cache {
         name: CacheName,
         config: &Config,
         cache_config: CacheConfig,
-        max_lazy_refreshes: Arc<AtomicIsize>,
+        lazy_refreshes: MaxDeferCounter,
         in_memory_capacity: u64,
     ) -> io::Result<Self> {
         let tmp_dir = config.cache_dir("tmp");
@@ -83,7 +82,7 @@ impl Cache {
             tmp_dir,
             start_time: SystemTime::now(),
             cache_config,
-            max_lazy_refreshes,
+            lazy_refreshes,
             in_memory_capacity,
         })
     }
@@ -96,8 +95,8 @@ impl Cache {
         self.cache_dir.as_deref()
     }
 
-    pub fn max_lazy_refreshes(&self) -> Arc<AtomicIsize> {
-        self.max_lazy_refreshes.clone()
+    pub fn lazy_refresh(&self) -> &MaxDeferCounter {
+        &self.lazy_refreshes
     }
 
     /// Validate cache expiration of path.

--- a/crates/symbolicator-service/src/caching/memory.rs
+++ b/crates/symbolicator-service/src/caching/memory.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -549,20 +548,16 @@ impl<T: CacheItemRequest> Cacher<T> {
             return;
         }
 
-        // We count down towards zero, and if we reach or surpass it, we will stop here.
-        let max_lazy_refreshes = self.config.max_lazy_refreshes();
-        if max_lazy_refreshes.fetch_sub(1, Ordering::Relaxed) <= 0 {
-            max_lazy_refreshes.fetch_add(1, Ordering::Relaxed);
-
+        let Some(lazy_refresh_token) = self.config.lazy_refresh().try_incr() else {
             metric!(counter("caches.lazy_limit_hit") += 1, "cache" => name.as_str());
             return;
-        }
+        };
 
         let done_token = {
             let key = cache_key.clone();
             let refreshes = Arc::clone(&self.refreshes);
             defer(move || {
-                max_lazy_refreshes.fetch_add(1, Ordering::Relaxed);
+                drop(lazy_refresh_token);
                 refreshes.lock().unwrap().remove(&key);
             })
         };
@@ -578,7 +573,7 @@ impl<T: CacheItemRequest> Cacher<T> {
 
         let this = self.clone();
         let task = async move {
-            let _done_token = done_token; // move into the future
+            let _done_token = done_token;
 
             let span = sentry::configure_scope(|scope| scope.get_span());
             let ctx = sentry::TransactionContext::continue_from_span(

--- a/crates/symbolicator-service/src/caching/mod.rs
+++ b/crates/symbolicator-service/src/caching/mod.rs
@@ -151,10 +151,9 @@
 //! the cache item itself is being computed / loaded.
 
 use std::io;
-use std::sync::Arc;
-use std::sync::atomic::AtomicIsize;
 
 use crate::config::Config;
+use crate::utils::defer::MaxDeferCounter;
 
 mod cache_error;
 mod cache_key;
@@ -209,12 +208,10 @@ impl Caches {
         // The minimum value here is clamped to 1, as it would otherwise completely disable lazy
         // re-generation. We might as well decide to hard `panic!` on startup if users have
         // misconfigured this instead of silently correcting it to a value that actually makes sense.
-        let max_lazy_redownloads = Arc::new(AtomicIsize::new(
-            config.caches.downloaded.max_lazy_redownloads.max(1),
-        ));
-        let max_lazy_recomputations = Arc::new(AtomicIsize::new(
-            config.caches.derived.max_lazy_recomputations.max(1),
-        ));
+        let max_lazy_redownloads = config.caches.downloaded.max_lazy_redownloads.max(1) as usize;
+        let max_lazy_recomputations = config.caches.derived.max_lazy_recomputations.max(1) as usize;
+        let lazy_redownloads = MaxDeferCounter::new(Some(max_lazy_redownloads));
+        let lazy_recomputations = MaxDeferCounter::new(Some(max_lazy_recomputations));
 
         // NOTE: A small cache item with all its structures is around ~100 bytes, which gives us an
         // approximate upper bound of items in the cache.
@@ -229,84 +226,84 @@ impl Caches {
                 CacheName::Objects,
                 config,
                 config.caches.downloaded.into(),
-                max_lazy_redownloads.clone(),
+                lazy_redownloads.clone(),
                 default_cap,
             )?,
             object_meta: Cache::from_config(
                 CacheName::ObjectMeta,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations.clone(),
+                lazy_recomputations.clone(),
                 in_memory.object_meta_capacity,
             )?,
             auxdifs: Cache::from_config(
                 CacheName::Auxdifs,
                 config,
                 config.caches.downloaded.into(),
-                max_lazy_redownloads.clone(),
+                lazy_redownloads.clone(),
                 default_cap,
             )?,
             il2cpp: Cache::from_config(
                 CacheName::Il2cpp,
                 config,
                 config.caches.downloaded.into(),
-                max_lazy_redownloads.clone(),
+                lazy_redownloads.clone(),
                 default_cap,
             )?,
             symcaches: Cache::from_config(
                 CacheName::Symcaches,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations.clone(),
+                lazy_recomputations.clone(),
                 default_cap,
             )?,
             cficaches: Cache::from_config(
                 CacheName::Cficaches,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations.clone(),
+                lazy_recomputations.clone(),
                 in_memory.cficaches_capacity,
             )?,
             ppdb_caches: Cache::from_config(
                 CacheName::PpdbCaches,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations.clone(),
+                lazy_recomputations.clone(),
                 default_cap,
             )?,
             sourcemap_caches: Cache::from_config(
                 CacheName::SourceMapCaches,
                 config,
                 config.caches.derived.into(),
-                max_lazy_recomputations,
+                lazy_recomputations,
                 default_cap,
             )?,
             sourcefiles: Cache::from_config(
                 CacheName::SourceFiles,
                 config,
                 config.caches.downloaded.into(),
-                max_lazy_redownloads.clone(),
+                lazy_redownloads.clone(),
                 default_cap,
             )?,
             diagnostics: Cache::from_config(
                 CacheName::Diagnostics,
                 config,
                 config.caches.diagnostics.into(),
-                Default::default(),
+                MaxDeferCounter::new(Some(0)),
                 default_cap,
             )?,
             proguard: Cache::from_config(
                 CacheName::Proguard,
                 config,
                 config.caches.downloaded.into(),
-                max_lazy_redownloads.clone(),
+                lazy_redownloads.clone(),
                 default_cap,
             )?,
             source_index: Cache::from_config(
                 CacheName::SourceIndex,
                 config,
                 config.caches.index.into(),
-                max_lazy_redownloads,
+                lazy_redownloads,
                 in_memory.source_index_capacity,
             )?,
         })

--- a/crates/symbolicator-service/src/caching/tests.rs
+++ b/crates/symbolicator-service/src/caching/tests.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
@@ -16,6 +17,7 @@ use crate::caches::{CachePathFormat, CacheVersion, CacheVersions};
 use crate::config::{CacheConfig, CacheConfigs, DerivedCacheConfig, DownloadedCacheConfig};
 use crate::test;
 use crate::types::Scope;
+use crate::utils::defer::MaxDeferCounter;
 
 use super::cache_error::cache_contents_from_bytes;
 use super::fs::metadata_path;
@@ -1045,7 +1047,7 @@ async fn test_cache_fallback() {
         CacheName::Objects,
         &config,
         CacheConfig::from(CacheConfigs::default().derived),
-        Arc::new(AtomicIsize::new(1)),
+        MaxDeferCounter::new(Some(1)),
         1024,
     )
     .unwrap();
@@ -1107,7 +1109,7 @@ async fn test_cache_fallback_notfound() {
         CacheName::Objects,
         &config,
         CacheConfig::from(CacheConfigs::default().derived),
-        Arc::new(AtomicIsize::new(1)),
+        MaxDeferCounter::new(Some(1)),
         1024,
     )
     .unwrap();
@@ -1133,7 +1135,7 @@ async fn test_lazy_computation_limit() {
         CacheName::Objects,
         &config,
         CacheConfig::from(CacheConfigs::default().derived),
-        Arc::new(AtomicIsize::new(1)),
+        MaxDeferCounter::new(Some(1)),
         1024,
     )
     .unwrap();
@@ -1220,7 +1222,7 @@ async fn test_failing_cache_write() {
         CacheName::Objects,
         &config,
         CacheConfig::from(CacheConfigs::default().derived),
-        Arc::new(AtomicIsize::new(1)),
+        MaxDeferCounter::new(Some(1)),
         1024,
     )
     .unwrap();

--- a/crates/symbolicator-service/src/utils/defer.rs
+++ b/crates/symbolicator-service/src/utils/defer.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 /// Guard that runs a closure when dropped.
 ///
 /// The closure must not panic under any circumstance. Since it is called while dropping an item,
@@ -16,4 +19,169 @@ impl<F: FnOnce()> Drop for DeferGuard<F> {
 /// run it when dropped.
 pub fn defer<F: FnOnce()>(f: F) -> DeferGuard<F> {
     DeferGuard(Some(f))
+}
+
+/// A shared counter similar to a semaphore.
+///
+/// The counter can be temporarily incremented and is automatically decremented again.
+#[derive(Debug, Clone)]
+pub struct DeferCounter(Arc<AtomicUsize>);
+
+impl DeferCounter {
+    /// Creates a new [`DeferCounter`] with a value of `0`.
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicUsize::new(0)))
+    }
+
+    /// Returns the current value of the counter.
+    pub fn value(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    /// Increments the counter and returns a [`DeferCounterToken`].
+    ///
+    /// When the returned token is dropped the counter will be decremented.
+    pub fn incr(&self) -> DeferCounterToken {
+        let counter = Some(self.clone());
+        let _ = self.0.fetch_add(1, Ordering::Relaxed);
+        DeferCounterToken { counter }
+    }
+
+    /// Attempts to increment the counter without exceeding `max`.
+    ///
+    /// Returns `None` if the counter is already at or above `max`.
+    /// A `None` max, will always increment the counter.
+    ///
+    /// When the returned token is dropped the counter will be decremented.
+    pub fn try_incr(&self, max: Option<usize>) -> Option<DeferCounterToken> {
+        let Some(max) = max else {
+            return Some(self.incr());
+        };
+
+        self.0
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                (value < max).then_some(value + 1)
+            })
+            .ok()?;
+
+        let counter = Some(self.clone());
+        Some(DeferCounterToken { counter })
+    }
+}
+
+impl Default for DeferCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A token which automatically decrements a [`DeferCounter`] on drop.
+pub struct DeferCounterToken {
+    counter: Option<DeferCounter>,
+}
+
+impl Drop for DeferCounterToken {
+    fn drop(&mut self) {
+        if let Some(counter) = self.counter.take() {
+            // Sanity check we should never be here and already be at a `0` count; each increment
+            // must only be followed by a single decrement.
+            debug_assert_ne!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            counter.0.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// A [`DeferCounter`] which cannot be incremented past a specified maximum.
+#[derive(Debug, Clone)]
+pub struct MaxDeferCounter {
+    max: Option<usize>,
+    counter: DeferCounter,
+}
+
+impl MaxDeferCounter {
+    /// Creates a new [`MaxDeferCounter`] with the specified `max`.
+    ///
+    /// A `None` maximum will always allow incrementing the counter.
+    pub fn new(max: Option<usize>) -> Self {
+        Self {
+            max,
+            counter: DeferCounter::new(),
+        }
+    }
+
+    /// Returns the current value of the counter.
+    pub fn value(&self) -> usize {
+        self.counter.value()
+    }
+
+    /// Attempts to increment the counter without exceeding the configured `max`.
+    ///
+    /// Returns `None` if the counter is already at or above `max`.
+    ///
+    /// When the returned token is dropped the counter will be decremented.
+    pub fn try_incr(&self) -> Option<DeferCounterToken> {
+        self.counter.try_incr(self.max)
+    }
+}
+
+impl Default for MaxDeferCounter {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeferCounter, MaxDeferCounter};
+
+    #[test]
+    fn test_defer_counter() {
+        let counter = DeferCounter::new();
+        assert_eq!(counter.value(), 0);
+
+        let token = counter.incr();
+        assert_eq!(counter.value(), 1);
+
+        drop(token);
+        assert_eq!(counter.value(), 0);
+    }
+
+    #[test]
+    fn test_defer_counter_try_incr() {
+        let counter = DeferCounter::new();
+
+        let token = counter.try_incr(Some(1)).unwrap();
+        assert_eq!(counter.value(), 1);
+
+        assert!(counter.try_incr(Some(1)).is_none());
+
+        drop(token);
+        assert_eq!(counter.value(), 0);
+        let _ = counter.try_incr(Some(1)).unwrap();
+    }
+
+    #[test]
+    fn test_max_defer_counter() {
+        let counter = MaxDeferCounter::new(Some(1));
+
+        let token = counter.try_incr().unwrap();
+        assert_eq!(counter.value(), 1);
+
+        assert!(counter.try_incr().is_none());
+
+        drop(token);
+        assert_eq!(counter.value(), 0);
+        let _ = counter.try_incr().unwrap();
+    }
+
+    #[test]
+    fn test_max_defer_counter_none() {
+        let counter = MaxDeferCounter::new(None);
+
+        for _ in 0..u16::MAX {
+            std::mem::forget(counter.try_incr().unwrap());
+        }
+
+        assert_eq!(counter.value(), u16::MAX as usize);
+    }
 }

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -12,7 +12,6 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -37,7 +36,7 @@ use symbolicator_service::metric;
 use symbolicator_service::objects::ObjectsActor;
 use symbolicator_service::services::SharedServices;
 use symbolicator_service::types::{FrameOrder, Platform};
-use symbolicator_service::utils::defer::defer;
+use symbolicator_service::utils::defer::{MaxDeferCounter, defer};
 use symbolicator_service::utils::futures::{m, measure};
 use symbolicator_service::utils::sentry::ConfigureScope;
 use symbolicator_sources::SourceConfig;
@@ -199,8 +198,7 @@ struct RequestServiceInner {
 
     cpu_pool: tokio::runtime::Handle,
     requests: ComputationMap,
-    max_concurrent_requests: Option<usize>,
-    current_requests: Arc<AtomicUsize>,
+    current_requests: MaxDeferCounter,
     symbolication_taskmon: tokio_metrics::TaskMonitor,
 }
 
@@ -249,8 +247,7 @@ impl RequestService {
 
             cpu_pool,
             requests: Arc::new(Mutex::new(BTreeMap::new())),
-            max_concurrent_requests,
-            current_requests: Arc::new(AtomicUsize::new(0)),
+            current_requests: MaxDeferCounter::new(max_concurrent_requests),
             symbolication_taskmon,
         };
 
@@ -408,18 +405,15 @@ impl RequestService {
 
         // Assume that there are no UUID4 collisions in practice.
         let requests = Arc::clone(&self.inner.requests);
-        let current_requests = Arc::clone(&self.inner.current_requests);
 
-        let num_requests = current_requests.load(Ordering::Relaxed);
+        let num_requests = self.inner.current_requests.value();
         metric!(gauge("requests.in_flight") = num_requests as f64);
 
-        // Reject the request if `requests` already contains `max_concurrent_requests` elements.
-        if let Some(max_concurrent_requests) = self.inner.max_concurrent_requests
-            && num_requests >= max_concurrent_requests
-        {
+        // Reject the request if `max_concurrent_requests` in-flight requests are already running.
+        let current_request = self.inner.current_requests.try_incr().ok_or_else(|| {
             metric!(counter("requests.rejected") += 1);
-            return Err(MaxRequestsError);
-        }
+            MaxRequestsError
+        })?;
 
         // Using `task_name` as the tag should be fine, there is only a small
         // fixed number of them.
@@ -430,7 +424,7 @@ impl RequestService {
             .lock()
             .unwrap()
             .insert(request_id, receiver.shared());
-        current_requests.fetch_add(1, Ordering::Relaxed);
+
         let token = defer(move || {
             requests.lock().unwrap().remove(&request_id);
         });
@@ -489,7 +483,7 @@ impl RequestService {
 
             // We stop counting the request as an in-flight request at this point, even though
             // it will stay in the `requests` map for another 90s.
-            current_requests.fetch_sub(1, Ordering::Relaxed);
+            drop(current_request);
 
             // Using `task_name` as the tag should be fine, there is only a small
             // fixed number of them.


### PR DESCRIPTION
The inflight requests counter would fail to be decrement on panic. This fixes the issue, but also introduces a new deferred primitive to make accidentally forgetting impossible in the type system.

Fixes: INGEST-969

