### PR TITLE
ref(auth): Allow Sentry requests to auth with Cookies

### DIFF
--- a/crates/symbolicator-js/src/api_lookup.rs
+++ b/crates/symbolicator-js/src/api_lookup.rs
@@ -143,7 +143,7 @@ impl SentryLookupApi {
 
         let query = SearchQuery {
             index_url: lookup_url,
-            token: source.token.clone(),
+            credentials: source.credentials.clone(),
         };
 
         metric!(counter("source.sentry.js_lookup.access") += 1);

--- a/crates/symbolicator-js/tests/integration/sourcemap.rs
+++ b/crates/symbolicator-js/tests/integration/sourcemap.rs
@@ -776,7 +776,7 @@ async fn test_manual_processing() {
             "https://sentry.io/api/0/projects/{org}/{project}/artifact-lookup/"
         ))
         .unwrap(),
-        token: SentryToken(token.to_string()),
+        credentials: SentryToken(token.to_string()).into(),
     };
 
     let request = make_js_request(source, frames, modules, release, dist);

--- a/crates/symbolicator-native/tests/integration/e2e.rs
+++ b/crates/symbolicator-native/tests/integration/e2e.rs
@@ -408,7 +408,7 @@ async fn test_unreachable_bucket() {
                 SourceConfig::Sentry(Arc::new(SentrySourceConfig {
                     id: SourceId::new(format!("broken-{ty}-{code}")),
                     url: hitcounter.url(&format!("respond_statuscode/{code}")),
-                    token: SentryToken("123abc".to_owned()),
+                    credentials: SentryToken("123abc".to_owned()).into(),
                 }))
             };
 

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -6,13 +6,14 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use reqwest::RequestBuilder;
 use sentry::SentryFutureExt;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use url::Url;
 
 use symbolicator_sources::{
-    ObjectId, RemoteFile, SentryFileId, SentryRemoteFile, SentrySourceConfig, SentryToken,
+    ObjectId, RemoteFile, SentryCredentials, SentryFileId, SentryRemoteFile, SentrySourceConfig,
 };
 
 use super::{Destination, FileType};
@@ -77,7 +78,7 @@ impl SentryFileType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SearchQuery {
     pub index_url: Url,
-    pub token: SentryToken,
+    pub credentials: SentryCredentials,
 }
 
 /// An LRU Cache for Sentry DIF (Native Debug Files) lookups.
@@ -132,9 +133,7 @@ impl SentryDownloader {
     where
         T: DeserializeOwned,
     {
-        let mut request = client
-            .get(query.index_url.clone())
-            .bearer_auth(&query.token.0)
+        let mut request = authenticate(client.get(query.index_url.clone()), &query.credentials)
             .header("Accept-Encoding", "identity");
 
         if propagate_traces && let Some(span) = sentry::configure_scope(|scope| scope.get_span()) {
@@ -190,7 +189,7 @@ impl SentryDownloader {
         // for every file type or combination of file types we need.
         let query = SearchQuery {
             index_url,
-            token: source.token.clone(),
+            credentials: source.credentials.clone(),
         };
 
         metric!(counter("source.sentry.dif_query.access") += 1);
@@ -262,7 +261,7 @@ impl SentryDownloader {
 
         let mut builder = self.client.get(url);
         if file_source.use_credentials() {
-            builder = builder.bearer_auth(&file_source.source.token.0);
+            builder = authenticate(builder, &file_source.source.credentials);
         }
 
         super::download_reqwest(
@@ -276,18 +275,25 @@ impl SentryDownloader {
     }
 }
 
+fn authenticate(builder: RequestBuilder, credentials: &SentryCredentials) -> RequestBuilder {
+    match credentials {
+        SentryCredentials::Token(token) => builder.bearer_auth(&token.0),
+        SentryCredentials::Cookies(cookies) => builder.header(reqwest::header::COOKIE, &cookies.0),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use symbolicator_sources::{RemoteFileUri, SourceId};
+    use symbolicator_sources::{RemoteFileUri, SentryToken, SourceId};
 
     #[test]
     fn test_download_url() {
         let source = SentrySourceConfig {
             id: SourceId::new("test"),
             url: Url::parse("https://example.net/endpoint/").unwrap(),
-            token: SentryToken("token".into()),
+            credentials: SentryToken("token".into()).into(),
         };
         let file_source =
             SentryRemoteFile::new(Arc::new(source), true, SentryFileId("abc123".into()), None);
@@ -300,7 +306,7 @@ mod tests {
         let source = SentrySourceConfig {
             id: SourceId::new("test"),
             url: Url::parse("https://example.net/endpoint/").unwrap(),
-            token: SentryToken("token".to_owned()),
+            credentials: SentryToken("token".to_owned()).into(),
         };
         let file_source =
             SentryRemoteFile::new(Arc::new(source), true, SentryFileId("abc123".into()), None);

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -15,8 +15,9 @@ pub struct SentrySourceConfig {
     /// Absolute URL of the endpoint.
     pub url: Url,
 
-    /// Bearer authorization token.
-    pub token: SentryToken,
+    /// Credentials to use.
+    #[serde(flatten)]
+    pub credentials: SentryCredentials,
 }
 
 /// The Sentry-specific [`RemoteFile`].
@@ -96,13 +97,92 @@ impl fmt::Display for SentryFileId {
     }
 }
 
-/// A sentry authentication token.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+/// Credentials for a Sentry source.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SentryCredentials {
+    /// A bearer authorization token.
+    Token(SentryToken),
+
+    /// A raw Cookie header value for an existing Sentry session.
+    Cookies(SentryCookies),
+}
+
+impl From<SentryToken> for SentryCredentials {
+    fn from(value: SentryToken) -> Self {
+        Self::Token(value)
+    }
+}
+
+impl From<SentryCookies> for SentryCredentials {
+    fn from(value: SentryCookies) -> Self {
+        Self::Cookies(value)
+    }
+}
+
+/// A Sentry authentication token.
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct SentryToken(pub String);
 
 impl fmt::Debug for SentryToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("<sentry token>")
+    }
+}
+
+/// A raw Cookie header value for an existing Sentry session.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct SentryCookies(pub String);
+
+impl fmt::Debug for SentryCookies {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<sentry cookies>")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sentry_source_credentials_token() {
+        let c: SentrySourceConfig = serde_json::from_str(
+            r#"{
+            "id": "foobar",
+            "url": "http://foo.bar",
+            "token": "123"
+}"#,
+        )
+        .unwrap();
+
+        insta::assert_json_snapshot!(c, @r#"
+        {
+          "id": "foobar",
+          "url": "http://foo.bar/",
+          "token": "123"
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_sentry_source_credentialsoken_cookies() {
+        let c: SentrySourceConfig = serde_json::from_str(
+            r#"{
+            "id": "foobar",
+            "url": "http://foo.bar",
+            "cookies": "foo=bar; asd=123"
+}"#,
+        )
+        .unwrap();
+
+        insta::assert_json_snapshot!(c, @r#"
+        {
+          "id": "foobar",
+          "url": "http://foo.bar/",
+          "cookies": "foo=bar; asd=123"
+        }
+        "#);
     }
 }

--- a/crates/symbolicator-sources/src/sources/sentry.rs
+++ b/crates/symbolicator-sources/src/sources/sentry.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sentry_source_credentialsoken_cookies() {
+    fn test_sentry_source_credentials() {
         let c: SentrySourceConfig = serde_json::from_str(
             r#"{
             "id": "foobar",

--- a/crates/symbolicator-test/src/lib.rs
+++ b/crates/symbolicator-test/src/lib.rs
@@ -1,5 +1,3 @@
-//! Helpers for testing the web server and service.
-//!
 //! When writing tests, keep the following points in mind:
 //!
 //!  - In every test, call [`setup`]. This will set up the logger so that all console output
@@ -399,7 +397,7 @@ where
     let source = SentrySourceConfig {
         id: SourceId::new("sentry:project"),
         url: server.url("/lookup"),
-        token: SentryToken(String::new()),
+        credentials: SentryToken(String::new()).into(),
     };
 
     (server, source)
@@ -440,7 +438,7 @@ where
     let source = SentrySourceConfig {
         id: SourceId::new("sentry:project"),
         url: server.url("/files/dsyms/"),
-        token: SentryToken(String::new()),
+        credentials: SentryToken(String::new()).into(),
     };
 
     (server, source)

--- a/crates/symbolicli/README.md
+++ b/crates/symbolicli/README.md
@@ -12,6 +12,13 @@ symbolicli -o <ORG> -p <PROJECT> --auth-token <TOKEN> <EVENT>
 * `<TOKEN>` is a Sentry authentication token that has access to the project;
 * `<EVENT>` is either a local file (minidump or event JSON) or the ID of an event from the Sentry instance.
 
+Instead of an auth token, you can use an existing Sentry session by passing the raw Cookie
+header value from your browser.
+
+```
+symbolicli -o <ORG> -p <PROJECT> --auth-cookies '<COOKIE_HEADER>' <EVENT>
+```
+
 Alternatively, you can run `symbolicli` in offline mode:
 ```
 symbolicli --offline <EVENT>
@@ -34,6 +41,9 @@ The available options are:
 * `url`: The base URL of the sentry instance. Defaults to `https://sentry.io/`.
 * `auth_token`: A Sentry authentication token. This can be overridden with the `SENTRY_AUTH_TOKEN`
   environment variable or the `--auth-token` command line option.
+* `auth_cookies`: A raw Cookie header value from an existing Sentry session. This can be
+  overridden with the `SENTRY_AUTH_COOKIES` environment variable or the `--auth-cookies` command
+  line option.
 * `org`: The default organization for which to process events. This can be overridden with the `--org`
   command line option.
 * `project`: The default project for which to process events. This can be overridden with the `--project`

--- a/crates/symbolicli/src/js_local_source.rs
+++ b/crates/symbolicli/src/js_local_source.rs
@@ -42,7 +42,7 @@ pub fn start_server(path: impl AsRef<Path> + Clone) -> anyhow::Result<SentrySour
     Ok(SentrySourceConfig {
         id: SourceId::new("local"),
         url: source_url,
-        token: SentryToken(String::new()),
+        credentials: SentryToken(String::new()).into(),
     })
 }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -9,6 +9,7 @@ use event::{create_js_symbolication_request, create_native_symbolication_request
 use output::{print_compact, print_pretty};
 use remote::EventKey;
 
+use reqwest::header;
 use settings::{Mode, SymbolsPath};
 use symbolicator_js::SourceMapService;
 use symbolicator_native::SymbolicationActor;
@@ -17,12 +18,11 @@ use symbolicator_service::config::Config;
 use symbolicator_service::services::SharedServices;
 use symbolicator_service::types::Scope;
 use symbolicator_sources::{
-    CommonSourceConfig, DirectoryLayout, FilesystemSourceConfig, SentrySourceConfig, SentryToken,
-    SourceConfig, SourceId,
+    CommonSourceConfig, DirectoryLayout, FilesystemSourceConfig, SentryCredentials,
+    SentrySourceConfig, SourceConfig, SourceId,
 };
 
 use anyhow::{Context, Result};
-use reqwest::header;
 use tracing_subscriber::filter;
 use tracing_subscriber::prelude::*;
 
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
                 ref base_url,
                 ref org,
                 ref project,
-                ref auth_token,
+                ref auth,
                 ..
             } = mode
             else {
@@ -97,10 +97,16 @@ async fn main() -> Result<()> {
             };
 
             let mut headers = header::HeaderMap::new();
-            headers.insert(
-                header::AUTHORIZATION,
-                header::HeaderValue::from_str(&format!("Bearer {auth_token}")).unwrap(),
-            );
+            match auth {
+                SentryCredentials::Token(token) => headers.insert(
+                    header::AUTHORIZATION,
+                    header::HeaderValue::from_str(&format!("Bearer {}", token.0)).unwrap(),
+                ),
+                SentryCredentials::Cookies(cookies) => headers.insert(
+                    header::COOKIE,
+                    header::HeaderValue::from_str(&cookies.0).unwrap(),
+                ),
+            };
 
             let client = reqwest::Client::builder()
                 .default_headers(headers)
@@ -202,13 +208,13 @@ fn prepare_dsym_sources(
         ref org,
         ref project,
         ref base_url,
-        ref auth_token,
+        ref auth,
         ..
     } = mode
     {
         let project_source = SourceConfig::Sentry(Arc::new(SentrySourceConfig {
             id: SourceId::new("sentry:project"),
-            token: SentryToken(auth_token.clone()),
+            credentials: auth.clone(),
             url: base_url
                 .join(&format!("projects/{org}/{project}/files/dsyms/"))
                 .unwrap(),
@@ -246,7 +252,7 @@ fn prepare_sourcemap_source(
             ref org,
             ref project,
             ref base_url,
-            ref auth_token,
+            ref auth,
         } => {
             if local_symbols.is_some() {
                 tracing::warn!("Local symbol source will not be used in online mode");
@@ -254,7 +260,7 @@ fn prepare_sourcemap_source(
 
             Ok(Arc::new(SentrySourceConfig {
                 id: SourceId::new("sentry:project"),
-                token: SentryToken(auth_token.clone()),
+                credentials: auth.clone(),
                 url: base_url
                     .join(&format!("projects/{org}/{project}/artifact-lookup/"))
                     .unwrap(),

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use symbolicator_service::config::{CacheConfigs, Config};
-use symbolicator_sources::{DirectoryLayoutType, SourceConfig};
+use symbolicator_sources::{
+    DirectoryLayoutType, SentryCookies, SentryCredentials, SentryToken, SourceConfig,
+};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, ValueEnum};
@@ -38,15 +40,16 @@ pub enum Mode {
     Online {
         org: String,
         project: String,
-        auth_token: String,
+        auth: SentryCredentials,
         base_url: reqwest::Url,
     },
 }
 
 /// A utility that provides local symbolication of Sentry events.
 ///
-/// A valid auth token needs to be provided via the `--auth-token` option,
-/// the `SENTRY_AUTH_TOKEN` environment variable, or `~/.symboliclirc`.
+/// Provide either a valid auth token or an existing Sentry admin session via
+/// `--auth-token`, `--auth-cookies`, `SENTRY_AUTH_TOKEN`,
+/// `SENTRY_AUTH_COOKIES`, or `~/.symboliclirc`.
 ///
 /// The output format can be controlled with the `--format` option.
 #[derive(Clone, Parser, Debug)]
@@ -78,6 +81,13 @@ struct Cli {
     /// or `~/.symboliclirc`.
     #[arg(long = "auth-token")]
     pub auth_token: Option<String>,
+
+    /// A raw Cookie header value from an existing Sentry session.
+    ///
+    /// This can alternatively be passed via the `SENTRY_AUTH_COOKIES` environment variable
+    /// or `~/.symboliclirc`.
+    #[arg(long = "auth-cookies", conflicts_with = "auth_token")]
+    pub auth_cookies: Option<String>,
 
     /// The output format.
     #[arg(long, value_enum, default_value = "json")]
@@ -122,7 +132,7 @@ struct ConfigFile {
     pub org: Option<String>,
     pub project: Option<String>,
     pub url: Option<String>,
-    pub auth_token: Option<String>,
+    pub auth: Option<SentryCredentials>,
     pub cache_dir: Option<PathBuf>,
     pub sources: Vec<SourceConfig>,
 }
@@ -206,14 +216,10 @@ impl Settings {
         let mode = if cli.offline {
             Mode::Offline
         } else {
-            let Some(auth_token) = cli
-                .auth_token
-                .or_else(|| std::env::var("SENTRY_AUTH_TOKEN").ok())
-                .or_else(|| project_config_file.auth_token.take())
-                .or_else(|| global_config_file.auth_token.take())
+            let Some(auth) = get_sentry_auth(&cli, &project_config_file, &global_config_file)
             else {
                 bail!(
-                    "No auth token provided. Pass it either via the `--auth-token` option or via the `SENTRY_AUTH_TOKEN` environment variable."
+                    "No auth token or admin session provided. Pass `--auth-token`, `--auth-cookies`, `SENTRY_AUTH_TOKEN`, or `SENTRY_AUTH_COOKIES`."
                 );
             };
 
@@ -251,7 +257,7 @@ impl Settings {
                 base_url: url,
                 org,
                 project,
-                auth_token,
+                auth,
             }
         };
 
@@ -292,6 +298,41 @@ impl Settings {
 
         Ok(args)
     }
+}
+
+fn get_sentry_auth(
+    cli: &Cli,
+    project_config_file: &ConfigFile,
+    global_config_file: &ConfigFile,
+) -> Option<SentryCredentials> {
+    {
+        let token = cli
+            .auth_token
+            .clone()
+            .map(SentryToken)
+            .map(SentryCredentials::Token);
+        let cookies = cli
+            .auth_cookies
+            .clone()
+            .map(SentryCookies)
+            .map(SentryCredentials::Cookies);
+
+        token.or(cookies)
+    }
+    .or_else(|| {
+        let token = std::env::var("SENTRY_AUTH_TOKEN")
+            .ok()
+            .map(SentryToken)
+            .map(SentryCredentials::Token);
+        let cookies = std::env::var("SENTRY_AUTH_COOKIES")
+            .ok()
+            .map(SentryCookies)
+            .map(SentryCredentials::Cookies);
+
+        token.or(cookies)
+    })
+    .or_else(|| project_config_file.auth.clone())
+    .or_else(|| global_config_file.auth.clone())
 }
 
 fn find_global_config_file() -> Result<PathBuf> {

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -47,7 +47,7 @@ pub enum Mode {
 
 /// A utility that provides local symbolication of Sentry events.
 ///
-/// Provide either a valid auth token or an existing Sentry admin session via
+/// Provide either a valid auth token or an existing Sentry session via
 /// `--auth-token`, `--auth-cookies`, `SENTRY_AUTH_TOKEN`,
 /// `SENTRY_AUTH_COOKIES`, or `~/.symboliclirc`.
 ///
@@ -219,7 +219,7 @@ impl Settings {
             let Some(auth) = get_sentry_auth(&cli, &project_config_file, &global_config_file)
             else {
                 bail!(
-                    "No auth token or admin session provided. Pass `--auth-token`, `--auth-cookies`, `SENTRY_AUTH_TOKEN`, or `SENTRY_AUTH_COOKIES`."
+                    "No auth token or cookies provided. Pass `--auth-token`, `--auth-cookies`, `SENTRY_AUTH_TOKEN`, or `SENTRY_AUTH_COOKIES`."
                 );
             };
 

--- a/crates/symbolicli/symboliclirc.example
+++ b/crates/symbolicli/symboliclirc.example
@@ -5,8 +5,9 @@
 # The Sentry server to access in online mode. Defaults to "https://sentry.io/".
 # url = "https://sentry.io/"
 
-# The default auth token to use for accessing Sentry.
-# auth_token = ""
+# The default auth to use for accessing Sentry.
+# auth = { token = "..." }
+# auth = { cookies = "..." }
 
 ### Example symbol sources
 


### PR DESCRIPTION
This make `symbolicli` work with a Sentry Cookie.

Example, testing the symbolic `13.6.1` upgrade with cookies:

```
└─ % cargo run -p symbolicli -- -o dev-curumas -p notjava be73db69fd5847169b109e5c7dd08e03
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/symbolicli -o dev-curumas -p notjava be73db69fd5847169b109e5c7dd08e03`
2026-06-26T08:26:06.310782Z  INFO symbolicli: event not found in local file system
2026-06-26T08:26:06.311003Z  INFO symbolicli: trying to resolve event remotely
2026-06-26T08:26:06.311077Z  INFO symbolicli::remote: downloading event json url=https://sentry.io/api/0/projects/dev-curumas/notjava/events/be73db69fd5847169b109e5c7dd08e03/json/
2026-06-26T08:26:06.722356Z  INFO symbolicli: event json file downloaded
2026-06-26T08:26:06.722497Z  INFO symbolicli::remote: fetching attachments url=https://sentry.io/api/0/projects/dev-curumas/notjava/events/be73db69fd5847169b109e5c7dd08e03/attachments/
2026-06-26T08:26:07.026045Z  INFO symbolicli: no crash attachment found
2026-06-26T08:26:07.026690Z  INFO symbolicli: symbolicating event
{"stacktraces":[{"frames":[{"function":"abort","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":576,"colno":11,"data":{"symbolicated":false}},{"function":"__abort_js","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":879,"colno":7,"data":{"symbolicated":false}},{"filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":608,"colno":12,"data":{"symbolicated":false}},{"function":"Object.ccall","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":1095,"colno":17,"data":{"symbolicated":false}},{"function":"HTMLButtonElement.<anonymous>","filename":"/index.html","abs_path":"http://localhost:8000/index.html","lineno":77,"colno":21,"data":{"symbolicated":false}},{"function":"sentryWrapped","filename":"../esm/npm/@sentry/browser@10.58.0/node_modules/@sentry/browser/src/helpers.ts","module":"@sentry/browser@10.58.0/esm/npm/@sentry/browser@10.58.0/node_modules/@sentry/browser/src/helpers","abs_path":"https://esm.sh/@sentry/browser@10.58.0/esm/npm/@sentry/browser@10.58.0/node_modules/@sentry/browser/src/helpers.ts","lineno":122,"colno":17,"pre_context":["","      // Attempt to invoke user-land function","      // NOTE: If you are a Sentry user, and you are seeing this stack frame, it","      //       means the sentry.javascript SDK caught an error invoking your application code. This","      //       is expected behavior and NOT indicative of a bug with sentry.javascript."],"context_line":"      return fn.apply(this, wrappedArguments);","post_context":["    } catch (ex) {","      ignoreNextOnError();","","      withScope(scope => {","        scope.addEventProcessor(event => {"],"data":{"sourcemap":"https://esm.sh/@sentry/browser@10.58.0/es2022/browser.mjs.map","sourcemap_origin":{"scraped_file":"https://esm.sh/@sentry/browser@10.58.0/es2022/browser.mjs.map#1782459967"},"resolved_with":"scraping","symbolicated":true}}]}],"raw_stacktraces":[{"frames":[{"function":"abort","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":576,"colno":11,"data":{"symbolicated":false}},{"function":"__abort_js","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":879,"colno":7,"data":{"symbolicated":false}},{"filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":608,"colno":12,"data":{"symbolicated":false}},{"function":"Object.ccall","filename":"/dist/index.js","abs_path":"http://localhost:8000/dist/index.js","lineno":1095,"colno":17,"data":{"symbolicated":false}},{"function":"HTMLButtonElement.<anonymous>","filename":"/index.html","abs_path":"http://localhost:8000/index.html","lineno":77,"colno":21,"data":{"symbolicated":false}},{"function":"HTMLButtonElement.n","filename":"/@sentry/browser@10.58.0/es2022/browser.mjs","abs_path":"https://esm.sh/@sentry/browser@10.58.0/es2022/browser.mjs","lineno":2,"colno":878,"pre_context":["/* esm.sh - @sentry/browser@10.58.0 */"],"context_line":"{snip} ntryWrappedDepth||0)+1;try{let i=o.map(s=>x(s,t));return e.apply(this,i)}catch(i){throw An(),Tn(s=>{s.addEventProcessor(a=>(t.mechanism&&(En {snip}","post_context":["{snip} .getOptions().stackParser(r,0,1):void 0,o=`HTTP Client Error with status code: ${e.status}`,i={message:o,exception:{values:[{type:\"Error\",va {snip}","{snip} p.method\"];if(!ir(c)||!ir(u))return;let{endpoints:f}=t,m=ar(c,f),h=lr(n);if(m&&h){let g=ur(h);if(g){let d=cr(g);r.updateName(`${u} ${c} (${d {snip}","//# sourceMappingURL=browser.mjs.map"],"data":{"symbolicated":false}}]}],"errors":[{"abs_path":"http://localhost:8000/dist/index.js","type":"missing_source"},{"abs_path":"http://localhost:8000/index.html","type":"missing_source"}],"scraping_attempts":[{"url":"http://localhost:8000/dist/index.js","status":"failure","reason":"download_error","details":"Connection refused (os error 61)"},{"url":"http://localhost:8000/index.html","status":"failure","reason":"download_error","details":"Connection refused (os error 61)"},{"url":"https://esm.sh/@sentry/browser@10.58.0/es2022/browser.mjs","status":"success"},{"url":"https://esm.sh/@sentry/browser@10.58.0/es2022/browser.mjs.map","status":"success"}]}
```