### PR TITLE
fix: Increase download timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   the decompressed sizes of compressed embedded sources during debug file parsing. The default
   value is 100MiB. ([#1972](https://github.com/getsentry/symbolicator/pull/1972))
 
+### Other
+
+- (symbolicator-service) Increase default download timeout. ([#1980](https://github.com/getsentry/symbolicator/pull/1980))
+
 ## 26.6.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other
 
-- (symbolicator-service) Increase default download timeout. ([#1980](https://github.com/getsentry/symbolicator/pull/1980))
+- (symbolicator-service) Increase default connect and head timeouts. ([#1980](https://github.com/getsentry/symbolicator/pull/1980))
 
 ## 26.6.0
 

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -716,8 +716,8 @@ pub struct DownloadTimeouts {
 impl Default for DownloadTimeouts {
     fn default() -> Self {
         Self {
-            connect: Duration::from_secs(1),
-            head: Duration::from_secs(5),
+            connect: Duration::from_secs(5),
+            head: Duration::from_secs(10),
             // We want to have a hard download timeout of 5 minutes.
             // This means a download connection needs to sustain ~6.7MB/s to download a 2GB file.
             max_download: Duration::from_mins(5),


### PR DESCRIPTION
Increase download timeouts for downloading debug files. These timeouts make up a probable suspect for the download failures seen by customers in recent events.

Ref: [Ingest-1003](https://linear.app/getsentry/issue/INGEST-1003/)