### PR TITLE
feat: add configurable unwind_strategy for minidump stackwalking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,22 @@ dependencies = [
 [[package]]
 name = "breakpad-symbols"
 version = "0.26.1"
+dependencies = [
+ "async-trait",
+ "cachemap2",
+ "circular",
+ "debugid",
+ "futures-util",
+ "minidump-common",
+ "nom",
+ "range-map",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "breakpad-symbols"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b544545512b213899840bb26f72cd13f9fb4c3de3dd5f8dc7219688f54aebe9"
 dependencies = [
@@ -2829,8 +2845,6 @@ dependencies = [
 [[package]]
 name = "minidump"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902ca21d9772a66d3d1b050b3436dcadb192694be01409e0219902dcf4bc1e8"
 dependencies = [
  "debugid",
  "encoding_rs",
@@ -2850,8 +2864,6 @@ dependencies = [
 [[package]]
 name = "minidump-common"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e16d10087ae9e375bad7a40e8ef5504bc08e808ccc6019067ff9de42a84570f"
 dependencies = [
  "bitflags 2.13.0",
  "debugid",
@@ -2869,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee81ed67b9b37e3e1e47b3677bebe739499b12dcec7cdc74440990fde64e232b"
 dependencies = [
  "async-trait",
- "breakpad-symbols",
+ "breakpad-symbols 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "debugid",
  "futures-util",
  "minidump",
@@ -2886,11 +2898,9 @@ dependencies = [
 [[package]]
 name = "minidump-unwind"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa8b7212f59c525f93c62457c54f9f9ac550316ee0e41f129b4b19165d5acd1"
 dependencies = [
  "async-trait",
- "breakpad-symbols",
+ "breakpad-symbols 0.26.1",
  "minidump",
  "minidump-common",
  "scroll 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,14 +42,15 @@ cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "se
 
 # This patch adds a configurable `UnwindStrategy` (CFI-first, the historical
 # default, vs. frame-pointer-first with CFI fallback) to `SymbolProvider`, used
-# by the `unwind_strategy` config option. Local checkout for now; point this at
-# a pushed fork branch (e.g. getsentry/rust-minidump) once one exists.
-# `minidump`/`minidump-common` must be patched to the same checkout so their
+# by the `unwind_strategy` config option. Pending upstream review/release,
+# pinned to a fork branch; switch back to a plain crates-io version once
+# https://github.com/rust-minidump/rust-minidump has released it.
+# `minidump`/`minidump-common` must be patched to the same branch so their
 # types unify with `minidump-processor`'s (unpatched, crates-io) dependency on
 # them.
-minidump = { path = "../rust-minidump/minidump" }
-minidump-common = { path = "../rust-minidump/minidump-common" }
-minidump-unwind = { path = "../rust-minidump/minidump-unwind" }
+minidump = { git = "https://github.com/aholza/rust-minidump", branch = "symbolicator-fp-first-unwind" }
+minidump-common = { git = "https://github.com/aholza/rust-minidump", branch = "symbolicator-fp-first-unwind" }
+minidump-unwind = { git = "https://github.com/aholza/rust-minidump", branch = "symbolicator-fp-first-unwind" }
 
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,17 @@ reqwest = { git = "https://github.com/getsentry/reqwest", branch = "swatinem/upd
 # This patch adds limited "templated lambdas" demangling support
 cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "sentry-patches" }
 
+# This patch adds a configurable `UnwindStrategy` (CFI-first, the historical
+# default, vs. frame-pointer-first with CFI fallback) to `SymbolProvider`, used
+# by the `unwind_strategy` config option. Local checkout for now; point this at
+# a pushed fork branch (e.g. getsentry/rust-minidump) once one exists.
+# `minidump`/`minidump-common` must be patched to the same checkout so their
+# types unify with `minidump-processor`'s (unpatched, crates-io) dependency on
+# them.
+minidump = { path = "../rust-minidump/minidump" }
+minidump-common = { path = "../rust-minidump/minidump-common" }
+minidump-unwind = { path = "../rust-minidump/minidump-unwind" }
+
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.
 # This only works for the very specific crate listed here, and not for its dependency tree.

--- a/crates/symbolicator-native/src/symbolication/process_minidump.rs
+++ b/crates/symbolicator-native/src/symbolication/process_minidump.rs
@@ -12,13 +12,16 @@ use minidump::{MinidumpModule, Module};
 use minidump_processor::ProcessState;
 use minidump_unwind::{
     FileError, FileKind, FillSymbolError, FrameSymbolizer, FrameWalker, SymbolProvider,
+    UnwindStrategy as MinidumpUnwindStrategy,
 };
 use sentry::types::DebugId;
 use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
 use symbolic::common::{Arch, ByteView};
 use symbolicator_service::metric;
-use symbolicator_service::types::{FrameOrder, ObjectFileStatus, RawObjectInfo, Scope};
+use symbolicator_service::types::{
+    FrameOrder, ObjectFileStatus, RawObjectInfo, Scope, UnwindStrategy,
+};
 use symbolicator_service::utils::hex::HexValue;
 use symbolicator_sources::{ObjectId, ObjectType, SourceConfig};
 use tokio::sync::Notify;
@@ -179,9 +182,12 @@ struct SymbolicatorSymbolProvider {
     rewrite_first_module: RewriteRules,
     /// An internal database of loaded CFI.
     cficaches: Mutex<HashMap<LookupKey, LazyCfiCache>>,
+    /// Which unwind method to try first (CFI vs. frame pointer chain).
+    unwind_strategy: UnwindStrategy,
 }
 
 impl SymbolicatorSymbolProvider {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         scope: Scope,
         sources: Arc<[SourceConfig]>,
@@ -190,6 +196,7 @@ impl SymbolicatorSymbolProvider {
         object_type: ObjectType,
         first_module_debug_id: Option<DebugId>,
         rewrite_first_module: RewriteRules,
+        unwind_strategy: UnwindStrategy,
     ) -> Self {
         Self {
             scope,
@@ -197,6 +204,7 @@ impl SymbolicatorSymbolProvider {
             cficache_actor,
             symcache_actor,
             object_type,
+            unwind_strategy,
             first_module_debug_id,
             rewrite_first_module,
             cficaches: Default::default(),
@@ -413,6 +421,13 @@ impl SymbolProvider for SymbolicatorSymbolProvider {
     ) -> Result<PathBuf, FileError> {
         Err(FileError::NotFound)
     }
+
+    fn unwind_strategy(&self) -> MinidumpUnwindStrategy {
+        match self.unwind_strategy {
+            UnwindStrategy::CfiFirst => MinidumpUnwindStrategy::CfiFirst,
+            UnwindStrategy::FramePointerFirst => MinidumpUnwindStrategy::FramePointerFirst,
+        }
+    }
 }
 
 fn object_info_from_minidump_module(ty: ObjectType, module: &MinidumpModule) -> CompleteObjectInfo {
@@ -441,6 +456,7 @@ fn object_info_from_minidump_module(ty: ObjectType, module: &MinidumpModule) -> 
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn stackwalk(
     cficaches: CfiCacheActor,
     symcaches: SymCacheActor,
@@ -448,6 +464,7 @@ async fn stackwalk(
     scope: Scope,
     sources: Arc<[SourceConfig]>,
     rewrite_first_module: RewriteRules,
+    unwind_strategy: UnwindStrategy,
 ) -> Result<StackWalkMinidumpResult> {
     // Stackwalk the minidump.
     let duration = Instant::now();
@@ -476,6 +493,7 @@ async fn stackwalk(
         ty,
         first_module_debug_id,
         rewrite_first_module,
+        unwind_strategy,
     );
     let process_state = minidump_processor::process_minidump(minidump, &provider).await?;
     let duration = duration.elapsed();
@@ -631,6 +649,7 @@ impl SymbolicationActor {
             scope.clone(),
             sources.clone(),
             rewrite_first_module.clone(),
+            self.unwind_strategy,
         )
         .await?;
 

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -7,7 +7,7 @@ use symbolicator_service::caching::CacheError;
 use symbolicator_service::download::DownloadService;
 use symbolicator_service::objects::ObjectsActor;
 use symbolicator_service::services::SharedServices;
-use symbolicator_service::types::FrameOrder;
+use symbolicator_service::types::{FrameOrder, UnwindStrategy};
 
 use crate::caches::bitcode::BitcodeService;
 use crate::caches::cficaches::CfiCacheActor;
@@ -37,6 +37,7 @@ pub struct SymbolicationActor {
     ppdb_caches: PortablePdbCacheActor,
     pub(crate) sourcefiles_cache: Arc<SourceFilesCache>,
     pub(crate) download_svc: Arc<DownloadService>,
+    pub(crate) unwind_strategy: UnwindStrategy,
 }
 
 impl SymbolicationActor {
@@ -47,6 +48,7 @@ impl SymbolicationActor {
         let download_svc = services.download_svc.clone();
         let source_index_svc = services.source_index_svc.clone();
         let sourcefiles_cache = services.sourcefiles_cache.clone();
+        let unwind_strategy = services.config.unwind_strategy;
 
         let bitcode = BitcodeService::new(
             caches.auxdifs.clone(),
@@ -93,6 +95,7 @@ impl SymbolicationActor {
             ppdb_caches,
             sourcefiles_cache,
             download_svc,
+            unwind_strategy,
         }
     }
 

--- a/crates/symbolicator-native/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-native/tests/integration/process_minidump.rs
@@ -11,12 +11,20 @@ use tempfile::tempfile;
 use symbolicator_native::interface::{
     AttachmentFile, CompletedSymbolicationResponse, ProcessMinidump,
 };
-use symbolicator_service::types::Scope;
+use symbolicator_service::types::{Scope, UnwindStrategy};
 
 use crate::{assert_snapshot, read_fixture, setup_service, symbol_server};
 
 async fn stackwalk_minidump(path: &str) -> CompletedSymbolicationResponse {
-    let (symbolication, _cache_dir) = setup_service(|_| ());
+    stackwalk_minidump_with_unwind_strategy(path, UnwindStrategy::CfiFirst).await
+}
+
+async fn stackwalk_minidump_with_unwind_strategy(
+    path: &str,
+    unwind_strategy: UnwindStrategy,
+) -> CompletedSymbolicationResponse {
+    let (symbolication, _cache_dir) =
+        setup_service(|cfg| cfg.unwind_strategy = unwind_strategy);
     let (_symsrv, source) = symbol_server();
 
     let minidump = read_fixture(path);
@@ -45,6 +53,47 @@ async fn test_minidump_windows() {
 #[tokio::test]
 async fn test_minidump_macos() {
     let res = stackwalk_minidump("macos.dmp").await;
+    assert_snapshot!(res);
+}
+
+/// Verifies that `UnwindStrategy::FramePointerFirst` doesn't regress stackwalking
+/// for minidumps that have intact frame pointer chains throughout: the two unwind
+/// methods should agree, producing identical stacktraces to the default
+/// `CfiFirst` strategy.
+///
+/// `windows.dmp` is deliberately excluded here: it's a 32-bit release build with
+/// frame pointer omission (FPO) in some system DLLs, so the two strategies are
+/// *expected* to diverge for it (see `test_minidump_windows_frame_pointer_first`).
+#[tokio::test]
+async fn test_minidump_frame_pointer_first_matches_cfi_first() {
+    for fixture in ["macos.dmp", "linux.dmp"] {
+        let cfi_first = stackwalk_minidump_with_unwind_strategy(fixture, UnwindStrategy::CfiFirst)
+            .await
+            .stacktraces;
+        let fp_first =
+            stackwalk_minidump_with_unwind_strategy(fixture, UnwindStrategy::FramePointerFirst)
+                .await
+                .stacktraces;
+        assert_eq!(
+            format!("{cfi_first:#?}"),
+            format!("{fp_first:#?}"),
+            "mismatch for fixture {fixture}"
+        );
+    }
+}
+
+/// Demonstrates the tradeoff `UnwindStrategy::FramePointerFirst` is documented to
+/// have: `windows.dmp` is a 32-bit release build where some system DLLs (e.g.
+/// `rpcrt4.dll`) omit frame pointers (FPO). Walking the (unreliable) `ebp` chain
+/// first there produces a spurious extra frame that the accurate PDB-derived CFI
+/// (used by the default `CfiFirst` strategy, see `test_minidump_windows`) does not.
+/// This confirms the `unwind_strategy` config option is wired up end-to-end and
+/// actually changes stackwalking behavior, not just that it's accepted/parsed.
+#[tokio::test]
+async fn test_minidump_windows_frame_pointer_first() {
+    let res =
+        stackwalk_minidump_with_unwind_strategy("windows.dmp", UnwindStrategy::FramePointerFirst)
+            .await;
     assert_snapshot!(res);
 }
 

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__process_minidump__minidump_windows_frame_pointer_first.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__process_minidump__minidump_windows_frame_pointer_first.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/symbolicator-native/tests/integration/process_minidump.rs
-assertion_line: 97
 expression: res
 ---
 timestamp: 1521713273
@@ -39,50 +38,26 @@ stacktraces:
         abs_path: "c:\\projects\\breakpad-tools\\windows\\crash\\main.cpp"
         lineno: 35
         trust: context
-        registers:
-          eax: "0x0"
-          ebp: "0x10ff670"
-          ebx: "0xfe5000"
-          ecx: "0x10ff670"
-          edi: "0x13bfd78"
-          edx: "0x7"
-          eflags: "0x10246"
-          eip: "0x2a2a3d"
-          esi: "0x759c6314"
-          esp: "0x10ff644"
       - status: missing_symbol
         original_index: 1
         instruction_addr: "0x2a28d0"
         package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
         trust: fp
-        registers:
-          ebp: "0x0"
-          eip: "0x2a28d0"
-          esp: "0x10ff678"
       - status: missing
         original_index: 2
         instruction_addr: "0x7584e9c0"
         package: "C:\\Windows\\System32\\rpcrt4.dll"
         trust: scan
-        registers:
-          eip: "0x7584e9c0"
-          esp: "0x10ff6a4"
       - status: missing
         original_index: 3
         instruction_addr: "0x70b7ae40"
         package: "C:\\Windows\\System32\\dbgcore.dll"
         trust: scan
-        registers:
-          eip: "0x70b7ae40"
-          esp: "0x10ff6dc"
       - status: missing
         original_index: 4
         instruction_addr: "0x7584e9c0"
         package: "C:\\Windows\\System32\\rpcrt4.dll"
         trust: scan
-        registers:
-          eip: "0x7584e9c0"
-          esp: "0x10ff6e8"
       - status: symbolicated
         original_index: 5
         instruction_addr: "0x2a3434"
@@ -94,9 +69,6 @@ stacktraces:
         abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\utility\\utility_desktop.cpp"
         lineno: 84
         trust: scan
-        registers:
-          eip: "0x2a3435"
-          esp: "0x10ff6f0"
       - status: symbolicated
         original_index: 6
         instruction_addr: "0x2a2d96"
@@ -108,37 +80,21 @@ stacktraces:
         abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl"
         lineno: 283
         trust: scan
-        registers:
-          ebp: "0x10ff784"
-          eip: "0x2a2d97"
-          esp: "0x10ff744"
       - status: missing
         original_index: 7
         instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: fp
-        registers:
-          ebp: "0x10ff798"
-          eip: "0x750662c4"
-          esp: "0x10ff78c"
       - status: missing
         original_index: 8
         instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x10ff7e0"
-          eip: "0x771d0f79"
-          esp: "0x10ff7a0"
       - status: missing
         original_index: 9
         instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x10ff7f0"
-          eip: "0x771d0f44"
-          esp: "0x10ff7e8"
   - thread_id: 3580
     is_requesting: false
     registers:
@@ -158,44 +114,21 @@ stacktraces:
         instruction_addr: "0x771e016c"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
-        registers:
-          eax: "0x0"
-          ebp: "0x159faa4"
-          ebx: "0x13b0990"
-          ecx: "0x0"
-          edi: "0x13b4af0"
-          edx: "0x0"
-          eflags: "0x216"
-          eip: "0x771e016c"
-          esi: "0x13b4930"
-          esp: "0x159f900"
       - status: missing
         original_index: 1
         instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: fp
-        registers:
-          ebp: "0x159fab8"
-          eip: "0x750662c4"
-          esp: "0x159faac"
       - status: missing
         original_index: 2
         instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x159fb00"
-          eip: "0x771d0f79"
-          esp: "0x159fac0"
       - status: missing
         original_index: 3
         instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x159fb10"
-          eip: "0x771d0f44"
-          esp: "0x159fb08"
   - thread_id: 2600
     is_requesting: false
     registers:
@@ -215,44 +148,21 @@ stacktraces:
         instruction_addr: "0x771e016c"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
-        registers:
-          eax: "0x0"
-          ebp: "0x169fb98"
-          ebx: "0x13b0990"
-          ecx: "0x0"
-          edi: "0x13b7c28"
-          edx: "0x0"
-          eflags: "0x202"
-          eip: "0x771e016c"
-          esi: "0x13b7a68"
-          esp: "0x169f9f4"
       - status: missing
         original_index: 1
         instruction_addr: "0x750662c4"
         package: "C:\\Windows\\System32\\kernel32.dll"
         trust: fp
-        registers:
-          ebp: "0x169fbac"
-          eip: "0x750662c4"
-          esp: "0x169fba0"
       - status: missing
         original_index: 2
         instruction_addr: "0x771d0f79"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x169fbf4"
-          eip: "0x771d0f79"
-          esp: "0x169fbb4"
       - status: missing
         original_index: 3
         instruction_addr: "0x771d0f44"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: fp
-        registers:
-          ebp: "0x169fc04"
-          eip: "0x771d0f44"
-          esp: "0x169fbfc"
   - thread_id: 2920
     is_requesting: false
     registers:
@@ -272,17 +182,6 @@ stacktraces:
         instruction_addr: "0x771df3dc"
         package: "C:\\Windows\\System32\\ntdll.dll"
         trust: context
-        registers:
-          eax: "0x0"
-          ebp: "0x179f2b8"
-          ebx: "0x17b1aa0"
-          ecx: "0x0"
-          edi: "0x17b1a90"
-          edx: "0x0"
-          eflags: "0x206"
-          eip: "0x771df3dc"
-          esi: "0x2cc"
-          esp: "0x179f2ac"
 modules:
   - debug_status: found
     unwind_status: found

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__process_minidump__minidump_windows_frame_pointer_first.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__process_minidump__minidump_windows_frame_pointer_first.snap
@@ -1,0 +1,695 @@
+---
+source: crates/symbolicator-native/tests/integration/process_minidump.rs
+assertion_line: 97
+expression: res
+---
+timestamp: 1521713273
+system_info:
+  os_name: Windows
+  os_version: 10.0.14393
+  os_build: ""
+  cpu_arch: x86
+  device_model: ""
+crashed: true
+crash_reason: EXCEPTION_ACCESS_VIOLATION_WRITE / 0x45
+assertion: ""
+stacktraces:
+  - thread_id: 1636
+    is_requesting: true
+    registers:
+      eax: "0x0"
+      ebp: "0x10ff670"
+      ebx: "0xfe5000"
+      ecx: "0x10ff670"
+      edi: "0x13bfd78"
+      edx: "0x7"
+      eflags: "0x10246"
+      eip: "0x2a2a3d"
+      esi: "0x759c6314"
+      esp: "0x10ff644"
+    frames:
+      - status: symbolicated
+        original_index: 0
+        instruction_addr: "0x2a2a3d"
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
+        symbol: main
+        sym_addr: "0x2a2910"
+        function: main
+        filename: main.cpp
+        abs_path: "c:\\projects\\breakpad-tools\\windows\\crash\\main.cpp"
+        lineno: 35
+        trust: context
+        registers:
+          eax: "0x0"
+          ebp: "0x10ff670"
+          ebx: "0xfe5000"
+          ecx: "0x10ff670"
+          edi: "0x13bfd78"
+          edx: "0x7"
+          eflags: "0x10246"
+          eip: "0x2a2a3d"
+          esi: "0x759c6314"
+          esp: "0x10ff644"
+      - status: missing_symbol
+        original_index: 1
+        instruction_addr: "0x2a28d0"
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
+        trust: fp
+        registers:
+          ebp: "0x0"
+          eip: "0x2a28d0"
+          esp: "0x10ff678"
+      - status: missing
+        original_index: 2
+        instruction_addr: "0x7584e9c0"
+        package: "C:\\Windows\\System32\\rpcrt4.dll"
+        trust: scan
+        registers:
+          eip: "0x7584e9c0"
+          esp: "0x10ff6a4"
+      - status: missing
+        original_index: 3
+        instruction_addr: "0x70b7ae40"
+        package: "C:\\Windows\\System32\\dbgcore.dll"
+        trust: scan
+        registers:
+          eip: "0x70b7ae40"
+          esp: "0x10ff6dc"
+      - status: missing
+        original_index: 4
+        instruction_addr: "0x7584e9c0"
+        package: "C:\\Windows\\System32\\rpcrt4.dll"
+        trust: scan
+        registers:
+          eip: "0x7584e9c0"
+          esp: "0x10ff6e8"
+      - status: symbolicated
+        original_index: 5
+        instruction_addr: "0x2a3434"
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
+        symbol: __scrt_set_unhandled_exception_filter
+        sym_addr: "0x2a3429"
+        function: __scrt_set_unhandled_exception_filter
+        filename: utility_desktop.cpp
+        abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\utility\\utility_desktop.cpp"
+        lineno: 84
+        trust: scan
+        registers:
+          eip: "0x2a3435"
+          esp: "0x10ff6f0"
+      - status: symbolicated
+        original_index: 6
+        instruction_addr: "0x2a2d96"
+        package: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
+        symbol: __scrt_common_main_seh
+        sym_addr: "0x2a2c9e"
+        function: __scrt_common_main_seh
+        filename: exe_common.inl
+        abs_path: "f:\\dd\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl"
+        lineno: 283
+        trust: scan
+        registers:
+          ebp: "0x10ff784"
+          eip: "0x2a2d97"
+          esp: "0x10ff744"
+      - status: missing
+        original_index: 7
+        instruction_addr: "0x750662c4"
+        package: "C:\\Windows\\System32\\kernel32.dll"
+        trust: fp
+        registers:
+          ebp: "0x10ff798"
+          eip: "0x750662c4"
+          esp: "0x10ff78c"
+      - status: missing
+        original_index: 8
+        instruction_addr: "0x771d0f79"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x10ff7e0"
+          eip: "0x771d0f79"
+          esp: "0x10ff7a0"
+      - status: missing
+        original_index: 9
+        instruction_addr: "0x771d0f44"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x10ff7f0"
+          eip: "0x771d0f44"
+          esp: "0x10ff7e8"
+  - thread_id: 3580
+    is_requesting: false
+    registers:
+      eax: "0x0"
+      ebp: "0x159faa4"
+      ebx: "0x13b0990"
+      ecx: "0x0"
+      edi: "0x13b4af0"
+      edx: "0x0"
+      eflags: "0x216"
+      eip: "0x771e016c"
+      esi: "0x13b4930"
+      esp: "0x159f900"
+    frames:
+      - status: missing
+        original_index: 0
+        instruction_addr: "0x771e016c"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: context
+        registers:
+          eax: "0x0"
+          ebp: "0x159faa4"
+          ebx: "0x13b0990"
+          ecx: "0x0"
+          edi: "0x13b4af0"
+          edx: "0x0"
+          eflags: "0x216"
+          eip: "0x771e016c"
+          esi: "0x13b4930"
+          esp: "0x159f900"
+      - status: missing
+        original_index: 1
+        instruction_addr: "0x750662c4"
+        package: "C:\\Windows\\System32\\kernel32.dll"
+        trust: fp
+        registers:
+          ebp: "0x159fab8"
+          eip: "0x750662c4"
+          esp: "0x159faac"
+      - status: missing
+        original_index: 2
+        instruction_addr: "0x771d0f79"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x159fb00"
+          eip: "0x771d0f79"
+          esp: "0x159fac0"
+      - status: missing
+        original_index: 3
+        instruction_addr: "0x771d0f44"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x159fb10"
+          eip: "0x771d0f44"
+          esp: "0x159fb08"
+  - thread_id: 2600
+    is_requesting: false
+    registers:
+      eax: "0x0"
+      ebp: "0x169fb98"
+      ebx: "0x13b0990"
+      ecx: "0x0"
+      edi: "0x13b7c28"
+      edx: "0x0"
+      eflags: "0x202"
+      eip: "0x771e016c"
+      esi: "0x13b7a68"
+      esp: "0x169f9f4"
+    frames:
+      - status: missing
+        original_index: 0
+        instruction_addr: "0x771e016c"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: context
+        registers:
+          eax: "0x0"
+          ebp: "0x169fb98"
+          ebx: "0x13b0990"
+          ecx: "0x0"
+          edi: "0x13b7c28"
+          edx: "0x0"
+          eflags: "0x202"
+          eip: "0x771e016c"
+          esi: "0x13b7a68"
+          esp: "0x169f9f4"
+      - status: missing
+        original_index: 1
+        instruction_addr: "0x750662c4"
+        package: "C:\\Windows\\System32\\kernel32.dll"
+        trust: fp
+        registers:
+          ebp: "0x169fbac"
+          eip: "0x750662c4"
+          esp: "0x169fba0"
+      - status: missing
+        original_index: 2
+        instruction_addr: "0x771d0f79"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x169fbf4"
+          eip: "0x771d0f79"
+          esp: "0x169fbb4"
+      - status: missing
+        original_index: 3
+        instruction_addr: "0x771d0f44"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: fp
+        registers:
+          ebp: "0x169fc04"
+          eip: "0x771d0f44"
+          esp: "0x169fbfc"
+  - thread_id: 2920
+    is_requesting: false
+    registers:
+      eax: "0x0"
+      ebp: "0x179f2b8"
+      ebx: "0x17b1aa0"
+      ecx: "0x0"
+      edi: "0x17b1a90"
+      edx: "0x0"
+      eflags: "0x206"
+      eip: "0x771df3dc"
+      esi: "0x2cc"
+      esp: "0x179f2ac"
+    frames:
+      - status: missing
+        original_index: 0
+        instruction_addr: "0x771df3dc"
+        package: "C:\\Windows\\System32\\ntdll.dll"
+        trust: context
+        registers:
+          eax: "0x0"
+          ebp: "0x179f2b8"
+          ebx: "0x17b1aa0"
+          ecx: "0x0"
+          edi: "0x17b1a90"
+          edx: "0x0"
+          eflags: "0x206"
+          eip: "0x771df3dc"
+          esi: "0x2cc"
+          esp: "0x179f2ac"
+modules:
+  - debug_status: found
+    unwind_status: found
+    features:
+      has_debug_info: true
+      has_unwind_info: true
+      has_symbols: true
+      has_sources: false
+    arch: x86
+    type: pe
+    code_id: 5ab380779000
+    code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe"
+    debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
+    debug_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb"
+    image_addr: "0x2a0000"
+    image_size: 36864
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/symbols/5a/b380779000.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.exe/5AB380779000/crash.ex_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.exe/5AB380779000/crash.exe"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.pdb/3249D99D0C4049318610F4E4FB0B69361/crash.pd_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.pdb/3249D99D0C4049318610F4E4FB0B69361/crash.pdb"
+        download:
+          status: ok
+          features:
+            has_debug_info: true
+            has_unwind_info: true
+            has_symbols: true
+            has_sources: false
+        unwind:
+          status: ok
+        debug:
+          status: ok
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.pdb/3249D99D0C4049318610F4E4FB0B69361/crash.src.zip"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/crash.pdb/3249D99D0C4049318610F4E4FB0B69361/crash.sym"
+        download:
+          status: notfound
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: "57898e12145000"
+    code_file: "C:\\Windows\\System32\\dbghelp.dll"
+    debug_id: 9c2a902b-6fdf-40ad-8308-588a41d572a0-1
+    debug_file: dbghelp.pdb
+    image_addr: "0x70850000"
+    image_size: 1331200
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 589abc846c000
+    code_file: "C:\\Windows\\System32\\msvcp140.dll"
+    debug_id: bf5257f7-8c26-43dd-9bb7-901625e1136a-1
+    debug_file: msvcp140.i386.pdb
+    image_addr: "0x709a0000"
+    image_size: 442368
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 57898eeb92000
+    code_file: "C:\\Windows\\System32\\apphelp.dll"
+    debug_id: 8daf7773-372f-460a-af38-944e193f7e33-1
+    debug_file: apphelp.pdb
+    image_addr: "0x70a10000"
+    image_size: 598016
+  - debug_status: missing
+    unwind_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 57898dab25000
+    code_file: "C:\\Windows\\System32\\dbgcore.dll"
+    debug_id: aec7ef2f-df4b-4642-a471-4c3e5fe8760a-1
+    debug_file: dbgcore.pdb
+    image_addr: "0x70b70000"
+    image_size: 151552
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/symbols/57/898dab25000.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.dll/57898DAB25000/dbgcore.dl_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.dll/57898DAB25000/dbgcore.dll"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.pd_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.pdb"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.src.zip"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/dbgcore.pdb/AEC7EF2FDF4B4642A4714C3E5FE8760A1/dbgcore.sym"
+        download:
+          status: notfound
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 589abc7714000
+    code_file: "C:\\Windows\\System32\\VCRUNTIME140.dll"
+    debug_id: 0ed80a50-ecda-472b-86a4-eb6c833f8e1b-1
+    debug_file: vcruntime140.i386.pdb
+    image_addr: "0x70c60000"
+    image_size: 81920
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 57899141a000
+    code_file: "C:\\Windows\\System32\\CRYPTBASE.dll"
+    debug_id: 147c51fb-7ca1-408f-85b5-285f2ad6f9c5-1
+    debug_file: cryptbase.pdb
+    image_addr: "0x73ba0000"
+    image_size: 40960
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 59bf30e31f000
+    code_file: "C:\\Windows\\System32\\sspicli.dll"
+    debug_id: 51e432b1-0450-4b19-8ed1-6d4335f9f543-1
+    debug_file: wsspicli.pdb
+    image_addr: "0x73bb0000"
+    image_size: 126976
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 5a49bb7677000
+    code_file: "C:\\Windows\\System32\\advapi32.dll"
+    debug_id: 0c799483-b549-417d-8433-4331852031fe-1
+    debug_file: advapi32.pdb
+    image_addr: "0x73c70000"
+    image_size: 487424
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 57899155be000
+    code_file: "C:\\Windows\\System32\\msvcrt.dll"
+    debug_id: 6f6409b3-d520-43c7-9b2f-62e00bfe761c-1
+    debug_file: msvcrt.pdb
+    image_addr: "0x73cf0000"
+    image_size: 778240
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 598942c741000
+    code_file: "C:\\Windows\\System32\\sechost.dll"
+    debug_id: 6f6a05dd-0a80-478b-a419-9b88703bf75b-1
+    debug_file: sechost.pdb
+    image_addr: "0x74450000"
+    image_size: 266240
+  - debug_status: missing
+    unwind_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 590285e9e0000
+    code_file: "C:\\Windows\\System32\\kernel32.dll"
+    debug_id: d3474559-96f7-47d6-bf43-c176b2171e68-1
+    debug_file: wkernel32.pdb
+    image_addr: "0x75050000"
+    image_size: 917504
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/symbols/59/0285e9e0000.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/kernel32.dll/590285E9e0000/kernel32.dl_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/kernel32.dll/590285E9e0000/kernel32.dll"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wkernel32.pdb/D347455996F747D6BF43C176B2171E681/wkernel32.pd_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wkernel32.pdb/D347455996F747D6BF43C176B2171E681/wkernel32.pdb"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wkernel32.pdb/D347455996F747D6BF43C176B2171E681/wkernel32.src.zip"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wkernel32.pdb/D347455996F747D6BF43C176B2171E681/wkernel32.sym"
+        download:
+          status: notfound
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 59b0df8f5a000
+    code_file: "C:\\Windows\\System32\\bcryptPrimitives.dll"
+    debug_id: 287b19c3-9209-4a2b-bb8f-bcc37f411b11-1
+    debug_file: bcryptprimitives.pdb
+    image_addr: "0x75130000"
+    image_size: 368640
+  - debug_status: missing
+    unwind_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 5a49bb75c1000
+    code_file: "C:\\Windows\\System32\\rpcrt4.dll"
+    debug_id: ae131c67-27a7-4fa1-9916-b5a4aef41190-1
+    debug_file: wrpcrt4.pdb
+    image_addr: "0x75810000"
+    image_size: 790528
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/symbols/5a/49bb75c1000.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/rpcrt4.dll/5A49BB75c1000/rpcrt4.dl_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/rpcrt4.dll/5A49BB75c1000/rpcrt4.dll"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.pd_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.pdb"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.src.zip"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wrpcrt4.pdb/AE131C6727A74FA19916B5A4AEF411901/wrpcrt4.sym"
+        download:
+          status: notfound
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 59bf2b5ae0000
+    code_file: "C:\\Windows\\System32\\ucrtbase.dll"
+    debug_id: 6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f-1
+    debug_file: ucrtbase.pdb
+    image_addr: "0x758f0000"
+    image_size: 917504
+  - debug_status: unused
+    unwind_status: unused
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 59bf2bcf1a1000
+    code_file: "C:\\Windows\\System32\\KERNELBASE.dll"
+    debug_id: 8462294a-c645-402d-ac82-a4e95f61ddf9-1
+    debug_file: wkernelbase.pdb
+    image_addr: "0x76db0000"
+    image_size: 1708032
+  - debug_status: missing
+    unwind_status: missing
+    features:
+      has_debug_info: false
+      has_unwind_info: false
+      has_symbols: false
+      has_sources: false
+    arch: unknown
+    type: pe
+    code_id: 59b0d8f3183000
+    code_file: "C:\\Windows\\System32\\ntdll.dll"
+    debug_id: 971f98e5-ce60-41ff-b2d7-235bbeb34578-1
+    debug_file: wntdll.pdb
+    image_addr: "0x77170000"
+    image_size: 1585152
+    candidates:
+      - source: local
+        location: "http://localhost:<port>/symbols/59/b0d8f3183000.debug"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/ntdll.dll/59B0D8F3183000/ntdll.dl_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/ntdll.dll/59B0D8F3183000/ntdll.dll"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wntdll.pdb/971F98E5CE6041FFB2D7235BBEB345781/wntdll.pd_"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wntdll.pdb/971F98E5CE6041FFB2D7235BBEB345781/wntdll.pdb"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wntdll.pdb/971F98E5CE6041FFB2D7235BBEB345781/wntdll.src.zip"
+        download:
+          status: notfound
+      - source: local
+        location: "http://localhost:<port>/symbols/wntdll.pdb/971F98E5CE6041FFB2D7235BBEB345781/wntdll.sym"
+        download:
+          status: notfound

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -17,6 +17,7 @@ use tracing::level_filters::LevelFilter;
 use symbolicator_sources::SourceConfig;
 
 use crate::caching::SharedCacheConfig;
+use crate::types::UnwindStrategy;
 
 /// Controls the log format
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
@@ -549,6 +550,22 @@ pub struct Config {
     ///
     /// Defaults to 128.
     pub max_unwind_chain_len: Option<usize>,
+
+    /// Which native stack unwinding method to try first when stackwalking a
+    /// minidump, `cfi_first` (the default) or `frame_pointer_first`.
+    ///
+    /// Symbolicator has historically relied on CFI (call frame information,
+    /// derived from `.eh_frame`/`.debug_frame`) as the primary unwind method,
+    /// falling back to the frame pointer chain when CFI is unavailable.
+    /// Debuggers like GDB do the opposite by default: walk the frame pointer
+    /// chain first, falling back to DWARF CFI. Setting this to
+    /// `frame_pointer_first` matches that behavior, which can produce more
+    /// reliable stacktraces for binaries built with frame pointers preserved
+    /// (e.g. `-fno-omit-frame-pointer`) whose CFI is present but inaccurate.
+    ///
+    /// Stack scanning remains the last-resort fallback either way.
+    #[serde(default)]
+    pub unwind_strategy: UnwindStrategy,
 }
 
 impl Config {
@@ -657,6 +674,7 @@ impl Default for Config {
             object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
             object_file_max_decompressed_source_size: Some(100 * 1024 * 1024),
             max_unwind_chain_len: Some(128),
+            unwind_strategy: UnwindStrategy::default(),
         }
     }
 }

--- a/crates/symbolicator-service/src/types.rs
+++ b/crates/symbolicator-service/src/types.rs
@@ -327,3 +327,23 @@ pub enum FrameOrder {
     /// how stacktraces are stored in Sentry events.
     CallerFirst,
 }
+
+/// Controls the order in which native stack unwinding methods are attempted
+/// while stackwalking a minidump.
+///
+/// Stack scanning is always tried last regardless of this setting; it is only
+/// used when neither CFI nor the frame pointer chain produce a usable frame.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UnwindStrategy {
+    /// Use CFI (call frame information, from `.eh_frame`/`.debug_frame`) first,
+    /// falling back to the frame pointer chain. This is Symbolicator's
+    /// historical/default behavior.
+    #[default]
+    CfiFirst,
+    /// Use the frame pointer chain first, falling back to CFI. This mirrors
+    /// what debuggers like GDB do by default, and can produce more reliable
+    /// unwinds for binaries built with frame pointers preserved
+    /// (e.g. `-fno-omit-frame-pointer`) when CFI is present but inaccurate.
+    FramePointerFirst,
+}

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use symbolicator_service::config::{CacheConfigs, Config};
+use symbolicator_service::types::UnwindStrategy;
 use symbolicator_sources::{
     DirectoryLayoutType, SentryCookies, SentryCredentials, SentryToken, SourceConfig,
 };
@@ -31,6 +32,28 @@ pub enum OutputFormat {
     Pretty,
     /// Outputs the crashed thread as a table.
     Compact,
+}
+
+/// CLI-facing mirror of [`UnwindStrategy`], since that type lives in
+/// `symbolicator-service`, which doesn't depend on `clap`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, ValueEnum)]
+pub enum UnwindStrategyArg {
+    /// Use CFI first, falling back to the frame pointer chain (Symbolicator's
+    /// historical default).
+    #[default]
+    CfiFirst,
+    /// Use the frame pointer chain first, falling back to CFI (matches GDB's
+    /// default unwinding behavior).
+    FramePointerFirst,
+}
+
+impl From<UnwindStrategyArg> for UnwindStrategy {
+    fn from(arg: UnwindStrategyArg) -> Self {
+        match arg {
+            UnwindStrategyArg::CfiFirst => UnwindStrategy::CfiFirst,
+            UnwindStrategyArg::FramePointerFirst => UnwindStrategy::FramePointerFirst,
+        }
+    }
 }
 
 /// Controls whether `symbolicli` will attempt to access a Sentry server.
@@ -124,6 +147,11 @@ struct Cli {
     /// debuginfod, unified, slashsymbols.
     #[arg(long)]
     symbols: Option<SymbolsPath>,
+
+    /// Which native stack unwinding method to try first when stackwalking a
+    /// minidump.
+    #[arg(long, value_enum, default_value = "cfi-first")]
+    unwind_strategy: UnwindStrategyArg,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -282,6 +310,7 @@ impl Settings {
                 cache_dir,
                 connect_to_reserved_ips: true,
                 caches,
+                unwind_strategy: cli.unwind_strategy.into(),
                 ..Default::default()
             }
         };


### PR DESCRIPTION
## Problem

Symbolicator has always tried CFI (`.eh_frame`/`.debug_frame`) before the
frame-pointer chain when stackwalking minidumps. Debuggers like GDB do the
opposite by default. For binaries built with frame pointers preserved
(`-fno-omit-frame-pointer`) whose CFI happens to be present but inaccurate
(e.g. FPO'd system libraries with truncated/wrong CFI), CFI-first can walk
into garbage before falling back, while frame-pointer-first would have
produced a correct unwind immediately.

## Solution

Adds an `unwind_strategy` config option (`cfi_first`, the default and
unchanged historical behavior, or `frame_pointer_first`) to `Config`,
threaded through `SymbolicationActor` → `SymbolicatorSymbolProvider` →
`minidump-unwind`'s per-architecture `get_caller_frame()`, which now
branches on the requested strategy to reorder the CFI vs. frame-pointer
attempts. Stack scanning remains the last-resort fallback in both cases.

This requires a small, currently-pending upstream change to
`minidump-unwind` (see https://github.com/rust-minidump/rust-minidump —
PR link once opened there), adding an `UnwindStrategy` enum and a
`SymbolProvider::unwind_strategy()` default method so the ordering can be
controlled from the calling crate rather than hardcoded per architecture.
`Cargo.toml` currently pins `minidump`/`minidump-common`/`minidump-unwind`
to that fork branch pending review/release there.

Also exposes `--unwind-strategy` on `symbolicli` for local comparison
against tools like GDB.

## Testing

- Full `symbolicator-native` suite (34 tests + 1 doctest) plus
  `minidump-unwind`'s own suite (76 tests) on the forked crate.
- New integration test `test_minidump_frame_pointer_first_matches_cfi_first`
  confirming both strategies agree when CFI is trustworthy.
- New snapshot test `test_minidump_windows_frame_pointer_first` against a
  real Windows minidump with an FPO'd `rpcrt4.dll`, showing
  `frame_pointer_first` produces `trust: fp` frames where `cfi_first`
  produces `trust: scan` for the same addresses — the actual real-world
  divergence this option exists for.
- End-to-end: ran both strategies via `symbolicli` against a real crash
  minidump to confirm the flag works cleanly through the full pipeline.

## Dependencies

Blocked on review/release of the companion `rust-minidump` PR; the
`[patch.crates-io]` git-branch pin in `Cargo.toml` can be replaced with a
plain crates-io version bump once that lands.