### PR TITLE
fix: Don't start crash reporting process on healtheck command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes 🐛
+
+- (crash reporter) Don't start the crash reporting process if there is no Sentry DSN
+  or if the CLI command is anything other than `run` by @loewenheim in [#1988](https://github.com/getsentry/symbolicator/pull/1988)
+
 ## 26.7.0
 
 ### Features

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -69,6 +69,12 @@ enum Command {
     },
 }
 
+impl Command {
+    fn requires_crash_reporter(&self) -> bool {
+        matches!(self, Self::Run)
+    }
+}
+
 /// Command line interface parser.
 #[derive(Parser)]
 #[command(
@@ -128,7 +134,10 @@ pub fn execute() -> Result<()> {
                 .map(|cache_dir| cache_dir.join(".sentry-native"))
         });
 
-        if let Some(crash_db) = crash_db {
+        if let Some(crash_db) = crash_db
+            && cli.command.requires_crash_reporter()
+            && config.sentry_dsn.is_some()
+        {
             symbolicator_crash::init(crash_db, (*sentry).clone());
         }
     }

--- a/crates/symbolicator/src/cli.rs
+++ b/crates/symbolicator/src/cli.rs
@@ -70,6 +70,7 @@ enum Command {
 }
 
 impl Command {
+    #[cfg(feature = "symbolicator-crash")]
     fn requires_crash_reporter(&self) -> bool {
         matches!(self, Self::Run)
     }


### PR DESCRIPTION
This gates the crash reporting process behind
1. the CLI command being `run` and
2. the existence of a Sentry DSN.

The crash reporter is only really interesting for the actual server process, and without a Sentry DSN, it can't do anything with a captured minidump anyway.