### PR TITLE
feat: Introduce `extract_variables` option

### DIFF
--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -62,6 +62,9 @@ struct FetchSymCacheInternal {
 
     /// ObjectMeta handle of the original DIF object to fetch.
     object_meta: Arc<ObjectMetaHandle>,
+
+    /// Whether to extract variables.
+    extract_variables: bool,
 }
 
 #[tracing::instrument(name = "compute_symcache", skip_all)]
@@ -70,6 +73,7 @@ async fn compute_symcache(
     objects_actor: &ObjectsActor,
     object_meta: Arc<ObjectMetaHandle>,
     secondary_sources: &SecondarySymCacheSources,
+    #[expect(unused_variables)] extract_varialbes: bool,
 ) -> CacheContents {
     let object_handle = objects_actor.fetch(object_meta).await?;
 
@@ -87,6 +91,7 @@ impl CacheItemRequest for FetchSymCacheInternal {
             &self.objects_actor,
             self.object_meta.clone(),
             &self.secondary_sources,
+            self.extract_variables,
         ))
     }
 
@@ -117,6 +122,8 @@ pub struct FetchSymCache {
     pub identifier: ObjectId,
     pub sources: Arc<[SourceConfig]>,
     pub scope: Scope,
+    /// Whether variables should be extracted.
+    pub extract_variables: bool,
 }
 
 impl SymCacheActor {
@@ -193,6 +200,7 @@ impl SymCacheActor {
                 objects_actor: self.objects.clone(),
                 secondary_sources,
                 object_meta: Arc::clone(&handle),
+                extract_variables: request.extract_variables,
             };
             self.symcaches
                 .compute_memoized(request, cache_key)
@@ -405,6 +413,7 @@ mod tests {
             identifier,
             sources: Arc::new([source]),
             scope: Scope::Scoped("12345".into()),
+            extract_variables: false,
         };
 
         let symcache_actor = symcache_actor(cache_dir.path().to_owned(), TIMEOUT).await;

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -66,6 +66,8 @@ pub struct SymbolicateStacktraces {
     pub rewrite_first_module: RewriteRules,
     /// The order of frames within stacktraces (innermost frame first or last).
     pub frame_order: FrameOrder,
+    /// Whether we extract variables.
+    pub extract_variables: bool,
 }
 
 /// Location of an attachment file, such as a minidump.
@@ -98,6 +100,8 @@ pub struct ProcessMinidump {
     /// Rules for rewriting the debug file of the first (lowest-address) module
     /// in the request.
     pub rewrite_first_module: RewriteRules,
+    /// Whether to extract varialbes.
+    pub extract_variables: bool,
 }
 
 /// The symbolicated crash data.

--- a/crates/symbolicator-native/src/symbolication/apple.rs
+++ b/crates/symbolicator-native/src/symbolication/apple.rs
@@ -28,6 +28,7 @@ impl SymbolicationActor {
         report: File,
         sources: Arc<[SourceConfig]>,
         scraping: ScrapingConfig,
+        extract_variables: bool,
     ) -> Result<(SymbolicateStacktraces, AppleCrashReportState)> {
         let report =
             AppleCrashReport::from_reader(report).context("failed to parse apple crash report")?;
@@ -87,6 +88,7 @@ impl SymbolicationActor {
             scraping,
             rewrite_first_module: Default::default(),
             frame_order: FrameOrder::CalleeFirst,
+            extract_variables,
         };
 
         let mut system_info = SystemInfo {
@@ -133,10 +135,17 @@ impl SymbolicationActor {
         report: AttachmentFile,
         sources: Arc<[SourceConfig]>,
         scraping: ScrapingConfig,
+        extract_variables: bool,
     ) -> Result<CompletedSymbolicationResponse> {
         let report = download_attachment(&self.download_svc, report).await?;
-        let (request, state) =
-            self.parse_apple_crash_report(platform, scope, report, sources, scraping)?;
+        let (request, state) = self.parse_apple_crash_report(
+            platform,
+            scope,
+            report,
+            sources,
+            scraping,
+            extract_variables,
+        )?;
         let mut response = self.symbolicate(request).await?;
 
         state.merge_into(&mut response);

--- a/crates/symbolicator-native/src/symbolication/module_lookup.rs
+++ b/crates/symbolicator-native/src/symbolication/module_lookup.rs
@@ -219,6 +219,7 @@ impl ModuleLookup {
         symcache_actor: SymCacheActor,
         ppdb_cache_actor: PortablePdbCacheActor,
         stacktraces: &[RawStacktrace],
+        extract_variables: bool,
     ) {
         let mut referenced_objects = HashSet::new();
         for stacktrace in stacktraces {
@@ -277,6 +278,7 @@ impl ModuleLookup {
                                 identifier,
                                 sources,
                                 scope,
+                                extract_variables,
                             };
 
                             let DerivedCache {

--- a/crates/symbolicator-native/src/symbolication/process_minidump.rs
+++ b/crates/symbolicator-native/src/symbolication/process_minidump.rs
@@ -179,9 +179,15 @@ struct SymbolicatorSymbolProvider {
     rewrite_first_module: RewriteRules,
     /// An internal database of loaded CFI.
     cficaches: Mutex<HashMap<LookupKey, LazyCfiCache>>,
+    /// Whether to extract variables
+    extract_variables: bool,
 }
 
 impl SymbolicatorSymbolProvider {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "https://github.com/getsentry/symbolicator/issues/2002"
+    )]
     pub fn new(
         scope: Scope,
         sources: Arc<[SourceConfig]>,
@@ -190,6 +196,7 @@ impl SymbolicatorSymbolProvider {
         object_type: ObjectType,
         first_module_debug_id: Option<DebugId>,
         rewrite_first_module: RewriteRules,
+        extract_variables: bool,
     ) -> Self {
         Self {
             scope,
@@ -200,6 +207,7 @@ impl SymbolicatorSymbolProvider {
             first_module_debug_id,
             rewrite_first_module,
             cficaches: Default::default(),
+            extract_variables,
         }
     }
 
@@ -293,6 +301,7 @@ impl SymbolicatorSymbolProvider {
                 identifier,
                 sources,
                 scope,
+                extract_variables: self.extract_variables,
             })
             // NOTE: this `bind_hub` is important!
             // `load_symcache` is being called concurrently from `rust-minidump` via
@@ -448,6 +457,7 @@ async fn stackwalk(
     scope: Scope,
     sources: Arc<[SourceConfig]>,
     rewrite_first_module: RewriteRules,
+    extract_variables: bool,
 ) -> Result<StackWalkMinidumpResult> {
     // Stackwalk the minidump.
     let duration = Instant::now();
@@ -476,6 +486,7 @@ async fn stackwalk(
         ty,
         first_module_debug_id,
         rewrite_first_module,
+        extract_variables,
     );
     let process_state = minidump_processor::process_minidump(minidump, &provider).await?;
     let duration = duration.elapsed();
@@ -610,6 +621,7 @@ impl SymbolicationActor {
             sources,
             scraping,
             rewrite_first_module,
+            extract_variables,
         } = request;
         let minidump_file = download_attachment(&self.download_svc, minidump_file).await?;
         let len = minidump_file.metadata()?.len();
@@ -631,6 +643,7 @@ impl SymbolicationActor {
             scope.clone(),
             sources.clone(),
             rewrite_first_module.clone(),
+            extract_variables,
         )
         .await?;
 
@@ -656,6 +669,7 @@ impl SymbolicationActor {
             scraping,
             rewrite_first_module,
             frame_order: FrameOrder::CalleeFirst,
+            extract_variables: request.extract_variables,
         };
 
         Ok((request, minidump_state))

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -113,6 +113,7 @@ impl SymbolicationActor {
             scraping,
             rewrite_first_module,
             frame_order,
+            extract_variables,
         } = request;
 
         if frame_order == FrameOrder::CallerFirst {
@@ -131,6 +132,7 @@ impl SymbolicationActor {
                 self.symcaches.clone(),
                 self.ppdb_caches.clone(),
                 &stacktraces,
+                extract_variables,
             )
             .await;
 

--- a/crates/symbolicator-native/tests/integration/e2e.rs
+++ b/crates/symbolicator-native/tests/integration/e2e.rs
@@ -158,6 +158,7 @@ async fn test_minidump_symstore_index() {
             sources: Arc::new([source]),
             scraping: Default::default(),
             rewrite_first_module: Default::default(),
+            extract_variables: false,
         })
         .await
         .unwrap();

--- a/crates/symbolicator-native/tests/integration/process_apple.rs
+++ b/crates/symbolicator-native/tests/integration/process_apple.rs
@@ -35,6 +35,7 @@ async fn test_attachment_download() {
             },
             Arc::new([source]),
             Default::default(),
+            false,
         )
         .await;
 

--- a/crates/symbolicator-native/tests/integration/process_minidump.rs
+++ b/crates/symbolicator-native/tests/integration/process_minidump.rs
@@ -31,6 +31,7 @@ async fn stackwalk_minidump(path: &str) -> CompletedSymbolicationResponse {
             sources: Arc::new([source]),
             scraping: Default::default(),
             rewrite_first_module: Default::default(),
+            extract_variables: false,
         })
         .await
         .unwrap()
@@ -112,6 +113,7 @@ async fn test_minidump_attachment_download() {
             sources: Arc::new([source]),
             scraping: Default::default(),
             rewrite_first_module: Default::default(),
+            extract_variables: false,
         })
         .await;
 

--- a/crates/symbolicator-native/tests/integration/symbolication.rs
+++ b/crates/symbolicator-native/tests/integration/symbolication.rs
@@ -60,6 +60,7 @@ async fn test_apple_crash_report() {
             AttachmentFile::Local(report_file),
             Arc::new([source]),
             Default::default(),
+            false,
         )
         .await;
 

--- a/crates/symbolicator-native/tests/integration/utils.rs
+++ b/crates/symbolicator-native/tests/integration/utils.rs
@@ -63,6 +63,7 @@ pub fn make_symbolication_request(
         scraping: Default::default(),
         rewrite_first_module: Default::default(),
         frame_order: FrameOrder::CalleeFirst,
+        extract_variables: false,
     }
 }
 

--- a/crates/symbolicator-stress/src/workloads.rs
+++ b/crates/symbolicator-stress/src/workloads.rs
@@ -90,6 +90,7 @@ pub fn prepare_payload(
                 modules,
                 rewrite_first_module: Default::default(),
                 frame_order: FrameOrder::CallerFirst,
+                extract_variables: true,
             })
         }
         Payload::Js { source, event } => {
@@ -169,6 +170,7 @@ pub async fn process_payload(
                     sources: Arc::clone(sources),
                     scraping: Default::default(),
                     rewrite_first_module: Default::default(),
+                    extract_variables: true,
                 })
                 .await
                 .unwrap();

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -80,6 +80,7 @@ pub async fn handle_minidump_request(
             sources,
             scraping,
             rewrite_first_module,
+            extract_variables: options.extract_variables,
         },
         options,
     )?;

--- a/crates/symbolicator/src/endpoints/symbolicate.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate.rs
@@ -78,6 +78,7 @@ pub async fn symbolicate_frames(
             scraping: body.scraping,
             rewrite_first_module: Default::default(),
             frame_order: body.options.frame_order,
+            extract_variables: body.options.extract_variables,
         },
         body.options,
     )?;

--- a/crates/symbolicator/src/endpoints/symbolicate_any.rs
+++ b/crates/symbolicator/src/endpoints/symbolicate_any.rs
@@ -73,6 +73,7 @@ pub async fn symbolicate_any(
                 sources: body.sources,
                 scraping: body.scraping,
                 rewrite_first_module,
+                extract_variables: body.options.extract_variables,
             },
             body.options,
         )?,

--- a/crates/symbolicator/src/service.rs
+++ b/crates/symbolicator/src/service.rs
@@ -136,6 +136,9 @@ pub struct RequestOptions {
 
     /// The order in which stack frames are received by Symbolicator and returned to the caller.
     pub frame_order: FrameOrder,
+
+    /// Whether to extract variables. Only applies to some symbolication requests
+    pub extract_variables: bool,
 }
 
 impl Default for RequestOptions {
@@ -144,6 +147,7 @@ impl Default for RequestOptions {
             dif_candidates: false,
             apply_source_context: true,
             frame_order: FrameOrder::CalleeFirst,
+            extract_variables: false,
         }
     }
 }
@@ -354,9 +358,17 @@ impl RequestService {
         options: RequestOptions,
     ) -> Result<RequestId, MaxRequestsError> {
         let slf = self.inner.clone();
+        let extract_variables = options.extract_variables;
         self.create_symbolication_request("parse_apple_crash_report", options, async move {
             slf.native
-                .process_apple_crash_report(platform, scope, apple_crash_report, sources, scraping)
+                .process_apple_crash_report(
+                    platform,
+                    scope,
+                    apple_crash_report,
+                    sources,
+                    scraping,
+                    extract_variables,
+                )
                 .await
                 .map(CompletedResponse::Native)
         })
@@ -623,6 +635,7 @@ mod tests {
             scraping: Default::default(),
             rewrite_first_module: Default::default(),
             frame_order: FrameOrder::CalleeFirst,
+            extract_variables: false,
         };
 
         let request_id = service
@@ -667,6 +680,7 @@ mod tests {
             scraping: Default::default(),
             rewrite_first_module: Default::default(),
             frame_order: FrameOrder::CalleeFirst,
+            extract_variables: false,
         }
     }
 

--- a/crates/symbolicli/src/event.rs
+++ b/crates/symbolicli/src/event.rs
@@ -89,6 +89,7 @@ pub fn create_native_symbolication_request(
     scope: Scope,
     sources: Arc<[SourceConfig]>,
     event: Event,
+    extract_variables: bool,
 ) -> anyhow::Result<SymbolicateStacktraces> {
     let Event {
         debug_meta,
@@ -151,6 +152,7 @@ pub fn create_native_symbolication_request(
         // we manually reversed the frames when we created the stacktraces, so this is
         // "callee first"
         frame_order: FrameOrder::CalleeFirst,
+        extract_variables,
     })
 }
 

--- a/crates/symbolicli/src/main.rs
+++ b/crates/symbolicli/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<()> {
         mode,
         symbols,
         scraping_enabled,
+        extract_variables,
     } = settings::Settings::get()?;
 
     // We depend on `rustls` with both the `aws-lc-rs` and
@@ -136,8 +137,9 @@ async fn main() -> Result<()> {
 
         Payload::Event(event) if event.platform.is_native() => {
             let dsym_sources = prepare_dsym_sources(mode, &symbolicator_config, symbols);
-            let request = create_native_symbolication_request(scope, dsym_sources, event)
-                .context("Event cannot be symbolicated")?;
+            let request =
+                create_native_symbolication_request(scope, dsym_sources, event, extract_variables)
+                    .context("Event cannot be symbolicated")?;
 
             tracing::info!("symbolicating event");
 
@@ -156,6 +158,7 @@ async fn main() -> Result<()> {
                     sources: dsym_sources,
                     scraping: Default::default(),
                     rewrite_first_module: Default::default(),
+                    extract_variables,
                 })
                 .await?;
             CompletedResponse::NativeSymbolication(res)
@@ -171,6 +174,7 @@ async fn main() -> Result<()> {
                     AttachmentFile::Local(file),
                     dsym_sources,
                     Default::default(),
+                    extract_variables,
                 )
                 .await?;
             CompletedResponse::NativeSymbolication(res)

--- a/crates/symbolicli/src/settings.rs
+++ b/crates/symbolicli/src/settings.rs
@@ -124,6 +124,10 @@ struct Cli {
     /// debuginfod, unified, slashsymbols.
     #[arg(long)]
     symbols: Option<SymbolsPath>,
+
+    /// Whether to extract variables from the minidump.
+    #[arg(long)]
+    extract_variables: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -200,6 +204,7 @@ pub struct Settings {
     pub mode: Mode,
     pub symbols: Option<SymbolsPath>,
     pub scraping_enabled: bool,
+    pub extract_variables: bool,
 }
 
 impl Settings {
@@ -216,6 +221,7 @@ impl Settings {
             log_level,
             no_scrape,
             symbols,
+            extract_variables,
         } = Cli::parse();
 
         let global_config_path = find_global_config_file()?;
@@ -307,6 +313,7 @@ impl Settings {
             mode,
             symbols,
             scraping_enabled: !no_scrape,
+            extract_variables,
         };
 
         Ok(args)


### PR DESCRIPTION
Introduce an `extract_variables` option to `RequestOptions` and the `symbolicli`. We will use this option in `compute_symcache` to determine whether to extract variables while computing symcaches; however, the option is currently unused and marked with `#[expect(unused_variables)]` in that function.

The intention is that this option will be passed from Sentry (see https://github.com/getsentry/sentry/pull/120882).

Resolves [INGEST-1104](https://linear.app/getsentry/issue/INGEST-1104/add-variable-extraction-flag-to-symbolicator-request-struct)