### PR TITLE
feat(download): Add `sentry` client with auto-decompression off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 
-### Bug Fixes
-
-- (sentry) Disable transparent decompression when downloading debug files.
-
 ### Features
 - Added a config setting `max_download_size` to restrict the size of downloaded files.
   For compressed files, this limit applies to the _decompressed_ size.
   The default value is 15GiB. ([#1993](https://github.com/getsentry/symbolicator/pull/1993))
+
+- Disabled per-request auto-decompression on the `trusted` download client.
+  This allows Symbolicator to support compressed files served by Sentry.
+  ([#1999](https://github.com/getsentry/symbolicator/pull/1999))
 
 ## 26.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   For compressed files, this limit applies to the _decompressed_ size.
   The default value is 15GiB. ([#1993](https://github.com/getsentry/symbolicator/pull/1993))
 
-- Disabled per-request auto-decompression on the `trusted` download client.
+- Introduced a `sentry` download client used for Sentry file downloads, which is
+  analogous to the `trusted` client, but disables automatic decompression.
   This allows Symbolicator to support compressed files served by Sentry.
   ([#1999](https://github.com/getsentry/symbolicator/pull/1999))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- (sentry) Disable transparent decompression when downloading debug files.
+
 ### Features
 - Added a config setting `max_download_size` to restrict the size of downloaded files.
   For compressed files, this limit applies to the _decompressed_ size.

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -141,8 +141,8 @@ impl DownloadService {
         };
         let trusted_settings = ClientSettings {
             connect_to_reserved_ips: true,
-            // Sentry debug files can be downloaded in ranges. Receiving compressed partial
-            // responses breaks the individual range streams.
+            // Sentry can return the raw byte stream on range requests, which might be part of a
+            // compressed stream, so transparent decompression would fail on those individual parts.
             compression: false,
             ..restricted_settings
         };

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -128,7 +128,7 @@ impl DownloadService {
 
         // |   client  | can connect to reserved IPs | accepts invalid SSL certs | compression |
         // | ----------| ----------------------------|---------------------------|-------------|
-        // |  trusted  |             yes             |             no            |     yes     |
+        // |  trusted  |             yes             |             no            |     no      |
         // | restrcted | according to config setting |             no            |     yes     |
         // |  no ssl   | according to config setting |             yes           |     yes     |
         // |    s3     | according to config setting |             no            |     no      |
@@ -141,6 +141,9 @@ impl DownloadService {
         };
         let trusted_settings = ClientSettings {
             connect_to_reserved_ips: true,
+            // Sentry debug files can be downloaded in ranges. Receiving compressed partial
+            // responses breaks the individual range streams.
+            compression: false,
             ..restricted_settings
         };
         let no_ssl_settings = ClientSettings {

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -128,7 +128,8 @@ impl DownloadService {
 
         // |   client  | can connect to reserved IPs | accepts invalid SSL certs | compression |
         // | ----------| ----------------------------|---------------------------|-------------|
-        // |  trusted  |             yes             |             no            |     no      |
+        // |  trusted  |             yes             |             no            |     yes     |
+        // |   sentry  |             yes             |             no            |     no      |
         // | restrcted | according to config setting |             no            |     yes     |
         // |  no ssl   | according to config setting |             yes           |     yes     |
         // |    s3     | according to config setting |             no            |     no      |
@@ -141,10 +142,13 @@ impl DownloadService {
         };
         let trusted_settings = ClientSettings {
             connect_to_reserved_ips: true,
+            ..restricted_settings
+        };
+        let sentry_settings = ClientSettings {
             // Sentry can return the raw byte stream on range requests, which might be part of a
             // compressed stream, so transparent decompression would fail on those individual parts.
             compression: false,
-            ..restricted_settings
+            ..trusted_settings
         };
         let no_ssl_settings = ClientSettings {
             accept_invalid_certs: true,
@@ -158,6 +162,7 @@ impl DownloadService {
         };
 
         let trusted_client = crate::utils::http::create_client(&trusted_settings);
+        let sentry_client = crate::utils::http::create_client(&sentry_settings);
         let http_restricted_client = crate::utils::http::create_client(&restricted_settings);
         let http_no_ssl_client = crate::utils::http::create_client(&no_ssl_settings);
         let s3_client = crate::utils::http::create_client(&no_compression_settings);
@@ -170,7 +175,7 @@ impl DownloadService {
             limits,
             trusted_client: trusted_client.clone(),
             sentry: sentry::SentryDownloader::new(
-                trusted_client,
+                sentry_client,
                 runtime,
                 limits,
                 in_memory,


### PR DESCRIPTION
We want to start storing (and serving) debug files compressed.
Without this PR, that won't work: Symbolicator uses range requests, but Sentry (Objectstore) would serve the range over the compressed bytes and return a response with `Content-Encoding: zstd`, so Symbolicator would try to decompress that stream individually and fail, as shown here: https://github.com/getsentry/sentry/pull/121182.

This creates an additional `sentry` client, which has the same settings as the `trusted` client, except that it disables auto-decompression. This way, we won't run into the problem described above: Symbolicator will fetch the whole compressed file via range requests, and then decompress it via `maybe_decompress_file`.

Ref FS-390