### PR TITLE
ref: Add logging for 403s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,6 +4834,7 @@ version = "26.6.0"
 dependencies = [
  "data-url",
  "futures",
+ "hex",
  "humantime",
  "insta",
  "moka",

--- a/crates/symbolicator-js/Cargo.toml
+++ b/crates/symbolicator-js/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { workspace = true, features = [
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+hex = { workspace = true }
 sha2 = { workspace = true }
 symbolic = { workspace = true, features = ["common-serde", "sourcemapcache"] }
 symbolicator-service = { workspace = true }

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -868,6 +868,11 @@ impl ArtifactFetcher {
             Err(e) => {
                 // Temporary logging for source map scraping 403s
                 if let CacheError::PermissionDenied(ref details) = e {
+                    let url_hash = {
+                        let mut hasher = Sha256::new();
+                        hasher.update(abs_path.as_bytes());
+                        format!("{:.16}", hex::encode(hasher.finalize()))
+                    };
                     let scope_hash = {
                         let mut hasher = Sha256::new();
                         hasher.update(self.scope.as_ref().as_bytes());
@@ -887,7 +892,8 @@ impl ArtifactFetcher {
                     });
 
                     tracing::info!(
-                        scraping_url = %abs_path,
+                        // 1) url, hashed
+                        scraping_url = %url_hash,
                         // 1) which project/scope this was for, hashed
                         scope_hash = %scope_hash,
                         // 2) did we have headers at all

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -889,13 +889,13 @@ impl ArtifactFetcher {
 
                     tracing::info!(
                         // 1) url, hashed
-                        scraping_url = %url_hash,
+                        url_hash = %url_hash,
                         // 1) which project/scope this was for, hashed
                         scope_hash = %scope_hash,
                         // 2) did we have headers at all
                         scraping_header_count = self.scraping.headers.0.len(),
                         // 3) was the token empty
-                        token_is_empty,
+                        token_is_empty= token_is_empty,
                         // 3) token length
                         token_length = ?token_length,
                         // 4) what the server actually replied

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -885,11 +885,7 @@ impl ArtifactFetcher {
                     });
                     let token_is_empty =
                         token_entry.is_none_or(|(_, value)| value.trim().is_empty());
-                    let token_hash = token_entry.map(|(key, value)| {
-                        let mut hasher = Sha256::new();
-                        hasher.update(value.as_bytes());
-                        format!("{key}={:.16}", hex::encode(hasher.finalize()))
-                    });
+                    let token_length = token_entry.map(|(_, value)| value.len());
 
                     tracing::info!(
                         // 1) url, hashed
@@ -900,8 +896,8 @@ impl ArtifactFetcher {
                         scraping_header_count = self.scraping.headers.0.len(),
                         // 3) was the token empty
                         token_is_empty,
-                        // 3) fingerprint of the token we sent, if any
-                        token_hash = ?token_hash,
+                        // 3) token length
+                        token_length = ?token_length,
                         // 4) what the server actually replied
                         error_details = %details,
                         "scraping: 403/permission denied fetching file"

--- a/crates/symbolicator-js/src/lookup.rs
+++ b/crates/symbolicator-js/src/lookup.rs
@@ -866,6 +866,42 @@ impl ArtifactFetcher {
                 })
             }
             Err(e) => {
+                // Temporary logging for source map scraping 403s
+                if let CacheError::PermissionDenied(ref details) = e {
+                    let scope_hash = {
+                        let mut hasher = Sha256::new();
+                        hasher.update(self.scope.as_ref().as_bytes());
+                        format!("{:.16}", hex::encode(hasher.finalize()))
+                    };
+
+                    let token_entry = self.scraping.headers.0.iter().find(|(key, _)| {
+                        let key = key.to_ascii_lowercase();
+                        key.contains("auth") || key.contains("token")
+                    });
+                    let token_is_empty =
+                        token_entry.is_none_or(|(_, value)| value.trim().is_empty());
+                    let token_hash = token_entry.map(|(key, value)| {
+                        let mut hasher = Sha256::new();
+                        hasher.update(value.as_bytes());
+                        format!("{key}={:.16}", hex::encode(hasher.finalize()))
+                    });
+
+                    tracing::info!(
+                        scraping_url = %abs_path,
+                        // 1) which project/scope this was for, hashed
+                        scope_hash = %scope_hash,
+                        // 2) did we have headers at all
+                        scraping_header_count = self.scraping.headers.0.len(),
+                        // 3) was the token empty
+                        token_is_empty,
+                        // 3) fingerprint of the token we sent, if any
+                        token_hash = ?token_hash,
+                        // 4) what the server actually replied
+                        error_details = %details,
+                        "scraping: 403/permission denied fetching file"
+                    );
+                }
+
                 self.scraping_attempts.push(JsScrapingAttempt {
                     url: abs_path.to_owned(),
                     result: e.clone().into(),


### PR DESCRIPTION
Add additional logging for 403 failures when trying to scrape source map with user configured auth token.

Ref: https://linear.app/getsentry/issue/INGEST-1111