### PR TITLE
feat(variables): Extract and add first variables to stack traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,8 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "pdb-addr2line"
-version = "0.12.0"
-source = "git+https://github.com/mstange/pdb-addr2line?rev=988756c251ed97fbd173de8685c401c41a0b9da4#988756c251ed97fbd173de8685c401c41a0b9da4"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3263467eb4f7871a8bd6650fe7230de816d1f744e32e9a9754df9898d0540ce"
 dependencies = [
  "bitflags",
  "elsa",
@@ -4792,8 +4793,7 @@ dependencies = [
 [[package]]
 name = "symbolic"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a3daa09736c330c4df698441473b658b918f262afe053de13c0bb17e462d83"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4808,8 +4808,7 @@ dependencies = [
 [[package]]
 name = "symbolic-cfi"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3af3e74dbdcd09191d8a7be99ddca00c30b6f06e254effa3a5116c7be1ff289"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4819,8 +4818,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ce6a0b122482d8cea8e4f136ff5616b53bc64e671616ac98efffe350d795dc"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4832,8 +4830,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf589660766eb28b42b4f91c321b4716fb4da5ab6633827e3180e71a9c6784e"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "debugid",
  "elementtree",
@@ -4845,7 +4842,6 @@ dependencies = [
  "memchr",
  "nom",
  "nom-supreme",
- "once_cell",
  "parking_lot",
  "pdb-addr2line",
  "regex",
@@ -4865,8 +4861,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c79cbfeb08c0cc751d879ba181f03ce07883b6a76f9d542acea067eff7d34e"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "bitflags",
  "cc",
@@ -4879,8 +4874,7 @@ dependencies = [
 [[package]]
 name = "symbolic-il2cpp"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc5a409b35510f10c1805aed4dbfbc6551d773853c2f7aef789af81972e23a"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4891,8 +4885,7 @@ dependencies = [
 [[package]]
 name = "symbolic-ppdb"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbf8a7e73981a806de063ad86233366591cbb785d408e78036df9f672d06d15"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4907,8 +4900,7 @@ dependencies = [
 [[package]]
 name = "symbolic-sourcemapcache"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07579e21750a02d1a83cb2636b83bfa81d62925d59e7a1954743ca1697d3add9"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "itertools 0.14.0",
  "js-source-scopes",
@@ -4922,8 +4914,7 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "14.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7486e91fc6b40684f736c46279c0ed9d63cc2b9fdc0a3e862d2c7d28ed71d7"
+source = "git+https://github.com/getsentry/symbolic.git?rev=785063490d1b15a2cb4a984117a028ec52e80ed3#785063490d1b15a2cb4a984117a028ec52e80ed3"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,6 @@ reqwest = { git = "https://github.com/getsentry/reqwest", branch = "swatinem/upd
 # This patch adds limited "templated lambdas" demangling support
 cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "sentry-patches" }
 
-# TODO(INGEST-1081): Once https://github.com/mstange/pdb-addr2line/pull/71 is released,
-# update pdb-addr2line in symbolic and release it.
-pdb-addr2line = { git = "https://github.com/mstange/pdb-addr2line", rev = "988756c251ed97fbd173de8685c401c41a0b9da4"}
-
 # For local development: uncomment the following three lines (and adjust the path if necessary)
 # to use a local symbolic checkout everywhere.
 # This only works for the very specific crate listed here, and not for its dependency tree.
@@ -130,7 +126,7 @@ serde_yaml = "0.9.14"
 sha-1 = "0.10.0"
 sha2 = "0.10.6"
 sketches-ddsketch = "0.3.0"
-symbolic = "14.0.0-alpha.3"
+symbolic = { git = "https://github.com/getsentry/symbolic.git", rev = "785063490d1b15a2cb4a984117a028ec52e80ed3" }
 symbolicator-crash = { path = "crates/symbolicator-crash" }
 symbolicator-js = { path = "crates/symbolicator-js" }
 symbolicator-native = { path = "crates/symbolicator-native" }

--- a/crates/symbolicator-native/src/caches/symcaches.rs
+++ b/crates/symbolicator-native/src/caches/symcaches.rs
@@ -73,11 +73,16 @@ async fn compute_symcache(
     objects_actor: &ObjectsActor,
     object_meta: Arc<ObjectMetaHandle>,
     secondary_sources: &SecondarySymCacheSources,
-    #[expect(unused_variables)] extract_varialbes: bool,
+    extract_varialbes: bool,
 ) -> CacheContents {
     let object_handle = objects_actor.fetch(object_meta).await?;
 
-    write_symcache(temp_file.as_file_mut(), &object_handle, secondary_sources)
+    write_symcache(
+        temp_file.as_file_mut(),
+        &object_handle,
+        secondary_sources,
+        extract_varialbes,
+    )
 }
 
 impl CacheItemRequest for FetchSymCacheInternal {
@@ -227,6 +232,7 @@ fn write_symcache(
     file: &mut File,
     object_handle: &ObjectHandle,
     secondary_sources: &SecondarySymCacheSources,
+    extract_varialbes: bool,
 ) -> CacheContents {
     object_handle.configure_scope();
 
@@ -265,6 +271,7 @@ fn write_symcache(
     tracing::debug!("Converting symcache for {}", object_handle.cache_key);
 
     let mut converter = SymCacheConverter::new();
+    converter.set_collect_variables(extract_varialbes);
 
     if let Some(bcsymbolmap) = bcsymbolmap_transformer {
         converter.add_transformer(bcsymbolmap);

--- a/crates/symbolicator-native/src/interface.rs
+++ b/crates/symbolicator-native/src/interface.rs
@@ -336,6 +336,12 @@ pub struct RawFrame {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_app: Option<bool>,
 
+    /// Mapping of local variables and expression names that were available in this frame.
+    ///
+    /// Current format is heavily work in progress.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vars: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Information about how the raw frame was created.
     #[serde(default, skip_serializing_if = "is_default_value")]
     pub trust: FrameTrust,

--- a/crates/symbolicator-native/src/symbolication/native.rs
+++ b/crates/symbolicator-native/src/symbolication/native.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeMap;
+
 use symbolic::common::{InstructionInfo, Language, split_path};
-use symbolic::symcache::SymCache;
+use symbolic::symcache::{SourceLocation, SymCache, Type};
 use symbolicator_service::metric;
 use symbolicator_service::utils::hex::HexValue;
 
@@ -17,6 +19,7 @@ pub fn symbolicate_native_frame(
     relative_addr: u64,
     frame: &RawFrame,
     index: usize,
+    extract_variables: bool,
 ) -> Result<Vec<SymbolicatedFrame>, FrameStatus> {
     tracing::trace!("Symbolicating {:#x}", relative_addr);
     let mut rv = vec![];
@@ -45,6 +48,12 @@ pub fn symbolicate_native_frame(
         } else {
             frame.filename.clone()
         };
+
+        let mut vars = None;
+        if extract_variables {
+            vars = do_extract_variables(&source_location, symcache);
+        }
+
         rv.push(SymbolicatedFrame {
             status: FrameStatus::Symbolicated,
             original_index: Some(index),
@@ -74,6 +83,7 @@ pub fn symbolicate_native_frame(
                     language => Some(language),
                 },
                 in_app: None,
+                vars,
                 trust: frame.trust,
             },
         });
@@ -146,5 +156,59 @@ pub fn get_relative_caller_addr(
         );
         metric!(counter("relative_addr.underflow") += 1);
         Err(FrameStatus::MissingSymbol)
+    }
+}
+
+fn do_extract_variables<'data, 'cache>(
+    source_location: &SourceLocation<'data, 'cache>,
+    cache: &SymCache<'cache>,
+) -> Option<BTreeMap<String, serde_json::Value>> {
+    let mut result = BTreeMap::new();
+
+    for variable in source_location.variables() {
+        let Some(name) = variable.name() else {
+            continue;
+        };
+
+        let mut ty = String::new();
+        resolve_type_name(&mut ty, cache, variable.ty(), 0);
+
+        // This doesn't handle name collisions currently.
+        result.insert(name.to_owned(), ty.into());
+    }
+
+    match result.is_empty() {
+        false => Some(result),
+        true => None,
+    }
+}
+
+fn resolve_type_name(
+    result: &mut String,
+    cache: &SymCache<'_>,
+    ty: Option<Type<'_>>,
+    depth: usize,
+) {
+    let Some(ty) = ty else {
+        result.push_str("<unknown>");
+        return;
+    };
+
+    // This really is just temporary and not even necessary, the current depth limit in symbolic is 5.
+    // With more changes we'll have to solve this properly. As we're also going to have to resolve
+    // the variable contents, not just a type name.
+    if depth > 10 {
+        return;
+    }
+
+    match ty {
+        Type::Primitive(primitive) => result.push_str(primitive.name().unwrap_or("")),
+        Type::Pointer(pointer) if pointer.pointee().is_none() => result.push_str("void*"),
+        Type::Pointer(pointer) => {
+            let ty = pointer.pointee().and_then(|p| cache.lookup_type(p));
+            resolve_type_name(result, cache, ty, depth);
+            result.push('*');
+        }
+        _ => result.push_str("<not implemented>"),
     }
 }

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -146,6 +146,7 @@ impl SymbolicationActor {
                     &module_lookup,
                     &mut metrics,
                     signal,
+                    extract_variables,
                 )
             })
             .collect();
@@ -181,6 +182,7 @@ fn symbolicate_stacktrace(
     caches: &ModuleLookup,
     metrics: &mut StacktraceMetrics,
     signal: Option<Signal>,
+    extract_variables: bool,
 ) -> CompleteStacktrace {
     let default_adjustment = AdjustInstructionAddr::default_for_thread(&thread);
     let mut symbolicated_frames = vec![];
@@ -196,6 +198,7 @@ fn symbolicate_stacktrace(
             &mut frame,
             index,
             adjustment,
+            extract_variables,
         ) {
             Ok(frames) => {
                 if matches!(frame.trust, FrameTrust::Scan) {
@@ -307,6 +310,10 @@ fn symbolicate_stacktrace(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "https://github.com/getsentry/symbolicator/issues/2002"
+)]
 fn symbolicate_frame(
     demangle_cache: &DemangleCache,
     caches: &ModuleLookup,
@@ -315,6 +322,7 @@ fn symbolicate_frame(
     frame: &mut RawFrame,
     index: usize,
     adjustment: AdjustInstructionAddr,
+    extract_variables: bool,
 ) -> Result<Vec<SymbolicatedFrame>, FrameStatus> {
     let lookup_result = caches
         .lookup_cache(frame.instruction_addr.0, frame.addr_mode)
@@ -342,6 +350,7 @@ fn symbolicate_frame(
                 relative_addr,
                 frame,
                 index,
+                extract_variables,
             )
         }
         Ok(CacheFileEntry::PortablePdbCache(ppdb_cache)) => {

--- a/crates/symbolicator-service/src/download/destination.rs
+++ b/crates/symbolicator-service/src/download/destination.rs
@@ -211,7 +211,9 @@ impl WriteStream for OffsetFileWriteStream {
 
         debug_assert!(
             offset + length < self.end,
-            "attempt to write past end of stream"
+            "attempt to write past end of stream {offset}+{length} ({}) < {}",
+            offset + length,
+            self.end
         );
 
         let file = Arc::clone(&self.file);

--- a/crates/symbolicli/src/event.rs
+++ b/crates/symbolicli/src/event.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::bail;
@@ -245,48 +246,30 @@ struct Frame {
     platform: Option<Platform>,
     #[serde(default)]
     addr_mode: AddrMode,
-
     instruction_addr: Option<HexValue>,
-
     #[serde(default)]
     function_id: Option<HexValue>,
-
     #[serde(default)]
     package: Option<String>,
-
     lang: Option<Language>,
-
     symbol: Option<String>,
-
     sym_addr: Option<HexValue>,
-
     function: Option<String>,
-
     filename: Option<String>,
-
     abs_path: Option<String>,
-
     lineno: Option<u32>,
-
     colno: Option<u32>,
-
     #[serde(default)]
     pre_context: Vec<String>,
-
     context_line: Option<String>,
-
     #[serde(default)]
     post_context: Vec<String>,
-
     module: Option<String>,
-
     source_link: Option<String>,
-
     in_app: Option<bool>,
-
+    vars: Option<BTreeMap<String, serde_json::Value>>,
     #[serde(default)]
     trust: FrameTrust,
-
     #[serde(default)]
     data: JsFrameData,
 }
@@ -311,6 +294,7 @@ fn to_raw_frame(value: Frame) -> Option<RawFrame> {
         post_context: value.post_context,
         source_link: value.source_link,
         in_app: value.in_app,
+        vars: value.vars,
         trust: value.trust,
     })
 }


### PR DESCRIPTION
Adds variables to symbolicated frames. It adds the variable name and its resolved type, it doesn't actually require a minidump to lookup the contents of the variables at that location, it only adds the metadata. This will be changed in the future to actually add real information.

`vars` on the `RawFrame` follows the [schema](https://github.com/getsentry/relay/blob/6fab393d7e3fafc6c153649b7fd2cb6ab297ebf0/relay-event-schema/src/protocol/stacktrace.rs#L127-L130) defined in Relay.

The entire thing is optional and needs to be specifically requested (through a feature flag in Sentry).

Verified with `symbolicli`:

```json
          "vars": {
            "buffer": "<unknown>",
            "damage": "float",
            "frame_number": "int",
            "local_counter": "int",
            "player": "<unknown>*"
          },
```

Closes: INGEST-1081