### PR TITLE
feat(download): Support compressed range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@
   For compressed files, this limit applies to the _decompressed_ size.
   The default value is 15GiB. ([#1993](https://github.com/getsentry/symbolicator/pull/1993))
 
-- Introduced a `sentry` download client used for Sentry file downloads, which is
-  analogous to the `trusted` client, but disables automatic decompression.
-  This allows Symbolicator to support compressed files served by Sentry.
-  ([#1999](https://github.com/getsentry/symbolicator/pull/1999))
+- Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
+  ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
 
 ## 26.7.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,13 +163,12 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.30"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977eb15ea9efd848bb8a4a1a2500347ed7f0bf794edf0dc3ddcf439f43d36b23"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -1035,9 +1034,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.30"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1049,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -3429,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -5056,11 +5055,13 @@ name = "symbolicator-service"
 version = "26.7.2"
 dependencies = [
  "anyhow",
+ "async-compression",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-smithy-types",
  "aws-smithy-xml",
+ "axum",
  "bytes",
  "cab",
  "chrono",
@@ -5077,6 +5078,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-dogstatsd",
  "moka",
+ "pin-project-lite",
  "proguard",
  "rand 0.9.4",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ cpp_demangle = { git = "https://github.com/getsentry/cpp_demangle", branch = "se
 anyhow = "1.0.66"
 apple-crash-report-parser = "0.6.0"
 async-trait = "0.1.53"
+async-compression = "0.4.43"
 aws-config = { version = "1.8.12", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1.2.11", features = [
     "hardcoded-credentials",
@@ -100,6 +101,7 @@ minidump-processor = "0.26.1"
 minidump-unwind = "0.26.1"
 minidumper-child = "0.5.0"
 moka = { version = "0.12.8", features = ["future", "sync"] }
+pin-project-lite = "0.2.17"
 prettytable-rs = "0.10.0"
 proguard = "5.10.4"
 rand = "0.9.4"

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__add_bucket-2.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__add_bucket-2.snap
@@ -41,17 +41,12 @@ modules:
             has_unwind_info: false
             has_symbols: true
             has_sources: false
+        debug:
+          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
-          status: ok
-          features:
-            has_debug_info: true
-            has_unwind_info: false
-            has_symbols: true
-            has_sources: false
-        debug:
-          status: ok
+          status: notfound
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.src.zip"
         download:

--- a/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__remove_bucket.snap
+++ b/crates/symbolicator-native/tests/integration/snapshots/integration__symbolication__remove_bucket.snap
@@ -41,17 +41,12 @@ modules:
             has_unwind_info: false
             has_symbols: true
             has_sources: false
+        debug:
+          status: ok
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.app"
         download:
-          status: ok
-          features:
-            has_debug_info: true
-            has_unwind_info: false
-            has_symbols: true
-            has_sources: false
-        debug:
-          status: ok
+          status: notfound
       - source: local
         location: "http://localhost:<port>/symbols/502F/C0A5/1EC1/3E47/9998/684FA139DCA7.src.zip"
         download:

--- a/crates/symbolicator-proguard/src/service.rs
+++ b/crates/symbolicator-proguard/src/service.rs
@@ -9,14 +9,13 @@ use symbolicator_service::caches::versions::PROGUARD_CACHE_VERSIONS;
 use symbolicator_service::caching::{
     CacheContents, CacheError, CacheItemRequest, CacheKey, Cacher,
 };
-use symbolicator_service::download::{
-    self, DownloadService, SourceIndexService, fetch_file, tempfile_in_parent,
-};
+use symbolicator_service::download::{self, DownloadService, SourceIndexService, fetch_file};
 use symbolicator_service::objects::{
     FindObject, FindResult, ObjectHandle, ObjectPurpose, ObjectsActor,
 };
 use symbolicator_service::services::SharedServices;
 use symbolicator_service::types::Scope;
+use symbolicator_service::utils::fs::tempfile_in_parent;
 use symbolicator_sources::{FileType, ObjectId, RemoteFile, SourceConfig};
 use tempfile::NamedTempFile;
 

--- a/crates/symbolicator-service/Cargo.toml
+++ b/crates/symbolicator-service/Cargo.toml
@@ -7,6 +7,7 @@ license-file = "../../LICENSE.md"
 
 [dependencies]
 anyhow = { workspace = true }
+async-compression = { workspace = true, features = ["tokio", "brotli", "gzip", "zlib", "zstd"] }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }
 aws-sdk-s3 = { workspace = true }
@@ -27,6 +28,7 @@ jsonwebtoken = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-dogstatsd = { workspace = true }
 moka = { workspace = true }
+pin-project-lite = { workspace = true }
 proguard = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -56,7 +58,7 @@ symbolicator-sources = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "fs"] }
-tokio-util = { workspace = true, features = ["io"] }
+tokio-util = { workspace = true, features = ["io", "io-util"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
 url = { workspace = true }
@@ -65,6 +67,7 @@ zip = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]
+axum = { workspace = true }
 sha-1 = { workspace = true }
 symbolicator-test = { workspace = true }
 insta = { workspace = true }

--- a/crates/symbolicator-service/src/caching/fs.rs
+++ b/crates/symbolicator-service/src/caching/fs.rs
@@ -282,43 +282,7 @@ impl Cache {
 
     /// Create a new temporary file to use in the cache.
     pub fn tempfile(&self) -> io::Result<NamedTempFile> {
-        match self.tmp_dir {
-            Some(ref path) => {
-                // The `cleanup` process could potentially remove the parent directories we are
-                // operating in, so be defensive here and retry the fs operations.
-                const MAX_RETRIES: usize = 2;
-                let mut retries = 0;
-                loop {
-                    retries += 1;
-
-                    if let Err(e) = std::fs::create_dir_all(path) {
-                        sentry::with_scope(
-                            |scope| scope.set_extra("path", path.display().to_string().into()),
-                            || tracing::error!("Failed to create cache directory: {:?}", e),
-                        );
-                        if retries > MAX_RETRIES {
-                            return Err(e);
-                        }
-                        continue;
-                    }
-
-                    match tempfile::Builder::new().prefix("tmp").tempfile_in(path) {
-                        Ok(temp_file) => return Ok(temp_file),
-                        Err(e) => {
-                            sentry::with_scope(
-                                |scope| scope.set_extra("path", path.display().to_string().into()),
-                                || tracing::error!("Failed to create cache file: {:?}", e),
-                            );
-                            if retries > MAX_RETRIES {
-                                return Err(e);
-                            }
-                            continue;
-                        }
-                    }
-                }
-            }
-            None => Ok(NamedTempFile::new()?),
-        }
+        crate::utils::fs::tempfile(self.tmp_dir.as_deref())
     }
 }
 

--- a/crates/symbolicator-service/src/download/compression.rs
+++ b/crates/symbolicator-service/src/download/compression.rs
@@ -2,7 +2,11 @@ use std::io::{self, Read, Seek};
 
 use cab::Cabinet;
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
+use reqwest::header::HeaderMap;
 use tempfile::NamedTempFile;
+use tokio::io::{AsyncBufRead, AsyncRead};
+
+use crate::caching::CacheError;
 
 /// Decompresses a downloaded file.
 ///
@@ -49,7 +53,7 @@ pub fn maybe_decompress_file(
         [0x28, 0xb5, 0x2f, 0xfd] => {
             metric!(counter("compression") += 1, "type" => "zstd");
 
-            let mut dst = tempfile_in_parent(src)?;
+            let mut dst = crate::utils::fs::tempfile_in_parent(src)?;
             let mut reader = zstd::stream::Decoder::new(file)?.take(read_limit);
             io::copy(&mut reader, &mut dst)?;
 
@@ -62,7 +66,7 @@ pub fn maybe_decompress_file(
 
             // We assume MultiGzDecoder accepts a strict superset of input
             // values compared to GzDecoder.
-            let mut dst = tempfile_in_parent(src)?;
+            let mut dst = crate::utils::fs::tempfile_in_parent(src)?;
             let mut reader = MultiGzDecoder::new(file).take(read_limit);
             io::copy(&mut reader, &mut dst)?;
 
@@ -72,7 +76,7 @@ pub fn maybe_decompress_file(
         [0x78, 0x01, _, _] | [0x78, 0x9c, _, _] | [0x78, 0xda, _, _] => {
             metric!(counter("compression") += 1, "type" => "zlib");
 
-            let mut dst = tempfile_in_parent(src)?;
+            let mut dst = crate::utils::fs::tempfile_in_parent(src)?;
             let mut reader = ZlibDecoder::new(file).take(read_limit);
             io::copy(&mut reader, &mut dst)?;
 
@@ -94,7 +98,7 @@ pub fn maybe_decompress_file(
                     ));
                 }
 
-                let mut dst = tempfile_in_parent(src)?;
+                let mut dst = crate::utils::fs::tempfile_in_parent(src)?;
                 let mut reader = archive.by_index(0)?.take(read_limit);
                 io::copy(&mut reader, &mut dst)?;
 
@@ -129,7 +133,7 @@ pub fn maybe_decompress_file(
                 ));
             }
 
-            let mut dst = tempfile_in_parent(src)?;
+            let mut dst = crate::utils::fs::tempfile_in_parent(src)?;
             let mut reader = cab_file.read_file(&first_file)?.take(read_limit);
             std::io::copy(&mut reader, &mut dst)?;
 
@@ -151,11 +155,244 @@ pub fn maybe_decompress_file(
     Ok(())
 }
 
-// FIXME(swatinem): this fn needs a better place
-pub fn tempfile_in_parent(file: &NamedTempFile) -> io::Result<NamedTempFile> {
-    let dir = file
-        .path()
-        .parent()
-        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
-    NamedTempFile::new_in(dir)
+/// Different compressions supported by Symbolicator.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Compression {
+    /// The identity compression.
+    ///
+    /// Also known as no compression.
+    Identity,
+    /// Brotli compression.
+    Brotli,
+    /// Deflate compression.
+    Deflate,
+    /// GZIP compression.
+    Gzip,
+    /// Zstd compression.
+    Zstd,
+}
+
+impl Compression {
+    /// Parses the [`Compression`] from [HTTP headers](`HeaderMap`).
+    pub fn from_headers(headers: &HeaderMap) -> Result<Self, CompressionError> {
+        let content_encodings = headers.get_all(reqwest::header::CONTENT_ENCODING);
+        let mut content_encodings = content_encodings.iter();
+
+        let Some(content_encoding) = content_encodings.next() else {
+            return Ok(Self::Identity);
+        };
+
+        if content_encodings.next().is_some() {
+            return Err(CompressionError("Multiple content encodings not supported"));
+        }
+
+        Ok(match content_encoding.as_bytes().trim_ascii() {
+            b"" | b"identity" => Self::Identity,
+            b"br" => Self::Brotli,
+            b"gzip" | b"x-gzip" => Self::Gzip,
+            b"deflate" => Self::Deflate,
+            b"zstd" => Self::Zstd,
+            _ => {
+                return Err(CompressionError("Unsupported content encoding"));
+            }
+        })
+    }
+
+    /// Returns a `Accept-Encoding` compatible header of all supported compressions.
+    pub fn accept_encoding() -> reqwest::header::HeaderValue {
+        const ENCODINGS: &str = "br, deflate, gzip, zstd";
+        reqwest::header::HeaderValue::from_static(ENCODINGS)
+    }
+
+    /// Returns a [`Decoder`] which decompresses `r`.
+    pub fn decompress<R>(self, r: R) -> Decoder<R>
+    where
+        R: AsyncBufRead,
+    {
+        match self {
+            Self::Identity => Decoder {
+                inner: DecoderInner::Identity { r },
+            },
+            Self::Brotli => Decoder {
+                inner: DecoderInner::Brotli {
+                    r: async_compression::tokio::bufread::BrotliDecoder::new(r),
+                },
+            },
+            Self::Deflate => Decoder {
+                inner: DecoderInner::Deflate {
+                    r: async_compression::tokio::bufread::ZlibDecoder::new(r),
+                },
+            },
+            Self::Gzip => Decoder {
+                inner: DecoderInner::Gzip {
+                    r: async_compression::tokio::bufread::GzipDecoder::new(r),
+                },
+            },
+            Self::Zstd => Decoder {
+                inner: DecoderInner::Zstd {
+                    r: async_compression::tokio::bufread::ZstdDecoder::new(r),
+                },
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
+pub struct CompressionError(&'static str);
+
+impl From<CompressionError> for CacheError {
+    fn from(error: CompressionError) -> Self {
+        Self::Malformed(error.0.to_owned())
+    }
+}
+
+pin_project_lite::pin_project! {
+    pub struct Decoder<R> { #[pin] inner: DecoderInner<R> }
+}
+
+impl<R> AsyncRead for Decoder<R>
+where
+    R: AsyncBufRead,
+{
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        match self.project().inner.project() {
+            DecoderInnerProj::Identity { r } => r.poll_read(cx, buf),
+            DecoderInnerProj::Brotli { r } => r.poll_read(cx, buf),
+            DecoderInnerProj::Deflate { r } => r.poll_read(cx, buf),
+            DecoderInnerProj::Gzip { r } => r.poll_read(cx, buf),
+            DecoderInnerProj::Zstd { r } => r.poll_read(cx, buf),
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    #[project = DecoderInnerProj]
+    enum DecoderInner<R> {
+        Identity { #[pin] r: R },
+        Brotli{ #[pin] r: async_compression::tokio::bufread::BrotliDecoder<R> },
+        // In HTTP 1.1 `Content-Encoding: deflate` refers to `DEFLATE` compression,
+        // wrapped in the zlip data format.
+        //
+        // See: <https://github.com/seanmonstar/reqwest/pull/1257>.
+        Deflate{ #[pin] r: async_compression::tokio::bufread::ZlibDecoder<R> },
+        Gzip{ #[pin] r: async_compression::tokio::bufread::GzipDecoder<R> },
+        Zstd{ #[pin] r: async_compression::tokio::bufread::ZstdDecoder<R> },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{CONTENT_ENCODING, HeaderValue};
+    use tokio::io::{AsyncReadExt, BufReader};
+
+    use super::*;
+
+    #[test]
+    fn test_from_headers_identity() {
+        let mut headers = HeaderMap::new();
+
+        assert_eq!(
+            Compression::from_headers(&headers),
+            Ok(Compression::Identity)
+        );
+
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static(""));
+        assert_eq!(
+            Compression::from_headers(&headers),
+            Ok(Compression::Identity)
+        );
+
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static(" identity "));
+        assert_eq!(
+            Compression::from_headers(&headers),
+            Ok(Compression::Identity)
+        );
+    }
+
+    #[test]
+    fn test_from_headers_supported_encodings() {
+        for (header, expected) in [
+            ("br", Compression::Brotli),
+            (" br ", Compression::Brotli),
+            ("deflate", Compression::Deflate),
+            ("gzip", Compression::Gzip),
+            ("x-gzip", Compression::Gzip),
+            ("zstd", Compression::Zstd),
+            (" zstd ", Compression::Zstd),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_ENCODING, HeaderValue::from_static(header));
+
+            assert_eq!(Compression::from_headers(&headers), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn test_from_headers_unsupported_encoding() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static("compress"));
+
+        assert_eq!(
+            Compression::from_headers(&headers),
+            Err(CompressionError("Unsupported content encoding"))
+        );
+    }
+
+    #[test]
+    fn test_from_headers_multiple_encodings() {
+        let mut headers = HeaderMap::new();
+        headers.append(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        headers.append(CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+        assert_eq!(
+            Compression::from_headers(&headers),
+            Err(CompressionError("Multiple content encodings not supported"))
+        );
+    }
+
+    macro_rules! test_decompress {
+        ($test_name:ident, $compression:ident, $encoder:expr) => {
+            #[tokio::test]
+            async fn $test_name() {
+                let input = b"hello from a compressed response";
+                let mut encoder = ($encoder)(BufReader::new(&input[..]));
+                let mut compressed = Vec::new();
+                encoder.read_to_end(&mut compressed).await.unwrap();
+
+                let source = BufReader::new(compressed.as_slice());
+                let mut decoder = Compression::$compression.decompress(source);
+                let mut output = Vec::new();
+                decoder.read_to_end(&mut output).await.unwrap();
+
+                assert_eq!(output, input);
+            }
+        };
+    }
+
+    test_decompress!(test_decompress_identity, Identity, std::convert::identity);
+    test_decompress!(
+        test_decompress_brotli,
+        Brotli,
+        async_compression::tokio::bufread::BrotliEncoder::new
+    );
+    test_decompress!(
+        test_decompress_deflate,
+        Deflate,
+        async_compression::tokio::bufread::ZlibEncoder::new
+    );
+    test_decompress!(
+        test_decompress_gzip,
+        Gzip,
+        async_compression::tokio::bufread::GzipEncoder::new
+    );
+    test_decompress!(
+        test_decompress_zstd,
+        Zstd,
+        async_compression::tokio::bufread::ZstdEncoder::new
+    );
 }

--- a/crates/symbolicator-service/src/download/destination.rs
+++ b/crates/symbolicator-service/src/download/destination.rs
@@ -15,16 +15,16 @@ use std::{io::Write, sync::Arc};
 pub trait WriteStream: Send {
     /// Attempts to write an entire buffer into this writer.
     ///
-    /// See also: [`AsyncWriteExt::write_buf`].
-    fn write_buf(&mut self, buf: Bytes) -> impl Future<Output = io::Result<()>> + Send;
+    /// See also: [`AsyncWriteExt::write_all`].
+    fn write_all(&mut self, buf: Bytes) -> impl Future<Output = io::Result<()>> + Send;
 }
 
 impl<T> WriteStream for T
 where
     T: AsyncWrite + Unpin + Send,
 {
-    async fn write_buf(&mut self, mut buf: Bytes) -> io::Result<()> {
-        AsyncWriteExt::write_buf(self, &mut buf).await.map(|_| ())
+    async fn write_all(&mut self, buf: Bytes) -> io::Result<()> {
+        AsyncWriteExt::write_all(self, &buf).await
     }
 }
 
@@ -200,7 +200,7 @@ pub struct OffsetFileWriteStream {
 
 #[cfg(unix)]
 impl WriteStream for OffsetFileWriteStream {
-    async fn write_buf(&mut self, buf: Bytes) -> io::Result<()>
+    async fn write_all(&mut self, buf: Bytes) -> io::Result<()>
     where
         Self: Unpin,
     {
@@ -258,11 +258,11 @@ mod tests {
         let mut ee = streams.stream(8, 10);
 
         let mut futures = FuturesUnordered::new();
-        futures.push(aa.write_buf(Bytes::from("aa")));
-        futures.push(cc.write_buf(Bytes::from("cc")));
-        futures.push(bb.write_buf(Bytes::from("bb")));
-        futures.push(ee.write_buf(Bytes::from("ee")));
-        futures.push(dd.write_buf(Bytes::from("dd")));
+        futures.push(aa.write_all(Bytes::from("aa")));
+        futures.push(cc.write_all(Bytes::from("cc")));
+        futures.push(bb.write_all(Bytes::from("bb")));
+        futures.push(ee.write_all(Bytes::from("ee")));
+        futures.push(dd.write_all(Bytes::from("dd")));
         while futures.next().await.transpose().unwrap().is_some() {}
 
         streams.flush().await.unwrap();

--- a/crates/symbolicator-service/src/download/fetch_file.rs
+++ b/crates/symbolicator-service/src/download/fetch_file.rs
@@ -21,8 +21,11 @@ pub async fn fetch_file(
     temp_file: &mut NamedTempFile,
 ) -> CacheContents {
     downloader
-        .download(file_id, temp_file.path().to_owned())
+        .download(file_id)
+        .await?
+        .materialize_into(temp_file)
         .await?;
+
     tracing::trace!("Finished download");
 
     // Treat decompression errors as malformed files. It is more likely that

--- a/crates/symbolicator-service/src/download/filesystem.rs
+++ b/crates/symbolicator-service/src/download/filesystem.rs
@@ -8,7 +8,10 @@ use tokio::fs::File;
 
 use symbolicator_sources::FilesystemRemoteFile;
 
-use crate::caching::{CacheContents, CacheError};
+use crate::{
+    caching::{CacheContents, CacheError},
+    download::compression::Compression,
+};
 
 use super::Destination;
 
@@ -26,7 +29,7 @@ impl FilesystemDownloader {
         &self,
         file_source: &FilesystemRemoteFile,
         destination: impl Destination,
-    ) -> CacheContents {
+    ) -> CacheContents<Compression> {
         let path = file_source.path();
         tracing::debug!("Fetching debug file from {:?}", path);
 
@@ -36,6 +39,6 @@ impl FilesystemDownloader {
         })?;
         let mut destination = std::pin::pin!(destination.into_write());
         tokio::io::copy(&mut file, &mut destination).await?;
-        Ok(())
+        Ok(Compression::Identity)
     }
 }

--- a/crates/symbolicator-service/src/download/gcs.rs
+++ b/crates/symbolicator-service/src/download/gcs.rs
@@ -5,6 +5,7 @@ use symbolicator_sources::{GcsRemoteFile, GcsSourceAuthorization, GcsSourceKey, 
 
 use crate::caching::{CacheContents, CacheError};
 use crate::download::DownloadLimits;
+use crate::download::compression::Compression;
 use crate::utils::gcs::{self, CacheableToken};
 
 use super::Destination;
@@ -71,7 +72,7 @@ impl GcsDownloader {
         source_name: &str,
         file_source: &GcsRemoteFile,
         destination: impl Destination,
-    ) -> CacheContents {
+    ) -> CacheContents<Compression> {
         let key = file_source.key();
         let bucket = &file_source.source.bucket;
         tracing::debug!("Fetching from GCS: {} (from {})", key, bucket);

--- a/crates/symbolicator-service/src/download/http.rs
+++ b/crates/symbolicator-service/src/download/http.rs
@@ -6,7 +6,7 @@ use symbolicator_sources::HttpRemoteFile;
 
 use crate::{
     caching::{CacheContents, CacheError},
-    download::DownloadLimits,
+    download::{DownloadLimits, compression::Compression},
 };
 
 use super::Destination;
@@ -34,7 +34,7 @@ impl HttpDownloader {
         source_name: &str,
         file_source: &HttpRemoteFile,
         destination: impl Destination,
-    ) -> CacheContents {
+    ) -> CacheContents<Compression> {
         let download_url = file_source.url().map_err(|_| CacheError::NotFound)?;
 
         tracing::debug!("Fetching debug file from `{}`", download_url);

--- a/crates/symbolicator-service/src/download/index.rs
+++ b/crates/symbolicator-service/src/download/index.rs
@@ -13,6 +13,7 @@ use symbolicator_sources::{
     SourceConfig, SourceId, SourceIndex, SourceLocation, SymstoreIndex,
 };
 use tempfile::NamedTempFile;
+use tokio::io::AsyncReadExt as _;
 
 use crate::caches::CacheVersions;
 use crate::caches::versions::SYMSTORE_INDEX_VERSIONS;
@@ -26,6 +27,9 @@ use super::DownloadService;
 /// The path of the file containing the ID of the most recent upload
 /// log file.
 const LASTID_FILE: &str = "000Admin/lastid.txt";
+
+/// Maximum length for a valid id stored in the [`LASTID_FILE`].
+const LASTID_MAX_LENGTH: usize = 200;
 
 /// The time for which a successfully fetched Symstore "last id" should be cached in memory.
 const LASTID_OK_CACHE_TIME: Duration = Duration::from_secs(24 * 60 * 60);
@@ -166,24 +170,28 @@ async fn download_index_segment(
 ) -> CacheContents {
     let loc = SourceLocation::new(format!("000Admin/{segment:0>10}"));
     let remote_file = source.remote_file(loc);
-    let temp_file = NamedTempFile::new()?;
 
     tracing::debug!(segment, "Downloading Symstore index segment");
 
-    if let Err(e) = downloader
-        .download(remote_file, temp_file.path().to_path_buf())
-        .await
-    {
-        tracing::error!(
-            error = &e as &dyn std::error::Error,
-            source_id = %source.id(),
-            segment,
-            "Failed to download Symstore index segment",
-        )
-    }
+    let download = match downloader.download(remote_file).await {
+        Ok(download) => download,
+        Err(err) => {
+            tracing::error!(
+                error = &err as &dyn std::error::Error,
+                source_id = %source.id(),
+                segment,
+                "Failed to download Symstore index segment",
+            );
+            return Err(err);
+        }
+    };
 
-    let buf = BufReader::new(temp_file);
-    let index = SymstoreIndex::parse_from_reader(buf)?;
+    let reader = tokio_util::io::SyncIoBridge::new(download.into_read());
+    let index = tokio::task::spawn_blocking(move || {
+        SymstoreIndex::parse_from_reader(BufReader::new(reader))
+    })
+    .await
+    .map_err(CacheError::from_std_error)??;
 
     index.write(file)?;
 
@@ -453,18 +461,28 @@ impl SourceIndexService {
     /// `000Admin` directory.
     #[tracing::instrument(skip_all, fields(source.id = %source.id()), ret)]
     async fn fetch_symstore_last_id(&self, source: &IndexSourceConfig) -> Result<u32, CacheError> {
-        let temp_file = NamedTempFile::new()?;
         let remote_file = source.remote_file(SourceLocation::new(LASTID_FILE));
-        self.downloader
-            .download(remote_file, temp_file.path().to_path_buf())
+
+        let mut last_id = String::new();
+        let read = self
+            .downloader
+            .download(remote_file)
+            .await?
+            .into_read()
+            .take(LASTID_MAX_LENGTH as u64 + 1)
+            .read_to_string(&mut last_id)
             .await?;
-        let bv = ByteView::map_file(temp_file.into_file())?;
-        let last_id = std::str::from_utf8(&bv)
-            .map_err(|e| CacheError::Malformed(format!("Not valid UTF8: {e}")))?
+
+        if read > LASTID_MAX_LENGTH {
+            return Err(CacheError::Malformed(
+                "Invalid Symstore Id (too big)".to_owned(),
+            ));
+        }
+
+        last_id
             .trim()
             .parse()
-            .map_err(|e| CacheError::Malformed(format!("Not a number: {e}")))?;
-        Ok(last_id)
+            .map_err(|e| CacheError::Malformed(format!("Not a number: {e}")))
     }
 
     /// Fetches a Symstore index for the given source.

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -4,13 +4,15 @@
 //! <https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/>
 
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize};
 use std::time::{Duration, Instant};
 
 use ::sentry::SentryFutureExt;
-use futures::{future::Either, prelude::*};
+use futures::future::Either;
+use futures::prelude::*;
+use futures::stream::FuturesUnordered;
 use reqwest::StatusCode;
 
 use crate::caching::{CacheContents, CacheError};
@@ -21,7 +23,6 @@ use crate::utils::futures::{CancelOnDrop, SendFuture as _, m, measure};
 use crate::utils::gcs::GcsError;
 use crate::utils::http::ClientSettings;
 use crate::utils::sentry::ConfigureScope;
-use stream::FuturesUnordered;
 pub use symbolicator_sources::{
     DirectoryLayout, FileType, ObjectId, ObjectType, RemoteFile, RemoteFileUri, SourceConfig,
     SourceFilters, SourceLocation,
@@ -42,10 +43,11 @@ mod index;
 mod partial;
 mod s3;
 pub mod sentry;
+mod stream;
 
-pub use self::compression::tempfile_in_parent;
 pub use self::destination::{Destination, MultiStreamDestination, WriteStream};
 pub use self::fetch_file::fetch_file;
+pub use self::stream::Download;
 pub use index::SourceIndexService;
 
 impl ConfigureScope for RemoteFile {
@@ -108,6 +110,9 @@ pub struct DownloadLimits {
 pub struct DownloadService {
     pub runtime: tokio::runtime::Handle,
     pub limits: DownloadLimits,
+    // This client ideally would not accept and all users used the download service to download files.
+    //
+    // See also: <https://github.com/getsentry/symbolicator/pull/1928>.
     pub trusted_client: reqwest::Client,
     sentry: sentry::SentryDownloader,
     http: http::HttpDownloader,
@@ -116,6 +121,7 @@ pub struct DownloadService {
     fs: filesystem::FilesystemDownloader,
     host_deny_list: Option<HostDenyList>,
     connect_to_reserved_ips: bool,
+    tmp_dir: Option<PathBuf>,
 }
 
 impl DownloadService {
@@ -126,46 +132,37 @@ impl DownloadService {
             max_download_size: config.max_download_size,
         };
 
-        // |   client  | can connect to reserved IPs | accepts invalid SSL certs | compression |
-        // | ----------| ----------------------------|---------------------------|-------------|
-        // |  trusted  |             yes             |             no            |     yes     |
-        // |   sentry  |             yes             |             no            |     no      |
-        // | restrcted | according to config setting |             no            |     yes     |
-        // |  no ssl   | according to config setting |             yes           |     yes     |
-        // |    s3     | according to config setting |             no            |     no      |
-        // |    gcs    | according to config setting |             no            |     yes     |
+        // |   client  | can connect to reserved IPs | accepts invalid SSL certs
+        // | ----------| ----------------------------|---------------------------
+        // |  trusted  |             yes             |             no
+        // |   sentry  |             yes             |             no
+        // | restrcted | according to config setting |             no
+        // |  no ssl   | according to config setting |             yes
         let restricted_settings = ClientSettings {
             timeouts: limits.timeouts,
             connect_to_reserved_ips: config.connect_to_reserved_ips,
             accept_invalid_certs: false,
-            compression: true,
+            compression: false,
         };
-        let trusted_settings = ClientSettings {
+        let trusted_client = ClientSettings {
             connect_to_reserved_ips: true,
+            compression: true,
             ..restricted_settings
         };
         let sentry_settings = ClientSettings {
-            // Sentry can return the raw byte stream on range requests, which might be part of a
-            // compressed stream, so transparent decompression would fail on those individual parts.
-            compression: false,
-            ..trusted_settings
+            connect_to_reserved_ips: true,
+            ..restricted_settings
         };
         let no_ssl_settings = ClientSettings {
             accept_invalid_certs: true,
             ..restricted_settings
         };
-        let no_compression_settings = ClientSettings {
-            // S3 returns the raw byte stream on range requests, with transparent decompression
-            // enabled this breaks for individual parts.
-            compression: false,
-            ..restricted_settings
-        };
 
-        let trusted_client = crate::utils::http::create_client(&trusted_settings);
+        let trusted_client = crate::utils::http::create_client(&trusted_client);
         let sentry_client = crate::utils::http::create_client(&sentry_settings);
         let http_restricted_client = crate::utils::http::create_client(&restricted_settings);
         let http_no_ssl_client = crate::utils::http::create_client(&no_ssl_settings);
-        let s3_client = crate::utils::http::create_client(&no_compression_settings);
+        let s3_client = crate::utils::http::create_client(&restricted_settings);
         let gcs_client = crate::utils::http::create_client(&restricted_settings);
 
         let in_memory = &config.caches.in_memory;
@@ -173,7 +170,7 @@ impl DownloadService {
         Arc::new(Self {
             runtime: runtime.clone(),
             limits,
-            trusted_client: trusted_client.clone(),
+            trusted_client,
             sentry: sentry::SentryDownloader::new(
                 sentry_client,
                 runtime,
@@ -189,16 +186,18 @@ impl DownloadService {
                 .deny_list_enabled
                 .then_some(HostDenyList::from_config(config)),
             connect_to_reserved_ips: config.connect_to_reserved_ips,
+            tmp_dir: config.cache_dir("tmp"),
         })
     }
 
     /// Dispatches downloading of the given file to the appropriate source.
-    async fn dispatch_download(&self, source: &RemoteFile, destination: &Path) -> CacheContents {
+    async fn dispatch_download(&self, source: &RemoteFile) -> CacheContents<Download> {
         let source_name = source.source_metric_key();
         let result = retry(|| async {
             // XXX: we have to create the file here, as doing so outside in `download`
             // would run into borrow checker problems due to the `&mut`.
-            let mut destination = tokio::fs::File::create(destination).await?;
+            let temp = crate::utils::fs::tempfile(self.tmp_dir.as_deref())?;
+            let mut destination = tokio::fs::File::from_std(temp.reopen()?);
             let result = match source {
                 RemoteFile::Sentry(source) => {
                     self.sentry
@@ -225,7 +224,8 @@ impl DownloadService {
                 }
             };
             let _ = destination.flush().await;
-            result
+
+            result.map(|compression| Download::new(temp, compression, self.limits))
         })
         .await;
 
@@ -238,18 +238,12 @@ impl DownloadService {
         result
     }
 
-    /// Download a file from a source and store it on the local filesystem.
+    /// Download a file from a source.
     ///
     /// This does not do any deduplication of requests, every requested file is freshly downloaded.
     ///
-    /// The downloaded file is saved into `destination`. The file will be created if it does not
-    /// exist and truncated if it does. In case of any error, the file's contents is considered
-    /// garbage.
-    pub async fn download(
-        self: &Arc<Self>,
-        source: RemoteFile,
-        destination: PathBuf,
-    ) -> CacheContents {
+    /// The downloaded file is returned as a stream.
+    pub async fn download(self: &Arc<Self>, source: RemoteFile) -> CacheContents<Download> {
         let host = source.host();
 
         let is_builtin_source = source.is_builtin();
@@ -271,7 +265,7 @@ impl DownloadService {
 
         let timeout = self.limits.timeouts.max_download;
         let slf = self.clone();
-        let job = async move { slf.dispatch_download(&source, &destination).await };
+        let job = async move { slf.dispatch_download(&source).await };
         let job = CancelOnDrop::new(self.runtime.spawn(job.bind_hub(::sentry::Hub::current())));
         let job = tokio::time::timeout(timeout, job);
         let job = measure("service.download", m::timed_result, job);
@@ -447,7 +441,7 @@ async fn download_reqwest(
     limits: &DownloadLimits,
     destination: impl Destination,
     error_handler: &impl ErrorHandler,
-) -> CacheContents {
+) -> CacheContents<compression::Compression> {
     let (client, request) = builder.build_split();
     let request = request?;
 
@@ -478,7 +472,7 @@ async fn download_reqwest(
         }
         Err(destination) => {
             let destination = std::pin::pin!(destination.into_write());
-            do_download_reqwest(request, destination, error_handler)
+            do_download_reqwest(request, true, destination, error_handler)
                 .send()
                 .await
         }
@@ -507,7 +501,7 @@ async fn do_download_reqwest_range(
     request: SymRequest<'_>,
     mut destination: impl MultiStreamDestination,
     error_handler: &impl ErrorHandler,
-) -> CacheContents {
+) -> CacheContents<compression::Compression> {
     let source = request.to_source();
 
     let response = request
@@ -548,7 +542,7 @@ async fn do_download_reqwest_range(
             }
 
             let destination = std::pin::pin!(destination.into_write());
-            response.download(destination).await
+            response.download(true, destination).await
         }
         None if response.status() == StatusCode::RANGE_NOT_SATISFIABLE => {
             incr!("range_not_satisfiable");
@@ -562,7 +556,7 @@ async fn do_download_reqwest_range(
             drop(response);
 
             let destination = std::pin::pin!(destination.into_write());
-            do_download_reqwest(request, destination, error_handler).await
+            do_download_reqwest(request, true, destination, error_handler).await
         }
         // Server returned some generic error, we need to bubble it up.
         None => {
@@ -586,7 +580,7 @@ async fn do_download_reqwest_range(
             drop(response);
 
             let destination = std::pin::pin!(destination.into_write());
-            do_download_reqwest(request, destination, error_handler).await
+            do_download_reqwest(request, true, destination, error_handler).await
         }
         // Server indicates it supports ranges.
         Some(Ok(content_range)) => {
@@ -609,7 +603,7 @@ async fn do_download_reqwest_range(
             //  - https://github.com/seanmonstar/reqwest/issues/1559
             //  - https://github.com/tower-rs/tower-http/pull/556
             if content_range.total_size == 0 {
-                return Ok(());
+                return Ok(compression::Compression::Identity);
             }
 
             if content_range.total_size > response.measure.max_bytes_transferred {
@@ -620,7 +614,10 @@ async fn do_download_reqwest_range(
 
             let mut futures = FuturesUnordered::new();
 
-            let head = response.download(destination.stream(0, content_range.range().size()));
+            let compression = response.compression()?;
+            let head =
+                response.download(false, destination.stream(0, content_range.range().size()));
+
             futures.push(Either::Left(head.send()));
 
             for range in partial::split(content_range) {
@@ -630,7 +627,8 @@ async fn do_download_reqwest_range(
                     .with_range(range);
 
                 let destination = destination.stream(range.start, range.size());
-                let partial = do_download_reqwest(request, destination, error_handler).send();
+                let partial =
+                    do_download_reqwest(request, false, destination, error_handler).send();
                 futures.push(Either::Right(partial));
             }
 
@@ -641,7 +639,7 @@ async fn do_download_reqwest_range(
 
             let _ = destination.flush().await;
 
-            Ok(())
+            Ok(compression)
         }
     }
 }
@@ -649,9 +647,10 @@ async fn do_download_reqwest_range(
 /// Downloads the requested resource with a single download request into the `destination`.
 async fn do_download_reqwest(
     request: SymRequest<'_>,
+    should_decompress: bool,
     destination: impl WriteStream,
     error_handler: &impl ErrorHandler,
-) -> CacheContents {
+) -> CacheContents<compression::Compression> {
     let source = request.to_source();
     let response = request.execute().await?;
 
@@ -665,7 +664,7 @@ async fn do_download_reqwest(
             return Err(CacheError::size_exceeded());
         }
 
-        response.download(destination).await
+        response.download(should_decompress, destination).await
     } else {
         Err(error_handler.handle(&source, response).await)
     }
@@ -748,10 +747,6 @@ impl<'a> SymRequest<'a> {
 
         let headers = self.request.headers_mut();
         headers.insert(reqwest::header::RANGE, header);
-        headers.insert(
-            reqwest::header::ACCEPT_ENCODING,
-            reqwest::header::HeaderValue::from_static("identity"),
-        );
 
         self
     }
@@ -771,7 +766,15 @@ impl<'a> SymRequest<'a> {
     }
 
     /// Executes the request and returns the corresponding [`SymResponse`].
-    async fn execute(self) -> CacheContents<SymResponse<'a>> {
+    async fn execute(mut self) -> CacheContents<SymResponse<'a>> {
+        use reqwest::header::ACCEPT_ENCODING;
+
+        if !self.request.headers().contains_key(ACCEPT_ENCODING) {
+            self.request
+                .headers_mut()
+                .insert(ACCEPT_ENCODING, compression::Compression::accept_encoding());
+        }
+
         let request = self.client.execute(self.request);
         let request = tokio::time::timeout(self.limits.timeouts.head, request);
         // Use a separate measure for the head request.
@@ -823,16 +826,59 @@ impl SymResponse<'_> {
         partial::BytesContentRange::from_response(&self.response)
     }
 
+    fn compression(&self) -> CacheContents<compression::Compression> {
+        compression::Compression::from_headers(self.response.headers()).map_err(Into::into)
+    }
+
     /// Downloads the resource into `destination`, applying timeouts.
-    async fn download(self, mut destination: impl WriteStream) -> CacheContents {
-        let mut stream = self.response.bytes_stream().map_err(CacheError::from);
+    ///
+    /// If `should_decompress` is `true` the response body is decompressed before being
+    /// written to `destination`.
+    ///
+    /// Returns the decompression the bytes written to `destination` are compressed with.
+    /// When `should_decompress` is `true`, this is always the identity compression,
+    /// otherwise returns the compression as contained in the HTTP response.
+    async fn download(
+        self,
+        should_decompress: bool,
+        mut destination: impl WriteStream,
+    ) -> CacheContents<compression::Compression> {
+        let (final_compression, decompress_with) = {
+            let compression = self.compression()?;
+            // Now this will overwrite the compression set on the measure guard if it was already
+            // set for concurrent range requests, but that's okay, in this case the compression
+            // must be the same for all individual requests.
+            //
+            // It is also much less error prone to track the compression in a central place here
+            // instead of trying to capture it on the caller side.
+            self.measure.set_compression(compression);
+
+            match should_decompress {
+                true => (compression::Compression::Identity, compression),
+                false => (compression, compression::Compression::Identity),
+            }
+        };
+
+        let body = self.response.bytes_stream().map_err(std::io::Error::other);
+        let mut body = match decompress_with {
+            // No compression -> no need to go through the decompression layer dance.
+            compression::Compression::Identity => Either::Left(body),
+            _ => {
+                let body = tokio_util::io::StreamReader::new(body);
+                let body = decompress_with.decompress(body);
+                // Unfortunately we need to convert back to a `Stream` here, because `WriteStream`
+                // requires an owned `Buf`. This is roughly equivalent to what reqwest does internally.
+                Either::Right(tokio_util::io::ReaderStream::new(body))
+            }
+        };
+
         // Transfer the contents, into the destination and track progress.
-        while let Some(chunk) = stream.next().await.transpose()? {
+        while let Some(chunk) = body.next().await.transpose()? {
             self.measure.add_bytes_transferred(chunk.len() as u64)?;
-            destination.write_buf(chunk).await?;
+            destination.write_all(chunk).await?;
         }
 
-        Ok(())
+        Ok(final_compression)
     }
 }
 
@@ -862,6 +908,7 @@ pub struct MeasureSourceDownloadGuard<'a> {
     bytes_transferred: AtomicU64,
     max_bytes_transferred: u64,
     streams: AtomicUsize,
+    compression: AtomicU8,
 }
 
 impl<'a> MeasureSourceDownloadGuard<'a> {
@@ -875,6 +922,7 @@ impl<'a> MeasureSourceDownloadGuard<'a> {
             max_bytes_transferred,
             creation_time: Instant::now(),
             streams: AtomicUsize::new(0),
+            compression: AtomicU8::new(u8::MAX),
         }
     }
 
@@ -884,6 +932,18 @@ impl<'a> MeasureSourceDownloadGuard<'a> {
     pub fn set_streams(&self, num_streams: usize) {
         self.streams
             .store(num_streams, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn set_compression(&self, compression: compression::Compression) {
+        let compression = match compression {
+            compression::Compression::Identity => 0,
+            compression::Compression::Brotli => 1,
+            compression::Compression::Deflate => 2,
+            compression::Compression::Gzip => 3,
+            compression::Compression::Zstd => 4,
+        };
+        self.compression
+            .store(compression, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// A checked add to the amount of bytes transferred during the download.
@@ -922,6 +982,15 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
 
         let streams = (*self.streams.get_mut()).to_string();
 
+        let compression = match *self.compression.get_mut() {
+            0 => "identity",
+            1 => "brotli",
+            2 => "deflate",
+            3 => "gzip",
+            4 => "zstd",
+            _ => "unknown",
+        };
+
         let duration = self.creation_time.elapsed();
         metric!(
             timer("download_duration") = duration,
@@ -929,6 +998,7 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
             "status" => status.to_owned(),
             "source" => self.source_name.to_owned(),
             "streams" => streams.clone(),
+            "compression" => compression,
         );
 
         let bytes_transferred = *self.bytes_transferred.get_mut();
@@ -948,6 +1018,7 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
                 "status" => status.to_owned(),
                 "source" => self.source_name.to_owned(),
                 "streams" => streams.clone(),
+                "compression" => compression,
             );
 
             metric!(
@@ -956,6 +1027,7 @@ impl Drop for MeasureSourceDownloadGuard<'_> {
                 "status" => status.to_owned(),
                 "source" => self.source_name.to_owned(),
                 "streams" => streams,
+                "compression" => compression,
             );
         }
     }
@@ -990,6 +1062,7 @@ mod tests {
 
     use symbolicator_sources::{HttpSourceConfig, SourceId};
     use symbolicator_test::fixture;
+    use tokio::io::AsyncReadExt;
 
     use super::*;
 
@@ -1016,9 +1089,12 @@ mod tests {
 
         let service = DownloadService::new(&config(), tokio::runtime::Handle::current());
 
-        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
         service
-            .download(file_source, temp_file.path().to_owned())
+            .download(file_source)
+            .await
+            .unwrap()
+            .materialize_into(&mut temp_file)
             .await
             .unwrap();
 
@@ -1070,9 +1146,11 @@ mod tests {
         let file_source = HttpRemoteFile::new(source, SourceLocation::new("hello_world")).into();
 
         let service = DownloadService::new(&config(), tokio::runtime::Handle::current());
-        let file = tempfile::NamedTempFile::new().unwrap();
-        service
-            .download(file_source, file.path().to_owned())
+        let file = service
+            .download(file_source)
+            .await
+            .unwrap()
+            .materialize()
             .await
             .unwrap();
 
@@ -1113,5 +1191,66 @@ mod tests {
         assert!(!file_list.is_empty());
         let item = &file_list[0];
         assert_eq!(item.source_id(), source.id());
+    }
+
+    #[tokio::test]
+    async fn test_download_compressed_ranges() {
+        test::setup();
+
+        use axum::extract::State;
+        use axum::http::{HeaderMap, Response, StatusCode, header};
+        use axum::routing::get;
+
+        let minidump = symbolicator_test::read_fixture("windows.dmp");
+        let compressed = Arc::new(zstd::bulk::compress(&minidump, 0).unwrap());
+        assert!(compressed.len() > partial::initial_range().size() as usize);
+
+        async fn serve_range(
+            State(compressed): State<Arc<Vec<u8>>>,
+            headers: HeaderMap,
+        ) -> Response<axum::body::Body> {
+            let Some(range) = headers.get(header::RANGE) else {
+                unreachable!("range header expected");
+            };
+
+            let range = range.to_str().unwrap().strip_prefix("bytes=").unwrap();
+            let (start, end) = range.split_once('-').unwrap();
+            let start = start.parse::<usize>().unwrap();
+            let end = end.parse::<usize>().unwrap().min(compressed.len() - 1);
+            let body = compressed[start..=end].to_vec();
+
+            Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {start}-{end}/{}", compressed.len()),
+                )
+                .header(header::CONTENT_ENCODING, "zstd")
+                .body(body.into())
+                .unwrap()
+        }
+
+        let server = test::Server::with_router(
+            axum::Router::new()
+                .route("/file", get(serve_range))
+                .with_state(compressed),
+        );
+
+        let source = Arc::new(HttpSourceConfig {
+            id: SourceId::new("local"),
+            url: server.url("/"),
+            headers: Default::default(),
+            files: Default::default(),
+            accept_invalid_certs: false,
+        });
+        let remote_file = HttpRemoteFile::new(source, SourceLocation::new("file")).into();
+        let service = DownloadService::new(&config(), tokio::runtime::Handle::current());
+
+        let mut downloaded = Vec::new();
+        let mut download = service.download(remote_file).await.unwrap().into_read();
+        download.read_to_end(&mut downloaded).await.unwrap();
+
+        assert_eq!(downloaded, minidump);
+        assert!(server.accesses() > 1);
     }
 }

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -110,7 +110,7 @@ pub struct DownloadLimits {
 pub struct DownloadService {
     pub runtime: tokio::runtime::Handle,
     pub limits: DownloadLimits,
-    // This client ideally would not accept and all users used the download service to download files.
+    // This client ideally would not accept and all users use the download service to download files.
     //
     // See also: <https://github.com/getsentry/symbolicator/pull/1928>.
     pub trusted_client: reqwest::Client,

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -16,6 +16,7 @@ use symbolicator_sources::{AwsCredentialsProvider, S3Region, S3RemoteFile, S3Sou
 
 use crate::caching::{CacheContents, CacheError};
 use crate::download::DownloadLimits;
+use crate::download::compression::Compression;
 
 use super::{Destination, ErrorHandler, SymResponse};
 
@@ -131,7 +132,7 @@ impl S3Downloader {
         source_name: &str,
         file_source: &S3RemoteFile,
         destination: impl Destination,
-    ) -> CacheContents {
+    ) -> CacheContents<Compression> {
         let key = file_source.key();
         let bucket = file_source.bucket();
         tracing::debug!("Fetching from s3: {} (from {})", &key, &bucket);

--- a/crates/symbolicator-service/src/download/sentry.rs
+++ b/crates/symbolicator-service/src/download/sentry.rs
@@ -20,6 +20,7 @@ use super::{Destination, FileType};
 use crate::caching::{CacheContents, CacheError};
 use crate::config::InMemoryCacheConfig;
 use crate::download::DownloadLimits;
+use crate::download::compression::Compression;
 use crate::utils::futures::{CancelOnDrop, m, measure};
 
 #[derive(Clone, Debug, Deserialize)]
@@ -256,7 +257,7 @@ impl SentryDownloader {
         source_name: &str,
         file_source: &SentryRemoteFile,
         destination: impl Destination,
-    ) -> CacheContents {
+    ) -> CacheContents<Compression> {
         let url = file_source.url();
         tracing::debug!("Fetching Sentry artifact from {}", url);
 

--- a/crates/symbolicator-service/src/download/stream.rs
+++ b/crates/symbolicator-service/src/download/stream.rs
@@ -50,6 +50,10 @@ impl Download {
         }
 
         let mut destination = tokio::fs::File::from_std(file.reopen()?);
+        // The file is at position zero, through the re-open, but it is possible that the file
+        // already contains some leftover data from a previous download. We truncate the file
+        // to make sure only these new contents are stored in it.
+        destination.set_len(0).await?;
         let mut source = self.into_read();
 
         tokio::io::copy(&mut source, &mut destination).await?;
@@ -158,6 +162,9 @@ fn limit_exceeded(limit: u64) -> io::Error {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Seek as _, Write as _};
+
+    use flate2::write::GzEncoder;
     use tokio::io::AsyncReadExt;
 
     use super::*;
@@ -213,5 +220,24 @@ mod tests {
         assert!(output.is_empty());
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "read limit of 0 bytes exceeded");
+    }
+
+    #[tokio::test]
+    async fn test_materialize_into_truncates_destination() {
+        let expected = b"hello";
+
+        let mut compressed = NamedTempFile::new().unwrap();
+        let mut encoder = GzEncoder::new(compressed.as_file_mut(), flate2::Compression::default());
+        encoder.write_all(expected).unwrap();
+        encoder.finish().unwrap();
+        compressed.as_file_mut().rewind().unwrap();
+
+        let download = Download::new(compressed, Compression::Gzip, DownloadLimits::default());
+        let mut destination = NamedTempFile::new().unwrap();
+        destination.write_all(b"stale contents").unwrap();
+
+        download.materialize_into(&mut destination).await.unwrap();
+
+        assert_eq!(std::fs::read(destination.path()).unwrap(), expected);
     }
 }

--- a/crates/symbolicator-service/src/download/stream.rs
+++ b/crates/symbolicator-service/src/download/stream.rs
@@ -41,7 +41,7 @@ impl Download {
 
     /// Materializes the download into the provided `file`.
     ///
-    /// The passed mutable reference to the file may be swapped with a different file.
+    /// The passed mutable reference to the file might be swapped with a different file.
     pub async fn materialize_into(mut self, file: &mut NamedTempFile) -> CacheContents {
         // If the file here has no compression applied, we can just swap the temp file.
         if self.compression == Compression::Identity {

--- a/crates/symbolicator-service/src/download/stream.rs
+++ b/crates/symbolicator-service/src/download/stream.rs
@@ -1,0 +1,217 @@
+use std::io::{self, Seek as _};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncRead, ReadBuf};
+
+use crate::{
+    caching::CacheContents,
+    download::{DownloadLimits, compression::Compression},
+};
+
+/// A stream returned from [`crate::download::DownloadService::download`].
+///
+/// The stream can be backed by various different types depending on the file being downloaded.
+pub struct Download {
+    inner: NamedTempFile,
+    compression: Compression,
+    limits: DownloadLimits,
+}
+
+impl Download {
+    /// Creates a new [`Self`].
+    ///
+    /// The passed temp file must contain the download contents and be rewound to the beginning of
+    /// the file.
+    ///
+    /// On access `compression` is used to transparently decompress the contents for the caller,
+    /// `limits` are enforced during the decompression.
+    pub fn new(mut f: NamedTempFile, compression: Compression, limits: DownloadLimits) -> Self {
+        // Just to make sure the file is rewound to position `0`, so we can safely read from it
+        // and return it to callers.
+        debug_assert_eq!(f.stream_position().unwrap_or(0), 0);
+
+        Self {
+            inner: f,
+            compression,
+            limits,
+        }
+    }
+
+    /// Materializes the download into the provided `file`.
+    ///
+    /// The passed mutable reference to the file may be swapped with a different file.
+    pub async fn materialize_into(mut self, file: &mut NamedTempFile) -> CacheContents {
+        // If the file here has no compression applied, we can just swap the temp file.
+        if self.compression == Compression::Identity {
+            std::mem::swap(&mut self.inner, file);
+            return Ok(());
+        }
+
+        let mut destination = tokio::fs::File::from_std(file.reopen()?);
+        let mut source = self.into_read();
+
+        tokio::io::copy(&mut source, &mut destination).await?;
+
+        Ok(())
+    }
+
+    /// Materializes the download into a [`NamedTempFile`].
+    ///
+    /// This is very similar to [`Self::materialize_into`], but slightly more convenient
+    /// and efficient as not always a new temp file must be created.
+    pub async fn materialize(self) -> CacheContents<NamedTempFile> {
+        if self.compression == Compression::Identity {
+            return Ok(self.inner);
+        }
+
+        let mut file = NamedTempFile::new()?;
+        self.materialize_into(&mut file).await?;
+        Ok(file)
+    }
+
+    /// Returns the downloaded contents as an [`AsyncRead`].
+    pub fn into_read(self) -> impl AsyncRead + Unpin {
+        let source = tokio::fs::File::from_std(self.inner.into_file());
+        let source = tokio::io::BufReader::new(source);
+        let source = self.compression.decompress(source);
+        LimitRead::new(source, self.limits.max_download_size)
+    }
+}
+
+/// A reader which enforces a maximum for amount of bytes read.
+struct LimitRead<R> {
+    /// The inner `AsyncRead`.
+    inner: R,
+    /// The maximum amount of bytes allowed to read.
+    limit: u64,
+    /// The amount of bytes read so far.
+    bytes_read: u64,
+}
+
+impl<R> LimitRead<R> {
+    fn new(inner: R, limit: Option<u64>) -> Self {
+        Self {
+            inner,
+            limit: limit.unwrap_or(u64::MAX),
+            bytes_read: 0,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for LimitRead<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        if this.bytes_read > this.limit {
+            return Poll::Ready(Err(limit_exceeded(this.limit)));
+        }
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let start = buf.filled().len();
+        std::task::ready!(Pin::new(&mut this.inner).poll_read(cx, buf))?;
+
+        let n = buf.filled().len() - start;
+        this.bytes_read += n as u64;
+
+        if this.bytes_read > this.limit {
+            // For our use-case this isn't technically necessary, since we only want to bound compression
+            // we could safely overfill the buffer a bit and then fail on the next read.
+            //
+            // But for the sake of testability and correctness, let's handle the case where the last
+            // read went over the limit.
+            //
+            // The problem is, we can't just error here, as `AsyncRead`'s contract states no bytes
+            // must be read on error.
+
+            // Amount of bytes, which were read too much.
+            let over = this.bytes_read - this.limit;
+            // Rewind the buffer to the actual max which is allowed.
+            buf.set_filled(buf.filled().len() - over as usize);
+
+            // We rewound back all bytes that were just read, we can error as we filled no bytes.
+            if buf.filled().len() == start {
+                return Poll::Ready(Err(limit_exceeded(this.limit)));
+            }
+
+            // Now we did write some bytes, `bytes_read > this.limit` is still true, which means the
+            // next read will fail.
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn limit_exceeded(limit: u64) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("read limit of {limit} bytes exceeded"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_limit_read_without_limit() {
+        let mut reader = LimitRead::new(&b"hello world"[..], None);
+        let mut output = Vec::new();
+
+        reader.read_to_end(&mut output).await.unwrap();
+
+        assert_eq!(output, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn test_limit_read_within_limit() {
+        for (input, limit) in [(&b""[..], 0), (&b"hello"[..], 5), (&b"hello"[..], 6)] {
+            let mut reader = LimitRead::new(input, Some(limit));
+            let mut output = Vec::new();
+
+            reader.read_to_end(&mut output).await.unwrap();
+
+            assert_eq!(output, input);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_limit_read_exceeded() {
+        let mut reader = LimitRead::new(&b"hello world"[..], Some(5));
+        let mut output = Vec::new();
+        let mut buffer = [0; 3];
+
+        let bytes_read = reader.read(&mut buffer).await.unwrap();
+        output.extend_from_slice(&buffer[..bytes_read]);
+
+        let bytes_read = reader.read(&mut buffer).await.unwrap();
+        output.extend_from_slice(&buffer[..bytes_read]);
+
+        let error = reader.read(&mut buffer).await.unwrap_err();
+
+        assert_eq!(output, b"hello");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "read limit of 5 bytes exceeded");
+    }
+
+    #[tokio::test]
+    async fn test_limit_read_zero_limit() {
+        let mut reader = LimitRead::new(&b"hello"[..], Some(0));
+        let mut output = Vec::new();
+
+        let error = reader.read_to_end(&mut output).await.unwrap_err();
+
+        assert!(output.is_empty());
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "read limit of 0 bytes exceeded");
+    }
+}

--- a/crates/symbolicator-service/src/objects/data_cache.rs
+++ b/crates/symbolicator-service/src/objects/data_cache.rs
@@ -21,7 +21,7 @@ use symbolicator_sources::{ObjectId, RemoteFile};
 
 use crate::caches::versions::{CacheVersions, OBJECTS_CACHE_VERSIONS};
 use crate::caching::{CacheContents, CacheError, CacheItemRequest, CacheKey};
-use crate::download::{DownloadService, fetch_file, tempfile_in_parent};
+use crate::download::{DownloadService, fetch_file};
 use crate::types::Scope;
 use crate::utils::sentry::ConfigureScope;
 
@@ -157,7 +157,7 @@ async fn fetch_object_file(
             }
         };
 
-        let mut dst = tempfile_in_parent(temp_file)?;
+        let mut dst = crate::utils::fs::tempfile_in_parent(temp_file)?;
 
         io::copy(&mut object.data(), dst.as_file_mut())?;
 

--- a/crates/symbolicator-service/src/utils/fs.rs
+++ b/crates/symbolicator-service/src/utils/fs.rs
@@ -1,0 +1,54 @@
+use std::io;
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
+/// Creates a new [`NamedTempFile`] in the same directory as `file`.
+pub fn tempfile_in_parent(file: &NamedTempFile) -> io::Result<NamedTempFile> {
+    let dir = file
+        .path()
+        .parent()
+        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+
+    tempfile(Some(dir))
+}
+
+/// Creates a new [`NamedTempFile`] in `tmp_dir`.
+pub fn tempfile(tmp_dir: Option<&Path>) -> io::Result<NamedTempFile> {
+    let Some(tmp_dir) = tmp_dir else {
+        return NamedTempFile::new();
+    };
+
+    // The `cleanup` process could potentially remove the parent directories we are
+    // operating in, so be defensive here and retry the fs operations.
+    const MAX_RETRIES: usize = 2;
+    let mut retries = 0;
+    loop {
+        retries += 1;
+
+        if let Err(e) = std::fs::create_dir_all(tmp_dir) {
+            sentry::with_scope(
+                |scope| scope.set_extra("tmp_dir", tmp_dir.display().to_string().into()),
+                || tracing::error!("Failed to create cache directory: {:?}", e),
+            );
+            if retries > MAX_RETRIES {
+                return Err(e);
+            }
+            continue;
+        }
+
+        match tempfile::Builder::new().prefix("tmp").tempfile_in(tmp_dir) {
+            Ok(temp_file) => return Ok(temp_file),
+            Err(e) => {
+                sentry::with_scope(
+                    |scope| scope.set_extra("tmp_dir", tmp_dir.display().to_string().into()),
+                    || tracing::error!("Failed to create cache file: {:?}", e),
+                );
+                if retries > MAX_RETRIES {
+                    return Err(e);
+                }
+                continue;
+            }
+        }
+    }
+}

--- a/crates/symbolicator-service/src/utils/mod.rs
+++ b/crates/symbolicator-service/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod defer;
+pub mod fs;
 pub mod futures;
 pub mod gcs;
 pub mod hex;


### PR DESCRIPTION
Implements: #1891 

Range requests can now be compressed, it also supports the previously problematic S3 downloads, where the individual ranges would be compressed even if the original request only allows the identity compression. This is also how `objectstore` behaves.

See the original ticket #1891 for more details.

There are now also more potential optimizations possible, for example, getting rid of `maybe_decompress_file` and avoiding downloading to a tempfile at all if only a stream is required.
