### PR TITLE
fix(download): Categorize download errors as download errors

### DIFF
--- a/crates/symbolicator-service/src/caching/cache_error.rs
+++ b/crates/symbolicator-service/src/caching/cache_error.rs
@@ -57,7 +57,10 @@ pub enum CacheError {
 impl From<std::io::Error> for CacheError {
     #[track_caller]
     fn from(err: std::io::Error) -> Self {
-        Self::from_std_error(err)
+        err.get_ref()
+            .and_then(|inner| inner.downcast_ref::<Self>())
+            .cloned()
+            .unwrap_or_else(|| Self::from_std_error(err))
     }
 }
 

--- a/crates/symbolicator-service/src/download/compression.rs
+++ b/crates/symbolicator-service/src/download/compression.rs
@@ -243,7 +243,7 @@ pub struct CompressionError(&'static str);
 
 impl From<CompressionError> for CacheError {
     fn from(error: CompressionError) -> Self {
-        Self::Malformed(error.0.to_owned())
+        Self::DownloadError(error.0.to_owned())
     }
 }
 

--- a/crates/symbolicator-service/src/download/index.rs
+++ b/crates/symbolicator-service/src/download/index.rs
@@ -463,14 +463,14 @@ impl SourceIndexService {
     async fn fetch_symstore_last_id(&self, source: &IndexSourceConfig) -> Result<u32, CacheError> {
         let remote_file = source.remote_file(SourceLocation::new(LASTID_FILE));
 
-        let mut last_id = String::new();
+        let mut last_id = Vec::new();
         let read = self
             .downloader
             .download(remote_file)
             .await?
             .into_read()
             .take(LASTID_MAX_LENGTH as u64 + 1)
-            .read_to_string(&mut last_id)
+            .read_to_end(&mut last_id)
             .await?;
 
         if read > LASTID_MAX_LENGTH {
@@ -479,7 +479,8 @@ impl SourceIndexService {
             ));
         }
 
-        last_id
+        std::str::from_utf8(&last_id)
+            .map_err(|e| CacheError::Malformed(format!("Invalid Symstore Id: {e}")))?
             .trim()
             .parse()
             .map_err(|e| CacheError::Malformed(format!("Not a number: {e}")))

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -60,7 +60,18 @@ impl ConfigureScope for RemoteFile {
 }
 
 impl CacheError {
-    fn download_error(mut error: &dyn Error) -> Self {
+    #[track_caller]
+    fn download_error(error: &(dyn Error + 'static)) -> Self {
+        let io_inner = error
+            .downcast_ref::<std::io::Error>()
+            .and_then(|error| error.get_ref())
+            .and_then(|inner| inner.downcast_ref::<Self>());
+
+        if let Some(err) = io_inner {
+            return err.clone();
+        }
+
+        let mut error = error;
         while let Some(src) = error.source() {
             error = src;
         }
@@ -79,18 +90,21 @@ impl CacheError {
         Self::DownloadError(error_string)
     }
 
+    #[track_caller]
     fn size_exceeded() -> Self {
         Self::Malformed("Maximum file size exceeded".to_owned())
     }
 }
 
 impl From<reqwest::Error> for CacheError {
+    #[track_caller]
     fn from(error: reqwest::Error) -> Self {
         Self::download_error(&error)
     }
 }
 
 impl From<GcsError> for CacheError {
+    #[track_caller]
     fn from(error: GcsError) -> Self {
         Self::DownloadError(error.to_string())
     }
@@ -843,6 +857,44 @@ impl SymResponse<'_> {
         should_decompress: bool,
         mut destination: impl WriteStream,
     ) -> CacheContents<compression::Compression> {
+        let measure = self.measure;
+        let (compression, mut body) = self.bytes_stream(should_decompress)?;
+
+        // Transfer the contents, into the destination and track progress.
+        while let Some(chunk) = body.next().await.transpose()? {
+            measure.add_bytes_transferred(chunk.len() as u64)?;
+            destination.write_all(chunk).await?;
+        }
+
+        Ok(compression)
+    }
+
+    /// Get the full response body up to `max_size` bytes.
+    async fn bytes(self, max_size: u64) -> CacheContents<bytes::Bytes> {
+        let (_, mut stream) = self.bytes_stream(true)?;
+        let mut buf = bytes::BytesMut::new();
+
+        while let Some(chunk) = stream.try_next().await? {
+            if chunk.len() as u64 > max_size - buf.len() as u64 {
+                return Err(CacheError::size_exceeded());
+            }
+            buf.extend_from_slice(&chunk);
+        }
+
+        Ok(buf.freeze())
+    }
+
+    /// Returns a bytes stream of the response and its compression.
+    ///
+    /// If `should_decompress` is `true` then the response body is decompressed and the returned compression
+    /// is [`compression::Compression::Identity`].
+    fn bytes_stream(
+        self,
+        should_decompress: bool,
+    ) -> CacheContents<(
+        compression::Compression,
+        impl Stream<Item = CacheContents<bytes::Bytes>>,
+    )> {
         let (final_compression, decompress_with) = {
             let compression = self.compression()?;
             // Now this will overwrite the compression set on the measure guard if it was already
@@ -859,26 +911,26 @@ impl SymResponse<'_> {
             }
         };
 
-        let body = self.response.bytes_stream().map_err(std::io::Error::other);
-        let mut body = match decompress_with {
+        let body = self
+            .response
+            .bytes_stream()
+            .map_err(|err| CacheError::download_error(&err));
+
+        let body = match decompress_with {
             // No compression -> no need to go through the decompression layer dance.
             compression::Compression::Identity => Either::Left(body),
             _ => {
-                let body = tokio_util::io::StreamReader::new(body);
+                let body = tokio_util::io::StreamReader::new(body.map_err(std::io::Error::other));
                 let body = decompress_with.decompress(body);
                 // Unfortunately we need to convert back to a `Stream` here, because `WriteStream`
                 // requires an owned `Buf`. This is roughly equivalent to what reqwest does internally.
-                Either::Right(tokio_util::io::ReaderStream::new(body))
+                let body = tokio_util::io::ReaderStream::new(body)
+                    .map_err(|err| CacheError::download_error(&err));
+                Either::Right(body)
             }
         };
 
-        // Transfer the contents, into the destination and track progress.
-        while let Some(chunk) = body.next().await.transpose()? {
-            self.measure.add_bytes_transferred(chunk.len() as u64)?;
-            destination.write_all(chunk).await?;
-        }
-
-        Ok(final_compression)
+        Ok((final_compression, body))
     }
 }
 

--- a/crates/symbolicator-service/src/download/s3.rs
+++ b/crates/symbolicator-service/src/download/s3.rs
@@ -29,6 +29,11 @@ type ClientCache = moka::future::Cache<Arc<S3SourceKey>, Arc<Client>>;
 /// this duration are fine.
 const PRE_SIGN_EXPIRY: Duration = Duration::from_mins(15);
 
+/// Maximum size allowed for an S3 error response.
+///
+/// Responses above this threshold will not be parsed and treated as missing.
+const MAX_ERROR_SIZE: u64 = 64 * 1024;
+
 /// Downloader implementation that supports the S3 source.
 pub struct S3Downloader {
     client_cache: ClientCache,
@@ -174,7 +179,7 @@ impl ErrorHandler for S3ErrorHandler {
         let status = response.status();
         debug_assert!(!status.is_success());
 
-        let body = response.response.bytes().await.ok();
+        let body = response.bytes(MAX_ERROR_SIZE).await.ok();
         let metadata = body.and_then(|body| parse_error_metadata(&body).ok());
 
         if let Some(error) = metadata.as_ref().and_then(error_from_metadata) {

--- a/crates/symbolicator-service/src/download/stream.rs
+++ b/crates/symbolicator-service/src/download/stream.rs
@@ -6,7 +6,7 @@ use tempfile::NamedTempFile;
 use tokio::io::{AsyncRead, ReadBuf};
 
 use crate::{
-    caching::CacheContents,
+    caching::{CacheContents, CacheError},
     download::{DownloadLimits, compression::Compression},
 };
 
@@ -80,7 +80,12 @@ impl Download {
         let source = tokio::fs::File::from_std(self.inner.into_file());
         let source = tokio::io::BufReader::new(source);
         let source = self.compression.decompress(source);
-        LimitRead::new(source, self.limits.max_download_size)
+        let source = LimitRead::new(source, self.limits.max_download_size);
+        MapError::new(source, |error| {
+            // Wrap all errors in a download error, so that later conversions from io error to cache
+            // error pick up the inner error as a download error instead of internal error.
+            io::Error::other(CacheError::download_error(&error))
+        })
     }
 }
 
@@ -113,7 +118,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for LimitRead<R> {
         let this = self.get_mut();
 
         if this.bytes_read > this.limit {
-            return Poll::Ready(Err(limit_exceeded(this.limit)));
+            return Poll::Ready(Err(io::Error::other(CacheError::size_exceeded())));
         }
         if buf.remaining() == 0 {
             return Poll::Ready(Ok(()));
@@ -142,7 +147,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for LimitRead<R> {
 
             // We rewound back all bytes that were just read, we can error as we filled no bytes.
             if buf.filled().len() == start {
-                return Poll::Ready(Err(limit_exceeded(this.limit)));
+                return Poll::Ready(Err(io::Error::other(CacheError::size_exceeded())));
             }
 
             // Now we did write some bytes, `bytes_read > this.limit` is still true, which means the
@@ -153,11 +158,36 @@ impl<R: AsyncRead + Unpin> AsyncRead for LimitRead<R> {
     }
 }
 
-fn limit_exceeded(limit: u64) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidData,
-        format!("read limit of {limit} bytes exceeded"),
-    )
+pin_project_lite::pin_project! {
+    struct MapError<S, F> {
+        #[pin]
+        inner: S,
+        map: F,
+    }
+}
+
+impl<S, F> MapError<S, F> {
+    fn new(inner: S, map: F) -> Self {
+        Self { inner, map }
+    }
+}
+
+impl<S, F> AsyncRead for MapError<S, F>
+where
+    S: AsyncRead,
+    F: Fn(io::Error) -> io::Error,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.project();
+        match this.inner.poll_read(cx, buf) {
+            Poll::Ready(res) => Poll::Ready(res.map_err(|err| (this.map)(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -206,8 +236,10 @@ mod tests {
         let error = reader.read(&mut buffer).await.unwrap_err();
 
         assert_eq!(output, b"hello");
-        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-        assert_eq!(error.to_string(), "read limit of 5 bytes exceeded");
+        assert_eq!(
+            CacheError::from(error),
+            CacheError::Malformed("Maximum file size exceeded".to_owned())
+        );
     }
 
     #[tokio::test]
@@ -218,8 +250,10 @@ mod tests {
         let error = reader.read_to_end(&mut output).await.unwrap_err();
 
         assert!(output.is_empty());
-        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-        assert_eq!(error.to_string(), "read limit of 0 bytes exceeded");
+        assert_eq!(
+            CacheError::from(error),
+            CacheError::Malformed("Maximum file size exceeded".to_owned())
+        );
     }
 
     #[tokio::test]
@@ -239,5 +273,31 @@ mod tests {
         download.materialize_into(&mut destination).await.unwrap();
 
         assert_eq!(std::fs::read(destination.path()).unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_materialize_enforces_size_limit() {
+        let input = b"hello world";
+
+        let mut compressed = NamedTempFile::new().unwrap();
+        let mut encoder = GzEncoder::new(compressed.as_file_mut(), flate2::Compression::default());
+        encoder.write_all(input).unwrap();
+        encoder.finish().unwrap();
+        compressed.as_file_mut().rewind().unwrap();
+
+        let download = Download::new(
+            compressed,
+            Compression::Gzip,
+            DownloadLimits {
+                max_download_size: Some(5),
+                ..DownloadLimits::default()
+            },
+        );
+
+        let error = download.materialize().await.unwrap_err();
+        assert_eq!(
+            error,
+            CacheError::Malformed("Maximum file size exceeded".to_owned())
+        );
     }
 }


### PR DESCRIPTION
`reqwest` errors are considered download errors, since that code now wraps the streams, we turn the reqwest error into an io error, which then gets classified as an internal error, which it shouldn't.

The shuffling of streams and async reads is a bit annoying, especially since `AsyncRead` forces an `io::Error`. So at certain parts we map our `CacheError` into `io::Error::other`, then later we need to unpack the error again.

This also fixes an issue in the `S3` stream where we didn't decompress the body. Drive by fix to also limit the amount of bytes downloaded for extracting the error.