### PR TITLE
fix: Increase decompressed source map limit to 190 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
   ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
 
+- Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB.
+
 ## 26.7.2
 
 ### Internal Changes 🔧

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,12 @@
 ### Features
 
 - Files uploaded to the shared cache are zstd compressed. ([#2006](https://github.com/getsentry/symbolicator/pull/2006))
-
 - Added a config setting `max_download_size` to restrict the size of downloaded files.
   For compressed files, this limit applies to the _decompressed_ size.
   The default value is 15GiB. ([#1993](https://github.com/getsentry/symbolicator/pull/1993))
-
 - Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
   ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
-
-- Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB.
+- Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB ([#2009]).
 
 ## 26.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   The default value is 15GiB. ([#1993](https://github.com/getsentry/symbolicator/pull/1993))
 - Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
   ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
-- Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB ([#2009]).
+- Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB. ([#2009](https://github.com/getsentry/symbolicator/pull/2009))
 
 ## 26.7.2
 

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -542,7 +542,7 @@ pub struct Config {
 
     /// Maximum decompressed size of compressed source files embedded in debug files.
     ///
-    /// Defaults to 100MiB.
+    /// Defaults to 200MiB.
     pub object_file_max_decompressed_source_size: Option<usize>,
 
     /// Maximum length of the CFI unwind chain.
@@ -660,7 +660,7 @@ impl Default for Config {
             // plus some extra for the rest of the request.
             symbolicate_body_max_bytes: 55 * 1024 * 1024,
             object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
-            object_file_max_decompressed_source_size: Some(100 * 1024 * 1024),
+            object_file_max_decompressed_source_size: Some(200 * 1024 * 1024),
             max_unwind_chain_len: Some(128),
             max_download_size: Some(15 * 1024 * 1024 * 1024),
         }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -660,7 +660,7 @@ impl Default for Config {
             // plus some extra for the rest of the request.
             symbolicate_body_max_bytes: 55 * 1024 * 1024,
             object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
-            object_file_max_decompressed_source_size: Some(200 * 1024 * 1024),
+            object_file_max_decompressed_source_size: Some(190 * 1024 * 1024),
             max_unwind_chain_len: Some(128),
             max_download_size: Some(15 * 1024 * 1024 * 1024),
         }

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -542,7 +542,7 @@ pub struct Config {
 
     /// Maximum decompressed size of compressed source files embedded in debug files.
     ///
-    /// Defaults to 200MiB.
+    /// Defaults to 190MiB.
     pub object_file_max_decompressed_source_size: Option<usize>,
 
     /// Maximum length of the CFI unwind chain.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,8 @@ metrics:
 - `propagate_traces`: When tracing is enabled, inherit the sample rate from incoming parent traces and if Sentry is used as a symbol source also propagate traces back to Sentry. Defaults to `true`.
 - `max_concurrent_requests`: The maximum number of requests symbolicator will process concurrently. Further requests will result in a 503 status code.
   Set it to `null` to turn off the limit. Defaults to 120.
+- `object_file_max_decompressed_source_size`: The maximum decompressed size of an individual
+  source file read from a source/artifact bundle.
 
 > All time units for the following configuration settings can be either a time
 expression like `1s`.  Units can be `s`, `seconds`, `m`, `minutes`, `h`,


### PR DESCRIPTION
Increase decompressed source map limit as the 100 MiB limit is too small for some customers. The 190 MiB should be safe - there is headroom even at max concurrent requests based on the average RSS.

Ref https://linear.app/getsentry/issue/INGEST-1112