### PR TITLE
docs: Add comment to keep source file limit synced

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -660,6 +660,7 @@ impl Default for Config {
             // plus some extra for the rest of the request.
             symbolicate_body_max_bytes: 55 * 1024 * 1024,
             object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
+            // Keep in sync with Sentry's `MAX_SOURCE_FILE_SIZE` and https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/
             object_file_max_decompressed_source_size: Some(190 * 1024 * 1024),
             max_unwind_chain_len: Some(128),
             max_download_size: Some(15 * 1024 * 1024 * 1024),


### PR DESCRIPTION
Ref https://linear.app/getsentry/issue/INGEST-1112/missing-sourcemap-with-debug-id