### PR TITLE
feat(symbolicator): Enable io-uring in Tokio

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   lints:
     name: Lints
@@ -37,7 +34,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --all-features --workspace --tests --examples
+        run: cargo clippy --all-features --workspace --tests --examples -- -D warnings
 
   test:
     name: Tests

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 0 * * 1" # every monday at 00:00
   workflow_dispatch:
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   weekly-ci:
     strategy:
@@ -32,7 +29,7 @@ jobs:
           rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy --no-self-update
           rustup default ${{ matrix.rust }}
 
-      - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
+      - run: cargo clippy --all-features --workspace --tests --examples -- -D warnings
 
       - run: cargo test --workspace --all-features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
   ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
 - Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB. ([#2009](https://github.com/getsentry/symbolicator/pull/2009))
+- Use IO-Uring for file operations, if it is available. ([#2014](https://github.com/getsentry/symbolicator/pull/2014))
 
 ## 26.7.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64d8ca234d152948ceaede1f419b6a83983a5ecccaac05fb337a809c96d3aa6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5420,10 +5431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.2.2",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.0",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -32,7 +32,7 @@ symbolicator-service = { workspace = true }
 symbolicator-sources = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true}
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-uring"] }
 tokio-metrics = { workspace = true }
 tokio-util = { workspace = true, features = ["io"] }
 tower = { workspace = true}


### PR DESCRIPTION
Enables io-uring. The idea is that all file operations will now run with io-uring if it is available. Tokio falls back gracefully to non io-uring if it isn't available (non Linux, old Kernel, not allowed).

CI changes are so CI doesn't override the flags from the cargo config.