### PR TITLE
Revert "feat(symbolicator): Enable io-uring in Tokio (#2014)"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Support compressed range requests. This allows backends (like S3 and objectstore) to serve partial
   ranges from a compressed file. ([#2004](https://github.com/getsentry/symbolicator/pull/1999))
 - Raised the default of `object_file_max_decompressed_source_size` from 100MiB to 190MiB. ([#2009](https://github.com/getsentry/symbolicator/pull/2009))
-- Use IO-Uring for file operations, if it is available. ([#2014](https://github.com/getsentry/symbolicator/pull/2014))
 
 ## 26.7.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,17 +2423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64d8ca234d152948ceaede1f419b6a83983a5ecccaac05fb337a809c96d3aa6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5431,12 +5420,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
- "io-uring",
  "libc",
  "mio 1.2.2",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.0",

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -32,7 +32,7 @@ symbolicator-service = { workspace = true }
 symbolicator-sources = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true}
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-uring"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tokio-metrics = { workspace = true }
 tokio-util = { workspace = true, features = ["io"] }
 tower = { workspace = true}


### PR DESCRIPTION
This reverts commit c560b64f5b496b23b70f3e93a5eb6814bc3ffb54 (except CI changes, those are good).

It works, there are no issues from what I can tell, less threads in use (as expected, nice), but also basically no noticeable upsides. We have experience in running Symbolicator without io-uring, no need to introduce potentially new failures. We can also go back to stable Tokio.