### PR TITLE
ref(native): Make demangle cache as a wrapper type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1815,20 +1815,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
 ]
 
 [[package]]
@@ -2659,19 +2645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,23 +2943,21 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "equivalent",
  "event-listener",
  "futures-util",
- "loom",
  "parking_lot",
  "portable-atomic",
- "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -6120,28 +6091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6152,17 +6101,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
- "windows-threading",
 ]
 
 [[package]]
@@ -6198,16 +6136,6 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-registry"
@@ -6329,15 +6257,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ minidump = "0.26.1"
 minidump-processor = "0.26.1"
 minidump-unwind = "0.26.1"
 minidumper-child = "0.5.0"
-moka = { version = "0.12.8", features = ["future", "sync"] }
+moka = { version = "0.12.16", features = ["future", "sync"] }
 pin-project-lite = "0.2.17"
 prettytable-rs = "0.10.0"
 proguard = "5.10.4"

--- a/crates/symbolicator-native/src/symbolication/demangle.rs
+++ b/crates/symbolicator-native/src/symbolication/demangle.rs
@@ -1,54 +1,124 @@
+use moka::Equivalent;
 use symbolic::common::{Language, Name};
 use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::symcache::Function;
 
 /// Options for demangling all symbols.
-pub const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
+const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_type(false);
 
-/// A cache for demangled symbols
-pub type DemangleCache = moka::sync::Cache<(String, Language), String>;
-
-/// Demangles the name of the given [`Function`].
-pub fn demangle_symbol(cache: &DemangleCache, func: &Function) -> (String, String) {
-    let symbol = func.name();
-    let language = func.language();
-    let key = (symbol.to_string(), language);
-
-    let init = || {
-        func.name_for_demangling()
-            .demangle(DEMANGLE_OPTIONS)
-            .unwrap_or_else(|| report_demangling_failure(symbol.to_string(), language))
-    };
-
-    let entry = cache.entry_by_ref(&key).or_insert_with(init);
-
-    (key.0, entry.into_value())
+/// A cache for demangled symbols.
+#[derive(Debug, Clone)]
+pub struct DemangleCache {
+    cache: moka::sync::Cache<MangleKey, String>,
 }
 
-#[allow(unused)] // we early return `symbol` here for now, but we might change that in the future
-fn report_demangling_failure(symbol: String, language: Language) -> String {
-    return symbol;
+impl DemangleCache {
+    pub fn new(max_capacity: u64) -> Self {
+        let cache = moka::sync::Cache::builder()
+            .max_capacity(max_capacity) // 10 MiB, considering key and value:
+            .weigher(|k: &MangleKey, v: &String| {
+                (k.symbol.len() + v.len()).try_into().unwrap_or(u32::MAX)
+            })
+            .build();
 
-    // Detect the language from the bare name, ignoring any pre-set language. There are a few
-    // languages that we should always be able to demangle. Only complain about those that we
-    // detect explicitly, but silently ignore the rest. For instance, there are C-identifiers
-    // reported as C++, which are expected not to demangle.
-    let detected_language = Name::from(symbol).detect_language();
-    let should_demangle = match (language, detected_language) {
-        (_, Language::Unknown) => false, // can't demangle what we cannot detect
-        (Language::ObjCpp, Language::Cpp) => true, // C++ demangles even if it was in ObjC++
-        (Language::Unknown, _) => true,  // if there was no language, then rely on detection
-        (lang, detected) => lang == detected, // avoid false-positive detections
-    };
-
-    if should_demangle {
-        sentry::with_scope(
-            |scope| scope.set_extra("identifier", symbol.clone().into()),
-            || {
-                let message = format!("Failed to demangle {language} identifier");
-                sentry::capture_message(&message, sentry::Level::Error);
-            },
-        );
+        Self { cache }
     }
-    symbol
+
+    /// Demangles the name of the given [`Function`].
+    pub fn demangle_function(&self, func: &Function<'_>) -> String {
+        self.demangle(&func.name_for_demangling())
+    }
+
+    /// Demangles the given [`Name`].
+    pub fn demangle(&self, name: &Name<'_>) -> String {
+        let key = MangleKeyRef {
+            symbol: name.as_str(),
+            language: name.language(),
+        };
+
+        if let Some(demangled) = self.cache.get(&key) {
+            return demangled;
+        }
+
+        let demangled = name
+            .demangle(DEMANGLE_OPTIONS)
+            .unwrap_or_else(|| name.as_str().to_owned());
+
+        self.cache.insert(key.to_owned(), demangled.clone());
+
+        demangled
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MangleKey {
+    symbol: String,
+    language: Language,
+}
+
+impl std::hash::Hash for MangleKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        MangleKeyRef {
+            symbol: &self.symbol,
+            language: self.language,
+        }
+        .hash(state);
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+struct MangleKeyRef<'a> {
+    symbol: &'a str,
+    language: Language,
+}
+
+impl MangleKeyRef<'_> {
+    fn to_owned(self) -> MangleKey {
+        MangleKey {
+            symbol: self.symbol.to_owned(),
+            language: self.language,
+        }
+    }
+}
+
+impl<'a> Equivalent<MangleKey> for MangleKeyRef<'a> {
+    fn equivalent(&self, key: &MangleKey) -> bool {
+        let MangleKey { symbol, language } = key;
+        self.symbol == symbol && self.language == *language
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_demangle_cache() {
+        let cache = DemangleCache::new(1024);
+
+        let name = Name::from("_ZN4core3fmt9Formatter3pad17h0123456789abcdefE");
+        let result = cache.demangle(&name);
+        assert_eq!(result, "core::fmt::Formatter::pad");
+
+        let result = cache.demangle(&name);
+        assert_eq!(result, "core::fmt::Formatter::pad");
+    }
+
+    #[test]
+    fn test_ref_key_hash_equivalent() {
+        use std::hash::{BuildHasher, RandomState};
+
+        let state = RandomState::new();
+        let owned = MangleKey {
+            symbol: "_ZN4core3fmt9Formatter3pad17h0123456789abcdefE".to_owned(),
+            language: Language::Rust,
+        };
+        let borrowed = MangleKeyRef {
+            symbol: &owned.symbol,
+            language: owned.language,
+        };
+
+        assert_eq!(state.hash_one(&owned), state.hash_one(borrowed));
+        assert!(borrowed.equivalent(&owned));
+    }
 }

--- a/crates/symbolicator-native/src/symbolication/demangle.rs
+++ b/crates/symbolicator-native/src/symbolication/demangle.rs
@@ -9,15 +9,17 @@ const DEMANGLE_OPTIONS: DemangleOptions = DemangleOptions::complete().return_typ
 /// A cache for demangled symbols.
 #[derive(Debug, Clone)]
 pub struct DemangleCache {
-    cache: moka::sync::Cache<MangleKey, String>,
+    cache: moka::sync::Cache<MangleKey, Option<String>>,
 }
 
 impl DemangleCache {
     pub fn new(max_capacity: u64) -> Self {
         let cache = moka::sync::Cache::builder()
             .max_capacity(max_capacity) // 10 MiB, considering key and value:
-            .weigher(|k: &MangleKey, v: &String| {
-                (k.symbol.len() + v.len()).try_into().unwrap_or(u32::MAX)
+            .weigher(|k: &MangleKey, v: &Option<String>| {
+                (k.symbol.len() + v.as_ref().map_or(0, |v| v.len()))
+                    .try_into()
+                    .unwrap_or(u32::MAX)
             })
             .build();
 
@@ -25,12 +27,16 @@ impl DemangleCache {
     }
 
     /// Demangles the name of the given [`Function`].
-    pub fn demangle_function(&self, func: &Function<'_>) -> String {
+    ///
+    /// Returns `None` if the function can't be de-mangled.
+    pub fn demangle_function(&self, func: &Function<'_>) -> Option<String> {
         self.demangle(&func.name_for_demangling())
     }
 
     /// Demangles the given [`Name`].
-    pub fn demangle(&self, name: &Name<'_>) -> String {
+    ///
+    /// Returns `None` if the symbol can't be de-mangled.
+    pub fn demangle(&self, name: &Name<'_>) -> Option<String> {
         let key = MangleKeyRef {
             symbol: name.as_str(),
             language: name.language(),
@@ -40,10 +46,7 @@ impl DemangleCache {
             return demangled;
         }
 
-        let demangled = name
-            .demangle(DEMANGLE_OPTIONS)
-            .unwrap_or_else(|| name.as_str().to_owned());
-
+        let demangled = name.demangle(DEMANGLE_OPTIONS);
         self.cache.insert(key.to_owned(), demangled.clone());
 
         demangled
@@ -98,10 +101,10 @@ mod test {
 
         let name = Name::from("_ZN4core3fmt9Formatter3pad17h0123456789abcdefE");
         let result = cache.demangle(&name);
-        assert_eq!(result, "core::fmt::Formatter::pad");
+        assert_eq!(result.as_deref(), Some("core::fmt::Formatter::pad"));
 
         let result = cache.demangle(&name);
-        assert_eq!(result, "core::fmt::Formatter::pad");
+        assert_eq!(result.as_deref(), Some("core::fmt::Formatter::pad"));
     }
 
     #[test]

--- a/crates/symbolicator-native/src/symbolication/native.rs
+++ b/crates/symbolicator-native/src/symbolication/native.rs
@@ -9,7 +9,7 @@ use crate::interface::{
     AdjustInstructionAddr, FrameStatus, RawFrame, Registers, Signal, SymbolicatedFrame,
 };
 
-use super::demangle::{DemangleCache, demangle_symbol};
+use super::demangle::DemangleCache;
 use super::module_lookup::CacheLookupResult;
 
 pub fn symbolicate_native_frame(
@@ -38,7 +38,7 @@ pub fn symbolicate_native_frame(
         let filename = split_path(&abs_path).1;
 
         let func = source_location.function();
-        let (symbol, function) = demangle_symbol(demangle_cache, &func);
+        let symbol = demangle_cache.demangle_function(&func);
 
         sym_addr = Some(HexValue(
             lookup_result.expose_preferred_addr(func.entry_pc() as u64),
@@ -70,7 +70,7 @@ pub fn symbolicate_native_frame(
                 } else {
                     frame.abs_path.clone()
                 },
-                function: Some(function),
+                function: Some(func.name().to_owned()),
                 filename,
                 lineno: Some(source_location.line()),
                 pre_context: vec![],

--- a/crates/symbolicator-native/src/symbolication/native.rs
+++ b/crates/symbolicator-native/src/symbolication/native.rs
@@ -38,7 +38,9 @@ pub fn symbolicate_native_frame(
         let filename = split_path(&abs_path).1;
 
         let func = source_location.function();
-        let symbol = demangle_cache.demangle_function(&func);
+        let function = demangle_cache
+            .demangle_function(&func)
+            .unwrap_or_else(|| func.name().to_owned());
 
         sym_addr = Some(HexValue(
             lookup_result.expose_preferred_addr(func.entry_pc() as u64),
@@ -64,13 +66,13 @@ pub fn symbolicate_native_frame(
                 instruction_addr,
                 adjust_instruction_addr: frame.adjust_instruction_addr,
                 function_id: frame.function_id,
-                symbol: Some(symbol),
+                symbol: Some(func.name().to_owned()),
                 abs_path: if !abs_path.is_empty() {
                     Some(abs_path)
                 } else {
                     frame.abs_path.clone()
                 },
-                function: Some(func.name().to_owned()),
+                function: Some(function),
                 filename,
                 lineno: Some(source_location.line()),
                 pre_context: vec![],

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use symbolic::common::Name;
-use symbolic::demangle::Demangle;
 use symbolicator_service::caches::SourceFilesCache;
 use symbolicator_service::caching::CacheError;
 use symbolicator_service::download::DownloadService;
@@ -21,7 +20,7 @@ use crate::interface::{
 };
 use crate::metrics::{StacktraceMetrics, record_symbolication_metrics};
 
-use super::demangle::{DEMANGLE_OPTIONS, DemangleCache};
+use super::demangle::DemangleCache;
 use super::dotnet::symbolicate_dotnet_frame;
 use super::module_lookup::{CacheFileEntry, ModuleLookup};
 use super::native::{get_relative_caller_addr, symbolicate_native_frame};
@@ -80,10 +79,7 @@ impl SymbolicationActor {
         let ppdb_caches =
             PortablePdbCacheActor::new(caches.ppdb_caches.clone(), shared_cache, objects.clone());
 
-        let demangle_cache = DemangleCache::builder()
-            .max_capacity(10 * 1024 * 1024) // 10 MiB, considering key and value:
-            .weigher(|k, v| (k.0.len() + v.len()).try_into().unwrap_or(u32::MAX))
-            .build();
+        let demangle_cache = DemangleCache::new(10 * 1024 * 1024); // 10 MiB, considering key and value:
 
         SymbolicationActor {
             demangle_cache,
@@ -211,7 +207,8 @@ fn symbolicate_stacktrace(
                 // either one of `function` or `symbol`, treat that as mangled name and try to
                 // demangle it. If that succeeds, write the demangled name back.
                 let mangled = frame.function.as_deref().xor(frame.symbol.as_deref());
-                let demangled = mangled.and_then(|m| Name::from(m).demangle(DEMANGLE_OPTIONS));
+                let demangled = mangled.map(|m| demangle_cache.demangle(&Name::from(m)));
+
                 if let Some(demangled) = demangled
                     && let Some(old_mangled) = frame.function.replace(demangled)
                 {

--- a/crates/symbolicator-native/src/symbolication/symbolicate.rs
+++ b/crates/symbolicator-native/src/symbolication/symbolicate.rs
@@ -207,7 +207,7 @@ fn symbolicate_stacktrace(
                 // either one of `function` or `symbol`, treat that as mangled name and try to
                 // demangle it. If that succeeds, write the demangled name back.
                 let mangled = frame.function.as_deref().xor(frame.symbol.as_deref());
-                let demangled = mangled.map(|m| demangle_cache.demangle(&Name::from(m)));
+                let demangled = mangled.and_then(|m| demangle_cache.demangle(&Name::from(m)));
 
                 if let Some(demangled) = demangled
                     && let Some(old_mangled) = frame.function.replace(demangled)


### PR DESCRIPTION
Small refactor to make the cache easier to use and to have a central place for demangling. For example only 1 of 2 code paths actually used the cache for demangling.