### PR TITLE
build(deps): Bump symbolic to include dwarf invalid op fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "symbolic"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "symbolic-cfi"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "symbolic-common",
  "symbolic-debuginfo",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "symbolic-common"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "symbolic-debuginfo"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "debugid",
  "elementtree",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "symbolic-demangle"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "bitflags",
  "cc",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "symbolic-il2cpp"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "symbolic-ppdb"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "flate2",
  "indexmap",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "symbolic-sourcemapcache"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "itertools 0.14.0",
  "js-source-scopes",
@@ -4902,7 +4902,7 @@ dependencies = [
 [[package]]
 name = "symbolic-symcache"
 version = "14.0.0-alpha.3"
-source = "git+https://github.com/getsentry/symbolic.git?rev=54486a9661aa56b215022d9c9d9f712b51538697#54486a9661aa56b215022d9c9d9f712b51538697"
+source = "git+https://github.com/getsentry/symbolic.git?rev=d1902eacd7b9e8f8811158a59d6e03d4e2a70df4#d1902eacd7b9e8f8811158a59d6e03d4e2a70df4"
 dependencies = [
  "indexmap",
  "symbolic-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ serde_yaml = "0.9.14"
 sha-1 = "0.10.0"
 sha2 = "0.10.6"
 sketches-ddsketch = "0.3.0"
-symbolic = { git = "https://github.com/getsentry/symbolic.git", rev = "54486a9661aa56b215022d9c9d9f712b51538697" }
+symbolic = { git = "https://github.com/getsentry/symbolic.git", rev = "d1902eacd7b9e8f8811158a59d6e03d4e2a70df4" }
 symbolicator-crash = { path = "crates/symbolicator-crash" }
 symbolicator-js = { path = "crates/symbolicator-js" }
 symbolicator-native = { path = "crates/symbolicator-native" }


### PR DESCRIPTION
See: https://github.com/getsentry/symbolic/pull/1045 (needs to be merged first)