### PR TITLE
fix(limits): Bump max decompressed source size

### DIFF
--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -542,7 +542,7 @@ pub struct Config {
 
     /// Maximum decompressed size of compressed source files embedded in debug files.
     ///
-    /// Defaults to 190MiB.
+    /// Defaults to 1GiB.
     pub object_file_max_decompressed_source_size: Option<usize>,
 
     /// Maximum length of the CFI unwind chain.
@@ -661,7 +661,7 @@ impl Default for Config {
             symbolicate_body_max_bytes: 55 * 1024 * 1024,
             object_file_max_decompressed_section_size: Some(4 * 1024 * 1024 * 1024),
             // Keep in sync with Sentry's `MAX_SOURCE_FILE_SIZE` and https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/
-            object_file_max_decompressed_source_size: Some(190 * 1024 * 1024),
+            object_file_max_decompressed_source_size: Some(1024 * 1024 * 1024),
             max_unwind_chain_len: Some(128),
             max_download_size: Some(15 * 1024 * 1024 * 1024),
         }


### PR DESCRIPTION
190 MiB was too little in practice.