### PR TITLE
fix: Always create temp files in cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes 🐛
+
+- Temp files are now always created in the configured cache directory. ([#2028](https://github.com/getsentry/symbolicator/pull/2028))
+
 ## 26.8.0
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,7 +4940,6 @@ dependencies = [
  "symbolicator-service",
  "symbolicator-sources",
  "symbolicator-test",
- "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-metrics",

--- a/crates/symbolicator-native/src/symbolication/attachments.rs
+++ b/crates/symbolicator-native/src/symbolication/attachments.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use futures::TryStreamExt;
 use symbolicator_service::caching::CacheError;
 use symbolicator_service::download::{self, DownloadService};
+use symbolicator_service::utils::fs;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
 
 use crate::interface::AttachmentFile;
@@ -40,7 +41,7 @@ pub async fn download_attachment(
 
         let mut stream = response.bytes_stream();
 
-        let file = tempfile::tempfile()?;
+        let file = fs::tempfile(download_svc.tmp_dir.as_deref())?.into_file();
         let mut writer = BufWriter::new(tokio::fs::File::from_std(file));
         while let Some(chunk) = stream.try_next().await? {
             writer.write_all(&chunk).await?;

--- a/crates/symbolicator-service/src/config.rs
+++ b/crates/symbolicator-service/src/config.rs
@@ -568,6 +568,13 @@ impl Config {
         self.cache_dir.as_ref().map(|base| base.join(dir))
     }
 
+    /// Returns a directory for temporary files within the configured base cache directory.
+    ///
+    /// If there is no base cache directory configured this returns `None`.
+    pub fn tmp_dir(&self) -> Option<PathBuf> {
+        self.cache_dir("tmp")
+    }
+
     pub fn default_sources(&self) -> Arc<[SourceConfig]> {
         self.sources.clone()
     }

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -135,7 +135,7 @@ pub struct DownloadService {
     fs: filesystem::FilesystemDownloader,
     host_deny_list: Option<HostDenyList>,
     connect_to_reserved_ips: bool,
-    tmp_dir: Option<PathBuf>,
+    pub tmp_dir: Option<PathBuf>,
 }
 
 impl DownloadService {

--- a/crates/symbolicator-service/src/download/mod.rs
+++ b/crates/symbolicator-service/src/download/mod.rs
@@ -200,7 +200,7 @@ impl DownloadService {
                 .deny_list_enabled
                 .then_some(HostDenyList::from_config(config)),
             connect_to_reserved_ips: config.connect_to_reserved_ips,
-            tmp_dir: config.cache_dir("tmp"),
+            tmp_dir: config.tmp_dir(),
         })
     }
 

--- a/crates/symbolicator/Cargo.toml
+++ b/crates/symbolicator/Cargo.toml
@@ -30,7 +30,6 @@ symbolicator-native = { workspace = true }
 symbolicator-proguard = { workspace = true }
 symbolicator-service = { workspace = true }
 symbolicator-sources = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true}
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tokio-metrics = { workspace = true }

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -2,6 +2,7 @@ use axum::extract;
 use axum::http::StatusCode;
 use axum::response::Json;
 use symbolicator_native::interface::AttachmentFile;
+use symbolicator_service::utils::fs;
 use tokio::fs::File;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -18,6 +19,8 @@ pub async fn handle_apple_crash_report_request(
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     params.configure_scope();
 
+    let temp_dir = service.config().cache_dir("tmp");
+
     let mut report = None;
     let mut sources = service.config().default_sources();
     let mut scraping = Default::default();
@@ -27,7 +30,8 @@ pub async fn handle_apple_crash_report_request(
     while let Some(field) = multipart.next_field().await? {
         match field.name() {
             Some("apple_crash_report") => {
-                let mut report_file = File::from_std(tempfile::tempfile()?);
+                let temp_file = fs::tempfile(temp_dir.as_deref())?.into_file();
+                let mut report_file = File::from_std(temp_file);
                 stream_multipart_file(field, &mut report_file).await?;
                 report = Some(report_file.into_std().await)
             }

--- a/crates/symbolicator/src/endpoints/applecrashreport.rs
+++ b/crates/symbolicator/src/endpoints/applecrashreport.rs
@@ -19,8 +19,6 @@ pub async fn handle_apple_crash_report_request(
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     params.configure_scope();
 
-    let temp_dir = service.config().cache_dir("tmp");
-
     let mut report = None;
     let mut sources = service.config().default_sources();
     let mut scraping = Default::default();
@@ -30,7 +28,7 @@ pub async fn handle_apple_crash_report_request(
     while let Some(field) = multipart.next_field().await? {
         match field.name() {
             Some("apple_crash_report") => {
-                let temp_file = fs::tempfile(temp_dir.as_deref())?.into_file();
+                let temp_file = fs::tempfile(service.config().tmp_dir().as_deref())?.into_file();
                 let mut report_file = File::from_std(temp_file);
                 stream_multipart_file(field, &mut report_file).await?;
                 report = Some(report_file.into_std().await)

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -3,6 +3,7 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use symbolic::common::ByteView;
 use symbolicator_native::interface::{AttachmentFile, ProcessMinidump};
+use symbolicator_service::utils::fs;
 use tokio::fs::File;
 
 use crate::endpoints::symbolicate::SymbolicationRequestQueryParams;
@@ -20,6 +21,8 @@ pub async fn handle_minidump_request(
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     params.configure_scope();
 
+    let temp_dir = service.config().cache_dir("tmp");
+
     let mut minidump = None;
     let mut sources = service.config().default_sources();
     let mut scraping = Default::default();
@@ -30,7 +33,8 @@ pub async fn handle_minidump_request(
     while let Some(field) = multipart.next_field().await? {
         match field.name() {
             Some("upload_file_minidump") => {
-                let mut minidump_file = File::from_std(tempfile::tempfile()?);
+                let temp_file = fs::tempfile(temp_dir.as_deref())?.into_file();
+                let mut minidump_file = File::from_std(temp_file);
                 stream_multipart_file(field, &mut minidump_file).await?;
                 minidump = Some(minidump_file.into_std().await)
             }

--- a/crates/symbolicator/src/endpoints/minidump.rs
+++ b/crates/symbolicator/src/endpoints/minidump.rs
@@ -21,8 +21,6 @@ pub async fn handle_minidump_request(
 ) -> Result<Json<SymbolicationResponse>, ResponseError> {
     params.configure_scope();
 
-    let temp_dir = service.config().cache_dir("tmp");
-
     let mut minidump = None;
     let mut sources = service.config().default_sources();
     let mut scraping = Default::default();
@@ -33,7 +31,7 @@ pub async fn handle_minidump_request(
     while let Some(field) = multipart.next_field().await? {
         match field.name() {
             Some("upload_file_minidump") => {
-                let temp_file = fs::tempfile(temp_dir.as_deref())?.into_file();
+                let temp_file = fs::tempfile(service.config().tmp_dir().as_deref())?.into_file();
                 let mut minidump_file = File::from_std(temp_file);
                 stream_multipart_file(field, &mut minidump_file).await?;
                 minidump = Some(minidump_file.into_std().await)


### PR DESCRIPTION
Some code paths for Apple crash reports and minidumps were creating temp files directly with `tempfile::tempfile`, which caused the files to be created in the `/tmp` directory. In production this is a problem because that directory is not on the same disk as the caches.

This PR instead routes all temp file creation through the `utils::fs::tempfile` function, which can be passed a base cache directory. The only exceptions are in tests and utilities like `symbolicli`.

ref: INC-2470