### PR TITLE
chore(gocd): use GitHub App credentials

### DIFF
--- a/gocd/templates/bash/github-checks.sh
+++ b/gocd/templates/bash/github-checks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-checks-githubactions-checkruns \
+checks-githubactions-checkruns2 \
   getsentry/symbolicator \
   ${GO_REVISION_SYMBOLICATOR_REPO} \
   'Tests' \

--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -61,7 +61,8 @@ function(region) {
         fetch_materials: true,
         environment_variables: {
           // Required for checkruns.
-          GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+          GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+          GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
         },
         jobs: {
           checks: {

--- a/gocd/templates/pipelines/symbolicator.libsonnet
+++ b/gocd/templates/pipelines/symbolicator.libsonnet
@@ -60,7 +60,7 @@ function(region) {
       checks: {
         fetch_materials: true,
         environment_variables: {
-          // Required for checkruns.
+          // Required for checkruns2.
           GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
           GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
         },


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.